### PR TITLE
Restore pydantic settings config and set local_path as unique configurable path from CLI

### DIFF
--- a/DashAI/__main__.py
+++ b/DashAI/__main__.py
@@ -1,4 +1,4 @@
-import logging
+import pathlib
 import webbrowser
 
 import typer
@@ -7,9 +7,6 @@ from typing_extensions import Annotated
 
 from DashAI.back.app import create_app
 
-logging.basicConfig(level=logging.DEBUG)
-_logger = logging.getLogger(__name__)
-
 
 def open_browser():
     url = "http://localhost:8000/app/"
@@ -17,14 +14,15 @@ def open_browser():
 
 
 def main(
-    dev_mode: Annotated[
-        bool, typer.Option(help="Run DashAI in development mode.")
-    ] = True,
+    local_path: Annotated[
+        pathlib.Path, typer.Option(help="Path where DashAI files will be stored.")
+    ] = "~/.DashAI",
 ):
-    if dev_mode:
-        logging.info("DashAI was set to development mode.")
-
-    uvicorn.run(create_app(), host="127.0.0.1", port=8000)
+    uvicorn.run(
+        create_app(local_path=local_path),
+        host="127.0.0.1",
+        port=8000,
+    )
 
 
 if __name__ == "__main__":

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import pathlib
 import shutil
 from typing import Any, Callable, Dict, Union
 

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -148,9 +148,7 @@ async def upload_dataset(
 
     parsed_params = parse_params(DatasetParams, params)
     dataloader = component_registry[parsed_params.dataloader]["class"]()
-    folder_path = (
-        pathlib.Path(config["DATASETS_PATH"]).expanduser() / parsed_params.dataset_name
-    )
+    folder_path = config["DATASETS_PATH"] / parsed_params.dataset_name
 
     # create dataset path
     try:
@@ -197,7 +195,7 @@ async def upload_dataset(
                 # so it will correspond to the class column.
             )
 
-        save_dataset(dataset, os.path.join(folder_path, "dataset"))
+        save_dataset(dataset, folder_path / "dataset")
 
         # - NOTE -------------------------------------------------------------
         # Is important that the DatasetDict dataset it be saved in "/dataset"

--- a/DashAI/back/api/api_v1/endpoints/predict.py
+++ b/DashAI/back/api/api_v1/endpoints/predict.py
@@ -1,7 +1,5 @@
 import json
 import logging
-import os
-import pathlib
 from typing import Any, Callable, ContextManager, Dict, List, Union
 
 import pandas as pd

--- a/DashAI/back/api/api_v1/endpoints/predict.py
+++ b/DashAI/back/api/api_v1/endpoints/predict.py
@@ -117,14 +117,11 @@ async def predict(
     trained_model: BaseModel = model.load(run.run_path)
 
     # Load Dataset using Dataloader
-    tmp_path = (
-        pathlib.Path(config["DATASETS_PATH"]).expanduser()
-        / "tmp_predict"
-        / str(params.run_id)
-    )
+    tmp_path = config["DATASETS_PATH"] / "tmp_predict" / str(params.run_id)
+
     try:
         logger.debug("Trying to create a new dataset path: %s", tmp_path)
-        os.makedirs(tmp_path, exist_ok=True)
+        tmp_path.mkdir(parents=True, exist_ok=False)
     except FileExistsError as e:
         logger.exception(e)
         raise HTTPException(

--- a/DashAI/back/app.py
+++ b/DashAI/back/app.py
@@ -1,6 +1,7 @@
 """FastAPI Application module."""
 import logging
 import pathlib
+from typing import Any, Dict, Union
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,30 +9,69 @@ from fastapi.middleware.cors import CORSMiddleware
 from DashAI.back.api.api_v0.api import api_router_v0
 from DashAI.back.api.api_v1.api import api_router_v1
 from DashAI.back.api.front_api import router as app_router
+from DashAI.back.config import DefaultSettings
 from DashAI.back.containers import Container
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def _create_path(new_path: str) -> None:
-    full_path = pathlib.Path(new_path)
-    if not full_path.is_absolute():
-        full_path = full_path.expanduser()
-
-    if not full_path.exists():
-        logging.info("Creating new path: %s.", str(full_path))
-        full_path.mkdir(parents=True)
+def _create_path_if_not_exists(new_path: str) -> None:
+    """Create a new path if it does not exist."""
+    if not new_path.exists():
+        logging.info("Creating new path: %s.", str(new_path))
+        new_path.mkdir(parents=True)
 
     else:
-        logger.info("Using existant path: %s.", str(full_path))
+        logger.info("Using existant path: %s.", str(new_path))
 
 
-def create_app() -> FastAPI:
+def _generate_config_dict(
+    local_path: Union[pathlib.Path, None] = None
+) -> Dict[str, Any]:
+    """Generate the initial app configuration.
+
+    The configuration is generated from the DashAI DefaultSettings class, and
+    is intended to be used by the configuration provider of the app dependency
+    injection container.
+
+    Parameters
+    ----------
+    local_path : Union[pathlib.Path, None], optional
+        Path where DashAI files will be stored. If None, the default
+        value of config (~/.DashAI) will be used , by default None.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The configuration dictionary.
+    """
+    settings = DefaultSettings().model_dump()
+
+    if local_path is not None:
+        local_path = pathlib.Path(local_path)
+    else:
+        local_path = pathlib.Path(settings["LOCAL_PATH"])
+
+    if not local_path.is_absolute():
+        local_path = local_path.expanduser().absolute()
+
+    settings["LOCAL_PATH"] = local_path
+    settings["SQLITE_DB_PATH"] = local_path / settings["SQLITE_DB_PATH"]
+    settings["DATASETS_PATH"] = local_path / settings["DATASETS_PATH"]
+    settings["RUNS_PATH"] = local_path / settings["RUNS_PATH"]
+    settings["FRONT_BUILD_PATH"] = pathlib.Path(settings["FRONT_BUILD_PATH"]).absolute()
+
+    return settings
+
+
+def create_app(local_path: Union[pathlib.Path, None] = None) -> FastAPI:
     container = Container()
+    config = _generate_config_dict(local_path=local_path)
+    container.config.from_dict(config)
 
-    _create_path(container.config.provided()["DATASETS_PATH"])
-    _create_path(container.config.provided()["RUNS_PATH"])
+    _create_path_if_not_exists(container.config.provided()["DATASETS_PATH"])
+    _create_path_if_not_exists(container.config.provided()["RUNS_PATH"])
 
     db = container.db()
     db.create_database()

--- a/DashAI/back/config.py
+++ b/DashAI/back/config.py
@@ -1,0 +1,14 @@
+from pydantic_settings import BaseSettings
+
+
+class DefaultSettings(BaseSettings):
+    """Default settings for DashAI."""
+
+    FRONT_BUILD_PATH: str = "DashAI/front/build"
+    API_V0_STR: str = "/api/v0"
+    API_V1_STR: str = "/api/v1"
+
+    LOCAL_PATH: str = "~/.DashAI"
+    SQLITE_DB_PATH: str = "db.sqlite"
+    DATASETS_PATH: str = "datasets"
+    RUNS_PATH: str = "runs"

--- a/DashAI/back/config.yaml
+++ b/DashAI/back/config.yaml
@@ -1,8 +1,0 @@
-FRONT_BUILD_PATH: DashAI/front/build
-
-SQLITE_DB_PATH: ~/.DashAI/db.sqlite
-DATASETS_PATH: ~/.DashAI/datasets
-RUNS_PATH: ~/.DashAI/runs
-
-API_V0_STR: /api/v0
-API_V1_STR: /api/v1

--- a/DashAI/back/containers.py
+++ b/DashAI/back/containers.py
@@ -32,7 +32,7 @@ class Container(containers.DeclarativeContainer):
         auto_wire=True,
     )
 
-    config = providers.Configuration(yaml_files=["DashAI/back/config.yaml"])
+    config = providers.Configuration()
 
     db = providers.Singleton(SQLiteDatabase, db_path=config.SQLITE_DB_PATH)
     job_queue = providers.Singleton(SimpleJobQueue)

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -1,6 +1,7 @@
 """DashAI Dataset implementation."""
 import json
 import os
+import pathlib
 from typing import Dict, List, Literal, Union
 
 import numpy as np
@@ -322,7 +323,7 @@ def load_dataset(dataset_path: str) -> DatasetDict:
 
 
 @beartype
-def save_dataset(datasetdict: DatasetDict, path: str) -> None:
+def save_dataset(datasetdict: DatasetDict, path: Union[str, pathlib.Path]) -> None:
     """Save the datasetdict with dashaidatasets inside.
 
     Parameters

--- a/DashAI/back/dependencies/database/sqlite_database.py
+++ b/DashAI/back/dependencies/database/sqlite_database.py
@@ -14,14 +14,11 @@ class Base(DeclarativeBase):
 
 
 class SQLiteDatabase:
-    def __init__(self, db_path: str) -> None:
-        _db_path = pathlib.Path(db_path)
+    def __init__(self, db_path: pathlib.Path) -> None:
+        _db_path = str(db_path)
 
-        if not _db_path.is_absolute():
-            _db_path = _db_path.expanduser()
-
-        if not str(_db_path).startswith("sqlite:///"):
-            db_url = "sqlite:///" + str(_db_path)
+        if not _db_path.startswith("sqlite:///"):
+            db_url = "sqlite:///" + _db_path
 
         logger.info("Using %s as SQLite path.", db_url)
 

--- a/tests/back/api/conftest.py
+++ b/tests/back/api/conftest.py
@@ -1,38 +1,17 @@
-import pathlib
 import shutil
 
 import pytest
 from fastapi.testclient import TestClient
 
-from DashAI.back.app import _create_path, create_app
-from DashAI.back.dependencies.database import SQLiteDatabase
+from DashAI.back.app import create_app
 
 TEST_PATH = "tmp"
-TEST_DATASETS_PATH = "tmp/datasets"
-TEST_RUNS_PATH = "tmp/runs"
-TEST_SQLITE_DB_PATH = "tmp/test_db.sqlite"
 
 
 @pytest.fixture(scope="module", autouse=True)
 def client():
-    app = create_app()
-    container = app.container
+    app = create_app(TEST_PATH)
 
-    with container.config.SQLITE_DB_PATH.override(
-        TEST_SQLITE_DB_PATH
-    ), container.config.DATASETS_PATH.override(
-        TEST_DATASETS_PATH
-    ), container.config.RUNS_PATH.override(
-        TEST_RUNS_PATH
-    ), container.db.override(
-        SQLiteDatabase(TEST_SQLITE_DB_PATH)
-    ):
-        _create_path(TEST_DATASETS_PATH)
-        _create_path(TEST_RUNS_PATH)
+    yield TestClient(app)
 
-        db = app.container.db.provided()
-        db.create_database()
-
-        yield TestClient(app)
-
-    shutil.rmtree(pathlib.Path(TEST_PATH).expanduser())
+    shutil.rmtree(app.container.config.provided()["LOCAL_PATH"])


### PR DESCRIPTION
# Summary

This pull request has two main tasks:

1. Restore the default settings handling using pydantic_settings 2.
2. Unify all paths under the local_path parameter, which can be configured from the DashAI CLI.

## Type of change

- Back end new feature.
- Refactoring.

## Changes

- The settings were moved to the original `DashAI/back/config.py` pydantic-settings model. 
- Now, the settings class is called `DefaultSettings`, which expresses the fact that these are default settings and can be overridden by the CLI.
- `create_app` now accepts the `local_path` from which all other routes (db, runs, datasets, etc...) are derived (in `_generate_config_dict` function).
- Given the above change, the api conftest now does not need to do overrides since the routes are configured when a new app is created with `create_app`.


## How to Test

Execute DashAI with no path (the execution path will be setted to `~/.DashAI`.

```bash
$ python -m DashAI 
```

The initialization should create the corresponding path (check with `cd ~&& ls -a`.
Then, if you create a dataset, it should be stored in `~/.DashAI/datasets/<dataset_name>`

Execute DashAI with a custom path

```bash
 python -m DashAI --local-path ~./DashAI_param_test
```

Then, use the same operation as before


Execute the tests:

`pytest .`


## Notes

This pr depends on #167 
