### PR TITLE
fix: update device handling in OpusMtEnESTransformer

### DIFF
--- a/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 from typing import List, Optional, Union
 
+import torch
 from datasets import Dataset
 from sklearn.exceptions import NotFittedError
 from transformers import (
@@ -22,6 +23,13 @@ from DashAI.back.core.schema_fields import (
     schema_field,
 )
 from DashAI.back.models.translation_model import TranslationModel
+
+if torch.cuda.is_available():
+    DEVICE_ENUM = [f"cuda:{i}" for i in range(torch.cuda.device_count())] + ["cpu"]
+    DEVICE_PLACEHOLDER = "cuda:0"
+else:
+    DEVICE_ENUM = ["cpu"]
+    DEVICE_PLACEHOLDER = "cpu"
 
 
 class OpusMtEnESTransformerSchema(BaseSchema):
@@ -45,8 +53,8 @@ class OpusMtEnESTransformerSchema(BaseSchema):
         description="The initial learning rate for AdamW optimizer",
     )  # type: ignore
     device: schema_field(
-        enum_field(enum=["gpu", "cpu"]),
-        placeholder="gpu",
+        enum_field(enum=DEVICE_ENUM),
+        placeholder=DEVICE_PLACEHOLDER,
         description="Hardware on which the training is run. If available, GPU is "
         "recommended for efficiency reasons. Otherwise, use CPU.",
     )  # type: ignore


### PR DESCRIPTION
# Improve Device Selection in `OpusMtEnESTransformerSchema`

This pull request updates the `OpusMtEnESTransformerSchema` in `opus_mt_en_es_transformer.py` to dynamically detect and enumerate available hardware devices (CPU and CUDA GPUs) for model training. This makes the device selection more robust and reflective of the actual environment, improving usability and reducing configuration errors.

## Device Selection Improvements

* Added dynamic detection of available CUDA devices using `torch`, and updated the `DEVICE_ENUM` and `DEVICE_PLACEHOLDER` variables to reflect the actual hardware present.
* Updated the `device` field in the `OpusMtEnESTransformerSchema` to use the dynamically determined `DEVICE_ENUM` and `DEVICE_PLACEHOLDER` instead of hardcoded values.

## Before (without cuda)

<img width="1204" height="772" alt="image" src="https://github.com/user-attachments/assets/4ebf226a-6f6f-42ae-b987-de508eaf28ac" />


## After (without cuda)

<img width="1208" height="772" alt="image" src="https://github.com/user-attachments/assets/4892dff8-2369-4230-8c94-55ccbad69e19" />