### PR TITLE
Back/db tables

### DIFF
--- a/DashAI/back/database/db.py
+++ b/DashAI/back/database/db.py
@@ -7,5 +7,3 @@ from DashAI.back.config import settings
 engine = create_engine(f"sqlite:///{settings.db_path}")
 Session = sessionmaker(bind=engine)
 session = Session()
-
-Base = declarative_base()

--- a/DashAI/back/database/db.py
+++ b/DashAI/back/database/db.py
@@ -1,5 +1,4 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from DashAI.back.config import settings

--- a/DashAI/back/database/models.py
+++ b/DashAI/back/database/models.py
@@ -1,10 +1,9 @@
-from sqlalchemy import Enum, String, ForeignKey, JSON
-from sqlalchemy.orm import Mapped
-from sqlalchemy.orm import relationship
-from sqlalchemy.orm import mapped_column
-from sqlalchemy.orm import DeclarativeBase
-from DashAI.back.models.enums.states import State
 from typing import List
+
+from sqlalchemy import JSON, Enum, ForeignKey, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from DashAI.back.models.enums.states import State
 
 
 class Base(DeclarativeBase):
@@ -50,4 +49,3 @@ class Model(Base):
     validation_restuls: Mapped[JSON] = mapped_column(JSON)
     weights_path: Mapped[str] = mapped_column(String)
     trained: Mapped[bool] = mapped_column(bool)
-

--- a/DashAI/back/database/models.py
+++ b/DashAI/back/database/models.py
@@ -31,11 +31,11 @@ class Experiment(Base):
     dataset_id: Mapped[int] = mapped_column(ForeignKey("dataset.id"))
     task_name: Mapped[str] = mapped_column(String, nullable=False)
     step: Mapped[Enum] = mapped_column(Enum(State), nullable=False)
-    models: Mapped[List["Model"]] = relationship()
+    models: Mapped[List["ModelInstance"]] = relationship()
 
 
-class Model(Base):
-    __tablename__ = "model"
+class ModelInstance(Base):
+    __tablename__ = "model_instance"
     """
     Table to store all the information about a model.
     """
@@ -52,10 +52,10 @@ class Run(Base):
     Table to store all the information about a specific run of a model.
     """
     id: Mapped[int] = mapped_column(primary_key=True)
-    model_id: Mapped[int] = mapped_column(ForeignKey("model.id"))
+    model_id: Mapped[int] = mapped_column(ForeignKey("model_instance.id"))
     train_results: Mapped[JSON] = mapped_column(JSON)
     test_results: Mapped[JSON] = mapped_column(JSON)
     validation_restuls: Mapped[JSON] = mapped_column(JSON)
     weights_path: Mapped[str] = mapped_column(String)
     trained: Mapped[Boolean] = mapped_column(Boolean)
-    model: Mapped["Model"] = relationship(back_populates="model", cascade="all, delete")
+    model: Mapped["ModelInstance"] = relationship(back_populates="model_instance", cascade="all, delete")

--- a/DashAI/back/database/models.py
+++ b/DashAI/back/database/models.py
@@ -19,8 +19,7 @@ class Dataset(Base):
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     task_name: Mapped[str] = mapped_column(String, nullable=False)
     file_path: Mapped[str] = mapped_column(String, nullable=False)
-    experiments: Mapped[List["Experiment"]] = relationship(cascade="all, delete")
-    # TODO: Check If we delete a dataset, should all experiments be deleted?
+    experiments: Mapped[List["Experiment"]] = relationship()
 
 
 class Experiment(Base):
@@ -32,7 +31,7 @@ class Experiment(Base):
     dataset_id: Mapped[int] = mapped_column(ForeignKey("dataset.id"))
     task_name: Mapped[str] = mapped_column(String, nullable=False)
     step: Mapped[Enum] = mapped_column(Enum(State), nullable=False)
-    models: Mapped[List["Model"]] = relationship(cascade="all, delete")
+    models: Mapped[List["Model"]] = relationship()
 
 
 class Model(Base):

--- a/DashAI/back/database/models.py
+++ b/DashAI/back/database/models.py
@@ -58,4 +58,6 @@ class Run(Base):
     validation_restuls: Mapped[JSON] = mapped_column(JSON)
     weights_path: Mapped[str] = mapped_column(String)
     trained: Mapped[Boolean] = mapped_column(Boolean)
-    model: Mapped["ModelInstance"] = relationship(back_populates="model_instance", cascade="all, delete")
+    model: Mapped["ModelInstance"] = relationship(
+        back_populates="model_instance", cascade="all, delete"
+    )

--- a/DashAI/back/database/models.py
+++ b/DashAI/back/database/models.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from sqlalchemy import JSON, Enum, ForeignKey, String
+from sqlalchemy import JSON, Boolean, Enum, ForeignKey, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from DashAI.back.models.enums.states import State
@@ -48,4 +48,4 @@ class Model(Base):
     test_results: Mapped[JSON] = mapped_column(JSON)
     validation_restuls: Mapped[JSON] = mapped_column(JSON)
     weights_path: Mapped[str] = mapped_column(String)
-    trained: Mapped[bool] = mapped_column(bool)
+    trained: Mapped[Boolean] = mapped_column(Boolean)

--- a/DashAI/back/database/models.py
+++ b/DashAI/back/database/models.py
@@ -13,7 +13,7 @@ class Base(DeclarativeBase):
 class Dataset(Base):
     __tablename__ = "dataset"
     """
-    Class to store all the information about a dataset.
+    Table to store all the information about a dataset.
     """
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
@@ -26,7 +26,7 @@ class Dataset(Base):
 class Experiment(Base):
     __tablename__ = "experiment"
     """
-    Class to store all the information about an experiment.
+    Table to store all the information about a model.
     """
     id: Mapped[int] = mapped_column(primary_key=True)
     dataset_id: Mapped[int] = mapped_column(ForeignKey("dataset.id"))
@@ -36,16 +36,27 @@ class Experiment(Base):
 
 
 class Model(Base):
-    __tablename__ = "execution"
+    __tablename__ = "model"
     """
-    Class to store all the information about a specific model.
+    Table to store all the information about a model.
     """
     id: Mapped[int] = mapped_column(primary_key=True)
     experiment_id: Mapped[int] = mapped_column(ForeignKey("experiment.id"))
     parameters: Mapped[JSON] = mapped_column(JSON)
     model_name: Mapped[str] = mapped_column(String)
+    run: Mapped["Run"] = relationship(back_populates="run", cascade="all, delete")
+
+
+class Run(Base):
+    __tablename__ = "run"
+    """
+    Table to store all the information about a specific run of a model.
+    """
+    id: Mapped[int] = mapped_column(primary_key=True)
+    model_id: Mapped[int] = mapped_column(ForeignKey("model.id"))
     train_results: Mapped[JSON] = mapped_column(JSON)
     test_results: Mapped[JSON] = mapped_column(JSON)
     validation_restuls: Mapped[JSON] = mapped_column(JSON)
     weights_path: Mapped[str] = mapped_column(String)
     trained: Mapped[Boolean] = mapped_column(Boolean)
+    model: Mapped["Model"] = relationship(back_populates="model", cascade="all, delete")

--- a/DashAI/back/dataloaders/classes/csv_dataloader.py
+++ b/DashAI/back/dataloaders/classes/csv_dataloader.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict
 
 from datasets import DatasetDict, load_dataset
 from fastapi import UploadFile
@@ -14,7 +15,7 @@ class CSVDataLoader(TabularDataLoader):
     def load_data(
         self,
         dataset_path: str,
-        params: dict[str, any],
+        params: Dict[str, any],
         file: UploadFile = None,
         url: str = None,
     ) -> DatasetDict:

--- a/DashAI/back/dataloaders/classes/tabular_dataloader.py
+++ b/DashAI/back/dataloaders/classes/tabular_dataloader.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 from datasets import ClassLabel, DatasetDict
 
@@ -68,7 +68,7 @@ class TabularDataLoader(BaseDataLoader):
         return dataset, label
 
     def select_features(
-        self, dataset: DatasetDict, selected_features: list[str]
+        self, dataset: DatasetDict, selected_features: List[str]
     ) -> DatasetDict:
         """
         Remove the features (columns) not selected for the dataset

--- a/DashAI/back/main.py
+++ b/DashAI/back/main.py
@@ -5,7 +5,8 @@ from fastapi import Body, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from DashAI.back.config_object import ConfigObject
-from DashAI.back.database import db
+from DashAI.back.database.models import Base
+from DashAI.back.database.db import engine
 from DashAI.back.models.classes.getters import filter_by_parent
 from DashAI.back.models.enums.squema_types import SquemaTypes
 from DashAI.back.routers import datasets, experiments
@@ -37,6 +38,6 @@ app.include_router(experiments.router)
 
 
 if __name__ == "__main__":
-    db.Base.metadata.create_all(db.engine)
+    Base.metadata.create_all(engine)
     # TODO: Check if db is running
     uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/DashAI/back/main.py
+++ b/DashAI/back/main.py
@@ -5,8 +5,8 @@ from fastapi import Body, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from DashAI.back.config_object import ConfigObject
-from DashAI.back.database.models import Base
 from DashAI.back.database.db import engine
+from DashAI.back.database.models import Base
 from DashAI.back.models.classes.getters import filter_by_parent
 from DashAI.back.models.enums.squema_types import SquemaTypes
 from DashAI.back.routers import datasets, experiments

--- a/DashAI/back/models/enums/states.py
+++ b/DashAI/back/models/enums/states.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class State(Enum):
+   TaskSelection = 0
+   DatasetSelection = 1
+   ModelConfiguration = 2
+   Execution = 3
+   Completed = 4

--- a/DashAI/back/models/enums/states.py
+++ b/DashAI/back/models/enums/states.py
@@ -1,8 +1,9 @@
 from enum import Enum
 
+
 class State(Enum):
-   TaskSelection = 0
-   DatasetSelection = 1
-   ModelConfiguration = 2
-   Execution = 3
-   Completed = 4
+    TaskSelection = 0
+    DatasetSelection = 1
+    ModelConfiguration = 2
+    Execution = 3
+    Completed = 4


### PR DESCRIPTION
# DB Tables
This PR intention is to implement new database model, hopefully giving all the tools necessary for the next pipeline orchestrator.

The model diagram is on DashAI's Miro board.
## Changes

### `DashAI/back/database/models.py`
We are now using the modern version of SQLAlchemy Mapped syntax
- We have 4 tables now: Dataset, Experiment, Model and Run
- Dataset One-to-Many Experiment
- Experiment One-to-Many Model
- Model One-to-One Run
- Model and Run cascades on deletion.

### `DashAI/back/models/enums/states.py`
- Added states for the future state machine.