### PR TITLE
Add nan remover converter

### DIFF
--- a/DashAI/back/converters/__init__.py
+++ b/DashAI/back/converters/__init__.py
@@ -63,3 +63,4 @@ from DashAI.back.converters.simple_converters.character_replacer import (
     CharacterReplacer,
 )
 from DashAI.back.converters.simple_converters.column_remover import ColumnRemover
+from DashAI.back.converters.simple_converters.nan_remover import NanRemover

--- a/DashAI/back/converters/simple_converters/nan_remover.py
+++ b/DashAI/back/converters/simple_converters/nan_remover.py
@@ -18,7 +18,11 @@ class NanRemover(BaseConverter):
     """
 
     SCHEMA = NanRemoverSchema
-    DESCRIPTION = "Removes the rows with NaN values from the dataset."
+    DESCRIPTION = (
+        "Removes the rows with NaN values from the dataset. "
+        "Keep in mind that this converter will also remove "
+        "columns not selected in the scope."
+    )
     SHORT_DESCRIPTION = "Removes the rows with NaN values from the dataset."
     DISPLAY_NAME = "NaN Remover"
 

--- a/DashAI/back/converters/simple_converters/nan_remover.py
+++ b/DashAI/back/converters/simple_converters/nan_remover.py
@@ -43,15 +43,18 @@ class NanRemover(BaseConverter):
         missing = [col for col in self.columns if col not in x.column_names]
         if missing:
             raise ValueError(
-                f"Cannot remove nan from columns that do not exist in the dataset: {missing}"
+                (
+                    "Cannot remove NaN from columns that do not exist "
+                    "in the dataset: {}"
+                ).format(missing)
             )
 
-        df = x.to_pandas()
-        mask = df[self.columns].notna().all(axis=1)
+        dataset = x.to_pandas()
+        mask = dataset[self.columns].notna().all(axis=1)
 
-        cleaned_df = df[mask]
+        cleaned_dataset = dataset[mask]
 
-        return to_dashai_dataset(cleaned_df)
+        return to_dashai_dataset(cleaned_dataset)
 
     def changes_row_count(self) -> bool:
         """

--- a/DashAI/back/converters/simple_converters/nan_remover.py
+++ b/DashAI/back/converters/simple_converters/nan_remover.py
@@ -1,0 +1,60 @@
+from DashAI.back.converters.base_converter import BaseConverter
+from DashAI.back.core.schema_fields.base_schema import BaseSchema
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    DashAIDataset,
+    to_dashai_dataset,
+)
+
+
+class NanRemoverSchema(BaseSchema):
+    pass
+
+
+class NanRemover(BaseConverter):
+    """
+    Converter that removes specified columns from the dataset.
+    This converter uses the scope columns defined in the converter job UI.
+    The columns selected in the scope will be the ones removed from the dataset.
+    """
+
+    SCHEMA = NanRemoverSchema
+    DESCRIPTION = "Removes the rows with NaN values from the dataset."
+    SHORT_DESCRIPTION = "Removes the rows with NaN values from the dataset."
+    DISPLAY_NAME = "NaN Remover"
+
+    def __init__(self):
+        super().__init__()
+        self.columns = []
+
+    def fit(self, x: DashAIDataset, y: DashAIDataset = None) -> "NanRemover":
+        """
+        Fit the NaN remover.
+
+        The columns to be affected are determined by the columns passed to x,
+        which are selected by scope in converter_job.
+        """
+        self.columns = x.column_names
+        return self
+
+    def transform(self, x: DashAIDataset, y: DashAIDataset = None) -> DashAIDataset:
+        """
+        Remove the nan rows from the columns selected in the scope.
+        """
+        missing = [col for col in self.columns if col not in x.column_names]
+        if missing:
+            raise ValueError(
+                f"Cannot remove nan from columns that do not exist in the dataset: {missing}"
+            )
+
+        df = x.to_pandas()
+        mask = df[self.columns].notna().all(axis=1)
+
+        cleaned_df = df[mask]
+
+        return to_dashai_dataset(cleaned_df)
+
+    def changes_row_count(self) -> bool:
+        """
+        Indicates that the converter changes the number of rows in the dataset.
+        """
+        return True

--- a/DashAI/back/converters/simple_converters/nan_remover.py
+++ b/DashAI/back/converters/simple_converters/nan_remover.py
@@ -12,9 +12,9 @@ class NanRemoverSchema(BaseSchema):
 
 class NanRemover(BaseConverter):
     """
-    Converter that removes specified columns from the dataset.
-    This converter uses the scope columns defined in the converter job UI.
-    The columns selected in the scope will be the ones removed from the dataset.
+    A converter that removes rows with NaN values from the dataset.
+    Only the columns selected in the scope are used to determine which
+    rows to drop; other columns are deleted entirely.
     """
 
     SCHEMA = NanRemoverSchema

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -553,7 +553,7 @@ def to_dashai_dataset(
         arrow_tbl = get_arrow_table(dataset)
         return DashAIDataset(arrow_tbl)
     if isinstance(dataset, DataFrame):
-        hf_dataset = Dataset.from_pandas(dataset)
+        hf_dataset = Dataset.from_pandas(dataset, preserve_index=False)
         arrow_tbl = get_arrow_table(hf_dataset)
         return DashAIDataset(arrow_tbl)
     if isinstance(dataset, DatasetDict) and len(dataset) == 1:

--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -17,6 +17,7 @@ from DashAI.back.converters import (
     MaxAbsScaler,
     MinMaxScaler,
     MissingIndicator,
+    NanRemover,
     Normalizer,
     Nystroem,
     OneHotEncoder,
@@ -204,6 +205,7 @@ def get_initial_components():
         ParallelCordinatesExplorer,
         # Converters
         ColumnRemover,
+        NanRemover,
         CharacterReplacer,
         FastICA,
         IncrementalPCA,


### PR DESCRIPTION
This pull request introduces a new converter to remove rows with NaN values from datasets and integrates it into the DashAI backend. The main changes include the implementation of the `NanRemover` converter, updates to the initial components list, and a minor fix in dataset conversion to ensure proper index handling.

**New Converter Implementation:**

* Added `NanRemover` class in `simple_converters/nan_remover.py`, which removes rows containing NaN values from specified columns in a dataset.