### PR TITLE
fix labels in splits

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -833,10 +833,11 @@ def prepare_for_experiment(
             output_column = output_columns[0]
             try:
                 column_values = dataset[output_column]
-                
+
                 # Check column type and convert to numerical indices if needed
                 if isinstance(column_values[0], str):
                     import pandas as pd
+
                     labels_array, unique_values = pd.factorize(column_values)
                     labels = labels_array.tolist()
                 else:

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -1,6 +1,7 @@
 """DashAI Dataset implementation."""
 
 import json
+import logging
 import os
 from typing import Dict, List, Literal, Tuple, Union
 
@@ -11,6 +12,8 @@ from beartype import beartype
 from datasets import ClassLabel, Dataset, DatasetDict, Value, concatenate_datasets
 from datasets.features import Features
 from sklearn.model_selection import train_test_split
+
+log = logging.getLogger(__name__)
 
 
 def get_arrow_table(ds: Dataset) -> pa.Table:
@@ -825,11 +828,27 @@ def prepare_for_experiment(
         )
     else:
         n = len(dataset)
-        if splits.get("stratify", False):
-            output_column = output_columns
-            labels = dataset[output_column]
-        else:
-            labels = None
+        labels = None
+        if splits.get("stratify", False) and output_columns:
+            output_column = output_columns[0]
+            try:
+                column_values = dataset[output_column]
+                
+                # Check column type and convert to numerical indices if needed
+                if isinstance(column_values[0], str):
+                    import pandas as pd
+                    labels_array, unique_values = pd.factorize(column_values)
+                    labels = labels_array.tolist()
+                else:
+                    labels = [
+                        int(x) if not isinstance(x, (list, tuple)) else int(x[0])
+                        for x in column_values
+                    ]
+            except Exception as e:
+                raise ValueError(
+                    f"Error while trying to stratify the dataset: {e}"
+                ) from e
+
         train_indexes, test_indexes, val_indexes = split_indexes(
             n,
             splits["train"],

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -72,7 +72,7 @@ class DatasetJob(BaseJob):
             try:
                 log.debug("Storing dataset in %s", folder_path)
                 dataset_save_path = folder_path / "dataset"
-                if dataloader == ImageDataLoader:
+                if isinstance(dataloader, ImageDataLoader):
                     new_dataset = dataloader.load_data(
                         filepath_or_buffer=str(file_path)
                         if file_path is not None

--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -118,6 +118,15 @@ class ModelJob(BaseJob):
                 prepared_dataset = task.prepare_for_task(
                     loaded_dataset, experiment.output_columns
                 )
+                n_labels = None
+                if experiment.task_name in [
+                    "TextClassificationTask",
+                    "TabularClassificationTask",
+                ]:
+                    all_classes = prepared_dataset.unique(experiment.output_columns[0])
+                    n_labels = len(all_classes)
+                    print(all_classes)
+
                 splits = json.loads(experiment.splits)
                 prepared_dataset = prepare_for_experiment(
                     dataset=prepared_dataset,
@@ -148,7 +157,7 @@ class ModelJob(BaseJob):
                     f"Unable to find Model with name {run.model_name} in registry.",
                 ) from e
             try:
-                factory = ModelFactory(run_model_class, run.parameters)
+                factory = ModelFactory(run_model_class, run.parameters, n_labels=n_labels)
                 model: BaseModel = factory.model
                 run_optimizable_parameters = factory.optimizable_parameters
 

--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -157,7 +157,9 @@ class ModelJob(BaseJob):
                     f"Unable to find Model with name {run.model_name} in registry.",
                 ) from e
             try:
-                factory = ModelFactory(run_model_class, run.parameters, n_labels=n_labels)
+                factory = ModelFactory(
+                    run_model_class, run.parameters, n_labels=n_labels
+                )
                 model: BaseModel = factory.model
                 run_optimizable_parameters = factory.optimizable_parameters
 

--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -122,6 +122,7 @@ class ModelJob(BaseJob):
                 if experiment.task_name in [
                     "TextClassificationTask",
                     "TabularClassificationTask",
+                    "ImageClassificationTask",
                 ]:
                     all_classes = prepared_dataset.unique(experiment.output_columns[0])
                     n_labels = len(all_classes)
@@ -149,7 +150,6 @@ class ModelJob(BaseJob):
                 ) from e
 
             try:
-                print("Nombre del modelo sgnmodeljob", run.model_name)
                 run_model_class = component_registry[run.model_name]["class"]
             except Exception as e:
                 log.exception(e)

--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -118,6 +118,14 @@ class ModelJob(BaseJob):
                 prepared_dataset = task.prepare_for_task(
                     loaded_dataset, experiment.output_columns
                 )
+                n_labels = None
+                if experiment.task_name in [
+                    "TextClassificationTask",
+                    "TabularClassificationTask",
+                ]:
+                    all_classes = prepared_dataset.unique(experiment.output_columns[0])
+                    n_labels = len(all_classes)
+
                 splits = json.loads(experiment.splits)
                 prepared_dataset = prepare_for_experiment(
                     dataset=prepared_dataset,
@@ -141,6 +149,7 @@ class ModelJob(BaseJob):
                 ) from e
 
             try:
+                print("Nombre del modelo sgnmodeljob", run.model_name)
                 run_model_class = component_registry[run.model_name]["class"]
             except Exception as e:
                 log.exception(e)
@@ -148,7 +157,7 @@ class ModelJob(BaseJob):
                     f"Unable to find Model with name {run.model_name} in registry.",
                 ) from e
             try:
-                factory = ModelFactory(run_model_class, run.parameters)
+                factory = ModelFactory(run_model_class, run.parameters, n_labels=n_labels)
                 model: BaseModel = factory.model
                 run_optimizable_parameters = factory.optimizable_parameters
 

--- a/DashAI/back/metrics/classification/f1.py
+++ b/DashAI/back/metrics/classification/f1.py
@@ -14,17 +14,20 @@ class F1(ClassificationMetric):
     """F1 score to classification tasks."""
 
     @staticmethod
-    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray) -> float:
+    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None) -> float:
         """Calculate f1 score between true labels and predicted labels.
 
         Parameters
         ----------
         true_labels : DashAIDataset
-             A DashAI dataset with labels.
+            A DashAI dataset with labels.
         probs_pred_labels : np.ndarray
             A two-dimensional matrix in which each column represents a class
             and the row values represent the probability that an example belongs
             to the class associated with the column.
+        multiclass : bool, optional
+            Whether the task is a multiclass classification. If None, it will be
+            determined automatically from the number of unique labels.
 
         Returns
         -------
@@ -32,7 +35,12 @@ class F1(ClassificationMetric):
             f1 score between true labels and predicted labels
         """
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
-        multiclass = len(np.unique(true_labels)) > 2
+        print("nlabels", np.unique(true_labels))
+        
+        # Use the provided multiclass parameter or determine it using is_multiclass
+        if multiclass is None:
+            multiclass = ClassificationMetric.is_multiclass(true_labels)
+            
         if multiclass:
             return f1_score(true_labels, pred_labels, average="macro")
         else:

--- a/DashAI/back/metrics/classification/f1.py
+++ b/DashAI/back/metrics/classification/f1.py
@@ -14,7 +14,9 @@ class F1(ClassificationMetric):
     """F1 score to classification tasks."""
 
     @staticmethod
-    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None) -> float:
+    def score(
+        true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None
+    ) -> float:
         """Calculate f1 score between true labels and predicted labels.
 
         Parameters
@@ -38,7 +40,7 @@ class F1(ClassificationMetric):
         # Use the provided multiclass parameter or determine it using is_multiclass
         if multiclass is None:
             multiclass = ClassificationMetric.is_multiclass(true_labels)
-            
+
         if multiclass:
             return f1_score(true_labels, pred_labels, average="macro")
         else:

--- a/DashAI/back/metrics/classification/f1.py
+++ b/DashAI/back/metrics/classification/f1.py
@@ -14,17 +14,20 @@ class F1(ClassificationMetric):
     """F1 score to classification tasks."""
 
     @staticmethod
-    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray) -> float:
+    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None) -> float:
         """Calculate f1 score between true labels and predicted labels.
 
         Parameters
         ----------
         true_labels : DashAIDataset
-             A DashAI dataset with labels.
+            A DashAI dataset with labels.
         probs_pred_labels : np.ndarray
             A two-dimensional matrix in which each column represents a class
             and the row values represent the probability that an example belongs
             to the class associated with the column.
+        multiclass : bool, optional
+            Whether the task is a multiclass classification. If None, it will be
+            determined automatically from the number of unique labels.
 
         Returns
         -------
@@ -32,7 +35,10 @@ class F1(ClassificationMetric):
             f1 score between true labels and predicted labels
         """
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
-        multiclass = len(np.unique(true_labels)) > 2
+        # Use the provided multiclass parameter or determine it using is_multiclass
+        if multiclass is None:
+            multiclass = ClassificationMetric.is_multiclass(true_labels)
+            
         if multiclass:
             return f1_score(true_labels, pred_labels, average="macro")
         else:

--- a/DashAI/back/metrics/classification/precision.py
+++ b/DashAI/back/metrics/classification/precision.py
@@ -14,7 +14,9 @@ class Precision(ClassificationMetric):
     """Precision metric to classification tasks."""
 
     @staticmethod
-    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None) -> float:
+    def score(
+        true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None
+    ) -> float:
         """Calculate precision between true labels and predicted labels.
 
         Parameters
@@ -35,11 +37,11 @@ class Precision(ClassificationMetric):
             Precision score between true labels and predicted labels
         """
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
-        
+
         # Use the provided multiclass parameter or determine it using is_multiclass
         if multiclass is None:
             multiclass = ClassificationMetric.is_multiclass(true_labels)
-            
+
         if multiclass:
             return precision_score(true_labels, pred_labels, average="macro")
         else:

--- a/DashAI/back/metrics/classification/precision.py
+++ b/DashAI/back/metrics/classification/precision.py
@@ -14,7 +14,7 @@ class Precision(ClassificationMetric):
     """Precision metric to classification tasks."""
 
     @staticmethod
-    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray) -> float:
+    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None) -> float:
         """Calculate precision between true labels and predicted labels.
 
         Parameters
@@ -25,6 +25,9 @@ class Precision(ClassificationMetric):
             A two-dimensional matrix in which each column represents a class
             and the row values represent the probability that an example belongs
             to the class associated with the column.
+        multiclass : bool, optional
+            Whether the task is a multiclass classification. If None, it will be
+            determined automatically from the number of unique labels.
 
         Returns
         -------
@@ -32,7 +35,11 @@ class Precision(ClassificationMetric):
             Precision score between true labels and predicted labels
         """
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
-        multiclass = len(np.unique(true_labels)) > 2
+        
+        # Use the provided multiclass parameter or determine it using is_multiclass
+        if multiclass is None:
+            multiclass = ClassificationMetric.is_multiclass(true_labels)
+            
         if multiclass:
             return precision_score(true_labels, pred_labels, average="macro")
         else:

--- a/DashAI/back/metrics/classification/recall.py
+++ b/DashAI/back/metrics/classification/recall.py
@@ -14,17 +14,20 @@ class Recall(ClassificationMetric):
     """Recall metric to classification tasks."""
 
     @staticmethod
-    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray) -> float:
+    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None) -> float:
         """Calculate recall between true labels and predicted labels.
 
         Parameters
         ----------
         true_labels : DashAIDataset
             A DashAI dataset with labels.
-        probs_pred_labels :  np.ndarray
+        probs_pred_labels : np.ndarray
             A two-dimensional matrix in which each column represents a class and the row
             values represent the probability that an example belongs to the class
             associated with the column.
+        multiclass : bool, optional
+            Whether the task is a multiclass classification. If None, it will be
+            determined automatically from the number of unique labels.
 
         Returns
         -------
@@ -32,7 +35,11 @@ class Recall(ClassificationMetric):
             recall score between true labels and predicted labels
         """
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
-        multiclass = len(np.unique(true_labels)) > 2
+        
+        # Use the provided multiclass parameter or determine it using is_multiclass
+        if multiclass is None:
+            multiclass = ClassificationMetric.is_multiclass(true_labels)
+            
         if multiclass:
             return recall_score(true_labels, pred_labels, average="macro")
         else:

--- a/DashAI/back/metrics/classification/recall.py
+++ b/DashAI/back/metrics/classification/recall.py
@@ -14,7 +14,9 @@ class Recall(ClassificationMetric):
     """Recall metric to classification tasks."""
 
     @staticmethod
-    def score(true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None) -> float:
+    def score(
+        true_labels: DashAIDataset, probs_pred_labels: np.ndarray, multiclass=None
+    ) -> float:
         """Calculate recall between true labels and predicted labels.
 
         Parameters
@@ -35,11 +37,11 @@ class Recall(ClassificationMetric):
             recall score between true labels and predicted labels
         """
         true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
-        
+
         # Use the provided multiclass parameter or determine it using is_multiclass
         if multiclass is None:
             multiclass = ClassificationMetric.is_multiclass(true_labels)
-            
+
         if multiclass:
             return recall_score(true_labels, pred_labels, average="macro")
         else:

--- a/DashAI/back/metrics/classification_metric.py
+++ b/DashAI/back/metrics/classification_metric.py
@@ -15,6 +15,27 @@ class ClassificationMetric(BaseMetric):
         "TextClassificationTask",
     ]
 
+    @staticmethod
+    def is_multiclass(true_labels: np.ndarray) -> bool:
+        """
+        Determine if the classification problem is multiclass (more than 2 classes).
+
+        This method is used by metrics to decide whether to use binary or multiclass
+        scoring strategies.
+
+        Parameters
+        ----------
+        true_labels : np.ndarray
+            Array of true labels.
+
+        Returns
+        -------
+        bool
+            True if the problem has more than 2 unique classes, False otherwise.
+        """
+        unique_labels = np.unique(true_labels)
+        return len(unique_labels) > 2
+
 
 def validate_inputs(true_labels: np.ndarray, pred_labels: np.ndarray) -> None:
     """Validate inputs.

--- a/DashAI/back/models/hugging_face/distilbert_transformer.py
+++ b/DashAI/back/models/hugging_face/distilbert_transformer.py
@@ -87,6 +87,7 @@ class DistilBertTransformer(TextClassificationModel):
         associated tokenizer.
         """
         self.num_labels = kwargs.get("num_labels")
+        print("num_labels en init", self.num_labels)
         kwargs = self.validate_and_transform(kwargs)
         self.model_name = "distilbert-base-uncased"
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
@@ -139,7 +140,9 @@ class DistilBertTransformer(TextClassificationModel):
         output_column_name = y_train.column_names[0]
         if self.num_labels is None:
             self.num_labels = len(set(y_train[output_column_name]))
+        print("num_labelsenfit", self.num_labels)
         self.model.config.num_labels = self.num_labels
+        print("numlabels del mmodelo",self.model.config.num_labels)
         train_dataset = self.tokenize_data(x_train)
         train_dataset = train_dataset.add_column("label", y_train[output_column_name])
 

--- a/DashAI/back/models/hugging_face/distilbert_transformer.py
+++ b/DashAI/back/models/hugging_face/distilbert_transformer.py
@@ -87,7 +87,6 @@ class DistilBertTransformer(TextClassificationModel):
         associated tokenizer.
         """
         self.num_labels = kwargs.get("num_labels")
-        print("num_labels en init", self.num_labels)
         kwargs = self.validate_and_transform(kwargs)
         self.model_name = "distilbert-base-uncased"
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
@@ -140,9 +139,7 @@ class DistilBertTransformer(TextClassificationModel):
         output_column_name = y_train.column_names[0]
         if self.num_labels is None:
             self.num_labels = len(set(y_train[output_column_name]))
-        print("num_labelsenfit", self.num_labels)
         self.model.config.num_labels = self.num_labels
-        print("numlabels del mmodelo", self.model.config.num_labels)
         train_dataset = self.tokenize_data(x_train)
         train_dataset = train_dataset.add_column("label", y_train[output_column_name])
 

--- a/DashAI/back/models/hugging_face/distilbert_transformer.py
+++ b/DashAI/back/models/hugging_face/distilbert_transformer.py
@@ -142,7 +142,7 @@ class DistilBertTransformer(TextClassificationModel):
             self.num_labels = len(set(y_train[output_column_name]))
         print("num_labelsenfit", self.num_labels)
         self.model.config.num_labels = self.num_labels
-        print("numlabels del mmodelo",self.model.config.num_labels)
+        print("numlabels del mmodelo", self.model.config.num_labels)
         train_dataset = self.tokenize_data(x_train)
         train_dataset = train_dataset.add_column("label", y_train[output_column_name])
 

--- a/DashAI/back/models/model_factory.py
+++ b/DashAI/back/models/model_factory.py
@@ -1,6 +1,8 @@
 import torch
 from sklearn.exceptions import NotFittedError
 
+from DashAI.back.metrics.classification_metric import ClassificationMetric
+
 
 class ModelFactory:
     """
@@ -22,12 +24,18 @@ class ModelFactory:
         Extracts fixed and optimizable parameters from a dictionary.
     """
 
-    def __init__(self, model, params: dict):
+    def __init__(self, model, params: dict, n_labels=None):
         self.fixed_parameters, self.optimizable_parameters = self._extract_parameters(
             params
         )
+
+        self.num_labels = n_labels
+
+        print("fixed_parameters",self.fixed_parameters)
         self.model = model(**self.fixed_parameters)
         self.fitted = False
+        if n_labels is not None:
+            self._adjust_params_after_init(n_labels)
 
         if hasattr(self.model, "optimizable_params"):
             self.optimizable_parameters = self.model.optimizable_params
@@ -44,6 +52,36 @@ class ModelFactory:
         result = self.original_fit(*args, **kwargs)
         self.fitted = True
         return result
+
+    def _adjust_params_after_init(self, num_labels):
+        """
+        Adjust model parameters based on the number of labels after model initialization.
+
+        This method checks the instantiated model to see if it has num_labels attribute
+        and updates it accordingly.
+
+        Parameters
+        ----------
+        num_labels : int
+            Number of unique labels in the classification task.
+        """
+        # For Hugging Face models
+        if hasattr(self.model, "config") and hasattr(self.model.config, "num_labels"):
+            self.model.config.num_labels = num_labels
+            print(f"Actualizando num_labels a {num_labels} en modelo Hugging Face")
+            return
+
+        # For scikit-learn models
+        if hasattr(self.model, "n_classes_"):
+            self.model.n_classes_ = num_labels
+            print(f"Actualizando n_classes_ a {num_labels} en modelo scikit-learn")
+            return
+            
+        # For other models that have the num_labels attribute
+        if hasattr(self.model, "num_labels"):
+            self.model.num_labels = num_labels
+            print(f"Actualizando num_labels a {num_labels} en modelo genérico")
+            return
 
     def _extract_parameters(self, parameters: dict) -> dict:
         """
@@ -79,13 +117,48 @@ class ModelFactory:
         return fixed_params, optimizable_params
 
     def evaluate(self, x, y, metrics):
-        """Computes metrics only if the model is fitted."""
+        """
+        Computes metrics only if the model is fitted.
+
+        Parameters
+        ----------
+        x : dict
+            Dictionary with input data for each split.
+        y : dict
+            Dictionary with output data for each split.
+        metrics : list
+            List of metric classes to evaluate.
+
+        Returns
+        -------
+        dict
+            Dictionary with metrics scores for each split.
+        """
         if not self.fitted:
             raise NotFittedError("Model must be trained before evaluating metrics.")
-        return {
-            split: {
-                metric.__name__: metric.score(y[split], self.model.predict(x[split]))
-                for metric in metrics
-            }
-            for split in ["train", "validation", "test"]
-        }
+
+        multiclass = None
+        if hasattr(self, "num_labels") and self.num_labels is not None:
+            multiclass = self.num_labels > 2
+
+        results = {}
+        for split in ["train", "validation", "test"]:
+            split_results = {}
+            predictions = self.model.predict(x[split])
+
+            for metric in metrics:
+                # Check if the metric is a classification metric that supports multiclass
+                if (isinstance(metric, type) and 
+                    issubclass(metric, ClassificationMetric) and 
+                    "multiclass" in metric.score.__code__.co_varnames and
+                    multiclass is not None):
+                    score = metric.score(y[split], predictions, multiclass=multiclass)
+                else:
+                    # For metrics that don't accept the multiclass parameter
+                    score = metric.score(y[split], predictions)
+
+                split_results[metric.__name__] = score
+
+            results[split] = split_results
+
+        return results

--- a/DashAI/back/models/model_factory.py
+++ b/DashAI/back/models/model_factory.py
@@ -31,7 +31,6 @@ class ModelFactory:
 
         self.num_labels = n_labels
 
-        print("fixed_parameters", self.fixed_parameters)
         self.model = model(**self.fixed_parameters)
         self.fitted = False
         if n_labels is not None:
@@ -69,19 +68,16 @@ class ModelFactory:
         # For Hugging Face models
         if hasattr(self.model, "config") and hasattr(self.model.config, "num_labels"):
             self.model.config.num_labels = num_labels
-            print(f"Actualizando num_labels a {num_labels} en modelo Hugging Face")
             return
 
         # For scikit-learn models
         if hasattr(self.model, "n_classes_"):
             self.model.n_classes_ = num_labels
-            print(f"Actualizando n_classes_ a {num_labels} en modelo scikit-learn")
             return
 
         # For other models that have the num_labels attribute
         if hasattr(self.model, "num_labels"):
             self.model.num_labels = num_labels
-            print(f"Actualizando num_labels a {num_labels} en modelo genérico")
             return
 
     def _extract_parameters(self, parameters: dict) -> dict:
@@ -146,7 +142,6 @@ class ModelFactory:
         for split in ["train", "validation", "test"]:
             split_results = {}
             predictions = self.model.predict(x[split])
-
             for metric in metrics:
                 if (
                     isinstance(metric, type)

--- a/DashAI/back/models/model_factory.py
+++ b/DashAI/back/models/model_factory.py
@@ -1,5 +1,9 @@
+import numpy as np
 import torch
 from sklearn.exceptions import NotFittedError
+
+from DashAI.back.metrics.classification_metric import ClassificationMetric
+from DashAI.back.models.scikit_learn.sklearn_like_model import SklearnLikeModel
 
 
 class ModelFactory:
@@ -22,10 +26,18 @@ class ModelFactory:
         Extracts fixed and optimizable parameters from a dictionary.
     """
 
-    def __init__(self, model, params: dict):
+    def __init__(self, model, params: dict, n_labels = None):
+
+
         self.fixed_parameters, self.optimizable_parameters = self._extract_parameters(
             params
         )
+
+        if n_labels is not None:
+            self._adjust_params_for_num_labels(n_labels, model.__class__)
+            self.num_labels = n_labels
+
+        print("LOsparametros son", self.fixed_parameters)
         self.model = model(**self.fixed_parameters)
         self.fitted = False
 
@@ -44,6 +56,34 @@ class ModelFactory:
         result = self.original_fit(*args, **kwargs)
         self.fitted = True
         return result
+
+    def _adjust_params_for_num_labels(self, num_labels, model_class):
+        """
+        Adjust model parameters based on the number of labels.
+        
+        Parameters
+        ----------
+        num_labels : int
+            Number of unique labels in the classification task.
+        model_class : class
+            The class of the model being created.
+        """
+        # Check if it's a scikit-learn model
+        if hasattr(model_class, '__mro__') and any('SklearnLikeModel' in str(cls) for cls in model_class.__mro__):
+            # For models that explicitly need n_classes
+            if hasattr(model_class.__init__, "__code__"):
+                init_params = model_class.__init__.__code__.co_varnames
+                if "n_classes" in init_params and "n_classes" not in self.fixed_parameters:
+                    self.fixed_parameters["n_classes"] = num_labels
+                elif "n_components" in init_params and "n_components" not in self.fixed_parameters:
+                    self.fixed_parameters["n_components"] = num_labels
+
+                
+        # Check if it's a HuggingFace model 
+        else:
+            self.fixed_parameters["num_labels"] = num_labels
+
+        print("model_class es", str(model_class).lower())
 
     def _extract_parameters(self, parameters: dict) -> dict:
         """
@@ -79,13 +119,54 @@ class ModelFactory:
         return fixed_params, optimizable_params
 
     def evaluate(self, x, y, metrics):
-        """Computes metrics only if the model is fitted."""
+        """
+        Computes metrics only if the model is fitted.
+
+        Parameters
+        ----------
+        x : dict
+            Dictionary with input data for each split.
+        y : dict
+            Dictionary with output data for each split.
+        metrics : list
+            List of metric classes to evaluate.
+
+        Returns
+        -------
+        dict
+            Dictionary with metrics scores for each split.
+        """
         if not self.fitted:
             raise NotFittedError("Model must be trained before evaluating metrics.")
-        return {
-            split: {
-                metric.__name__: metric.score(y[split], self.model.predict(x[split]))
-                for metric in metrics
-            }
-            for split in ["train", "validation", "test"]
-        }
+
+        # Determine if we're dealing with multiclass classification
+        # based on the number of unique labels in training data
+        multiclass = None
+        if hasattr(self, "num_labels") and self.num_labels is not None:
+            multiclass = self.num_labels > 2
+
+        results = {}
+        for split in ["train", "validation", "test"]:
+            split_results = {}
+            predictions = self.model.predict(x[split])
+
+            for metric in metrics:
+                # Check if the metric is a classification metric that supports multiclass
+                if (isinstance(metric, type) and 
+                    issubclass(metric, ClassificationMetric) and 
+                    "multiclass" in metric.score.__code__.co_varnames and
+                    multiclass is not None):
+
+                    print("metric is", metric)
+                    print("multiclass is", multiclass)
+                    print("y[split] is", y[split])
+                    score = metric.score(y[split], predictions, multiclass=multiclass)
+                else:
+                    # For metrics that don't accept the multiclass parameter
+                    score = metric.score(y[split], predictions)
+
+                split_results[metric.__name__] = score
+
+            results[split] = split_results
+
+        return results

--- a/DashAI/back/models/model_factory.py
+++ b/DashAI/back/models/model_factory.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 from sklearn.exceptions import NotFittedError
 
@@ -32,7 +31,7 @@ class ModelFactory:
 
         self.num_labels = n_labels
 
-        print("fixed_parameters",self.fixed_parameters)
+        print("fixed_parameters", self.fixed_parameters)
         self.model = model(**self.fixed_parameters)
         self.fitted = False
         if n_labels is not None:
@@ -56,7 +55,8 @@ class ModelFactory:
 
     def _adjust_params_after_init(self, num_labels):
         """
-        Adjust model parameters based on the number of labels after model initialization.
+        Adjust model parameters based on the number of labels after model
+        initialization.
 
         This method checks the instantiated model to see if it has num_labels attribute
         and updates it accordingly.
@@ -77,7 +77,7 @@ class ModelFactory:
             self.model.n_classes_ = num_labels
             print(f"Actualizando n_classes_ a {num_labels} en modelo scikit-learn")
             return
-            
+
         # For other models that have the num_labels attribute
         if hasattr(self.model, "num_labels"):
             self.model.num_labels = num_labels
@@ -148,11 +148,12 @@ class ModelFactory:
             predictions = self.model.predict(x[split])
 
             for metric in metrics:
-                # Check if the metric is a classification metric that supports multiclass
-                if (isinstance(metric, type) and 
-                    issubclass(metric, ClassificationMetric) and 
-                    "multiclass" in metric.score.__code__.co_varnames and
-                    multiclass is not None):
+                if (
+                    isinstance(metric, type)
+                    and issubclass(metric, ClassificationMetric)
+                    and "multiclass" in metric.score.__code__.co_varnames
+                    and multiclass is not None
+                ):
                     score = metric.score(y[split], predictions, multiclass=multiclass)
                 else:
                     # For metrics that don't accept the multiclass parameter


### PR DESCRIPTION
I fixed a bug where, when splitting a dataset, the 'train' split could contain fewer labels than the total number of labels in the dataset. This issue caused the model to train with fewer labels, and when calculating metrics with another split containing the original labels, an error would occur. Now, the number of labels is calculated before performing the splits, and this information is passed as a parameter to the model if possible.