### PR TITLE
Fix: dataloaders info is not displayed

### DIFF
--- a/DashAI/front/src/components/custom/ItemSelectorWithInfo.jsx
+++ b/DashAI/front/src/components/custom/ItemSelectorWithInfo.jsx
@@ -73,10 +73,14 @@ function ItemSelectorWithInfo({
                   </Typography>
                 </Grid>
                 <Grid item xs={12}>
-                  {selectedItem.images === undefined
+                  {selectedItem.schema?.images === undefined
                     ? null
-                    : displayImages(selectedItem.images)}
-                  <Typography>{selectedItem.description}</Typography>
+                    : displayImages(selectedItem.schema.images)}
+                  <Typography>
+                    {selectedItem.description !== null
+                      ? selectedItem.description
+                      : selectedItem.schema.description}
+                  </Typography>
                 </Grid>
               </>
             ) : (
@@ -98,9 +102,11 @@ ItemSelectorWithInfo.propTypes = {
     .isRequired,
   selectedItem: PropTypes.shape({
     name: PropTypes.string,
-    class: PropTypes.string,
+    schema: PropTypes.shape({
+      description: PropTypes.string,
+      images: PropTypes.arrayOf(PropTypes.string),
+    }),
     description: PropTypes.string,
-    images: PropTypes.arrayOf(PropTypes.string),
   }),
   setSelectedItem: PropTypes.func.isRequired,
   disabled: PropTypes.bool,

--- a/DashAI/front/src/components/custom/ItemSelectorWithInfo.jsx
+++ b/DashAI/front/src/components/custom/ItemSelectorWithInfo.jsx
@@ -79,7 +79,7 @@ function ItemSelectorWithInfo({
                   <Typography>
                     {selectedItem.description !== null
                       ? selectedItem.description
-                      : selectedItem.schema.description}
+                      : selectedItem.schema?.description}
                   </Typography>
                 </Grid>
               </>


### PR DESCRIPTION
# Summary

<!--
Include a short summary of the changes made to the platforn and list any dependencies
of the pr - Required.
-->
This PR solves #95 
The dataset information is now displayed in the modal

## Type of change

<!-- Indicate the type of change. Delete those that do not apply  - Required -->
- Bug fix.

## Changes

<!--
Indicate the changes/fixes that you want to merge - Required.

- Bug 1
- Bug 2
- Feature 1
- Feature 2
-->
- Modified `custom/ItemsSelectorWithInfo.jsx` so that if it does not find a description in the object, it tries to look for the description inside the `schema` property. Also, images are always searched for in the `schema` property.

## How to Test

<!--
Describe the tests or executions that you ran to verify your changes and provide
instructions to reproduce them - Required.
-->
1. Go to `DashAI/DashAI/front` and run `yarn build`
2. Go back to `DashAI/` and run `python -c "import DashAI;DashAI.run()"`
3. Navigate to the Datasets tab
4. Click the "New Dataset" button
5. Select "TabularClassification" as your task.
6. Select any of the dataloaders shown, each of them should display their description and image

## Screenshots

<!--
In the case of modifying a view in the front-end, include screenshots with the changes.
Optional, delete this section if not needed.-->
[dataloader_info.webm](https://github.com/DashAISoftware/DashAI/assets/53657198/82868a33-cfe7-488f-8c64-66ad68591646)

