### PR TITLE
Remove target column selector for unsupervised converters

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/converters.py
+++ b/DashAI/back/api/api_v1/endpoints/converters.py
@@ -19,7 +19,7 @@ class ConverterParams(PydanticBaseModel):
     order: int = 0
     params: Dict[str, Union[str, int, float, bool, None]] = None
     scope: Dict[str, List[int]] = None
-    target_index: int = None
+    target_index: Union[int, None] = None
 
     def serialize(self) -> Dict[str, Any]:
         return {

--- a/DashAI/back/converters/base_converter.py
+++ b/DashAI/back/converters/base_converter.py
@@ -50,7 +50,7 @@ class BaseConverter(ConfigObject, ABC):
         metadata["short_description"] = (
             cls.SHORT_DESCRIPTION if cls.SHORT_DESCRIPTION else ""
         )
-        metadata["supervised"] = cls.SUPERVISED if cls.SUPERVISED else False
+        metadata["supervised"] = cls.SUPERVISED
 
         return metadata
 

--- a/DashAI/back/converters/base_converter.py
+++ b/DashAI/back/converters/base_converter.py
@@ -29,6 +29,7 @@ class BaseConverter(ConfigObject, ABC):
     DISPLAY_NAME: Final[str] = ""
     DESCRIPTION: Final[str] = ""
     SHORT_DESCRIPTION: Final[str] = ""
+    SUPERVISED: bool = False
     SCHEMA: BaseConverterSchema
     metadata: Dict[str, Any] = {}
 
@@ -49,6 +50,8 @@ class BaseConverter(ConfigObject, ABC):
         metadata["short_description"] = (
             cls.SHORT_DESCRIPTION if cls.SHORT_DESCRIPTION else ""
         )
+        metadata["supervised"] = cls.SUPERVISED if cls.SUPERVISED else False
+
         return metadata
 
     def changes_row_count(self) -> bool:

--- a/DashAI/back/converters/imbalanced_learn/smote_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smote_converter.py
@@ -33,7 +33,6 @@ class SMOTESchema(BaseSchema):
 class SMOTEConverter(ImbalancedLearnWrapper, SMOTE):
     SCHEMA = SMOTESchema
     DESCRIPTION = "SMOTE: Synthetic Minority Over-sampling Technique."
-    SUPERVISED = True
 
-    def __init___(self, **kwargs):
+    def __init__(self, **kwargs):
         super(SMOTEConverter, self).__init__(**kwargs)

--- a/DashAI/back/converters/imbalanced_learn/smote_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smote_converter.py
@@ -33,6 +33,7 @@ class SMOTESchema(BaseSchema):
 class SMOTEConverter(ImbalancedLearnWrapper, SMOTE):
     SCHEMA = SMOTESchema
     DESCRIPTION = "SMOTE: Synthetic Minority Over-sampling Technique."
+    SUPERVISED = True
 
     def __init___(self, **kwargs):
         super(SMOTEConverter, self).__init__(**kwargs)

--- a/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
@@ -33,6 +33,7 @@ class SMOTEENNSchema(BaseSchema):
 class SMOTEENNConverter(ImbalancedLearnWrapper, SMOTEENN):
     SCHEMA = SMOTEENNSchema
     DESCRIPTION = "SMOTEENN: SMOTE with noise reduction via Edited Nearest Neighbors."
+    SUPERVISED = True
 
     def __init___(self, **kwargs):
         super(SMOTEENNConverter, self).__init__(**kwargs)

--- a/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
@@ -33,7 +33,6 @@ class SMOTEENNSchema(BaseSchema):
 class SMOTEENNConverter(ImbalancedLearnWrapper, SMOTEENN):
     SCHEMA = SMOTEENNSchema
     DESCRIPTION = "SMOTEENN: SMOTE with noise reduction via Edited Nearest Neighbors."
-    SUPERVISED = True
 
-    def __init___(self, **kwargs):
+    def __init__(self, **kwargs):
         super(SMOTEENNConverter, self).__init__(**kwargs)

--- a/DashAI/back/converters/imbalanced_learn_wrapper.py
+++ b/DashAI/back/converters/imbalanced_learn_wrapper.py
@@ -4,6 +4,7 @@ from typing import Type, Union
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+from datasets.features import Features
 
 from DashAI.back.converters.base_converter import BaseConverter
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset

--- a/DashAI/back/converters/imbalanced_learn_wrapper.py
+++ b/DashAI/back/converters/imbalanced_learn_wrapper.py
@@ -4,7 +4,6 @@ from typing import Type, Union
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-from datasets.features import Features
 
 from DashAI.back.converters.base_converter import BaseConverter
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -13,6 +12,9 @@ from DashAI.back.job.base_job import JobError
 
 class ImbalancedLearnWrapper(BaseConverter, metaclass=ABCMeta):
     """Generic wrapper for imbalanced-learn samplers (e.g., SMOTE, ADASYN)."""
+
+    SUPERVISED = True
+    metadata = {}
 
     def __init__(self, **kwargs):
         super(ImbalancedLearnWrapper, self).__init__(**kwargs)

--- a/DashAI/back/converters/scikit_learn/generic_univariate_select.py
+++ b/DashAI/back/converters/scikit_learn/generic_univariate_select.py
@@ -34,3 +34,4 @@ class GenericUnivariateSelect(SklearnWrapper, GenericUnivariateSelectOperation):
 
     SCHEMA = GenericUnivariateSelectSchema
     DESCRIPTION = "Univariate feature selector with configurable strategy."
+    SUPERVISED = True

--- a/DashAI/back/converters/scikit_learn/generic_univariate_select.py
+++ b/DashAI/back/converters/scikit_learn/generic_univariate_select.py
@@ -35,3 +35,4 @@ class GenericUnivariateSelect(SklearnWrapper, GenericUnivariateSelectOperation):
     SCHEMA = GenericUnivariateSelectSchema
     DESCRIPTION = "Univariate feature selector with configurable strategy."
     SUPERVISED = True
+    metadata = {}

--- a/DashAI/back/converters/scikit_learn/select_fdr.py
+++ b/DashAI/back/converters/scikit_learn/select_fdr.py
@@ -19,3 +19,4 @@ class SelectFdr(SklearnWrapper, SelectFdrOperation):
     SCHEMA = SelectFdrSchema
     DESCRIPTION = "Filter: Select features according to a false discovery rate test."
     SUPERVISED = True
+    metadata = {}

--- a/DashAI/back/converters/scikit_learn/select_fdr.py
+++ b/DashAI/back/converters/scikit_learn/select_fdr.py
@@ -1,12 +1,7 @@
-from sklearn.feature_selection import (
-    SelectFdr as SelectFdrOperation,
-)
+from sklearn.feature_selection import SelectFdr as SelectFdrOperation
 
 from DashAI.back.converters.sklearn_wrapper import SklearnWrapper
-from DashAI.back.core.schema_fields import (
-    float_field,
-    schema_field,
-)
+from DashAI.back.core.schema_fields import float_field, schema_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 
 
@@ -23,3 +18,4 @@ class SelectFdr(SklearnWrapper, SelectFdrOperation):
 
     SCHEMA = SelectFdrSchema
     DESCRIPTION = "Filter: Select features according to a false discovery rate test."
+    SUPERVISED = True

--- a/DashAI/back/converters/scikit_learn/select_fpr.py
+++ b/DashAI/back/converters/scikit_learn/select_fpr.py
@@ -1,12 +1,7 @@
-from sklearn.feature_selection import (
-    SelectFpr as SelectFprOperation,
-)
+from sklearn.feature_selection import SelectFpr as SelectFprOperation
 
 from DashAI.back.converters.sklearn_wrapper import SklearnWrapper
-from DashAI.back.core.schema_fields import (
-    float_field,
-    schema_field,
-)
+from DashAI.back.core.schema_fields import float_field, schema_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 
 
@@ -23,3 +18,4 @@ class SelectFpr(SklearnWrapper, SelectFprOperation):
 
     SCHEMA = SelectFprSchema
     DESCRIPTION = "Filter: Select features according to a false positive rate test."
+    SUPERVISED = True

--- a/DashAI/back/converters/scikit_learn/select_fpr.py
+++ b/DashAI/back/converters/scikit_learn/select_fpr.py
@@ -19,3 +19,4 @@ class SelectFpr(SklearnWrapper, SelectFprOperation):
     SCHEMA = SelectFprSchema
     DESCRIPTION = "Filter: Select features according to a false positive rate test."
     SUPERVISED = True
+    metadata = {}

--- a/DashAI/back/converters/scikit_learn/select_fwe.py
+++ b/DashAI/back/converters/scikit_learn/select_fwe.py
@@ -1,12 +1,7 @@
-from sklearn.feature_selection import (
-    SelectFwe as SelectFweOperation,
-)
+from sklearn.feature_selection import SelectFwe as SelectFweOperation
 
 from DashAI.back.converters.sklearn_wrapper import SklearnWrapper
-from DashAI.back.core.schema_fields import (
-    float_field,
-    schema_field,
-)
+from DashAI.back.core.schema_fields import float_field, schema_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 
 
@@ -23,3 +18,4 @@ class SelectFwe(SklearnWrapper, SelectFweOperation):
 
     SCHEMA = SelectFweSchema
     DESCRIPTION = "Filter: Select features according to a family-wise error rate test."
+    SUPERVISED = True

--- a/DashAI/back/converters/scikit_learn/select_fwe.py
+++ b/DashAI/back/converters/scikit_learn/select_fwe.py
@@ -19,3 +19,4 @@ class SelectFwe(SklearnWrapper, SelectFweOperation):
     SCHEMA = SelectFweSchema
     DESCRIPTION = "Filter: Select features according to a family-wise error rate test."
     SUPERVISED = True
+    metadata = {}

--- a/DashAI/back/converters/scikit_learn/select_k_best.py
+++ b/DashAI/back/converters/scikit_learn/select_k_best.py
@@ -1,6 +1,4 @@
-from sklearn.feature_selection import (
-    SelectKBest as SelectKBestOperation,
-)
+from sklearn.feature_selection import SelectKBest as SelectKBestOperation
 
 from DashAI.back.converters.sklearn_wrapper import SklearnWrapper
 from DashAI.back.core.schema_fields import (
@@ -25,3 +23,4 @@ class SelectKBest(SklearnWrapper, SelectKBestOperation):
 
     SCHEMA = SelectKBestSchema
     DESCRIPTION = "Select features according to the k highest scores."
+    SUPERVISED = True

--- a/DashAI/back/converters/scikit_learn/select_k_best.py
+++ b/DashAI/back/converters/scikit_learn/select_k_best.py
@@ -24,3 +24,4 @@ class SelectKBest(SklearnWrapper, SelectKBestOperation):
     SCHEMA = SelectKBestSchema
     DESCRIPTION = "Select features according to the k highest scores."
     SUPERVISED = True
+    metadata = {}

--- a/DashAI/back/converters/scikit_learn/select_percentile.py
+++ b/DashAI/back/converters/scikit_learn/select_percentile.py
@@ -19,3 +19,4 @@ class SelectPercentile(SklearnWrapper, SelectPercentileOperation):
     SCHEMA = SelectPercentileSchema
     DESCRIPTION = "Select features according to a percentile of the highest scores."
     SUPERVISED = True
+    metadata = {}

--- a/DashAI/back/converters/scikit_learn/select_percentile.py
+++ b/DashAI/back/converters/scikit_learn/select_percentile.py
@@ -1,12 +1,7 @@
-from sklearn.feature_selection import (
-    SelectPercentile as SelectPercentileOperation,
-)
+from sklearn.feature_selection import SelectPercentile as SelectPercentileOperation
 
 from DashAI.back.converters.sklearn_wrapper import SklearnWrapper
-from DashAI.back.core.schema_fields import (
-    int_field,
-    schema_field,
-)
+from DashAI.back.core.schema_fields import int_field, schema_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 
 
@@ -23,3 +18,4 @@ class SelectPercentile(SklearnWrapper, SelectPercentileOperation):
 
     SCHEMA = SelectPercentileSchema
     DESCRIPTION = "Select features according to a percentile of the highest scores."
+    SUPERVISED = True

--- a/DashAI/back/job/converter_job.py
+++ b/DashAI/back/job/converter_job.py
@@ -225,13 +225,13 @@ class ConverterListJob(BaseJob):
         # Load dataset
         try:
             # Validate target column index
-            if target_column_index is not None:
-                if int(target_column_index) < 1 or int(target_column_index) > len(
-                    loaded_dataset.features
-                ):
-                    raise JobError(
-                        f"Target column index {target_column_index} is out of bounds"
-                    )
+            if target_column_index is not None and (
+                int(target_column_index) < 1
+                or int(target_column_index) > len(loaded_dataset.features)
+            ):
+                raise JobError(
+                    f"Target column index {target_column_index} is out of bounds"
+                )
 
         except Exception as e:
             log.exception(e)

--- a/DashAI/back/job/converter_job.py
+++ b/DashAI/back/job/converter_job.py
@@ -225,13 +225,13 @@ class ConverterListJob(BaseJob):
         # Load dataset
         try:
             # Validate target column index
-            if target_column_index is not None and (
-                int(target_column_index) < 1
-                or int(target_column_index) > len(loaded_dataset.features)
-            ):
-                raise JobError(
-                    f"Target column index {target_column_index} is out of bounds"
-                )
+            if target_column_index is not None:
+                if int(target_column_index) < 1 or int(target_column_index) > len(
+                    loaded_dataset.features
+                ):
+                    raise JobError(
+                        f"Target column index {target_column_index} is out of bounds"
+                    )
 
         except Exception as e:
             log.exception(e)
@@ -327,6 +327,7 @@ class ConverterListJob(BaseJob):
                         camel_to_snake,
                         converter_submodule_inverse_index,
                     )
+                    print(converter_instance.metadata)
 
                     # Get scope or use default
                     scope = converter_params.get("scope", {"columns": [], "rows": []})

--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -33,7 +33,7 @@ export default function FormConverterSection({
           rows: rows,
         },
         order: 1,
-        target_index: tool.metadata.supervised ? targetColumn : 1,
+        target_index: targetColumn,
       },
     };
 

--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -33,7 +33,7 @@ export default function FormConverterSection({
           rows: rows,
         },
         order: 1,
-        target_index: targetColumn,
+        target_index: tool.metadata.supervised ? targetColumn : 1,
       },
     };
 
@@ -73,6 +73,7 @@ export default function FormConverterSection({
       {/* Step content */}
       {step === 0 && (
         <ScopeStepConverter
+          supervised={tool.metadata.supervised}
           targetColumn={targetColumn}
           setTargetColumn={setTargetColumn}
           rows={rows}

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -11,6 +11,7 @@ import {
 } from "../../../api/datasets";
 
 export default function ScopeStepConverter({
+  supervised,
   targetColumn,
   setTargetColumn,
   rows,
@@ -117,22 +118,28 @@ export default function ScopeStepConverter({
           gap: 1,
         }}
       >
-        <Tooltip
-          title="Supervised converters will include this column in their learning process."
-          placement="top"
-        >
-          <IconButton>
-            <HelpIcon />
-          </IconButton>
-        </Tooltip>
-        <ConverterClassColumnModal
-          updateClassColumn={setTargetColumn}
-          classColumnInitialValue={targetColumn}
-          notebook={notebook}
-        />
+        {supervised && (
+          <Tooltip
+            title="Supervised converters will include this column in their learning process."
+            placement="top"
+          >
+            <IconButton>
+              <HelpIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+
+        {supervised && (
+          <ConverterClassColumnModal
+            updateClassColumn={setTargetColumn}
+            classColumnInitialValue={targetColumn}
+            notebook={notebook}
+          />
+        )}
+
         <FormSchemaButtonGroup
           onFormSubmit={() => setStep((s) => s + 1)}
-          error={!targetColumn}
+          error={supervised ? !targetColumn : false}
           saveButtonText="Next"
         />
       </Box>


### PR DESCRIPTION
This pull request adds the concept of "supervised" converters to the backend and frontend, ensuring that converters which require a target column (supervised learning) are properly flagged and handled in the UI. It also includes some minor code cleanups and bug fixes.

Backend changes:

* Added a `SUPERVISED` attribute to the `BaseConverter` class and set it to `True` for relevant scikit-learn and imbalanced-learn converters, such as `SelectKBest`, `SelectFpr`, `SelectFdr`, `SelectFwe`, `SelectPercentile`, `GenericUnivariateSelect`, and the imbalanced-learn wrappers. The `metadata` dictionary now includes the `supervised` flag for each converter. [[1]](diffhunk://#diff-49db9bcf65d7d24ee21dd1ba5608cc1c0518d9c594f9270b63dbfda1860c404fR32) [[2]](diffhunk://#diff-8ebebac49629f9e5ee12853cfd0d568ab59ca300fc29d107cf6109f2f342b04cR17-R19) [[3]](diffhunk://#diff-646a80eb865323be2e714b391843acbf426171e6e8330931415a07c81109be7cR37-R38) [[4]](diffhunk://#diff-c5e03c0341ab2029b6573ad8ea750165d7cf7b87cae8a471a178bcaea4dfd3aaR21-R22) [[5]](diffhunk://#diff-250b27b5e86afa61b47f0d762ade60c082137daa456a105baefaa0cbb0edd9c2R21-R22) [[6]](diffhunk://#diff-988aaaaf157c358fe78a44fea2d2cb1fa1331efa6be912fd29a8a958699d7c0eR21-R22) [[7]](diffhunk://#diff-86b10d6e59f39fcc2e993a7384065c1ddba0f9701c0ba5be74ba084f5511c09cR26-R27) [[8]](diffhunk://#diff-3fec24891973fb3c9799180c62c470879ccef6c96363aab7e20bc7a49ef35536R21-R22) [[9]](diffhunk://#diff-49db9bcf65d7d24ee21dd1ba5608cc1c0518d9c594f9270b63dbfda1860c404fR53-R54)
* Fixed typos in the `__init__` methods of `SMOTEConverter` and `SMOTEENNConverter`. [[1]](diffhunk://#diff-4aa3c2cfe7c68dcfa4009bda68f85e17ced314d5054edd26572b37cef313fa55L37-R37) [[2]](diffhunk://#diff-03beb43898402bf12f48d5482fbc66c519cd8dfa4e89d16a75450b75963db8d5L37-R37)
* Minor cleanup of import statements in several scikit-learn converter files. [[1]](diffhunk://#diff-c5e03c0341ab2029b6573ad8ea750165d7cf7b87cae8a471a178bcaea4dfd3aaL1-R4) [[2]](diffhunk://#diff-250b27b5e86afa61b47f0d762ade60c082137daa456a105baefaa0cbb0edd9c2L1-R4) [[3]](diffhunk://#diff-988aaaaf157c358fe78a44fea2d2cb1fa1331efa6be912fd29a8a958699d7c0eL1-R4) [[4]](diffhunk://#diff-86b10d6e59f39fcc2e993a7384065c1ddba0f9701c0ba5be74ba084f5511c09cL1-R1) [[5]](diffhunk://#diff-3fec24891973fb3c9799180c62c470879ccef6c96363aab7e20bc7a49ef35536L1-R4)
* Printed the converter's metadata during instantiation for debugging purposes.
* Updated `ConverterParams` to clarify the type of `target_index`.

Frontend changes:

* Passed the `supervised` flag from the converter's metadata to the `ScopeStepConverter` component. [[1]](diffhunk://#diff-8eeff4f0e04538ba9cb4faba8e7e8748aec4a299e61132e3a20730c24248ea76R76) [[2]](diffhunk://#diff-b2a383a9624be950258619b2b78f249dcf1619c925e6d14e75bc9e05bc37a54fR14)
* Displayed additional UI elements and tooltips when a converter is supervised, requiring the user to select a target column. The "Next" button is disabled until a target column is selected for supervised converters. [[1]](diffhunk://#diff-b2a383a9624be950258619b2b78f249dcf1619c925e6d14e75bc9e05bc37a54fR121) [[2]](diffhunk://#diff-b2a383a9624be950258619b2b78f249dcf1619c925e6d14e75bc9e05bc37a54fR130-R142)

Before (unsupervised converter)

<img width="1254" height="928" alt="image" src="https://github.com/user-attachments/assets/cfe55d1f-7628-4a36-9a51-15d2b1bd0e79" />

After (unsupervised converter)

<img width="1263" height="925" alt="image" src="https://github.com/user-attachments/assets/3651f1a5-b0c2-4289-805d-56a17a2df1ee" />

These changes ensure that supervised converters are clearly indicated and that the user experience is improved by requiring the necessary target column input only when appropriate.