### PR TITLE
Fix: Add inital tasks to registry

### DIFF
--- a/DashAI/back/core/config.py
+++ b/DashAI/back/core/config.py
@@ -3,9 +3,17 @@ from pydantic import BaseSettings
 from DashAI.back.dataloaders import CSVDataLoader, JSONDataLoader
 from DashAI.back.models import SVC, KNeighborsClassifier, RandomForestClassifier
 from DashAI.back.registries.component_registry import ComponentRegistry
+from DashAI.back.tasks import (
+    TabularClassificationTask,
+    TextClassificationTask,
+    TranslationTask,
+)
 
 component_registry = ComponentRegistry(
     initial_components=[
+        TabularClassificationTask,
+        TextClassificationTask,
+        TranslationTask,
         SVC,
         KNeighborsClassifier,
         RandomForestClassifier,


### PR DESCRIPTION
# Summary

Bugfix: add inital tasks to registry.
## Type of change

<!-- Indicate the type of change. Delete those that do not apply  - Required -->

- Bug fix.

## Changes

- Added TabularClassificationTask, TextClassificationTask and TranslationTask as initial tasks to the component registry.

## How to Test

- `pytest test` to run the tests.
- `python -c "import DashAI;DashAI.run()"` to init the server.