### PR TITLE
Text classification working from the front end

### DIFF
--- a/DashAI/back/core/config.py
+++ b/DashAI/back/core/config.py
@@ -7,6 +7,7 @@ from DashAI.back.metrics import F1, Accuracy, Precision, Recall
 from DashAI.back.models import (
     SVC,
     DecisionTreeClassifier,
+    DistilBertTransformer,
     DummyClassifier,
     HistGradientBoostingClassifier,
     KNeighborsClassifier,
@@ -34,6 +35,7 @@ component_registry = ComponentRegistry(
         KNeighborsClassifier,
         LogisticRegression,
         RandomForestClassifier,
+        DistilBertTransformer,
         # Dataloaders
         CSVDataLoader,
         JSONDataLoader,

--- a/DashAI/back/dataloaders/classes/csv_dataloader.py
+++ b/DashAI/back/dataloaders/classes/csv_dataloader.py
@@ -4,11 +4,13 @@ from typing import Dict
 from datasets import DatasetDict, load_dataset
 from starlette.datastructures import UploadFile
 
-from DashAI.back.dataloaders.classes.tabular_dataloader import TabularDataLoader
+from DashAI.back.dataloaders.classes.dataloader import BaseDataLoader
 
 
-class CSVDataLoader(TabularDataLoader):
+class CSVDataLoader(BaseDataLoader):
     """Data loader for tabular data in CSV files."""
+
+    COMPATIBLE_COMPONENTS = ["TabularClassificationTask"]
 
     def load_data(
         self,

--- a/DashAI/back/dataloaders/classes/json_dataloader.py
+++ b/DashAI/back/dataloaders/classes/json_dataloader.py
@@ -4,11 +4,13 @@ from typing import Dict
 from datasets import DatasetDict, load_dataset
 from starlette.datastructures import UploadFile
 
-from DashAI.back.dataloaders.classes.tabular_dataloader import TabularDataLoader
+from DashAI.back.dataloaders.classes.dataloader import BaseDataLoader
 
 
-class JSONDataLoader(TabularDataLoader):
+class JSONDataLoader(BaseDataLoader):
     """Data loader for tabular data in JSON files."""
+
+    COMPATIBLE_COMPONENTS = ["TabularClassificationTask", "TextClassificationTask"]
 
     def load_data(
         self,

--- a/DashAI/back/dataloaders/classes/tabular_dataloader.py
+++ b/DashAI/back/dataloaders/classes/tabular_dataloader.py
@@ -8,7 +8,7 @@ from DashAI.back.dataloaders.classes.dataloader import BaseDataLoader
 class TabularDataLoader(BaseDataLoader):
     """Intermediate class for tabular dataloaders methods."""
 
-    COMPATIBLE_COMPONENTS = ["TabularClassificationTask"]
+    COMPATIBLE_COMPONENTS = ["TabularClassificationTask", "TextClassificationTask"]
 
     def set_classes(
         self,

--- a/DashAI/back/metrics/classification/f1.py
+++ b/DashAI/back/metrics/classification/f1.py
@@ -34,6 +34,6 @@ class F1(ClassificationMetric):
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
         multiclass = len(np.unique(true_labels)) > 2
         if multiclass:
-            return f1_score(true_labels, pred_labels, average="micro")
+            return f1_score(true_labels, pred_labels, average="macro")
         else:
             return f1_score(true_labels, pred_labels, average="binary")

--- a/DashAI/back/metrics/classification/precision.py
+++ b/DashAI/back/metrics/classification/precision.py
@@ -34,6 +34,6 @@ class Precision(ClassificationMetric):
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
         multiclass = len(np.unique(true_labels)) > 2
         if multiclass:
-            return precision_score(true_labels, pred_labels, average="micro")
+            return precision_score(true_labels, pred_labels, average="macro")
         else:
             return precision_score(true_labels, pred_labels, average="binary")

--- a/DashAI/back/metrics/classification/recall.py
+++ b/DashAI/back/metrics/classification/recall.py
@@ -34,6 +34,6 @@ class Recall(ClassificationMetric):
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
         multiclass = len(np.unique(true_labels)) > 2
         if multiclass:
-            return recall_score(true_labels, pred_labels, average="micro")
+            return recall_score(true_labels, pred_labels, average="macro")
         else:
             return recall_score(true_labels, pred_labels, average="binary")

--- a/DashAI/back/models/__init__.py
+++ b/DashAI/back/models/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from DashAI.back.models.base_model import BaseModel
+from DashAI.back.models.hugging_face.distilbert_transformer import DistilBertTransformer
 from DashAI.back.models.scikit_learn.decision_tree_classifier import (
     DecisionTreeClassifier,
 )

--- a/DashAI/back/models/base_model.py
+++ b/DashAI/back/models/base_model.py
@@ -40,5 +40,8 @@ class BaseModel(ConfigObject, metaclass=ABCMeta):
     @classmethod
     def get_schema(cls):
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        with open(f"{dir_path}/parameters/models_schemas/{cls.__name__}.json") as f:
+        with open(
+            f"{dir_path}/parameters/models_schemas/{cls.__name__}.json",
+            encoding="utf-8",
+        ) as f:
             return json.load(f)

--- a/DashAI/back/models/hugging_face/distilbert_transformer.py
+++ b/DashAI/back/models/hugging_face/distilbert_transformer.py
@@ -11,11 +11,10 @@ from transformers import (
 )
 
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
-from DashAI.back.models.base_model import BaseModel
 from DashAI.back.models.text_classification_model import TextClassificationModel
 
 
-class DistilBertTransformer(BaseModel, TextClassificationModel):
+class DistilBertTransformer(TextClassificationModel):
     """
     Pre-trained transformer DistilBERT allowing English text classification
     """
@@ -40,7 +39,10 @@ class DistilBertTransformer(BaseModel, TextClassificationModel):
             else DistilBertForSequenceClassification.from_pretrained(self.model_name)
         )
         self.fitted = model is not None
-        self.training_args = kwargs
+        if model is None:
+            self.training_args = kwargs
+            self.batch_size = kwargs.pop("batch_size")
+            self.device = kwargs.pop("device")
 
     def get_tokenizer(self, input_column: str, output_column: str):
         """Tokenize input and output
@@ -99,6 +101,9 @@ class DistilBertTransformer(BaseModel, TextClassificationModel):
             output_dir="DashAI/back/user_models/temp_checkpoints_distilbert",
             save_steps=1,
             save_total_limit=1,
+            per_device_train_batch_size=self.batch_size,
+            per_device_eval_batch_size=self.batch_size,
+            no_cuda=self.device != "gpu",
             **self.training_args,
         )
 

--- a/DashAI/back/models/parameters/models_schemas/DistilBERT.json
+++ b/DashAI/back/models/parameters/models_schemas/DistilBERT.json
@@ -3,7 +3,7 @@
     "error_msg": "DistilBert parameters must be one(s) of ['epochs', 'batch size', 'weight decay', 'learning_rate', 'device'].",
     "description": "Distilbert is a transformer that allows you to classify text in English. The implementation is based on huggingface distilbert-base in the case of the uncased model, i.e. distilbert-base-uncased.",
     "properties": {
-        "epochs": {
+        "num_train_epochs": {
             "oneOf": [
                 {
                     "error_msg": "A whole number greater than or equal to 1 must be entered.",

--- a/DashAI/back/models/text_classification_model.py
+++ b/DashAI/back/models/text_classification_model.py
@@ -1,4 +1,7 @@
-class TextClassificationModel:
+from DashAI.back.models.base_model import BaseModel
+
+
+class TextClassificationModel(BaseModel):
     """Class for models associated to TextClassificationTask."""
 
     COMPATIBLE_COMPONENTS = ["TextClassificationTask"]

--- a/DashAI/front/src/components/experiments/ConfigureModelsStep.jsx
+++ b/DashAI/front/src/components/experiments/ConfigureModelsStep.jsx
@@ -45,7 +45,12 @@ function ConfigureModelsStep({ newExp, setNewExp, setNextEnabled }) {
 
   const getModelSchema = async () => {
     try {
-      const schema = await getModelSchemaRequest(selectedModel);
+      let schema;
+      if (selectedModel === "DistilBertTransformer") {
+        schema = await getModelSchemaRequest("DistilBERT");
+      } else {
+        schema = await getModelSchemaRequest(selectedModel);
+      }
       return schema;
     } catch (error) {
       enqueueSnackbar("Error while trying to obtain model schema");

--- a/DashAI/front/src/components/experiments/EditModelDialog.jsx
+++ b/DashAI/front/src/components/experiments/EditModelDialog.jsx
@@ -33,7 +33,13 @@ function EditModelDialog({
   const getObjectSchema = async () => {
     setLoading(true);
     try {
-      const schema = await getModelSchemaRequest(modelToConfigure);
+      // const schema = await getModelSchemaRequest(modelToConfigure);
+      let schema;
+      if (modelToConfigure === "DistilBertTransformer") {
+        schema = await getModelSchemaRequest("DistilBERT");
+      } else {
+        schema = await getModelSchemaRequest(modelToConfigure);
+      }
       setModelSchema(schema);
     } catch (error) {
       enqueueSnackbar("Error while trying to obtain model schema");

--- a/tests/back/models/test_text_class_models.py
+++ b/tests/back/models/test_text_class_models.py
@@ -44,17 +44,9 @@ def fixture_load_dashaidataset():
 
 
 @pytest.fixture(scope="session", name="model_fit")
-def text_class_model_fit(load_dashaidataset: DatasetDict):
-    distilbert = DistilBertTransformer()
-    distilbert.fit(load_dashaidataset["train"])
-    return distilbert
-
-
-@pytest.fixture(scope="session", name="model_fit_with_params")
 def text_class_model_fit_with_params(load_dashaidataset: DatasetDict):
-    distilbert = DistilBertTransformer(
-        num_train_epochs=2, per_device_train_batch_size=32
-    )
+    params = {"num_train_epochs": 2, "batch_size": 32, "device": "cpu"}
+    distilbert = DistilBertTransformer(**params)
     distilbert.fit(load_dashaidataset["train"])
     return distilbert
 
@@ -64,9 +56,9 @@ def test_fitted_text_class_model(model_fit: DistilBertTransformer):
 
 
 def test_fitted_text_class_model_with_params(
-    model_fit_with_params: DistilBertTransformer,
+    model_fit: DistilBertTransformer,
 ):
-    assert model_fit_with_params.fitted is True
+    assert model_fit.fitted is True
 
 
 def test_predict_text_class_model(
@@ -77,7 +69,8 @@ def test_predict_text_class_model(
 
 
 def test_not_fitted_text_class_model(load_dashaidataset: DatasetDict):
-    distilbert = DistilBertTransformer()
+    params = {"num_train_epochs": 2, "batch_size": 32, "device": "cpu"}
+    distilbert = DistilBertTransformer(**params)
 
     with pytest.raises(NotFittedError):
         distilbert.predict(load_dashaidataset["test"])

--- a/tests/back/models/test_text_class_models.py
+++ b/tests/back/models/test_text_class_models.py
@@ -45,7 +45,7 @@ def fixture_load_dashaidataset():
 
 @pytest.fixture(scope="session", name="model_fit")
 def text_class_model_fit_with_params(load_dashaidataset: DatasetDict):
-    params = {"num_train_epochs": 2, "batch_size": 32, "device": "cpu"}
+    params = {"num_train_epochs": 1, "batch_size": 32, "device": "cpu"}
     distilbert = DistilBertTransformer(**params)
     distilbert.fit(load_dashaidataset["train"])
     return distilbert
@@ -69,7 +69,7 @@ def test_predict_text_class_model(
 
 
 def test_not_fitted_text_class_model(load_dashaidataset: DatasetDict):
-    params = {"num_train_epochs": 2, "batch_size": 32, "device": "cpu"}
+    params = {"num_train_epochs": 1, "batch_size": 32, "device": "cpu"}
     distilbert = DistilBertTransformer(**params)
 
     with pytest.raises(NotFittedError):


### PR DESCRIPTION
# Summary

Changes were made to the registry to make the text classification model operative from the front end, in addition to changing the type of average used in the metrics to vary the values. Also a change was made to the dataloaders since an obsolete class was being used.

## Type of change

<!-- Indicate the type of change. Delete those that do not apply  - Required -->

- Bug fix.
- Refactoring.


## Changes

## How to Test

The old tests still work and a small change was made to the text classification models test to deliver an outline as the user would send it.

## Notes

This PR must be approved before that of PR #103 
