### PR TITLE
Update frontend to use new task endpoint

### DIFF
--- a/DashAI/front/src/api/task.ts
+++ b/DashAI/front/src/api/task.ts
@@ -1,0 +1,7 @@
+import api from "./api";
+import type { ITask } from "../../types/task";
+
+export const getTasks = async (): Promise<ITask> => {
+    const response = await api.get<ITask>("/v1/task");
+    return response.data;
+  };

--- a/DashAI/front/types/task.ts
+++ b/DashAI/front/types/task.ts
@@ -1,0 +1,7 @@
+export interface ITask {
+    class: string;
+    name: string;
+    help: string;
+    description: string;
+    type: string;
+  }


### PR DESCRIPTION
Use the new endpoint for tasks in the frontend.
- Define `getTasks()` function in `tasks.ts` to retrieve tasks using the new endpoint.
- Add `tasks.ts` to the types folder to define the properties expected in the tasks data.
- Modify `SchemaList.jsx` to use `getTasks()` function for retrieving tasks.
- Add conditional statement to change between new task endpoint and legacy endpoint, depending on the context (tasks need the new endpoint, dataloaders need the legacy endpoint)