### PR TITLE
Feat/explainer data tab

### DIFF
--- a/DashAI/front/src/App.jsx
+++ b/DashAI/front/src/App.jsx
@@ -12,6 +12,7 @@ import ResultsPage from "./pages/ResultsPage";
 import Test from "./pages/test";
 import Home from "./pages/Home";
 import ResponsiveAppBar from "./components/ResponsiveAppBar";
+import ExplainerData from "./components/explainers/ExplainerData";
 
 function App() {
   return (
@@ -32,6 +33,10 @@ function App() {
         <Route path="/app/explainers">
           <Route index element={<ExplainersPage />} />
           <Route path="runs/:id" element={<ExplainersDashboard />} />
+          <Route
+            path="explainer/:scope/:runId/:id"
+            element={<ExplainerData />}
+          />
         </Route>
         <Route path="/app/test" element={<Test />} />
       </Routes>

--- a/DashAI/front/src/components/explainers/ExplainerData.jsx
+++ b/DashAI/front/src/components/explainers/ExplainerData.jsx
@@ -1,0 +1,105 @@
+import { useSnackbar } from "notistack";
+import React, { useEffect, useState } from "react";
+import { Tabs, Tab, Paper, Box, Button } from "@mui/material";
+import { useNavigate, useParams } from "react-router-dom";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import CustomLayout from "../custom/CustomLayout";
+import { getExplainers } from "../../api/explainer";
+import ExplainerInfoTab from "./ExplainerInfoTab";
+import ExplainerParametersTab from "./ExplainerParametersTab";
+
+const tabs = [
+  { label: "Info", value: 0, disabled: false },
+  { label: "Parameters", value: 1, disabled: false },
+];
+/**
+ * Component that renders multiple tabs to visualize the results of a specific explainer.
+ */
+function ExplainerData() {
+  const { id, runId, scope } = useParams();
+  const { enqueueSnackbar } = useSnackbar();
+  const navigate = useNavigate();
+
+  const [explainerData, setExplainerData] = useState({});
+  const [updateDataFlag, setUpdateDataFlag] = useState(false);
+  const [currentTab, setCurrentTab] = useState(0);
+
+  const handleTabChange = (event, newValue) => {
+    setCurrentTab(newValue);
+  };
+
+  const getExplainer = async () => {
+    try {
+      const explainers = await getExplainers(runId, scope);
+      for (let i = 0; i < explainers.length; i++) {
+        const explainer = explainers[i];
+        console.log(explainer);
+        if (explainer.id === parseInt(id)) {
+          setExplainerData(explainer);
+          break;
+        }
+      }
+    } catch (error) {
+      enqueueSnackbar(
+        `Error while trying to obtain data of the explainer with id: ${id}`,
+      );
+      if (error.response) {
+        console.error("Response error:", error.message);
+      } else if (error.request) {
+        console.error("Request error", error.request);
+      } else {
+        console.error("Unknown Error", error.message);
+      }
+    }
+  };
+
+  // triggers an update of the explainer data when updateFlag is set to true
+  useEffect(() => {
+    if (updateDataFlag) {
+      setUpdateDataFlag(false);
+      getExplainer();
+    }
+  }, [updateDataFlag]);
+
+  // on mount, fetch the data of the explainer
+  useEffect(() => {
+    getExplainer();
+  }, []);
+  return (
+    <CustomLayout>
+      {/* Button to return to the explainers table */}
+      <Button
+        startIcon={<ArrowBackIosNewIcon />}
+        onClick={() => {
+          navigate(`/app/explainers/runs/${explainerData.run_id}`);
+        }}
+      >
+        Return to table
+      </Button>
+
+      {/* Tabs  */}
+      <Paper sx={{ mt: 2 }}>
+        <Tabs value={currentTab} onChange={handleTabChange}>
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.value}
+              value={tab.value}
+              label={tab.label}
+              disabled={tab.disabled}
+            />
+          ))}
+        </Tabs>
+        <Box sx={{ p: 3, height: "100%" }}>
+          {currentTab === 0 && (
+            <ExplainerInfoTab explainerData={explainerData} />
+          )}
+          {currentTab === 1 && (
+            <ExplainerParametersTab explainerData={explainerData} />
+          )}
+        </Box>
+      </Paper>
+    </CustomLayout>
+  );
+}
+
+export default ExplainerData;

--- a/DashAI/front/src/components/explainers/ExplainerInfoTab.jsx
+++ b/DashAI/front/src/components/explainers/ExplainerInfoTab.jsx
@@ -1,0 +1,99 @@
+import { Divider, Grid, Typography } from "@mui/material";
+import React from "react";
+import PropTypes from "prop-types";
+
+const explainerInfo = [
+  { key: "id", label: "Explainer ID" },
+  { key: "name", label: "Name" },
+  { key: "run_id", label: "Run ID" },
+  { key: "explainer_name", label: "Explainer Name" },
+  { key: "dataset_id", label: "Dataset ID" },
+  { key: "explanation_path", label: "Explanation Path" },
+  { key: "plot_path", label: "Plot Path" },
+  { key: "status", label: "Status" },
+];
+
+const explainerDateInfo = [{ key: "created", label: "Created" }];
+
+const formatDate = (dateStr) => {
+  const date = new Date(dateStr);
+  const options = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    locale: "en-US",
+  };
+
+  return date.toLocaleString("en-US", options);
+};
+/**
+ * Component that displays general information associated with a explainer.
+ * @param {object} explainerData object that contains all the necesary info of the explainer
+ */
+function ExplainerInfoTab({ explainerData }) {
+  return (
+    <Grid container direction="column">
+      {/* Explainer name related info */}
+      <Grid item>
+        <Grid
+          container
+          direction="row"
+          alignItems="center"
+          rowSpacing={3}
+          columnSpacing={15}
+        >
+          {explainerInfo.map((param) => (
+            <Grid item key={param.key}>
+              <Typography variant="subtitle1">{param.label}</Typography>
+              <Typography variant="p" sx={{ color: "gray" }}>
+                {explainerData[param.key] ?? "-"}
+              </Typography>
+            </Grid>
+          ))}
+        </Grid>
+      </Grid>
+
+      <Divider sx={{ mt: 3, mb: 3 }} />
+
+      {/* Explainer Date related info */}
+      <Grid item>
+        <Grid
+          container
+          direction="row"
+          alignItems="center"
+          rowSpacing={3}
+          columnSpacing={15}
+        >
+          {explainerDateInfo.map((param) => (
+            <Grid item key={param.key}>
+              <Typography variant="subtitle1">{param.label}</Typography>
+              <Typography variant="p" sx={{ color: "gray" }}>
+                {formatDate(explainerData[param.key] ?? "-")}
+              </Typography>
+            </Grid>
+          ))}
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+}
+
+ExplainerInfoTab.propTypes = {
+  explainerData: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    run_id: PropTypes.number,
+    explainer_name: PropTypes.string,
+    dataset_id: PropTypes.number,
+    explanation_path: PropTypes.string,
+    plot_path: PropTypes.string,
+    parameters: PropTypes.object,
+    created: PropTypes.string,
+    status: PropTypes.number,
+  }).isRequired,
+};
+
+export default ExplainerInfoTab;

--- a/DashAI/front/src/components/explainers/ExplainerParametersTab.jsx
+++ b/DashAI/front/src/components/explainers/ExplainerParametersTab.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Grid,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
+import ParameterListItem from "../results/ParameterListItem";
+
+/**
+ * Component that displays the parameters associated with a explainer.
+ * @param {object} explainerData object that contains all the necesary info of the explainer
+ */
+function ExplainerParametersTab({ explainerData }) {
+  const [displayMode, setDisplayMode] = useState("nested-list");
+  return (
+    <Grid container direction="column">
+      {/* Toggle to select the mode of displaying the JSON object. */}
+      <Grid item>
+        <ToggleButtonGroup
+          value={displayMode}
+          exclusive
+          onChange={(event, newMode) => {
+            if (newMode !== null) {
+              setDisplayMode(newMode);
+            }
+          }}
+          sx={{ float: "right" }}
+        >
+          <ToggleButton value="nested-list">List</ToggleButton>
+          <ToggleButton value="json">JSON</ToggleButton>
+        </ToggleButtonGroup>
+      </Grid>
+
+      {/* JSON object display */}
+      <Grid item>
+        {displayMode === "nested-list" && (
+          <ParameterListItem
+            name="Parameters"
+            value={explainerData.parameters}
+          />
+        )}
+
+        {displayMode === "json" && (
+          <Typography variant="body1" component="pre">
+            {JSON.stringify(explainerData.parameters, null, 4)}
+          </Typography>
+        )}
+      </Grid>
+    </Grid>
+  );
+}
+
+ExplainerParametersTab.propTypes = {
+  explainerData: PropTypes.shape({
+    parameters: PropTypes.objectOf(
+      PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+        // PropTypes.bool,
+        // PropTypes.object,
+      ]),
+    ),
+  }).isRequired,
+};
+
+export default ExplainerParametersTab;

--- a/DashAI/front/src/components/explainers/ExplainersDashboard.jsx
+++ b/DashAI/front/src/components/explainers/ExplainersDashboard.jsx
@@ -11,7 +11,7 @@ export default function ExplainersDashboard() {
   const { id } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const { modelName } = location.state;
+  const { modelName } = location.state ?? "";
   const [showNewGlobalExplainerModal, setShowNewGlobalExplainerModal] =
     useState(false);
   const handleNewGlobalExplainerModal = () => {

--- a/DashAI/front/src/components/explainers/ExplanainersCard.jsx
+++ b/DashAI/front/src/components/explainers/ExplanainersCard.jsx
@@ -4,6 +4,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import PropTypes from "prop-types";
 import ExplainersPlot from "./ExplainersPlot";
+import { useNavigate } from "react-router-dom";
 
 /**
  * GlobalExplainersCard
@@ -14,6 +15,8 @@ export default function ExplainersCard({ explainer, scope }) {
   function plotName(name) {
     return name.match(/[A-Z][a-z]+|[0-9]+/g).join(" ");
   }
+
+  const navigate = useNavigate();
 
   return (
     <Paper elevation={3}>
@@ -34,7 +37,14 @@ export default function ExplainersCard({ explainer, scope }) {
             </Typography>
           </Grid>
           <Grid item>
-            <IconButton aria-label="zoomin">
+            <IconButton
+              aria-label="zoomin"
+              onClick={() => {
+                navigate(
+                  `/app/explainers/explainer/${scope}/${explainer.run_id}/${explainer.id}`,
+                );
+              }}
+            >
               <ZoomInIcon />
             </IconButton>
             <IconButton aria-label="delete" color="error">
@@ -51,8 +61,12 @@ export default function ExplainersCard({ explainer, scope }) {
 // Duda: por qué algunas están en camelCase?
 ExplainersCard.propTypes = {
   explainer: PropTypes.shape({
-    explainer_name: PropTypes.string,
     id: PropTypes.number,
+    name: PropTypes.string,
+    run_id: PropTypes.number,
+    explainer_name: PropTypes.string,
+    explanation_path: PropTypes.string,
+    plot_path: PropTypes.string,
     parameters: PropTypes.objectOf(
       PropTypes.oneOfType([
         PropTypes.number,
@@ -60,12 +74,8 @@ ExplainersCard.propTypes = {
         PropTypes.arrayOf(PropTypes.string),
       ]),
     ),
-    status: PropTypes.number,
-    runId: PropTypes.number,
-    explanationPath: PropTypes.string,
-    plot_path: PropTypes.string,
-    name: PropTypes.string,
     created: PropTypes.string,
+    status: PropTypes.number,
   }).isRequired,
   scope: PropTypes.string.isRequired,
 };

--- a/DashAI/front/src/types/explainer.ts
+++ b/DashAI/front/src/types/explainer.ts
@@ -1,8 +1,13 @@
 export interface IExplainer {
   id: string;
-  run_id: string;
-  dataset_id: string;
-  created_at: Date;
+  name: string;
+  run_id: number;
   explainer_name: string;
-  explainer_path: string;
+  dataset_id: number;
+  explanation_path: string;
+  plot_path: string;
+  parameters: object;
+  fit_parameters: object;
+  created: Date;
+  status: number;
 }


### PR DESCRIPTION
# Summary

<!--
Include a short summary of the changes made to the platforn and list any dependencies
of the pr - Required.
-->
Add new tab with explainers information.

## Type of change

<!-- Indicate the type of change. Delete those that do not apply  - Required -->

- Front end new feature.

## Changes

<!--
Indicate the changes/fixes that you want to merge - Required.

- Bug 1
- Bug 2
- Feature 1
- Feature 2
-->
- Add _ExplainerData_ component to render the information of the explainer.
- Add _ExplainerInfoTab_ and _ExplainerParametersTab_ components tor render all the information about an explainer.
- Add `explainer/:scope/:runId/:id` route.
- Connect the zoomin icon in _ExplainersCard_ component to the _ExplainerData_ component.
- Change the _modelName_ variable to a default value when the location.state field is not passed through the url.
- Fix IExplainer type to have all the fields of an explainer.

## How to Test

<!--
Describe the tests or executions that you ran to verify your changes and provide
instructions to reproduce them - Required.
-->
1. Execute DashAI
2. Create a Dataset, Experiment and Run.
3. Start an Experiment and wait until it finishs.
4. Create a GlobalExplainer and execute it.
5. Go to RunsTable (`http://localhost:3000/app/explainers`) and select the previously created run.
6.  In the ExplainersDashboard click the zoomin icon in an ExplainersCard.
7. Check that the name and run_id of the explainer are ok.
8. Click the return to table button.
9. Check that run_id is ok.

## Screenshots

<!--
In the case of modifying a view in the front-end, include screenshots with the changes.
Optional, delete this section if not needed.-->

The new views are these:

![image](https://github.com/DashAISoftware/DashAI/assets/70785099/763c8225-f052-4fed-890d-f848dbf36b96)

![image](https://github.com/DashAISoftware/DashAI/assets/70785099/fc536c87-129e-4379-87db-8d216fdfa631)


## Notes

<!--
Include any additional information that would be useful to the reviewer.
Optional, delete this section if not needed.
-->
It is pending to add the fit_parameters dictionary to the ExplainerParametersTab, it will be added when the local explainers are released in a stable version.
