### PR TITLE
Beartype in Component Registry

### DIFF
--- a/DashAI/back/registries/component_registry.py
+++ b/DashAI/back/registries/component_registry.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Type, Union
 
+from beartype import beartype
+
 from DashAI.back.registries.relationship_manager import RelationshipManager
 
 
@@ -26,6 +28,7 @@ class ComponentRegistry:
     of component dicts.
     """
 
+    @beartype
     def __init__(
         self,
         initial_components: Union[List[type], None] = None,
@@ -45,12 +48,6 @@ class ComponentRegistry:
         TypeError
             If the task registry is neither none nor an instance of BaseRegistry.
         """
-        if not isinstance(initial_components, (list, type(None))):
-            raise TypeError(
-                f"initial_components should be a list of component classes or None, "
-                f"got {initial_components}."
-            )
-
         self._registry: Dict[str, Dict[str, Any]] = {}
         self._relationship_manager = RelationshipManager()
 
@@ -59,6 +56,7 @@ class ComponentRegistry:
                 self.register_component(component)
 
     @property
+    @beartype
     def registry(self) -> Dict[str, Dict[str, type]]:
         """Obtains the internal registry object.
 
@@ -77,6 +75,7 @@ class ComponentRegistry:
     def registry(self, _: Any) -> None:
         raise RuntimeError("It is not allowed to delete the registry list.")
 
+    @beartype
     def __contains__(self, item: str) -> bool:
         """Indicate if some component is in the registry.
 
@@ -90,14 +89,12 @@ class ComponentRegistry:
         bool
             True if the component exists in the task registry, False otherwise.
         """
-        if not isinstance(item, str):
-            raise TypeError(f"The key should be str, got {item}.")
-
         for base_type_container in self._registry.values():
             if item in base_type_container:
                 return True
         return False
 
+    @beartype
     def __getitem__(self, item: str) -> Dict[str, type]:
         """Obtain a component from the registry using an indexer.
 
@@ -118,15 +115,13 @@ class ComponentRegistry:
         KeyError
             If the object does not exist in the registry.
         """
-        if not isinstance(item, str):
-            raise TypeError(f"The indexer should be a string, got {item}.")
-
         for base_type_container in self._registry.values():
             if item in base_type_container:
                 return base_type_container[item]
 
         raise KeyError(f"Component '{item}' does not exists in the registry.")
 
+    @beartype
     def _get_base_type(self, new_component: type) -> str:
         # select only base classes ancestors
         component_base_ancestors = [
@@ -163,6 +158,7 @@ class ComponentRegistry:
 
         return base_classes_cantidates[0].TYPE
 
+    @beartype
     def register_component(self, new_component: Type) -> None:
         """Register a component within the registry.
 
@@ -171,20 +167,8 @@ class ComponentRegistry:
         new_component : Type
             The object to be registred.
 
-        Raises
-        ------
-        TypeError
-            If the provided component is not a class.
-        TypeError
-            If some task that the component declares compatible does not exist in the
-            task registry.
-        """
-        if not isinstance(new_component, type):
-            raise TypeError(
-                f'new_component "{new_component}" should be a class, '
-                f"got {type(new_component)}."
-            )
 
+        """
         base_type = self._get_base_type(new_component)
 
         is_configurable_object = "ConfigObject" in [
@@ -219,6 +203,7 @@ class ComponentRegistry:
                     compatible_component,
                 )
 
+    @beartype
     def get_components_by_types(
         self,
         select: Union[str, List[str], None] = None,
@@ -345,6 +330,7 @@ class ComponentRegistry:
                 for component in self._registry[component_type]
             ]
 
+    @beartype
     def get_child_components(
         self, parent_name: str, recursive: bool = False
     ) -> List[Dict[str, Any]]:
@@ -380,6 +366,7 @@ class ComponentRegistry:
 
         return selected_components
 
+    @beartype
     def get_related_components(self, component_id: str) -> List[Dict[str, Any]]:
         """Obtain any related component of the given component name.
 

--- a/DashAI/back/registries/relationship_manager.py
+++ b/DashAI/back/registries/relationship_manager.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List
 
+from beartype import beartype
+
 
 class RelationshipManager:
     """Class that implements a relationship registry between DashAI components.
@@ -46,6 +48,7 @@ class RelationshipManager:
             "It is not allowed to delete the task_component_relations attribute."
         )
 
+    @beartype
     def add_relationship(
         self, first_component_id: str, second_component_id: str
     ) -> None:
@@ -60,24 +63,11 @@ class RelationshipManager:
         second_component_id : str
             Second component id or name.
 
-        Raises
-        ------
-        TypeError
-            If the first_component_id is not a string
-        TypeError
-            If the second_component_id is not a string
         """
-        if not isinstance(first_component_id, str):
-            raise TypeError(
-                f"first_component_id should be a string, got {first_component_id}"
-            )
-        if not isinstance(second_component_id, str):
-            raise TypeError(
-                f"second_component_id should be a string, got {second_component_id}"
-            )
         self._relations[first_component_id].append(second_component_id)
         self._relations[second_component_id].append(first_component_id)
 
+    @beartype
     def __contains__(self, component_id: str) -> bool:
         """Indicate if the relation manager contains a relationship.
 
@@ -91,11 +81,9 @@ class RelationshipManager:
         bool
             True if the relation exists, False otherwise.
         """
-        if not isinstance(component_id, str):
-            raise TypeError(f"The indexator should be a string, got {component_id}.")
-
         return component_id in self._relations
 
+    @beartype
     def __getitem__(self, component_id: str) -> List[str]:
         """Obtain all stored relationships from a specific component.
 
@@ -111,15 +99,7 @@ class RelationshipManager:
         -------
         list[str]
             A list with the related components.
-
-        Raises
-        ------
-        TypeError
-            If component_id is not a string
         """
-        if not isinstance(component_id, str):
-            raise TypeError(f"component_id should be a string, got {component_id}")
-
         if component_id in self._relations:
             return self._relations[component_id]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ datasets>=2.9.0
 evaluate>=0.4.0
 accelerate>=0.20.3
 Pillow>=9.5.0
+beartype>=0.15.0
 
 torch==1.13.0 #+cu116
 --find-links https://download.pytorch.org/whl/torch_stable.html

--- a/tests/back/registries/test_registry.py
+++ b/tests/back/registries/test_registry.py
@@ -145,14 +145,6 @@ def test__init__empty_tasks():
     assert test_registry.registry == test_registry._registry
 
 
-def test__init__bad_tasks_argument():
-    with pytest.raises(
-        TypeError,
-        match=(r"new_component \"1\" should be a class, got <class 'int'>."),
-    ):
-        ComponentRegistry(initial_components=[1, 2, 3])
-
-
 def test_basic_register_component():
     # this test does not include relationship creation.
     test_registy = ComponentRegistry()
@@ -245,17 +237,6 @@ def test__contains__():
     assert "Component2" not in test_registry
 
 
-def test__contains__key_type_error():
-    test_registry = ComponentRegistry(
-        initial_components=[
-            Component1,
-            Component3,
-        ]
-    )
-    with pytest.raises(TypeError, match=r"The key should be str, got \<.*\>."):
-        Component1 in test_registry  # noqa
-
-
 def test__getitem__():
     test_registry = ComponentRegistry(
         initial_components=[
@@ -267,21 +248,6 @@ def test__getitem__():
     assert test_registry["Component1"] == COMPONENT1_DICT
     assert test_registry["Component2"] == COMPONENT2_DICT
     assert test_registry["Component3"] == COMPONENT3_DICT
-
-
-def test__getitem__key_type_error():
-    test_registry = ComponentRegistry(
-        initial_components=[
-            Component1,
-            Component2,
-        ]
-    )
-
-    with pytest.raises(
-        TypeError,
-        match=r"The indexer should be a string, got \<class .*\>.",
-    ):
-        test_registry[Component3]
 
 
 def test__getitem__key_error():
@@ -365,21 +331,6 @@ def test_get_components_by_type_select_param_errors():
         test_registry.get_components_by_types(select=[])
 
     with pytest.raises(
-        TypeError, match=r"Select must be a string or an array of strings, got 1."
-    ):
-        test_registry.get_components_by_types(select=1)
-
-    with pytest.raises(
-        TypeError, match=r"Select type at position 0 should be a string, got 1."
-    ):
-        test_registry.get_components_by_types(select=[1])
-
-    with pytest.raises(
-        TypeError, match=r"Select type at position 1 should be a string, got 1."
-    ):
-        test_registry.get_components_by_types(select=["ConfigComponent1", 1])
-
-    with pytest.raises(
         ValueError,
         match=r"Component type UnexistantComponents does not exist in the registry.",
     ):
@@ -434,21 +385,6 @@ def test_get_components_by_type_ignore_param_errors():
 
     with pytest.raises(ValueError, match=r"Ignore list has not types to select."):
         test_registry.get_components_by_types(ignore=[])
-
-    with pytest.raises(
-        TypeError, match=r"Ignore must be a string or an array of strings, got 1."
-    ):
-        test_registry.get_components_by_types(ignore=1)
-
-    with pytest.raises(
-        TypeError, match=r"Ignore type at position 0 should be a string, got 1."
-    ):
-        test_registry.get_components_by_types(ignore=[1])
-
-    with pytest.raises(
-        TypeError, match=r"Ignore type at position 1 should be a string, got 1."
-    ):
-        test_registry.get_components_by_types(ignore=["ConfigComponent1", 1])
 
     with pytest.raises(
         ValueError,

--- a/tests/back/registries/test_relationship_manager.py
+++ b/tests/back/registries/test_relationship_manager.py
@@ -1,7 +1,5 @@
 from collections import defaultdict
 
-import pytest
-
 from DashAI.back.registries.relationship_manager import RelationshipManager
 
 
@@ -43,10 +41,3 @@ def test_relationship_manager__getitem__():
 def test_relationship_manager__getitem__unexistant_component():
     test_relationship_manager = RelationshipManager()
     assert test_relationship_manager["UnexistantComponent"] == []
-
-
-def test_relationship_manager__getitem__type_error():
-    test_relationship_manager = RelationshipManager()
-
-    with pytest.raises(TypeError, match=r"component_id should be a string, got None"):
-        test_relationship_manager[None]


### PR DESCRIPTION
# Summary

This pr replaces the handcrafted type verification for the registry module (and submodules/tests) to the beartype.

Beartype is a library for fast runtime type checking. Check more in https://pypi.org/project/beartype/0.9.1/

Its operation is simple: 

1. add type hints that indicate the input and output types of the functions.
2. decorate the functions with the @beartype decorator.

This pr only changes the registries module. 
Later on I plan to refactor other modules, such as the dataloader (which also implements a lot of type checkers by hand).

## Type of change

- Back end new feature.

## Changes

Install the latest packages with pip

```bash
$ pip install -U requirements.txt
```


- Delete all isinstances that check params types.
- Add to every method of `ComponentRegistry` and `RelationshipManager` beartype
- Fix every affected test.


## How to Test

Run the back tests:

```bash
$ pytest .
```

Also, run the common flow in the frontend.

## Notes

This pr depends on #127 