### PR TITLE
Small fix on the results page

### DIFF
--- a/DashAI/front/src/components/results/RunResults.jsx
+++ b/DashAI/front/src/components/results/RunResults.jsx
@@ -7,6 +7,7 @@ import RunInfoTab from "./RunInfoTab";
 import RunParametersTab from "./RunParametersTab";
 import RunMetricsTab from "./RunMetricsTab";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import CustomLayout from "../custom/CustomLayout";
 
 const tabs = [
   { label: "Info", value: 0, disabled: false },
@@ -60,7 +61,7 @@ function RunResults() {
     getRunById(id);
   }, []);
   return (
-    <React.Fragment>
+    <CustomLayout>
       {/* Button to return to the experiment results table */}
       <Button
         startIcon={<ArrowBackIosNewIcon />}
@@ -96,7 +97,7 @@ function RunResults() {
           {currentTab === 4 && <Typography>TODO...</Typography>}
         </Box>
       </Paper>
-    </React.Fragment>
+    </CustomLayout>
   );
 }
 


### PR DESCRIPTION
# Summary

<!--
Include a short summary of the changes made to the platforn and list any dependencies
of the pr - Required.
-->
By deactivating the container on the results page, the specific view of a run was affected. This PR fixes this problem

## Type of change

<!-- Indicate the type of change. Delete those that do not apply  - Required -->

- Bug fix.

## Changes

<!--
Indicate the changes/fixes that you want to merge - Required.

- Bug 1
- Bug 2
- Feature 1
- Feature 2
-->
- A container (`CustomLayout`) is added in the specific view of runs to restore the layout as it was before.

## How to Test

<!--
Describe the tests or executions that you ran to verify your changes and provide
instructions to reproduce them - Required.
-->
1. Go to `DashAI/DashAI/front` and run `yarn build`
2. Go back to `DashAI/` and run `python -c "import DashAI;DashAI.run()"`

## Screenshots

<!--
In the case of modifying a view in the front-end, include screenshots with the changes.
Optional, delete this section if not needed.-->
![results](https://github.com/DashAISoftware/DashAI/assets/53657198/f089bac2-59c7-434d-8ce4-77c24efae014)

