### PR TITLE
feat/pipelines

### DIFF
--- a/DashAI/back/pipeline/nodes.json
+++ b/DashAI/back/pipeline/nodes.json
@@ -9,7 +9,8 @@
     "predecessors": [],
     "successors": ["DataExploration", "Train"],
     "description": "Loads a dataset stored in the system to be used in the pipeline.",
-    "output": "Dataset object"
+    "output": "Dataset object",
+    "configType": "custom"
   },
   {
     "type": "DataExploration",
@@ -21,7 +22,8 @@
     "predecessors": ["DataSelector"],
     "successors": [],
     "description": "Visualize and analyze your dataset to gain insights into its structure and content.",
-    "input": "Dataset object"
+    "input": "Dataset object",
+    "configType": "custom"
   },
   {
     "type": "Train",
@@ -34,7 +36,8 @@
     "successors": ["Prediction"],
     "description": "Trains a model using a selected dataset, with configurable columns, splits, task, model, and metrics.",
     "input": "Dataset object",
-    "output": "Trained model object and evaluation results"
+    "output": "Trained model object and evaluation results",
+    "configType": "custom"
   },
   {
     "type": "Prediction",
@@ -46,7 +49,8 @@
     "predecessors": ["Train", "RetrieveModel"],
     "successors": [],
     "description": "Generates predictions using a trained model.",
-    "input": "Trained model and dataset object"
+    "input": "Trained model and dataset object",
+    "configType": "custom"
   },
   {
     "type": "RetrieveModel",
@@ -59,6 +63,7 @@
     "successors": ["Prediction"],
     "description": "Loads a trained model from saved pipelines.",
     "input": "Dataset object",
-    "output": "Trained model object"
+    "output": "Trained model object",
+    "configType": "custom"
   }
 ]

--- a/DashAI/front/src/components/pipelines/nodeRegistry.jsx
+++ b/DashAI/front/src/components/pipelines/nodeRegistry.jsx
@@ -2,12 +2,14 @@ import DataSelectorNode from "./nodes/DataSelectorNode";
 import DataExplorationNode from "./nodes/DataExplorationNode";
 import TrainNode from "./nodes/TrainNode";
 import RetrieveModelNode from "./nodes/RetrieveModelNode";
+import ConfigurableNode from "./nodes/ConfigurableNode";
 
 const nodeRegistry = {
   DataSelector: DataSelectorNode,
   DataExploration: DataExplorationNode,
   Train: TrainNode,
   RetrieveModel: RetrieveModelNode,
+  Configurable: ConfigurableNode,
 };
 
 export default nodeRegistry;

--- a/DashAI/front/src/components/pipelines/nodes/ConfigurableNode.jsx
+++ b/DashAI/front/src/components/pipelines/nodes/ConfigurableNode.jsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  TextField,
+  MenuItem,
+} from "@mui/material";
+
+function ConfigurableNode({
+  open,
+  onClose,
+  onSave,
+  savedConfig = {},
+  configSchema,
+}) {
+  const [formValues, setFormValues] = useState({});
+
+  useEffect(() => {
+    if (Object.keys(formValues).length === 0) {
+      const defaults = {};
+      for (const field of configSchema?.fields || []) {
+        defaults[field.name] = savedConfig[field.name] ?? field.default ?? "";
+      }
+      setFormValues(defaults);
+    }
+  }, [configSchema, savedConfig]);
+
+  const handleChange = (fieldName) => (event) => {
+    setFormValues((prev) => ({
+      ...prev,
+      [fieldName]: event.target.value,
+    }));
+  };
+
+  const handleSubmit = () => {
+    onSave(formValues);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Configure Node</DialogTitle>
+      <DialogContent dividers>
+        {(configSchema?.fields || []).map((field) => (
+          <Box key={field.name} sx={{ my: 2 }}>
+            {field.type === "select" ? (
+              <TextField
+                select
+                fullWidth
+                label={field.label || field.name}
+                value={formValues[field.name] ?? ""}
+                onChange={handleChange(field.name)}
+              >
+                {field.options.map((opt) => (
+                  <MenuItem key={opt} value={opt}>
+                    {opt}
+                  </MenuItem>
+                ))}
+              </TextField>
+            ) : (
+              <TextField
+                fullWidth
+                type={field.type === "number" ? "number" : "text"}
+                label={field.label || field.name}
+                value={formValues[field.name] ?? ""}
+                onChange={handleChange(field.name)}
+              />
+            )}
+          </Box>
+        ))}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleSubmit}>
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default ConfigurableNode;

--- a/DashAI/front/src/hooks/usePipelineState.js
+++ b/DashAI/front/src/hooks/usePipelineState.js
@@ -151,6 +151,8 @@ export function usePipelineState(pipelineId, location, navigate) {
             source: nodeInfo?.source || false,
             target: nodeInfo?.target || false,
             type: nodeInfo?.type || node.type,
+            configType: nodeInfo?.configType,
+            configSchema: nodeInfo?.configSchema || null,
           },
         };
       }),

--- a/DashAI/front/src/pages/pipelines/NewPipeline.jsx
+++ b/DashAI/front/src/pages/pipelines/NewPipeline.jsx
@@ -69,8 +69,17 @@ function NewPipeline() {
 
   const renderNodeDialogContent = () => {
     if (!selectedNode) return null;
-    const { type, id } = selectedNode;
-    const NodeComponent = nodeRegistry[type];
+
+    const { type, id, data } = selectedNode;
+    const { configType, configSchema } = data;
+    let NodeComponent = null;
+
+    if (configType === "custom") {
+      NodeComponent = nodeRegistry[type];
+    } else if (configType === "generic") {
+      NodeComponent = nodeRegistry["Configurable"];
+    }
+
     if (!NodeComponent) return null;
 
     return (
@@ -80,6 +89,7 @@ function NewPipeline() {
         onSave={(data) => handleSaveNodeData(id, data)}
         savedConfig={nodeData[id]}
         prevNodes={getConnectedNodeData(selectedNode)}
+        configSchema={configSchema}
       />
     );
   };


### PR DESCRIPTION
Added support for configurable nodes using a `configSchema` object defined in `nodes.json`. Each node now includes a `configType` field that determines how the configuration is handled:

- If `configType` is "custom", a specific modal must be implemented.
- If it's "generic", the node must include a `configSchema` with the structure of the form, and the frontend will generate the configuration automatically.

This allows creating new nodes without the need to implement a specific modal for each one.