### PR TITLE
Remove unnecessary steps in explorer/converter modals

### DIFF
--- a/DashAI/front/src/components/notebooks/ConfigureToolModal.jsx
+++ b/DashAI/front/src/components/notebooks/ConfigureToolModal.jsx
@@ -38,7 +38,10 @@ export default function ConfigureToolModal({
     [notebook.file_path],
   );
 
-  const steps = ["Configure Scope", "Configure Parameters"];
+  const steps =
+    Object.values(tool.schema.properties).length > 0
+      ? ["Configure Scope", "Configure Parameters"]
+      : ["Configure Scope"];
 
   return (
     <Dialog

--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -76,12 +76,17 @@ export default function FormConverterSection({
           supervised={tool.metadata.supervised}
           targetColumn={targetColumn}
           setTargetColumn={setTargetColumn}
+          tool={tool}
           rows={rows}
           setRows={setRows}
           columns={columns}
           setColumns={setColumns}
           notebook={notebook}
-          setStep={setStep}
+          nextStep={
+            Object.values(tool.schema.properties).length > 0
+              ? () => setStep((s) => s + 1)
+              : () => handleSaveConverter({})
+          }
         />
       )}
 

--- a/DashAI/front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx
@@ -20,6 +20,7 @@ export default function ParameterStepConverter({
           modelToConfigure={converter}
           initialValues={initialParams}
           onCancel={() => setStep(0)}
+          saveButtonText="Create Converter"
         />
       </FormSchemaContainer>
     </Box>

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -14,12 +14,13 @@ export default function ScopeStepConverter({
   supervised,
   targetColumn,
   setTargetColumn,
+  tool,
   rows,
   setRows,
   columns,
   setColumns,
   notebook,
-  setStep,
+  nextStep,
 }) {
   const [datasetInfo, setDatasetInfo] = useState(0);
   const [datasetColumns, setDatasetColumns] = useState([]);
@@ -151,9 +152,13 @@ export default function ScopeStepConverter({
         )}
 
         <FormSchemaButtonGroup
-          onFormSubmit={() => setStep((s) => s + 1)}
+          onFormSubmit={nextStep}
           error={supervised ? !targetColumn : false}
-          saveButtonText="Next"
+          saveButtonText={
+            Object.values(tool.schema.properties).length > 0
+              ? "Next"
+              : "Create Converter"
+          }
         />
       </Box>
     </Box>

--- a/DashAI/front/src/components/notebooks/explorerCreation/FormExplorerSection.jsx
+++ b/DashAI/front/src/components/notebooks/explorerCreation/FormExplorerSection.jsx
@@ -94,7 +94,11 @@ export default function FormExplorerSection({
           notebook={notebook}
           tool={tool}
           setScopeColumns={setScopeColumns}
-          setStep={setStep}
+          nextStep={
+            Object.values(tool.schema.properties).length > 0
+              ? () => setStep((s) => s + 1)
+              : () => handleSaveExplorer({})
+          }
         />
       )}
 

--- a/DashAI/front/src/components/notebooks/explorerCreation/ParameterStepExplorer.jsx
+++ b/DashAI/front/src/components/notebooks/explorerCreation/ParameterStepExplorer.jsx
@@ -20,7 +20,7 @@ export default function ParameterStepExplorer({
           modelToConfigure={explorer}
           initialValues={initialParams}
           onCancel={() => setStep(0)}
-          saveButtonText="SAVE AND RUN"
+          saveButtonText="Create Explorer"
         />
       </FormSchemaContainer>
     </Box>

--- a/DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx
+++ b/DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx
@@ -7,7 +7,7 @@ export default function ScopeStepExplorer({
   notebook,
   tool,
   setScopeColumns,
-  setStep,
+  nextStep,
 }) {
   const [isSelectionValid, setIsSelectionValid] = useState(false);
   const allowedDtypes = tool?.metadata?.allowed_dtypes || [];
@@ -54,9 +54,11 @@ export default function ScopeStepExplorer({
         }}
       >
         <FormSchemaButtonGroup
-          onFormSubmit={() => setStep((s) => s + 1)}
+          onFormSubmit={nextStep}
           error={!isSelectionValid}
-          saveButtonText="Next"
+          saveButtonText={
+            Object.values(tool.schema.properties).length > 0 ? "Next" : "Save"
+          }
         />
       </Box>
     </Box>


### PR DESCRIPTION
This pull request streamlines the notebook tool configuration workflow by conditionally skipping the parameter configuration step when the selected tool does not require additional parameters. It achieves this by checking the presence of properties in the tool's schema and updating navigation logic and button labels accordingly. The changes affect both converter and explorer creation flows for a more intuitive user experience.

**Conditional step navigation and workflow improvements:**

* The configuration steps in `ConfigureToolModal.jsx` are now dynamically set: if the tool's schema has properties, both "Configure Scope" and "Configure Parameters" steps are shown; otherwise, only "Configure Scope" is presented.
* In both converter and explorer creation flows (`FormConverterSection.jsx`, `FormExplorerSection.jsx`), the navigation after the scope step is updated: if no parameters are required, the process skips directly to saving the tool; otherwise, it proceeds to the parameter configuration step. [[1]](diffhunk://#diff-8eeff4f0e04538ba9cb4faba8e7e8748aec4a299e61132e3a20730c24248ea76R79-R89) [[2]](diffhunk://#diff-605c09840b894cf7895bb83222065949fa5e5080ebab171738476b1fa7ffb08dL97-R101)

**Component interface and button label updates:**

* The `ScopeStepConverter.jsx` and `ScopeStepExplorer.jsx` components now receive a `nextStep` callback instead of `setStep`, allowing conditional navigation logic. [[1]](diffhunk://#diff-b2a383a9624be950258619b2b78f249dcf1619c925e6d14e75bc9e05bc37a54fR17-R23) [[2]](diffhunk://#diff-8e8147f65b67fee062d470d6e9a0b1af118e88b358de8744c5b6c4201a485e93L10-R10)
* The button labels in the scope and parameter steps are dynamically set: "Next" when parameters are required, otherwise "Create Converter" or "Save"/"Create Explorer" as appropriate. [[1]](diffhunk://#diff-b2a383a9624be950258619b2b78f249dcf1619c925e6d14e75bc9e05bc37a54fL154-R161) [[2]](diffhunk://#diff-8e8147f65b67fee062d470d6e9a0b1af118e88b358de8744c5b6c4201a485e93L57-R61) [[3]](diffhunk://#diff-5716226e90d2c9e3805e69294f7cb4e7d5aa2a3da07d8a39d28262d56ca0344aR23) [[4]](diffhunk://#diff-8d7c2b11269a37754b1c0916f574ee325e60f679ded5b1de8859cc782678866aL23-R23)


**Before**
<img width="1262" height="921" alt="image" src="https://github.com/user-attachments/assets/b6ec4e43-ec9d-4071-83ee-0eb7cbc9495c" />

**After**
<img width="1326" height="933" alt="image" src="https://github.com/user-attachments/assets/0898cc85-0769-4e21-a1c5-e249eca26f10" />