### PR TITLE
fix: :bug: Refactor main function and add app_init module because of …

### DIFF
--- a/DashAI/__main__.py
+++ b/DashAI/__main__.py
@@ -1,12 +1,8 @@
-import pathlib
 import threading
 import webbrowser
 
 import typer
 import uvicorn
-from typing_extensions import Annotated
-
-from DashAI.back.app import create_app
 
 
 def open_browser():
@@ -14,16 +10,12 @@ def open_browser():
     webbrowser.open(url, new=0, autoraise=True)
 
 
-def main(
-    local_path: Annotated[
-        pathlib.Path, typer.Option(help="Path where DashAI files will be stored.")
-    ] = "~/.DashAI",
-):
+def main():
     timer = threading.Timer(1, open_browser)
     timer.start()
 
     uvicorn.run(
-        create_app(local_path=local_path),
+        "DashAI.back.app_init:app",
         host="127.0.0.1",
         port=8000,
     )

--- a/DashAI/back/app_init.py
+++ b/DashAI/back/app_init.py
@@ -1,0 +1,3 @@
+from DashAI.back.app import create_app
+
+app = create_app("~/.DashAI")


### PR DESCRIPTION
# Summary

When training a model, the backend throw this error:

```
RuntimeError: Task <Task pending name='Task-64' coro=<RequestResponseCycle.run_asgi() running at C:\Users\lucas\python-envs\dashai-dev\lib\site-packages\uvicorn\protocols\http\httptools_impl.py:426> cb=[set.discard()]> got Future <Future pending> attached to a different loop
```

The changes solve this problem, but when running the backend, it doesnt wait for the timer to open the browser.

