### PR TITLE
Remove container_type parameter and simplify component loading

### DIFF
--- a/DashAI/__main__.py
+++ b/DashAI/__main__.py
@@ -35,13 +35,6 @@ def main(
             )
         ),
     ] = LoggingLevel.INFO,
-    container_type: Annotated[
-        str,
-        typer.Option(
-            help="Type of container to use ('local' or 'plugins').",
-            case_sensitive=False,
-        ),
-    ] = "local",
 ) -> None:
     """Main function for DashAI package.
 
@@ -71,7 +64,6 @@ def main(
         app=create_app(
             local_path=local_path,
             logging_level=logging_level.value,
-            container_type=container_type,
         ),
         host="127.0.0.1",
         port=8000,

--- a/DashAI/back/app.py
+++ b/DashAI/back/app.py
@@ -33,9 +33,9 @@ def create_app(
     logging_level: Literal[
         "NOTSET", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"
     ] = "INFO",
-    container_type: str = "local",
 ) -> FastAPI:
     """Create the main application.
+
 
     Steps:
     1. Create the configuration dictionary and sets it as container configuration.
@@ -62,7 +62,6 @@ def create_app(
     config = build_config_dict(
         local_path=local_path,
         logging_level=logging_level,
-        container_type=container_type,
     )
 
     logging.getLogger(__package__).setLevel(level=config["LOGGING_LEVEL"])

--- a/DashAI/back/dependencies/config_builder.py
+++ b/DashAI/back/dependencies/config_builder.py
@@ -12,7 +12,6 @@ from DashAI.back.initial_components import get_initial_components
 def build_config_dict(
     local_path: Union[pathlib.Path, None],
     logging_level: Literal["NOTSET", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"],
-    container_type: str,
 ) -> Dict[str, Union[str, int]]:
     """
     Read configuration settings from a default source and updates them based on a
@@ -59,6 +58,6 @@ def build_config_dict(
     config["RUNS_PATH"] = local_path / config["RUNS_PATH"]
     config["FRONT_BUILD_PATH"] = pathlib.Path(config["FRONT_BUILD_PATH"]).absolute()
     config["LOGGING_LEVEL"] = getattr(logging, logging_level)
-    config["INITIAL_COMPONENTS"] = get_initial_components(container_type)
+    config["INITIAL_COMPONENTS"] = get_initial_components()
 
     return config

--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -1,3 +1,5 @@
+import logging
+
 from DashAI.back.dataloaders import CSVDataLoader, ImageDataLoader, JSONDataLoader
 from DashAI.back.explainability import (
     KernelShap,
@@ -27,56 +29,64 @@ from DashAI.back.tasks import (
     TranslationTask,
 )
 
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
 
-def get_initial_components(container_type):
-    if container_type == "local":
-        return [
-            # Tasks
-            TabularClassificationTask,
-            TextClassificationTask,
-            TranslationTask,
-            ImageClassificationTask,
-            # Models
-            SVC,
-            DecisionTreeClassifier,
-            DummyClassifier,
-            HistGradientBoostingClassifier,
-            KNeighborsClassifier,
-            LogisticRegression,
-            RandomForestClassifier,
-            DistilBertTransformer,
-            ViTTransformer,
-            OpusMtEnESTransformer,
-            BagOfWordsTextClassificationModel,
-            # Dataloaders
-            CSVDataLoader,
-            JSONDataLoader,
-            ImageDataLoader,
-            # Metrics
-            F1,
-            Accuracy,
-            Precision,
-            Recall,
-            Bleu,
-            # Jobs
-            ExplainerJob,
-            ModelJob,
-            # Explainers
-            KernelShap,
-            PartialDependence,
-            PermutationFeatureImportance,
-        ]
-    elif container_type == "plugins":
+
+def get_initial_components():
+    """
+    Obtiene todos los componentes iniciales, incluyendo los básicos
+    y los plugins instalados.
+
+    Returns
+    -------
+    List[type]
+        Lista de todas las clases de componentes disponibles
+    """
+    # Componentes básicos que siempre deben estar disponibles
+    basic_components = [
+        # Tasks
+        TabularClassificationTask,
+        TextClassificationTask,
+        TranslationTask,
+        ImageClassificationTask,
+        # Models
+        SVC,
+        DecisionTreeClassifier,
+        DummyClassifier,
+        HistGradientBoostingClassifier,
+        KNeighborsClassifier,
+        LogisticRegression,
+        RandomForestClassifier,
+        DistilBertTransformer,
+        ViTTransformer,
+        OpusMtEnESTransformer,
+        BagOfWordsTextClassificationModel,
+        # Dataloaders
+        CSVDataLoader,
+        JSONDataLoader,
+        ImageDataLoader,
+        # Metrics
+        F1,
+        Accuracy,
+        Precision,
+        Recall,
+        Bleu,
+        # Jobs
+        ExplainerJob,
+        ModelJob,
+        # Explainers
+        KernelShap,
+        PartialDependence,
+        PermutationFeatureImportance,
+    ]
+
+    # Obtener plugins instalados
+    try:
         installed_plugins = get_available_plugins()
-        basic_components = [
-            # Jobs
-            ExplainerJob,
-            ModelJob,
-            # Explainers
-            KernelShap,
-            PartialDependence,
-            PermutationFeatureImportance,
-        ]
-        return installed_plugins + basic_components
-    else:
-        raise ValueError("Unknown container type")
+        log.info(f"Se cargaron {len(installed_plugins)} plugins instalados")
+    except Exception as e:
+        log.error(f"Error al cargar plugins instalados: {str(e)}")
+        installed_plugins = []
+
+    return basic_components + installed_plugins


### PR DESCRIPTION
This pull request removes the `container_type` parameter from several functions and simplifies the logic for loading initial components. The most important changes include updates to the `main` function, the `create_app` function, and the `build_config_dict` function, as well as modifications to the `get_initial_components` function to remove the dependency on `container_type`.

Removal of `container_type` parameter:

* [`DashAI/__main__.py`](diffhunk://#diff-84718b767f2264e0677ff0af4cc551d383148da0af701eaa9ff638424b0c33c7L38-L44): Removed `container_type` parameter from the `main` function and its usage within the function. [[1]](diffhunk://#diff-84718b767f2264e0677ff0af4cc551d383148da0af701eaa9ff638424b0c33c7L38-L44) [[2]](diffhunk://#diff-84718b767f2264e0677ff0af4cc551d383148da0af701eaa9ff638424b0c33c7L74)
* [`DashAI/back/app.py`](diffhunk://#diff-37a83314f584ebd1d601b99b4ad2f18cdb6935dc5632e75763a182b03fd45d04L36-R39): Removed `container_type` parameter from the `create_app` function and its usage within the function. [[1]](diffhunk://#diff-37a83314f584ebd1d601b99b4ad2f18cdb6935dc5632e75763a182b03fd45d04L36-R39) [[2]](diffhunk://#diff-37a83314f584ebd1d601b99b4ad2f18cdb6935dc5632e75763a182b03fd45d04L65)
* [`DashAI/back/dependencies/config_builder.py`](diffhunk://#diff-24052928cb0544c3a1cab7faca6e8f329c34bb34cbe53a629288db8138d04d22L15): Removed `container_type` parameter from the `build_config_dict` function. [[1]](diffhunk://#diff-24052928cb0544c3a1cab7faca6e8f329c34bb34cbe53a629288db8138d04d22L15) [[2]](diffhunk://#diff-24052928cb0544c3a1cab7faca6e8f329c34bb34cbe53a629288db8138d04d22L62-R61)

Simplification of initial components loading:

* [`DashAI/back/initial_components.py`](diffhunk://#diff-a28477ed1650ad56eedb57df3d07c5d0dfb6370c6e162eb81d5c692b3d7e32f8R32-R47): Removed the `container_type` parameter from the `get_initial_components` function and updated the function to always load both basic components and installed plugins. Added logging for debugging purposes. [[1]](diffhunk://#diff-a28477ed1650ad56eedb57df3d07c5d0dfb6370c6e162eb81d5c692b3d7e32f8R32-R47) [[2]](diffhunk://#diff-a28477ed1650ad56eedb57df3d07c5d0dfb6370c6e162eb81d5c692b3d7e32f8L69-R92)