### PR TITLE
Fix error in data summary with new data types

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -511,6 +511,11 @@ def get_columns_spec(dataset_path: str) -> Dict[str, Dict]:
                 "type": "Classlabel",
                 "dtype": "",
             }
+        else:
+            column_types[column] = {
+                "type": "Other",
+                "dtype": "",
+            }
     return column_types
 
 
@@ -543,6 +548,8 @@ def update_columns_spec(dataset_path: str, columns: Dict) -> DatasetDict:
                 new_features[column] = ClassLabel(names=names)
             elif columns[column].type == "Value":
                 new_features[column] = Value(columns[column].dtype)
+            else:
+                pass
         # Cast the column types with the changes
         try:
             dataset_dict[split] = dataset_dict[split].cast(new_features)


### PR DESCRIPTION
# Summary

The actual backend doesnt know how to handle unknown data types.
The implemented fixes allow new data types to be handled.

## Changes

- The sample endpoint try to json encode the dataset. If this operation throws an error, then the system looks for columns that cannot be encoded as json, and the values of these are converted to strings.
- Function get_columns_spec (in dashai_dataset.py) has a return option if the column type isnt Value or ClassLabel.
- Function update_columns_spec (in dashai_dataset.py) has a pass option if the column type isnt Value or ClassLabel
