### PR TITLE
fix: increase height of dataset preview box for better visibility

### DIFF
--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -149,7 +149,7 @@ export default function DatasetPreviewNotebook({
           </Box>
         </AccordionSummary>
         <AccordionDetails>
-          <Box sx={{ height: 325, width: "100%" }}>
+          <Box sx={{ height: 345, width: "100%" }}>
             {" "}
             {/* Table */}
             <DatasetTable


### PR DESCRIPTION
## Before
<img width="1050" height="447" alt="image" src="https://github.com/user-attachments/assets/5f3a3007-a4d9-4bd1-9f25-f462d00e61fc" />


## After
<img width="1060" height="486" alt="image" src="https://github.com/user-attachments/assets/eaa492ca-6581-4e07-8fa9-8482ebf49551" />
