### PR TITLE
Feat/dataset experiment chaining

### DIFF
--- a/DashAI/front/src/components/experiments/NewExperimentModal.jsx
+++ b/DashAI/front/src/components/experiments/NewExperimentModal.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-
 import {
   Button,
   Dialog,
@@ -18,64 +17,59 @@ import {
 import CloseIcon from "@mui/icons-material/Close";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import { useSnackbar } from "notistack";
 
 import { createExperiment as createExperimentRequest } from "../../api/experiment";
 import { createRun as createRunRequest } from "../../api/run";
-
-import SetNameAndTaskStep from "./SetNameAndTaskStep";
-import SelectDatasetStep from "./SelectDatasetStep";
-import PrepareDatasetStep from "./PrepareDatasetStep";
-import HyperparameterOptimizationStep from "./HyperparameterOptimizationStep";
-import ConfigureModelsStep from "./ConfigureModelsStep";
-
-import { useSnackbar } from "notistack";
 import { checkIfHaveOptimazers } from "../../utils/schema";
-
 import { TIMESTAMP_KEYS } from "../../constants/timestamp";
 import TimestampWrapper from "../shared/TimestampWrapper";
 
-const steps = [
-  { name: "selectTask", label: "Set name and task" },
-  { name: "selectDataset", label: "Select dataset" },
-  { name: "prepareDataset", label: "Prepare dataset" },
-  { name: "configureModels", label: "Configure models" },
-  {
-    name: "configureOptimizer",
-    label: "Configure hyperparameter optimization",
-  },
-];
+import { renderStep } from "./renderStep";
 
-const defaultNewExp = {
-  id: "",
-  name: "",
-  dataset: null,
-  task_name: "",
-  input_columns: [],
-  output_columns: [],
-  splits: {
-    train: 0.6,
-    validation: 0.2,
-    test: 0.2,
-  },
-  step: "SET_NAME",
-  created: null,
-  last_modified: null,
-  runs: [],
-};
-/**
- * This component renders a modal that takes the user through the process of creating a new experiment.
- * @param {bool} open true to open the modal, false to close it
- * @param {function} setOpen function to modify the value of open
- * @param {function} updateExperiments function to update the experiments table
- */
 export default function NewExperimentModal({
   open,
   setOpen,
   updateExperiments,
+  preselectedDataset,
+  setPreselectedDataset,
 }) {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("md"));
   const screenSm = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const defaultNewExp = {
+    id: "",
+    name: "",
+    dataset: preselectedDataset,
+    task_name: "",
+    input_columns: [],
+    output_columns: [],
+    splits: {
+      train: 0.6,
+      validation: 0.2,
+      test: 0.2,
+    },
+    step: "SET_NAME",
+    created: null,
+    last_modified: null,
+    runs: [],
+  };
+
+  // Build steps dynamically
+  const steps = [
+    { name: "selectTask", label: "Set name and task" },
+    ...(preselectedDataset
+      ? []
+      : [{ name: "selectDataset", label: "Select dataset" }]),
+    { name: "prepareDataset", label: "Prepare dataset" },
+    { name: "configureModels", label: "Configure models" },
+    {
+      name: "configureOptimizer",
+      label: "Configure hyperparameter optimization",
+    },
+  ];
+
   const { enqueueSnackbar } = useSnackbar();
 
   const [activeStep, setActiveStep] = useState(0);
@@ -146,6 +140,7 @@ export default function NewExperimentModal({
     setActiveStep(0);
     setOpen(false);
     setNewExp(defaultNewExp);
+    setPreselectedDataset(null);
     setNextEnabled(false);
   };
 
@@ -170,7 +165,7 @@ export default function NewExperimentModal({
       return;
     }
 
-    if (activeStep === 3) {
+    if (steps[activeStep].name === "configureModels") {
       const haveOptimazers = newExp.runs.some(checkIfHaveOptimazers);
 
       if (!haveOptimazers) {
@@ -254,41 +249,7 @@ export default function NewExperimentModal({
 
       {/* Main content - steps */}
       <DialogContent dividers>
-        {activeStep === 0 && (
-          <SetNameAndTaskStep
-            newExp={newExp}
-            setNewExp={setNewExp}
-            setNextEnabled={setNextEnabled}
-          />
-        )}
-        {activeStep === 1 && (
-          <SelectDatasetStep
-            newExp={newExp}
-            setNewExp={setNewExp}
-            setNextEnabled={setNextEnabled}
-          />
-        )}
-        {activeStep === 2 && (
-          <PrepareDatasetStep
-            newExp={newExp}
-            setNewExp={setNewExp}
-            setNextEnabled={setNextEnabled}
-          />
-        )}
-        {activeStep === 3 && (
-          <ConfigureModelsStep
-            newExp={newExp}
-            setNewExp={setNewExp}
-            setNextEnabled={setNextEnabled}
-          />
-        )}
-        {activeStep === 4 && (
-          <HyperparameterOptimizationStep
-            newExp={newExp}
-            setNewExp={setNewExp}
-            setNextEnabled={setNextEnabled}
-          />
-        )}
+        {renderStep(steps[activeStep].name, newExp, setNewExp, setNextEnabled)}
       </DialogContent>
 
       {/* Actions - Back and Next */}
@@ -299,13 +260,13 @@ export default function NewExperimentModal({
           </Button>
           <TimestampWrapper
             eventName={
-              activeStep === 2
+              steps[activeStep].name === "prepareDataset"
                 ? TIMESTAMP_KEYS.experiments.configureModel
-                : activeStep === 3
-                  ? TIMESTAMP_KEYS.experiments.submitModel
-                  : activeStep === 4
-                    ? TIMESTAMP_KEYS.experiments.configureOptimazer
-                    : null
+                : steps[activeStep].name === "configureModels"
+                ? TIMESTAMP_KEYS.experiments.submitModel
+                : steps[activeStep].name === "configureOptimizer"
+                ? TIMESTAMP_KEYS.experiments.configureOptimazer
+                : null
             }
           >
             <Button
@@ -315,7 +276,7 @@ export default function NewExperimentModal({
               color="primary"
               disabled={!nextEnabled}
             >
-              {activeStep === 4 ? "Save" : "Next"}
+              {activeStep === steps.length - 1 ? "Save" : "Next"}
             </Button>
           </TimestampWrapper>
         </ButtonGroup>
@@ -328,4 +289,6 @@ NewExperimentModal.propTypes = {
   open: PropTypes.bool.isRequired,
   setOpen: PropTypes.func.isRequired,
   updateExperiments: PropTypes.func.isRequired,
+  preselectedDataset: PropTypes.object,
+  setPreselectedDataset: PropTypes.func.isRequired,
 };

--- a/DashAI/front/src/components/experiments/NewExperimentModal.jsx
+++ b/DashAI/front/src/components/experiments/NewExperimentModal.jsx
@@ -299,10 +299,10 @@ export default function NewExperimentModal({
               steps[activeStep].name === "prepareDataset"
                 ? TIMESTAMP_KEYS.experiments.configureModel
                 : steps[activeStep].name === "configureModels"
-                ? TIMESTAMP_KEYS.experiments.submitModel
-                : steps[activeStep].name === "configureOptimizer"
-                ? TIMESTAMP_KEYS.experiments.configureOptimazer
-                : null
+                  ? TIMESTAMP_KEYS.experiments.submitModel
+                  : steps[activeStep].name === "configureOptimizer"
+                    ? TIMESTAMP_KEYS.experiments.configureOptimazer
+                    : null
             }
           >
             <Button

--- a/DashAI/front/src/components/experiments/NewExperimentModal.jsx
+++ b/DashAI/front/src/components/experiments/NewExperimentModal.jsx
@@ -263,10 +263,10 @@ export default function NewExperimentModal({
               steps[activeStep].name === "prepareDataset"
                 ? TIMESTAMP_KEYS.experiments.configureModel
                 : steps[activeStep].name === "configureModels"
-                ? TIMESTAMP_KEYS.experiments.submitModel
-                : steps[activeStep].name === "configureOptimizer"
-                ? TIMESTAMP_KEYS.experiments.configureOptimazer
-                : null
+                  ? TIMESTAMP_KEYS.experiments.submitModel
+                  : steps[activeStep].name === "configureOptimizer"
+                    ? TIMESTAMP_KEYS.experiments.configureOptimazer
+                    : null
             }
           >
             <Button

--- a/DashAI/front/src/components/experiments/SetNameAndTaskStep.jsx
+++ b/DashAI/front/src/components/experiments/SetNameAndTaskStep.jsx
@@ -37,7 +37,6 @@ function SetNameAndTaskStep({
         selectTypes: ["Task"],
         hasRelatedOfType: "Model",
       });
-      console.log("Fetched tasks:", tasks);
       setTasks(tasks);
       if (typeof newExp.task_name === "string" && newExp.task_name !== "") {
         const previouslySelectedTask =

--- a/DashAI/front/src/components/experiments/SetNameAndTaskStep.jsx
+++ b/DashAI/front/src/components/experiments/SetNameAndTaskStep.jsx
@@ -72,7 +72,6 @@ function SetNameAndTaskStep({ newExp, setNewExp, setNextEnabled }) {
       setNewExp({
         ...newExp,
         task_name: selectedTask.name,
-        dataset: null,
         runs: [],
       });
       setTaskNameOk(true);

--- a/DashAI/front/src/components/experiments/renderStep.js
+++ b/DashAI/front/src/components/experiments/renderStep.js
@@ -1,0 +1,53 @@
+import React from "react";
+import SetNameAndTaskStep from "./SetNameAndTaskStep";
+import SelectDatasetStep from "./SelectDatasetStep";
+import PrepareDatasetStep from "./PrepareDatasetStep";
+import ConfigureModelsStep from "./ConfigureModelsStep";
+import HyperparameterOptimizationStep from "./HyperparameterOptimizationStep";
+
+export function renderStep(stepName, newExp, setNewExp, setNextEnabled) {
+  switch (stepName) {
+    case "selectTask":
+      return (
+        <SetNameAndTaskStep
+          newExp={newExp}
+          setNewExp={setNewExp}
+          setNextEnabled={setNextEnabled}
+        />
+      );
+    case "selectDataset":
+      return (
+        <SelectDatasetStep
+          newExp={newExp}
+          setNewExp={setNewExp}
+          setNextEnabled={setNextEnabled}
+        />
+      );
+    case "prepareDataset":
+      return (
+        <PrepareDatasetStep
+          newExp={newExp}
+          setNewExp={setNewExp}
+          setNextEnabled={setNextEnabled}
+        />
+      );
+    case "configureModels":
+      return (
+        <ConfigureModelsStep
+          newExp={newExp}
+          setNewExp={setNewExp}
+          setNextEnabled={setNextEnabled}
+        />
+      );
+    case "configureOptimizer":
+      return (
+        <HyperparameterOptimizationStep
+          newExp={newExp}
+          setNewExp={setNewExp}
+          setNextEnabled={setNextEnabled}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/DashAI/front/src/components/notebooks/dataset/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetVisualization.jsx
@@ -15,11 +15,13 @@ import { createNotebook } from "../../../api/notebook";
 import DatasetTable from "../dataset/DatasetTable";
 import { CreateNotebookModal } from "../notebookCreation/CreateNotebookModal";
 import { useSnackbar } from "notistack";
+import { useNavigate } from "react-router-dom";
 
 export default function DatasetVisualization({ dataset, onNotebookCreated }) {
   const [showCreateNotebookModal, setShowCreateNotebookModal] = useState(false);
   const [datasetInfo, setDatasetInfo] = useState(null);
   const { enqueueSnackbar } = useSnackbar();
+  const navigate = useNavigate();
 
   // Format date for display
   const formatDate = (dateString) => {
@@ -181,6 +183,19 @@ export default function DatasetVisualization({ dataset, onNotebookCreated }) {
             {dataset.name}
           </Typography>
           <Grid item>
+            <Button
+              variant="contained"
+              disabled={isProcessing}
+              onClick={() => {
+                navigate("../app/experiments", {
+                  state: { dataset: dataset },
+                });
+              }}
+              endIcon={<AddIcon />}
+              sx={{ mr: 2 }}
+            >
+              New Experiment
+            </Button>
             <Button
               variant="contained"
               endIcon={<AddIcon />}

--- a/DashAI/front/src/pages/experiments/Experiments.jsx
+++ b/DashAI/front/src/pages/experiments/Experiments.jsx
@@ -11,7 +11,7 @@ function ExperimentsPage() {
   const location = useLocation();
   const [dataset, setDataset] = React.useState(location.state?.dataset);
   const [showNewExperimentModal, setShowNewExperimentModal] = React.useState(
-    dataset ? true : false,
+    !!dataset,
   );
 
   return (

--- a/DashAI/front/src/pages/experiments/Experiments.jsx
+++ b/DashAI/front/src/pages/experiments/Experiments.jsx
@@ -4,11 +4,15 @@ import NewExperimentModal from "../../components/experiments/NewExperimentModal"
 import ExperimentsTable from "../../components/experiments/ExperimentsTable";
 import { rows } from "../../example_data/experiments";
 import CustomLayout from "../../components/custom/CustomLayout";
+import { useLocation } from "react-router-dom";
 
 function ExperimentsPage() {
-  const [showNewExperimentModal, setShowNewExperimentModal] =
-    React.useState(false);
   const [updateTableFlag, setUpdateTableFlag] = React.useState(false);
+  const location = useLocation();
+  const [dataset, setDataset] = React.useState(location.state?.dataset);
+  const [showNewExperimentModal, setShowNewExperimentModal] = React.useState(
+    dataset ? true : false,
+  );
 
   return (
     <CustomLayout
@@ -20,6 +24,8 @@ function ExperimentsPage() {
         open={showNewExperimentModal}
         setOpen={setShowNewExperimentModal}
         updateExperiments={() => setUpdateTableFlag(true)}
+        preselectedDataset={dataset}
+        setPreselectedDataset={setDataset}
       />
 
       {/* Experiment table */}

--- a/DashAI/front/src/pages/experiments/Experiments.jsx
+++ b/DashAI/front/src/pages/experiments/Experiments.jsx
@@ -10,9 +10,8 @@ function ExperimentsPage() {
   const [updateTableFlag, setUpdateTableFlag] = React.useState(false);
   const location = useLocation();
   const [dataset, setDataset] = React.useState(location.state?.dataset);
-  const [showNewExperimentModal, setShowNewExperimentModal] = React.useState(
-    !!dataset,
-  );
+  const [showNewExperimentModal, setShowNewExperimentModal] =
+    React.useState(!!dataset);
 
   return (
     <CustomLayout

--- a/DashAI/front/src/pages/experiments/Experiments.jsx
+++ b/DashAI/front/src/pages/experiments/Experiments.jsx
@@ -10,9 +10,8 @@ import { getExperiments as getExperimentsRequest } from "../../api/experiment";
 function ExperimentsPage() {
   const location = useLocation();
   const [dataset, setDataset] = useState(location.state?.dataset);
-  const [showNewExperimentModal, setShowNewExperimentModal] = useState(
-    !!dataset,
-  );
+  const [showNewExperimentModal, setShowNewExperimentModal] =
+    useState(!!dataset);
   const [updateTableFlag, setUpdateTableFlag] = useState(false);
   const [experiments, setExperiments] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/DashAI/front/src/pages/experiments/Experiments.jsx
+++ b/DashAI/front/src/pages/experiments/Experiments.jsx
@@ -21,7 +21,6 @@ function ExperimentsPage() {
     setLoading(true);
     try {
       const experimentsData = await getExperimentsRequest();
-      console.log("Fetched experiments:", experimentsData);
       setExperiments(experimentsData);
     } catch (error) {
       enqueueSnackbar("Error while trying to obtain experiments.");


### PR DESCRIPTION
This pull request refactors the experiment creation flow to support pre-selecting a dataset and improves code maintainability by modularizing step rendering. It also enhances the user experience by allowing users to launch a new experiment directly from the dataset visualization page, with the selected dataset automatically passed to the experiment creation modal.

**User Experience Enhancements**
* A "New Experiment" button is added to the dataset visualization page, which navigates to the experiments page and opens the experiment creation modal with the selected dataset pre-filled. [[1]](diffhunk://#diff-dcecbed70c131b135b4ab161cbffd67b79a9af87cc5e56e02119c5518533f5edR186-R198) [[2]](diffhunk://#diff-38b885ed6c62db12eba010eabfcb466dfdc3893405cf0a5c8970f4c071ac80c3R7-R15) [[3]](diffhunk://#diff-38b885ed6c62db12eba010eabfcb466dfdc3893405cf0a5c8970f4c071ac80c3R27-R28)
* The experiment creation modal initializes the experiment's dataset field with the preselected dataset if provided, ensuring a smoother user workflow.

<img width="1914" height="955" alt="image" src="https://github.com/user-attachments/assets/9568dcce-f537-4e90-96d2-b632ed1bd3cc" />
<img width="1908" height="948" alt="image" src="https://github.com/user-attachments/assets/e8f529a6-1e5b-41c7-9df5-43c113397022" />

**Code Quality and Consistency**
* Step definitions and rendering are now dynamic, reducing duplication and making future changes easier. [[1]](diffhunk://#diff-93b616660101bc095119c980de2e069a37fe20ba329a21c357a0236e9209e948R1-R53) [[2]](diffhunk://#diff-5c894c548248a909bb2d7de0e93eb97ac45d9aca556e1a9b6cdd2c63774f0f69L65-R72) [[3]](diffhunk://#diff-5c894c548248a909bb2d7de0e93eb97ac45d9aca556e1a9b6cdd2c63774f0f69L257-R252)
* Redundant imports and logic are removed from `NewExperimentModal.jsx`, streamlining the component.
