### PR TITLE
fix: adjust height and overflow properties in DatasetPreviewNotebook

### DIFF
--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -149,7 +149,7 @@ export default function DatasetPreviewNotebook({
           </Box>
         </AccordionSummary>
         <AccordionDetails>
-          <Box sx={{ height: 320, width: "100%" }}>
+          <Box sx={{ height: 325, width: "100%" }}>
             {" "}
             {/* Table */}
             <DatasetTable
@@ -176,7 +176,7 @@ export default function DatasetPreviewNotebook({
               sx={{
                 height: "100%",
                 "& .MuiDataGrid-virtualScroller": {
-                  minHeight: "100%",
+                  "overflow-y": "hidden",
                 },
                 "& .MuiDataGrid-overlay": {
                   height: "100%",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = load_requirements("requirements-dev.txt")
 
 setup(
     name="DashAI",
-    version="0.2.4",
+    version="0.2.5",
     license="MIT",
     description=(
         "DashAI: a graphical toolbox for training, evaluating and deploying "


### PR DESCRIPTION
This pull request makes minor adjustments to the layout of the dataset preview notebook component to improve its appearance and scrolling behavior.

- Layout tweaks:
  * Increased the height of the outer `Box` from 320 to 325 pixels in `DatasetPreviewNotebook.jsx` to provide slightly more space for the table.

- Data grid scrolling behavior

**Before**
<img width="1051" height="430" alt="image" src="https://github.com/user-attachments/assets/775b757c-9f6f-4425-82ed-33b2feeb665f" />

**After**
<img width="1052" height="435" alt="image" src="https://github.com/user-attachments/assets/b18d1dfe-2e77-4575-824e-882dab1484ab" />

  
 