### PR TITLE
More classifiers

### DIFF
--- a/DashAI/back/core/config.py
+++ b/DashAI/back/core/config.py
@@ -2,7 +2,15 @@ from pydantic_settings import BaseSettings
 
 from DashAI.back.dataloaders import CSVDataLoader, JSONDataLoader
 from DashAI.back.metrics import F1, Accuracy, Precision, Recall
-from DashAI.back.models import SVC, KNeighborsClassifier, RandomForestClassifier
+from DashAI.back.models import (
+    SVC,
+    DecisionTreeClassifier,
+    DummyClassifier,
+    HistGradientBoostingClassifier,
+    KNeighborsClassifier,
+    LogisticRegression,
+    RandomForestClassifier,
+)
 from DashAI.back.registries.component_registry import ComponentRegistry
 from DashAI.back.tasks import (
     TabularClassificationTask,
@@ -18,7 +26,11 @@ component_registry = ComponentRegistry(
         TranslationTask,
         # Models
         SVC,
+        DecisionTreeClassifier,
+        DummyClassifier,
+        HistGradientBoostingClassifier,
         KNeighborsClassifier,
+        LogisticRegression,
         RandomForestClassifier,
         # Dataloaders
         CSVDataLoader,

--- a/DashAI/back/models/__init__.py
+++ b/DashAI/back/models/__init__.py
@@ -1,6 +1,14 @@
 # flake8: noqa
 from DashAI.back.models.base_model import BaseModel
+from DashAI.back.models.scikit_learn.decision_tree_classifier import (
+    DecisionTreeClassifier,
+)
+from DashAI.back.models.scikit_learn.dummy_classifier import DummyClassifier
+from DashAI.back.models.scikit_learn.hist_gradient_boosting_classifier import (
+    HistGradientBoostingClassifier,
+)
 from DashAI.back.models.scikit_learn.k_neighbors_classifier import KNeighborsClassifier
+from DashAI.back.models.scikit_learn.logistic_regression import LogisticRegression
 from DashAI.back.models.scikit_learn.random_forest_classifier import (
     RandomForestClassifier,
 )

--- a/DashAI/back/models/parameters/models_schemas/DecisionTreeClassifier.json
+++ b/DashAI/back/models/parameters/models_schemas/DecisionTreeClassifier.json
@@ -1,0 +1,63 @@
+{
+  "additionalProperties": false,
+  "error_msg": "The parameters for DecisionTreeClassifier should be one of ['criterion', 'max_depth', 'min_samples_split', 'min_samples_leaf', 'max_features'].",
+  "description": "Decision Trees are a set of are a non-parametric supervised learning method that learns simple decision rules (structured as a tree) inferred from the data features.",
+  "properties": {
+    "criterion": {
+      "oneOf": [
+        {
+          "error_msg": "The 'penalty' parameter should be one of 'gini' or 'entropy'.",
+          "description": "The function to measure the quality of a split. Supported criteria are “gini” for the Gini impurity and “entropy” for the Shannon information gain.",
+          "type": "string",
+          "default": "l2",
+          "enum": ["gini", "entropy"]
+        }
+      ]
+    },
+    "max_depth": {
+      "oneOf": [
+        {
+          "error_msg": "The 'max_depth' parameter should be an integer greater than or equal than 0.",
+          "description": "The maximum depth of the tree. If None, then nodes are expanded until all leaves are pure or until all leaves contain less than min_samples_split samples.",
+          "type": "integer",
+          "default": null,
+          "minimum": 1
+        }
+      ]
+    },
+    "min_samples_split": {
+      "oneOf": [
+        {
+          "error_msg": "The 'min_samples_split' parameter should be a positive integer.",
+          "description": "The minimum number of samples required to split an internal node.",
+          "type": "integer",
+          "default": 2,
+          "minimum": 1
+        }
+      ]
+    },
+    "min_samples_leaf": {
+      "oneOf": [
+        {
+          "error_msg": "The 'min_samples_leaf' parameter should be a interger greater than 0",
+          "description": "The minimum number of samples required to be at a leaf node.",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        }
+      ]
+    },
+    "max_features": {
+      "oneOf": [
+        {
+          "error_msg": "The 'max_features' parameter should be one of 'auto', 'sqrt', 'log2', 'null'.",
+          "description": "The number of features to consider when looking for the best split",
+          "type": "string",
+          "default": "l2",
+          "enum": ["auto", "sqrt", "log2", null]
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/DashAI/back/models/parameters/models_schemas/DummyClassifier.json
+++ b/DashAI/back/models/parameters/models_schemas/DummyClassifier.json
@@ -1,0 +1,19 @@
+{
+  "additionalProperties": false,
+  "error_msg": "The parameters for DummyClassifier  should be one of ['strategy'].",
+  "description": "Decision Trees are a set of are a non-parametric supervised learning method that learns simple decision rules (structured as a tree) inferred from the data features.",
+  "properties": {
+    "strategy": {
+      "oneOf": [
+        {
+          "error_msg": "The 'penalty' parameter should be one of 'most_frequent', 'prior', 'stratified', 'uniform'.",
+          "description": "Strategy to use to generate predictions.",
+          "type": "string",
+          "default": "prior",
+          "enum": ["most_frequent", "prior", "stratified", "uniform"]
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/DashAI/back/models/parameters/models_schemas/HistGradientBoostingClassifier.json
+++ b/DashAI/back/models/parameters/models_schemas/HistGradientBoostingClassifier.json
@@ -1,0 +1,74 @@
+{
+  "additionalProperties": false,
+  "error_msg": "The parameters for HistGradientBoostingClassifier should be one of ['learning_rate', 'max_iter', 'max_depth', 'max_leaf_nodes', 'min_samples_leaf', 'l2_regularization'].",
+  "description": "A gradient boosting classifier is a machine learning algorithm that combines multiple weak prediction models (typically decision trees) to create a strong predictive model by training the models sequentially, in which each new model is focused on correcting the errors made by the previous ones.",
+  "properties": {
+    "learning_rate": {
+      "oneOf": [
+        {
+          "error_msg": "The 'penalty' parameter should be one of 'gini' or 'entropy'.",
+          "description": "The learning rate, also known as shrinkage. This is used as a multiplicative factor for the leaves values.",
+          "type": "float",
+          "default": "0.1",
+          "minimum": 0.0
+        }
+      ]
+    },
+    "max_iter": {
+      "oneOf": [
+        {
+          "error_msg": "The 'max_iter' parameter should be an integer greater than or equal than 0.",
+          "description": "The maximum number of iterations of the boosting process, i.e. the maximum number of trees for binary classification.",
+          "type": "integer",
+          "default": 100,
+          "minimum": 10
+        }
+      ]
+    },
+    "max_depth": {
+      "oneOf": [
+        {
+          "error_msg": "The 'max_depth' parameter should be an integer greater than or equal than 0.",
+          "description": "The maximum depth of each tree. The depth of a tree is the number of edges to go from the root to the deepest leaf. Depth isn’t constrained by default.",
+          "type": "integer",
+          "default": null,
+          "minimum": 1
+        }
+      ]
+    },
+    "max_leaf_nodes": {
+      "oneOf": [
+        {
+          "error_msg": "The 'max_leaf_nodes' parameter should be an integer greater than or equal than 0.",
+          "description": "The maximum number of leaves for each tree. Must be strictly greater than 1. If None, there is no maximum limit.",
+          "type": "integer",
+          "default": 31,
+          "minimum": 2
+        }
+      ]
+    },
+    "min_samples_leaf": {
+      "oneOf": [
+        {
+          "error_msg": "The 'min_samples_leaf' parameter should be a interger greater than 0",
+          "description": "The minimum number of samples required to be at a leaf node.",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        }
+      ]
+    },
+    "l2_regularization": {
+      "oneOf": [
+        {
+          "error_msg": "The 'l2_regularization' parameter should be one of 'gini' or 'entropy'.",
+          "description": "The L2 regularization parameter. Use 0 for no regularization.",
+          "type": "float",
+          "default": "0.0",
+          "minimum": 0.0
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/DashAI/back/models/parameters/models_schemas/LogisticRegression.json
+++ b/DashAI/back/models/parameters/models_schemas/LogisticRegression.json
@@ -1,0 +1,52 @@
+{
+  "additionalProperties": false,
+  "error_msg": "The parameters for LogisticRegression should be one of ['penalty', 'tol', 'C', 'fit_intercept'].",
+  "description": "Logistic Regression is a supervised classification method that uses a linear model plus a a logistic funcion to predict binary outcomes (it can be configured as multiclass via the one-vs-rest strategy).",
+  "properties": {
+    "penalty": {
+      "oneOf": [
+        {
+          "error_msg": "The 'penalty' parameter must be null, 'l2', 'l1', 'elasticnet'.",
+          "description": "Specify the norm of the penalty",
+          "type": "string",
+          "default": "l2",
+          "enum": [null, "l2", "l1", "elasticnet"]
+        }
+      ]
+    },
+    "tol": {
+      "oneOf": [
+        {
+          "error_msg": "The 'tol' parameter should be an float greater than or equal than 0.",
+          "description": "Tolerance for stopping criteria.",
+          "type": "float",
+          "default": 0.0001,
+          "minimum": 0.0
+        }
+      ]
+    },
+    "C": {
+      "oneOf": [
+        {
+          "error_msg": "The 'C' parameter should be a positive float.",
+          "description": "Inverse of regularization strength, smaller values specify stronger regularization. Must be a positive float.",
+          "type": "float",
+          "default": 1.0,
+          "minimum": 0.0
+        }
+      ]
+    },
+    "max_iter": {
+      "oneOf": [
+        {
+          "error_msg": "The 'max_iter' parameter should be a interger greater than 0",
+          "description": "Maximum number of iterations taken for the solvers to converge.",
+          "type": "integer",
+          "default": 100,
+          "minimum": 50
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/DashAI/back/models/parameters/models_schemas/SVC.json
+++ b/DashAI/back/models/parameters/models_schemas/SVC.json
@@ -11,16 +11,6 @@
           "type": "number",
           "exclusiveMinimum": 0,
           "default": 1
-        },
-        {
-          "items": {
-            "error_msg": "The parameter 'C' must be of type positive number.",
-            "description": "The parameter 'C' is a regularization parameter. It must be of type positive number.",
-            "type": "number",
-            "exclusiveMinimum": 0,
-            "default": 1
-          },
-          "type": "array"
         }
       ]
     },
@@ -31,15 +21,6 @@
           "description": "The 'coef0' parameter is a kernel independent value. It is only significant for kernel poly and sigmoid. It must be of type number.",
           "type": "number",
           "default": 0
-        },
-        {
-          "items": {
-            "error_msg": "The parameter 'coef0' must be of type number.",
-            "description": "The 'coef0' parameter is a kernel independent value. It is only significant for kernel poly and sigmoid. It must be of type number.",
-            "type": "number",
-            "default": 0
-          },
-          "type": "array"
         }
       ]
     },
@@ -51,16 +32,6 @@
           "type": "number",
           "default": 3,
           "minimum": 0
-        },
-        {
-          "items": {
-            "error_msg": "The 'degree' parameter must type number",
-            "description": "The parameter 'degree' is the degree of the polynomial for the kernel = 'poly'. It must be of type number.",
-            "type": "number",
-            "default": 3,
-            "minimum": 0
-          },
-          "type": "array"
         }
       ]
     },
@@ -72,16 +43,6 @@
           "type": "string",
           "default": "scale",
           "enum": ["scale", "auto"]
-        },
-        {
-          "items": {
-            "error_msg": "The 'gamma' parameter must be in string format and can be either 'scale' or 'auto'",
-            "description": "Coefficient for 'rbf', 'poly' and 'sigmoid' kernels. Must be in string format and can be 'scale' or 'auto'.",
-            "type": "string",
-            "default": "scale",
-            "enum": ["scale", "auto"]
-          },
-          "type": "array"
         }
       ]
     },
@@ -93,16 +54,6 @@
           "type": "string",
           "default": "rbf",
           "enum": ["linear", "poly", "rbf", "sigmoid"]
-        },
-        {
-          "items": {
-            "error_msg": "The 'kernel' parameter must be 'linear', 'poly', 'rbf', 'sigmoid', 'precomputed'",
-            "description": "The 'kernel' parameter is the kernel used in the model. It must be a string equal to 'linear', 'poly', 'rbf', 'sigmoid' or 'precomputed'.",
-            "type": "string",
-            "default": "rbf",
-            "enum": ["linear", "poly", "rbf", "sigmoid"]
-          },
-          "type": "array"
         }
       ]
     },
@@ -114,16 +65,6 @@
           "type": "integer",
           "default": -1,
           "exclusiveMinimum": 0
-        },
-        {
-          "items": {
-            "error_msg": "The 'max_iter' parameter must be of type positive integer, -1 to indicate that there is no iteration limit.",
-            "description": "The 'max_iter' parameter determines the iteration limit for the solver. It must be of type positive integer or -1 to indicate no limit.",
-            "type": "integer",
-            "default": -1,
-            "exclusiveMinimum": 0
-          },
-          "type": "array"
         }
       ]
     },
@@ -134,15 +75,6 @@
           "description": "The parameter 'probability' indicates whether or not to predict with probabilities. It must be of type boolean.",
           "type": "boolean",
           "default": true
-        },
-        {
-          "items": {
-            "error_msg": "The parameter 'probability' must be of type boolean, it must be 'true' in order to estimate with probabilities.",
-            "description": "The parameter 'probability' indicates whether or not to predict with probabilities. It must be of type boolean.",
-            "type": "boolean",
-            "default": true
-          },
-          "type": "array"
         }
       ]
     },
@@ -153,15 +85,6 @@
           "description": "The 'shrinking' parameter determines whether a shrinking heristic is used. It must be of type boolean.",
           "type": "boolean",
           "default": true
-        },
-        {
-          "items": {
-            "error_msg": "The 'shrinking' parameter must be of type boolean.",
-            "description": "The 'shrinking' parameter determines whether a shrinking heristic is used. It must be of type boolean.",
-            "type": "boolean",
-            "default": true
-          },
-          "type": "array"
         }
       ]
     },
@@ -173,16 +96,6 @@
           "type": "number",
           "default": 0.001,
           "exclusiveMinimum": 0
-        },
-        {
-          "items": {
-            "error_msg": "The parameter 'tol' must be of type positive number.",
-            "description": "The parameter 'tol' determines the tolerance for the stop criterion. It must be of type positive number.",
-            "type": "number",
-            "default": 0.001,
-            "exclusiveMinimum": 0
-          },
-          "type": "array"
         }
       ]
     },
@@ -193,15 +106,6 @@
           "description": "The 'verbose' parameter allows to have a verbose output. It must be of type boolean.",
           "type": "boolean",
           "default": false
-        },
-        {
-          "items": {
-            "error_msg": "The 'verbose' parameter must be of boolean type.",
-            "description": "The 'verbose' parameter allows to have a verbose output. It must be of type boolean.",
-            "type": "boolean",
-            "default": false
-          },
-          "type": "array"
         }
       ]
     }

--- a/DashAI/back/models/scikit_learn/decision_tree_classifier.py
+++ b/DashAI/back/models/scikit_learn/decision_tree_classifier.py
@@ -1,0 +1,12 @@
+from sklearn.tree import DecisionTreeClassifier as _DecisionTreeClassifier
+
+from DashAI.back.models.scikit_learn.sklearn_like_model import SklearnLikeModel
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class DecisionTreeClassifier(
+    TabularClassificationModel, SklearnLikeModel, _DecisionTreeClassifier
+):
+    """
+    Scikit-learn's Decision Tree Classifier wrapper for DashAI.
+    """

--- a/DashAI/back/models/scikit_learn/dummy_classifier.py
+++ b/DashAI/back/models/scikit_learn/dummy_classifier.py
@@ -1,0 +1,10 @@
+from sklearn.dummy import DummyClassifier as _DummyClassifier
+
+from DashAI.back.models.scikit_learn.sklearn_like_model import SklearnLikeModel
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class DummyClassifier(TabularClassificationModel, SklearnLikeModel, _DummyClassifier):
+    """
+    Scikit-learn's DummyClassifier wrapper for DashAI.
+    """

--- a/DashAI/back/models/scikit_learn/hist_gradient_boosting_classifier.py
+++ b/DashAI/back/models/scikit_learn/hist_gradient_boosting_classifier.py
@@ -1,0 +1,14 @@
+from sklearn.ensemble import (
+    HistGradientBoostingClassifier as _HistGradientBoostingClassifier,
+)
+
+from DashAI.back.models.scikit_learn.sklearn_like_model import SklearnLikeModel
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class HistGradientBoostingClassifier(
+    TabularClassificationModel, SklearnLikeModel, _HistGradientBoostingClassifier
+):
+    """
+    Scikit-learn's HistGradientBoostingRegressor wrapper for DashAI.
+    """

--- a/DashAI/back/models/scikit_learn/logistic_regression.py
+++ b/DashAI/back/models/scikit_learn/logistic_regression.py
@@ -1,0 +1,12 @@
+from sklearn.linear_model import LogisticRegression as _LogisticRegression
+
+from DashAI.back.models.scikit_learn.sklearn_like_model import SklearnLikeModel
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class LogisticRegression(
+    TabularClassificationModel, SklearnLikeModel, _LogisticRegression
+):
+    """
+    Scikit-learn's Logistic Regression wrapper for DashAI.
+    """


### PR DESCRIPTION
# Summary

Add four new classifiers to the default pool of classifiers.


## Type of change

- Back end new feature.

## Changes

Add three new classifiers plus a dummy classifiers to test if the classifiers are better than chance.

- LogisticRegression
- HistGradientBoosting 
- DecisionTree,
- Dummy Classifiers

All of these classifiers implements a class in `DashAI/back/models/scikit_learn/` plus its configurable object schema, located in `DashAI/back/models/parameters/models_schemas/` and was registered in the centralized component registry.

## How to Test

Run a training example in the user interface.
