### PR TITLE
Task Filter in Runs table

### DIFF
--- a/DashAI/front/src/components/explainers/TrainedModelsTable.jsx
+++ b/DashAI/front/src/components/explainers/TrainedModelsTable.jsx
@@ -149,7 +149,6 @@ function TrainedModelsTable() {
 
   const taskFilter = (event) => {
     const taskName = event.target.value;
-    console.log(taskName);
     setSelectedTask(taskName);
     if (taskName === "All Tasks") {
       setRows(originalRows);


### PR DESCRIPTION
# Summary

<!--
Include a short summary of the changes made to the platforn and list any dependencies
of the pr - Required.
-->
It is useful to add a filter in the runs table of the explainability tab to see only the runs associated with a given task.

## Type of change

<!-- Indicate the type of change. Delete those that do not apply  - Required -->

- Front end new feature.

## Changes

<!--
Indicate the changes/fixes that you want to merge - Required.

- Bug 1
- Bug 2
- Feature 1
- Feature 2
-->
- Add _TextField_ component for the filter.
- Add _taskName_ field to the retrived data of an experiment.
- Add function _getTasks_ to retrive all the available tasks from the component registry.
- Add _taskFilter_ function to rebuild the rows of the runs table.

## How to Test

<!--
Describe the tests or executions that you ran to verify your changes and provide
instructions to reproduce them - Required.
-->
Execute DashAI and go to `/app/explainers`, in this tab the filter must be displayed in theand if you select any task the table content must change.

## Screenshots

<!--
In the case of modifying a view in the front-end, include screenshots with the changes.
Optional, delete this section if not needed.-->

Desire filter:
![image](https://github.com/DashAISoftware/DashAI/assets/70785099/27ffec0c-ce1c-4b21-85fe-699a41814b14)

Implemented filter:
![image](https://github.com/DashAISoftware/DashAI/assets/70785099/fa529808-c17d-419e-b4c7-3febf3afa289)

