### PR TITLE
fix: refactor DashAIDataset creation for imbalanced converter

### DIFF
--- a/DashAI/back/converters/imbalanced_learn_wrapper.py
+++ b/DashAI/back/converters/imbalanced_learn_wrapper.py
@@ -4,7 +4,6 @@ from typing import Type, Union
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-from datasets.features import Features
 
 from DashAI.back.converters.base_converter import BaseConverter
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset

--- a/DashAI/back/converters/imbalanced_learn_wrapper.py
+++ b/DashAI/back/converters/imbalanced_learn_wrapper.py
@@ -105,12 +105,7 @@ class ImbalancedLearnWrapper(BaseConverter, metaclass=ABCMeta):
             raise RuntimeError("Resampled PyArrow Table not available. Call fit first.")
 
         try:
-            resampled_features = Features.from_arrow_schema(
-                self._resampled_table.schema
-            )
-            return DashAIDataset(
-                table=self._resampled_table, features=resampled_features, splits={}
-            )
+            return DashAIDataset(table=self._resampled_table, splits={})
         except Exception as e:
             raise JobError(
                 f"Failed to create DashAIDataset from resampled data: {e}"


### PR DESCRIPTION
This pull request makes a small simplification to the `transform` method in `imbalanced_learn_wrapper.py`. The change removes the explicit construction of `Features` from the Arrow schema when creating a `DashAIDataset`.