### PR TITLE
fix: refactor import statements in ConfigureExplorersStep and NodeSid…

### DIFF
--- a/DashAI/front/src/components/explorations/Steps/ConfigureExplorersStep.jsx
+++ b/DashAI/front/src/components/explorations/Steps/ConfigureExplorersStep.jsx
@@ -19,7 +19,7 @@ import { useSnackbar } from "notistack";
 
 import useSchema from "../../../hooks/useSchema";
 import { useExplorationsContext } from "../context";
-import { ExplorersTable } from "../";
+import ExplorersTable from "../ExplorationsTable";
 
 import { getComponents } from "../../../api/component";
 

--- a/DashAI/front/src/components/pipelines/NodeSidebar.jsx
+++ b/DashAI/front/src/components/pipelines/NodeSidebar.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
-import { getNodeHelp } from ".";
+import { getNodeHelp } from "./nodeHelp";
 
 function NodeSidebar({ availableNodes, onDragStart, nodeHelp }) {
   return (


### PR DESCRIPTION
## Fix: Resolve circular dependency in frontend imports

This pull request resolves a **circular dependency issue** in the frontend components by updating import statements to use more explicit and direct paths.  

### Fixes and improvements
- Fixed a circular import between `ConfigureExplorersStep.jsx` and `ExplorersTable.jsx` by changing the import of `ExplorersTable` to a direct path (`../ExplorationsTable`).  
- Updated the import of `getNodeHelp` in `NodeSidebar.jsx` to reference `./nodeHelp` explicitly instead of relying on a relative index, removing ambiguity.  

#### Before
<img width="1285" height="232" alt="image" src="https://github.com/user-attachments/assets/47905daa-2e30-4f09-a345-32fe4c84b0f3" />


#### After
<img width="471" height="72" alt="image" src="https://github.com/user-attachments/assets/95272238-a923-4665-a077-1ed35e1503bc" />

