### PR TITLE
fix: refactor get_dataset_file to obtain total rows from metadata

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -607,7 +607,6 @@ async def get_dataset_file(
 
     start = page * page_size
     end = start + page_size
-    total_rows = 0
     rows_collected = 0
 
     with pa.memory_map(arrow_file_path, "r") as source:
@@ -619,9 +618,6 @@ async def get_dataset_file(
             batch_start = current_index
             batch_end = current_index + batch.num_rows
             current_index = batch_end
-
-            # Count total rows on the fly
-            total_rows += batch.num_rows
 
             # Skip batches before the page start
             if batch_end <= start:
@@ -645,6 +641,8 @@ async def get_dataset_file(
 
             if rows_collected >= page_size:
                 break
+
+    total_rows = get_dataset_info(f"{path}/dataset")["total_rows"]
 
     return JSONResponse(content={"rows": rows, "total": total_rows})
 


### PR DESCRIPTION
This pull request refactors how the total number of rows is determined in the `get_dataset_file` endpoint. Instead of incrementally counting rows while reading batches from the Arrow file, it now retrieves the total row count using the `get_dataset_info` function, which simplifies the code and fixes the count of rows

Dataset row count calculation:

* Removed the on-the-fly calculation of `total_rows` during batch iteration, eliminating the need to incrementally count rows while processing the file. [[1]](diffhunk://#diff-c9cef92fe4ca2b95de139f944cc80c71a17850b524378e73ad4db50ac23c3e5fL610) [[2]](diffhunk://#diff-c9cef92fe4ca2b95de139f944cc80c71a17850b524378e73ad4db50ac23c3e5fL623-L625)
* Added a call to `get_dataset_info` to retrieve the total number of rows after batch processing, streamlining the logic and making the code easier to maintain.

Before

<img width="1914" height="956" alt="image" src="https://github.com/user-attachments/assets/890c0c75-47c3-4d0e-89aa-2f7b266f12cc" />


After

<img width="1905" height="955" alt="image" src="https://github.com/user-attachments/assets/e70ea78e-572b-4c9f-9a57-85dffd5df9cd" />
