### PR TITLE
Configure dev front server

### DIFF
--- a/DashAI/back/main.py
+++ b/DashAI/back/main.py
@@ -1,6 +1,7 @@
 import os
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from starlette.responses import FileResponse
 
@@ -17,6 +18,14 @@ api_v1.include_router(api_router_v1)
 
 app.mount(settings.API_V0_STR, api_v0)
 app.mount(settings.API_V1_STR, api_v1)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 # React router should handle paths under /app, which are defined in index.html

--- a/DashAI/front/.env.development
+++ b/DashAI/front/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:3001/api
+REACT_APP_API_URL=http://localhost:8000/api


### PR DESCRIPTION
# Summary

This pr correctly configures the back and front end of the application to use the front end development server.


## Type of change

- Front end new feature.
- Back end new feature.

## Changes

- Configured cors in FastAPI to allow calls from any URL.
- The environment variable REACT_APP_API_URL=http://localhost:8000/api was set so that the development server goes to that address when making API calls.

## How to Test

To develop, two servers must now be started (each in its own console).

- On the one hand, the front end, using 

```bash
$ cd DashAI/front && yarn start
```

and on the other, the back one, using:

```
$ python -m DashAI
```
