### PR TITLE
Fix bug when changing from string to null in forms

### DIFF
--- a/DashAI/front/src/components/shared/FormSchemaFieldWithOptions.jsx
+++ b/DashAI/front/src/components/shared/FormSchemaFieldWithOptions.jsx
@@ -1,5 +1,5 @@
 import { Box } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import FormSchemaField from "./FormSchemaField";
 import SingleSelectChipGroup from "./SingleSelectChipGroup";
 import { getValidator } from "../../utils/schema";
@@ -47,13 +47,17 @@ function FormSchemaFieldsWithOptions({
   const [selectedType, setSelectedType] = useState(null);
   const [errorField, setErrorField] = useState(null);
 
-  const fieldProps = {
-    paramJsonSchema: {
+  const paramJsonSchema = useMemo(() => {
+    return {
       title,
       description,
       required,
       ...options.find((option) => option.type === selectedType),
-    },
+    };
+  }, [title, description, required, options, selectedType]);
+
+  const fieldProps = {
+    paramJsonSchema,
     field,
     ...rest,
   };


### PR DESCRIPTION
This pull request refactors the `FormSchemaFieldWithOptions.jsx` component to optimize how the JSON schema for form fields is computed and to fix a re-render loop bug that occurred when switching parameter types.

## Bug Description & Reproduction Steps

Previously, the `paramJsonSchema` object was created inline inside `fieldProps`, which meant a new object reference was generated on every render. This caused the `useEffect` that depended on `fieldProps.paramJsonSchema` to run unnecessarily, even when nothing semantically changed.

This became a problem when multiple parameters had validation errors:

1. Go to the **PCA converter** settings.
2. Change the first parameter (**N Components**) to **string**, triggering a "required" error.
3. Change the parameter back to **null**.
4. Scroll down to **Power Iteration Normalization**, change it to **null**, and then back to **string**.
5. At this point, the parameters list would enter an **infinite re-render loop**.

## Why It Happened

- Each re-render created a new `paramJsonSchema` object.
- This triggered the `useEffect` validator again, which called `handleSetError`.
- Calling `handleSetError` caused the parent list of parameters to re-render.
- The cycle repeated as the newly rendered components generated new schema objects, retriggering validation continuously.

## Fix

- Wrapped the creation of `paramJsonSchema` in a `useMemo` hook, with dependencies `[title, description, required, options, selectedType]`.
- This ensures that `paramJsonSchema` retains the same reference unless one of its dependencies actually changes, breaking the re-render loop and significantly improving performance.

## Performance and React Optimization

- Avoids unnecessary `useEffect` executions on every render.
- Prevents infinite re-renders when toggling parameter types with active validation errors.
- Improves rendering efficiency by reducing object churn in `fieldProps`.
