### PR TITLE
fix: add Hugging Face API key to StableDiffusionV3 parameters and remove deprecated model option

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10']
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/DashAI/back/models/hugging_face/stable_diffusion_v3_model.py
+++ b/DashAI/back/models/hugging_face/stable_diffusion_v3_model.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional
 
 import torch
 from diffusers import DiffusionPipeline
+from huggingface_hub import login
 
 from DashAI.back.core.schema_fields import (
     enum_field,
@@ -38,6 +39,12 @@ class StableDiffusionSchema(BaseSchema):
         ),
         placeholder="stabilityai/stable-diffusion-3-medium-diffusers",
         description="The specific Stable Diffusion model version to use.",
+    )  # type: ignore
+
+    huggingface_key: schema_field(
+        string_field(),
+        placeholder="",
+        description="Hugging Face API key for private models.",
     )  # type: ignore
 
     negative_prompt: Optional[
@@ -111,6 +118,22 @@ class StableDiffusionV3Model(TextToImageGenerationTaskModel):
         self.model_name = kwargs.get(
             "model_name", "stabilityai/stable-diffusion-3-medium-diffusers"
         )
+        self.huggingface_key = kwargs.get("huggingface_key")
+
+        if self.huggingface_key:
+            try:
+                login(token=self.huggingface_key)
+            except Exception as e:
+                raise ValueError(
+                    "Failed to login to Hugging Face. Please check your API key."
+                ) from e
+
+        try:
+            self.model = DiffusionPipeline.from_pretrained(
+                self.model_name,
+            ).to(self.device)
+        except Exception as e:
+            raise ValueError(f"Failed to load model {self.model_name}. {e}") from e
 
         self.model = DiffusionPipeline.from_pretrained(
             self.model_name,

--- a/DashAI/back/models/hugging_face/stable_diffusion_v3_model.py
+++ b/DashAI/back/models/hugging_face/stable_diffusion_v3_model.py
@@ -31,7 +31,6 @@ class StableDiffusionSchema(BaseSchema):
         enum_field(
             enum=[
                 "stabilityai/stable-diffusion-3-medium-diffusers",
-                "stabilityai/stable-diffusion-3-medium-tensorrt",
                 "stabilityai/stable-diffusion-3.5-medium",
                 "stabilityai/stable-diffusion-3.5-large",
                 "stabilityai/stable-diffusion-3.5-large-turbo",


### PR DESCRIPTION
This pull request updates the Stable Diffusion v3 model integration in DashAI to support loading private models from Hugging Face by allowing users to provide an API key. It also improves error handling during authentication and model loading. Additionally, it removes an unused model option from the schema.

Authentication and API key support:

* Added a new `huggingface_key` field to the `StableDiffusionSchema` to allow users to specify their Hugging Face API key for accessing private models.
* Updated the model initialization to authenticate with Hugging Face using the provided API key, with error handling for failed logins.
* Imported the `login` function from `huggingface_hub` to enable authentication.

Model selection schema update:

* Removed `"stabilityai/stable-diffusion-3-medium-tensorrt"` from the list of available model options in the schema, likely because it is deprecated or unsupported.

Robust model loading:

* Improved error handling when loading the selected model, raising a clear error if the model cannot be loaded.