### PR TITLE
fix add Hugging Face API key support for StableDiffusionV3 model

### DIFF
--- a/DashAI/back/models/hugging_face/stable_diffusion_v3_model.py
+++ b/DashAI/back/models/hugging_face/stable_diffusion_v3_model.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional
 
 import torch
 from diffusers import DiffusionPipeline
+from huggingface_hub import login
 
 from DashAI.back.core.schema_fields import (
     enum_field,
@@ -38,6 +39,12 @@ class StableDiffusionSchema(BaseSchema):
         ),
         placeholder="stabilityai/stable-diffusion-3-medium-diffusers",
         description="The specific Stable Diffusion model version to use.",
+    )  # type: ignore
+
+    huggingface_key: schema_field(
+        string_field(),
+        placeholder="",
+        description="Hugging Face API key for private models.",
     )  # type: ignore
 
     negative_prompt: Optional[
@@ -111,6 +118,22 @@ class StableDiffusionV3Model(TextToImageGenerationTaskModel):
         self.model_name = kwargs.get(
             "model_name", "stabilityai/stable-diffusion-3-medium-diffusers"
         )
+        self.huggingface_key = kwargs.get("huggingface_key")
+
+        if self.huggingface_key:
+            try:
+                login(token=self.huggingface_key)
+            except Exception as e:
+                raise ValueError(
+                    "Failed to login to Hugging Face. Please check your API key."
+                ) from e
+
+        try:
+            self.model = DiffusionPipeline.from_pretrained(
+                self.model_name,
+            ).to(self.device)
+        except Exception as e:
+            raise ValueError(f"Failed to load model {self.model_name}. {e}") from e
 
         self.model = DiffusionPipeline.from_pretrained(
             self.model_name,


### PR DESCRIPTION
This pull request adds support for authenticating with the Hugging Face API in the `StableDiffusionV3Model`, enabling access to private models. The main changes include adding a new field for the API key, handling authentication during model initialization, and improving error handling for both authentication and model loading.

**Authentication and configuration improvements:**

* Added a new `huggingface_key` field to the `StableDiffusionSchema` to allow users to provide a Hugging Face API key for accessing private models.
* Imported the `login` function from `huggingface_hub` and updated the model's `__init__` method to authenticate using the provided API key if available, with clear error messaging on failure. [[1]](diffhunk://#diff-e99421b6e5f128c0de368e56d97b92d9660d334cf85c55a7fd99cfba258ea957R5) [[2]](diffhunk://#diff-e99421b6e5f128c0de368e56d97b92d9660d334cf85c55a7fd99cfba258ea957R121-R136)

**Error handling enhancements:**

* Improved error handling when loading the model by raising a descriptive `ValueError` if model initialization fails.