### PR TITLE
🐛 Enhance image data loading by converting images to bytes in ImageDataloader

### DIFF
--- a/DashAI/back/dataloaders/classes/image_dataloader.py
+++ b/DashAI/back/dataloaders/classes/image_dataloader.py
@@ -60,15 +60,12 @@ class ImageDataLoader(BaseDataLoader):
 
         def convert_image_to_bytes(example):
             import io
+
             buffer = io.BytesIO()
             format = example["image"].format
             example["image"].save(buffer, format=format)
-            return {
-                "image": {
-                    "bytes": buffer.getvalue(),
-                    "format": format
-                }
-            }
+            return {"image": {"bytes": buffer.getvalue(), "format": format}}
+
         if prepared_path[1] == "dir":
             dataset = load_dataset("imagefolder", data_dir=prepared_path[0])
             dataset = dataset.map(convert_image_to_bytes)

--- a/DashAI/back/dataloaders/classes/image_dataloader.py
+++ b/DashAI/back/dataloaders/classes/image_dataloader.py
@@ -58,8 +58,20 @@ class ImageDataLoader(BaseDataLoader):
         """
         prepared_path = self.prepare_files(filepath_or_buffer, temp_path)
 
+        def convert_image_to_bytes(example):
+            import io
+            buffer = io.BytesIO()
+            format = example["image"].format
+            example["image"].save(buffer, format=format)
+            return {
+                "image": {
+                    "bytes": buffer.getvalue(),
+                    "format": format
+                }
+            }
         if prepared_path[1] == "dir":
             dataset = load_dataset("imagefolder", data_dir=prepared_path[0])
+            dataset = dataset.map(convert_image_to_bytes)
         else:
             raise Exception(
                 "The image dataloader requires the input file to be a zip file."

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import sessionmaker
 from DashAI.back.api.api_v1.schemas.datasets_params import DatasetParams
 from DashAI.back.api.utils import parse_params
 from DashAI.back.dataloaders.classes.dashai_dataset import save_dataset
-from DashAI.back.dataloaders.classes.image_dataloader import ImageDataLoader
 from DashAI.back.dependencies.database.models import Dataset
 from DashAI.back.dependencies.registry import ComponentRegistry
 from DashAI.back.job.base_job import BaseJob, JobError
@@ -72,9 +71,7 @@ class DatasetJob(BaseJob):
             try:
                 log.debug("Storing dataset in %s", folder_path)
                 new_dataset = dataloader.load_data(
-                    filepath_or_buffer=str(file_path)
-                    if file_path is not None
-                    else url,
+                    filepath_or_buffer=str(file_path) if file_path is not None else url,
                     temp_path=str(temp_dir),
                     params=parsed_params.model_dump(),
                 )

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -71,24 +71,15 @@ class DatasetJob(BaseJob):
 
             try:
                 log.debug("Storing dataset in %s", folder_path)
-                dataset_save_path = folder_path / "dataset"
-                if isinstance(dataloader, ImageDataLoader):
-                    new_dataset = dataloader.load_data(
-                        filepath_or_buffer=str(file_path)
-                        if file_path is not None
-                        else url,
-                        temp_path=str(dataset_save_path),
-                        params=parsed_params.model_dump(),
-                    )
-                else:
-                    new_dataset = dataloader.load_data(
-                        filepath_or_buffer=str(file_path)
-                        if file_path is not None
-                        else url,
-                        temp_path=str(temp_dir),
-                        params=parsed_params.model_dump(),
-                    )
+                new_dataset = dataloader.load_data(
+                    filepath_or_buffer=str(file_path)
+                    if file_path is not None
+                    else url,
+                    temp_path=str(temp_dir),
+                    params=parsed_params.model_dump(),
+                )
                 gc.collect()
+                dataset_save_path = folder_path / "dataset"
                 log.debug("Saving dataset in %s", str(dataset_save_path))
                 save_dataset(new_dataset, dataset_save_path)
             except Exception as e:

--- a/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
@@ -55,6 +55,7 @@ export default function SelectDatasetStep({
   const [selectedDatasetId, setSelectedDatasetId] = useState(false);
   const [isValidDataset, setIsValidDataset] = useState(false);
   const [requestError, setRequestError] = useState(false);
+  const [datasetPaths, setDatasetPaths] = useState([]);
 
   const getDatasets = async () => {
     setLoading(true);
@@ -76,29 +77,6 @@ export default function SelectDatasetStep({
     }
   };
 
-  // eslint-disable-next-line no-unused-vars
-  const validateDataset = async () => {
-    try {
-      const validation = await validateDatasetRequest(
-        newExpl.run_id,
-        selectedDatasetId,
-      );
-      setIsValidDataset(validation.dataset_status === "valid");
-      if (validation.dataset_status === "invalid") {
-        enqueueSnackbar("The selected dataset is not valid.");
-      }
-    } catch (error) {
-      enqueueSnackbar("Error while trying to validate the selected dataset.");
-      if (error.response) {
-        console.error("Response error:", error.message);
-      } else if (error.request) {
-        console.error("Request error", error.request);
-      } else {
-        console.error("Unknown Error", error.message);
-      }
-    }
-  };
-
   // fetch datasets when the component is mounting
   useEffect(() => {
     getDatasets();
@@ -113,12 +91,6 @@ export default function SelectDatasetStep({
       setSelectedDatasetId(dataset.id);
     }
   }, [rowSelectedDataset]);
-
-  useEffect(() => {
-    if (selectedDatasetId) {
-      validateDataset();
-    }
-  }, [selectedDatasetId]);
 
   useEffect(() => {
     if (isValidDataset) {


### PR DESCRIPTION
This PR updates the ImageDataloader to convert image files into raw byte format during dataset preprocessing. By storing images as bytes along with their format, we ensure that datasets are fully self-contained and independent of their original file paths.

- Images are no longer stored as separate files in the dataset folder — only the encoded bytes are saved inside the .arrow file.
 - Dataset can now be safely loaded without needing access to the original image files.

Additionally, this update improves generalization in the dataset job logic. It removes the need for special-case handling of the ImageDataloader, enabling a more consistent and modular approach across different dataloader types.

