### PR TITLE
Small fix in parameter form

### DIFF
--- a/DashAI/front/src/components/ConfigurableObject/FormRenderer.jsx
+++ b/DashAI/front/src/components/ConfigurableObject/FormRenderer.jsx
@@ -67,6 +67,8 @@ export function FormRenderer(objName, paramJsonSchema, formik, defaultValues) {
       return <BooleanInput {...commonProps} />;
     case "float":
       return <FloatInput {...commonProps} />;
+    case "list_of_strings": // TODO: Create a new component to handle this input
+      return <div />;
     default:
       throw new Error(
         `Error while rendering ${objName}: ${type} is not a valid parameter type.`,


### PR DESCRIPTION
# Summary

<!--
Include a short summary of the changes made to the platforn and list any dependencies
of the pr - Required.
-->
Small modification to fix a bug in the parameter form that is needed for some other PRs to work.

## Type of change

<!-- Indicate the type of change. Delete those that do not apply  - Required -->

- Bug fix.

## Changes

<!--
Indicate the changes/fixes that you want to merge - Required.

- Bug 1
- Bug 2
- Feature 1
- Feature 2
-->
A new type of parameter "list_of_strings" was defined, as this was not defined in the frontend it fell in the default case of the switch in `FormRenderer.jsx` and threw an error. 

It is solved by adding the case in the switch and returning a `<div />`.   It is left for another PR to add a component that properly handles this new type of parameter.

## How to Test

<!--
Describe the tests or executions that you ran to verify your changes and provide
instructions to reproduce them - Required.
-->
1. Go to `DashAI/DashAI/front` and run `yarn start`
2. In `pages/Home.jsx` add these lines of code:
```
...
import ParameterForm from "../components/ConfigurableObject/ParameterForm";
...
const schema = {... copy the content of the json file DashAI/DashAI/back/dataloaders/params_schemas/csvdataloader.json ...}
...
return (
  <React.Fragment>
    ...
    <ParameterForm parameterSchema={schema} />
  </React.Fragment>
)
...

```
You should see a form, which no longer throws an error when trying to handle the "list_of_strings" case.

## Screenshots

<!--
In the case of modifying a view in the front-end, include screenshots with the changes.
Optional, delete this section if not needed.-->
![2023-05-24 16 33 48 localhost f4fc06d1b46a](https://github.com/DashAISoftware/DashAI/assets/53657198/2e924a29-41fc-4407-b075-c132c225643b)

