### PR TITLE
fix uploading a second dataset by setting uploaded status right

### DIFF
--- a/DashAI/front/src/components/datasets/DatasetModal.jsx
+++ b/DashAI/front/src/components/datasets/DatasetModal.jsx
@@ -101,6 +101,7 @@ function DatasetModal({ open, setOpen, updateDatasets }) {
   const handleCloseDialog = () => {
     setActiveStep(0);
     setNewDataset(defaultNewDataset);
+    setUploaded(false);
     setNextEnabled(false);
     setOpen(false);
   };
@@ -138,6 +139,7 @@ function DatasetModal({ open, setOpen, updateDatasets }) {
       readyToUpload
     ) {
       handleSubmitNewDataset();
+      setReadyToUpload(false);
     }
   }, [newDataset]);
 


### PR DESCRIPTION
# Summary

<!--
Include a short summary of the changes made to the platforn and list any dependencies
of the pr - Required.
-->
Uploading a second dataset by setting uploaded status right

## Type of change

<!-- Indicate the type of change. Delete those that do not apply  - Required -->

- Bug fix.

## Changes

<!--
Indicate the changes/fixes that you want to merge - Required.

- Bug 1
- Bug 2
- Feature 1
- Feature 2
-->
- Fix the uploaded status to let user upload multiple datasets

## How to Test

<!--
Describe the tests or executions that you ran to verify your changes and provide
instructions to reproduce them - Required.
-->
1.- Run ```python -m DashAI```
2.- Go to ```dashai/front``` and run ```yarn start```
3.- Upload two datasets and check that theres is no problem the second time and the Datasets table shows both datasets.