### PR TITLE
Enhance dataset creation from notebooks by using DatasetJob

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/notebook.py
+++ b/DashAI/back/api/api_v1/endpoints/notebook.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Session, sessionmaker
 
 import DashAI.back.api.api_v1.schemas.datasets_params as dataset_params
 from DashAI.back.api.api_v1.schemas import notebook_params as schemas
-from DashAI.back.core.enums.status import DatasetStatus
 from DashAI.back.dependencies.database.models import (
     ConverterList,
     Dataset,

--- a/DashAI/back/api/api_v1/endpoints/notebook.py
+++ b/DashAI/back/api/api_v1/endpoints/notebook.py
@@ -313,40 +313,30 @@ async def create_dataset_from_notebook(
     notebook_id: int,
     params: dataset_params.DatasetUploadFromNotebookParams,
     session_factory: sessionmaker = Depends(lambda: di["session_factory"]),
-    config: dict = Depends(lambda: di["config"]),
 ):
     with session_factory() as db:
         try:
             notebook = db.get(Notebook, notebook_id)
             if not notebook:
                 raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found"
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Notebook not found",
                 )
-            dataset_folder = notebook.file_path
-            random_name = uuid.uuid4().hex[:8]
-            new_folder_path = os.path.join(
-                config["DATASETS_PATH"],
-                random_name,
-            )
-            os.makedirs(new_folder_path, exist_ok=True)
-            shutil.copytree(dataset_folder, new_folder_path, dirs_exist_ok=True)
 
-            dataset = Dataset(
+            new_dataset = Dataset(
                 name=params.name,
-                file_path=new_folder_path,
-                status=DatasetStatus.FINISHED,
+                file_path="",
             )
-            db.add(dataset)
+            db.add(new_dataset)
             db.commit()
-            db.refresh(dataset)
+            db.refresh(new_dataset)
+            return new_dataset
         except Exception as e:
             log.error(f"Error creating dataset from notebook {notebook_id}: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to create dataset",
             ) from e
-
-    return dataset
 
 
 @router.patch("/{notebook_id}")

--- a/DashAI/back/api/api_v1/schemas/datasets_params.py
+++ b/DashAI/back/api/api_v1/schemas/datasets_params.py
@@ -41,3 +41,4 @@ class Dataset(BaseModel):
 
 class DatasetCreateParams(BaseModel):
     name: str
+    notebook_id: int = None

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -105,9 +105,12 @@ class DatasetJob(BaseJob):
                             .first()
                         )
                         if not notebook_dataset:
-                            raise JobError(
-                                f"Notebook with ID {notebook_id} has no associated dataset."
+                            msg = (
+                                "Notebook with ID "
+                                f"{notebook_id}"
+                                " has no associated dataset."
                             )
+                            raise JobError(msg)
                         new_dataset = load_dataset(
                             os.path.join(notebook_dataset.file_path, "dataset")
                         )

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -12,8 +12,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from DashAI.back.api.api_v1.schemas.datasets_params import DatasetParams
 from DashAI.back.api.utils import parse_params
-from DashAI.back.dataloaders.classes.dashai_dataset import save_dataset
-from DashAI.back.dependencies.database.models import Dataset
+from DashAI.back.dataloaders.classes.dashai_dataset import load_dataset, save_dataset
+from DashAI.back.dependencies.database.models import Dataset, Notebook
 from DashAI.back.dependencies.registry import ComponentRegistry
 from DashAI.back.job.base_job import BaseJob, JobError
 
@@ -66,6 +66,7 @@ class DatasetJob(BaseJob):
         log.debug("Starting dataset creation process.")
 
         dataset_id = self.kwargs.get("dataset_id")
+        notebook_id = self.kwargs.get("notebook_id", None)
         params = self.kwargs.get("params", {})
         file_path = self.kwargs.get("file_path")
         temp_dir = self.kwargs.get("temp_dir")
@@ -81,8 +82,6 @@ class DatasetJob(BaseJob):
                 db.commit()
                 db.refresh(dataset)
 
-            parsed_params = parse_params(DatasetParams, json.dumps(params))
-            dataloader = component_registry[parsed_params.dataloader]["class"]()
             random_name = str(uuid.uuid4())
             folder_path = config["DATASETS_PATH"] / random_name
 
@@ -96,12 +95,34 @@ class DatasetJob(BaseJob):
                 ) from e
 
             try:
-                log.debug("Storing dataset in %s", folder_path)
-                new_dataset = dataloader.load_data(
-                    filepath_or_buffer=str(file_path) if file_path is not None else url,
-                    temp_path=str(temp_dir),
-                    params=parsed_params.model_dump(),
-                )
+                print("Notebook ID:", notebook_id)
+                if notebook_id is not None:
+                    log.debug(f"Copying dataset from notebook id {notebook_id}.")
+                    with session_factory() as db:
+                        notebook_dataset = (
+                            db.query(Notebook)
+                            .filter(Notebook.id == notebook_id)
+                            .first()
+                        )
+                        if not notebook_dataset:
+                            raise JobError(
+                                f"Notebook with ID {notebook_id} has no associated dataset."
+                            )
+                        new_dataset = load_dataset(
+                            os.path.join(notebook_dataset.file_path, "dataset")
+                        )
+
+                else:
+                    parsed_params = parse_params(DatasetParams, json.dumps(params))
+                    dataloader = component_registry[parsed_params.dataloader]["class"]()
+                    log.debug("Storing dataset in %s", folder_path)
+                    new_dataset = dataloader.load_data(
+                        filepath_or_buffer=(
+                            str(file_path) if file_path is not None else url
+                        ),
+                        temp_path=str(temp_dir),
+                        params=parsed_params.model_dump(),
+                    )
                 gc.collect()
                 dataset_save_path = folder_path / "dataset"
                 log.debug("Saving dataset in %s", str(dataset_save_path))

--- a/DashAI/front/src/api/job.ts
+++ b/DashAI/front/src/api/job.ts
@@ -23,25 +23,27 @@ export const enqueueRunnerJob = async (runId: number): Promise<object> => {
 
 export const enqueueDatasetJob = async (
   dataset_id: number,
-  file: File,
+  file: File | null,
   url: string,
   params: object,
+  notebook_id: number | null = null,
 ): Promise<object> => {
   const formData = new FormData();
   const kwargs = {
     dataset_id: dataset_id,
+    notebook_id: notebook_id,
     url: url,
     params: params,
   };
 
   formData.append("job_type", "DatasetJob");
   formData.append("kwargs", JSON.stringify(kwargs));
-  formData.append("file", file);
+  if (file) formData.append("file", file);
 
   const response = await api.post<object>("/v1/job/", formData, {
     headers: {
       "Content-Type": "multipart/form-data",
-      filename: encodeURIComponent(file.name),
+      filename: file ? encodeURIComponent(file.name) : "",
     },
   });
   return response.data;

--- a/DashAI/front/src/pages/datasets/Datasets.jsx
+++ b/DashAI/front/src/pages/datasets/Datasets.jsx
@@ -20,6 +20,8 @@ import {
   createDatasetFromNotebook,
   updateNotebook,
 } from "../../api/notebook";
+
+import { enqueueDatasetJob } from "../../api/job";
 import { useSnackbar } from "notistack";
 import { ExplorersAndConvertersProvider } from "../../components/notebooks/context/ExplorersAndConvertersContext";
 import { getDatasetStatus } from "../../utils/datasetStatus";
@@ -180,23 +182,51 @@ export default function DatasetsPage() {
     deleteNotebook(id);
   };
 
+  const checkDatasetReady = async (newDataset) => {
+    try {
+      const freshDatasets = await getDatasets();
+
+      const dataset = freshDatasets.find((d) => d.id === newDataset.id);
+      if (!dataset) {
+        console.error("Dataset not found in response:", newDataset.id);
+        return;
+      }
+
+      if (getDatasetStatus(dataset.status) === "Finished") {
+        // Get current datasets and enrich with preserved data
+        enqueueSnackbar("Dataset uploaded successfully!", {
+          variant: "success",
+        });
+        setDatasets((currentDatasets) => {
+          enrichDatasetsWithInfo(freshDatasets, currentDatasets).then(
+            setDatasets,
+          );
+          return currentDatasets;
+        });
+      } else if (getDatasetStatus(dataset.status) === "Error") {
+        console.error("Dataset creation failed:", dataset.error);
+        enqueueSnackbar("Dataset creation failed:", {
+          variant: "error",
+        });
+      } else {
+        timerId.current = setTimeout(checkDatasetReady, 1000);
+      }
+    } catch (error) {
+      console.error("Error checking dataset readiness:", error);
+    }
+  };
+
   const handleAddDatasetFromNotebook = async (name) => {
     if (selectedNotebook) {
       try {
         const data = await createDatasetFromNotebook(selectedNotebook.id, name);
+        console.log("Posting job for dataset:", data);
+        await enqueueDatasetJob(data.id, null, "", {}, selectedNotebook.id);
+        enqueueSnackbar("Dataset creation started", {
+          variant: "success",
+        });
 
-        if (data) {
-          enqueueSnackbar("Dataset created successfully", {
-            variant: "success",
-          });
-          const enrichedDatasets = await enrichDatasetsWithInfo(
-            [data],
-            datasets,
-          );
-          const enrichedNewDataset = enrichedDatasets[0];
-
-          setDatasets((prevDatasets) => [...prevDatasets, enrichedNewDataset]);
-        }
+        checkDatasetReady(data);
       } catch (error) {
         enqueueSnackbar("Failed to create dataset from notebook:", {
           variant: "error",
@@ -225,38 +255,7 @@ export default function DatasetsPage() {
     setSelectedNotebookId(null);
 
     // Check and wait for new dataset to be ready:
-    const checkDatasetReady = async () => {
-      try {
-        const freshDatasets = await getDatasets();
-
-        const dataset = freshDatasets.find((d) => d.id === newDataset.id);
-        if (!dataset) {
-          console.error("Dataset not found in response:", newDataset.id);
-          return;
-        }
-
-        if (getDatasetStatus(dataset.status) === "Finished") {
-          // Get current datasets and enrich with preserved data
-          setDatasets((currentDatasets) => {
-            enrichDatasetsWithInfo(freshDatasets, currentDatasets).then(
-              setDatasets,
-            );
-            return currentDatasets;
-          });
-        } else if (getDatasetStatus(dataset.status) === "Error") {
-          console.error("Dataset creation failed:", dataset.error);
-          enqueueSnackbar("Dataset creation failed:", {
-            variant: "error",
-          });
-        } else {
-          timerId.current = setTimeout(checkDatasetReady, 1000);
-        }
-      } catch (error) {
-        console.error("Error checking dataset readiness:", error);
-      }
-    };
-
-    checkDatasetReady();
+    checkDatasetReady(newDataset);
   };
 
   useEffect(() => {


### PR DESCRIPTION
This pull request refactors and improves the workflow for creating datasets from notebooks in DashAI. The main changes streamline the backend and frontend logic to support dataset creation from notebook files, add job queueing for dataset processing, and enhance user feedback during dataset creation. The changes are grouped below by backend and frontend improvements.

**Backend improvement:**

* Refactored the `create_dataset_from_notebook` endpoint in `notebook.py` to simplify dataset creation: removed copying of notebook files and dataset folder creation, and now creates a new `Dataset` entry with an empty `file_path`. The logic for processing and copying data is moved to the job handler.