### PR TITLE
Unify notebook dataset creation under DatasetJob workflow

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/notebook.py
+++ b/DashAI/back/api/api_v1/endpoints/notebook.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Session, sessionmaker
 
 import DashAI.back.api.api_v1.schemas.datasets_params as dataset_params
 from DashAI.back.api.api_v1.schemas import notebook_params as schemas
-from DashAI.back.core.enums.status import DatasetStatus
 from DashAI.back.dependencies.database.models import (
     ConverterList,
     Dataset,

--- a/DashAI/back/api/api_v1/endpoints/notebook.py
+++ b/DashAI/back/api/api_v1/endpoints/notebook.py
@@ -9,7 +9,6 @@ from kink import di, inject
 from sqlalchemy import exc
 from sqlalchemy.orm import Session, sessionmaker
 
-import DashAI.back.api.api_v1.schemas.datasets_params as dataset_params
 from DashAI.back.api.api_v1.schemas import notebook_params as schemas
 from DashAI.back.dependencies.database.models import (
     ConverterList,
@@ -305,37 +304,6 @@ async def delete_notebook(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete directory",
         ) from e
-
-
-@router.post("/{notebook_id}/dataset", response_model=dataset_params.Dataset)
-async def create_dataset_from_notebook(
-    notebook_id: int,
-    params: dataset_params.DatasetUploadFromNotebookParams,
-    session_factory: sessionmaker = Depends(lambda: di["session_factory"]),
-):
-    with session_factory() as db:
-        try:
-            notebook = db.get(Notebook, notebook_id)
-            if not notebook:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Notebook not found",
-                )
-
-            new_dataset = Dataset(
-                name=params.name,
-                file_path="",
-            )
-            db.add(new_dataset)
-            db.commit()
-            db.refresh(new_dataset)
-            return new_dataset
-        except Exception as e:
-            log.error(f"Error creating dataset from notebook {notebook_id}: {e}")
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create dataset",
-            ) from e
 
 
 @router.patch("/{notebook_id}")

--- a/DashAI/back/api/api_v1/endpoints/notebook.py
+++ b/DashAI/back/api/api_v1/endpoints/notebook.py
@@ -313,40 +313,30 @@ async def create_dataset_from_notebook(
     notebook_id: int,
     params: dataset_params.DatasetUploadFromNotebookParams,
     session_factory: sessionmaker = Depends(lambda: di["session_factory"]),
-    config: dict = Depends(lambda: di["config"]),
 ):
     with session_factory() as db:
         try:
             notebook = db.get(Notebook, notebook_id)
             if not notebook:
                 raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found"
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Notebook not found",
                 )
-            dataset_folder = notebook.file_path
-            random_name = uuid.uuid4().hex[:8]
-            new_folder_path = os.path.join(
-                config["DATASETS_PATH"],
-                random_name,
-            )
-            os.makedirs(new_folder_path, exist_ok=True)
-            shutil.copytree(dataset_folder, new_folder_path, dirs_exist_ok=True)
 
-            dataset = Dataset(
+            new_dataset = Dataset(
                 name=params.name,
-                file_path=new_folder_path,
-                status=DatasetStatus.FINISHED,
+                file_path="",
             )
-            db.add(dataset)
+            db.add(new_dataset)
             db.commit()
-            db.refresh(dataset)
+            db.refresh(new_dataset)
+            return new_dataset
         except Exception as e:
             log.error(f"Error creating dataset from notebook {notebook_id}: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to create dataset",
             ) from e
-
-    return dataset
 
 
 @router.patch("/{notebook_id}")

--- a/DashAI/back/api/api_v1/schemas/datasets_params.py
+++ b/DashAI/back/api/api_v1/schemas/datasets_params.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, Union
+from typing import Dict, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -41,4 +41,4 @@ class Dataset(BaseModel):
 
 class DatasetCreateParams(BaseModel):
     name: str
-    notebook_id: Union[int, None] = None
+    notebook_id: Optional[int] = None

--- a/DashAI/back/api/api_v1/schemas/datasets_params.py
+++ b/DashAI/back/api/api_v1/schemas/datasets_params.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Union
 
 from pydantic import BaseModel, ConfigDict
 
@@ -41,4 +41,4 @@ class Dataset(BaseModel):
 
 class DatasetCreateParams(BaseModel):
     name: str
-    notebook_id: int = None
+    notebook_id: Union[int, None] = None

--- a/DashAI/back/api/api_v1/schemas/datasets_params.py
+++ b/DashAI/back/api/api_v1/schemas/datasets_params.py
@@ -41,3 +41,4 @@ class Dataset(BaseModel):
 
 class DatasetCreateParams(BaseModel):
     name: str
+    notebook_id: int = None

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -105,9 +105,12 @@ class DatasetJob(BaseJob):
                             .first()
                         )
                         if not notebook_dataset:
-                            raise JobError(
-                                f"Notebook with ID {notebook_id} has no associated dataset."
+                            msg = (
+                                "Notebook with ID "
+                                f"{notebook_id}"
+                                " has no associated dataset."
                             )
+                            raise JobError(msg)
                         new_dataset = load_dataset(
                             os.path.join(notebook_dataset.file_path, "dataset")
                         )

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -95,7 +95,6 @@ class DatasetJob(BaseJob):
                 ) from e
 
             try:
-                print("Notebook ID:", notebook_id)
                 if notebook_id is not None:
                     log.debug(f"Copying dataset from notebook id {notebook_id}.")
                     with session_factory() as db:

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -12,8 +12,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from DashAI.back.api.api_v1.schemas.datasets_params import DatasetParams
 from DashAI.back.api.utils import parse_params
-from DashAI.back.dataloaders.classes.dashai_dataset import save_dataset
-from DashAI.back.dependencies.database.models import Dataset
+from DashAI.back.dataloaders.classes.dashai_dataset import load_dataset, save_dataset
+from DashAI.back.dependencies.database.models import Dataset, Notebook
 from DashAI.back.dependencies.registry import ComponentRegistry
 from DashAI.back.job.base_job import BaseJob, JobError
 
@@ -66,6 +66,7 @@ class DatasetJob(BaseJob):
         log.debug("Starting dataset creation process.")
 
         dataset_id = self.kwargs.get("dataset_id")
+        notebook_id = self.kwargs.get("notebook_id", None)
         params = self.kwargs.get("params", {})
         file_path = self.kwargs.get("file_path")
         temp_dir = self.kwargs.get("temp_dir")
@@ -81,8 +82,6 @@ class DatasetJob(BaseJob):
                 db.commit()
                 db.refresh(dataset)
 
-            parsed_params = parse_params(DatasetParams, json.dumps(params))
-            dataloader = component_registry[parsed_params.dataloader]["class"]()
             random_name = str(uuid.uuid4())
             folder_path = config["DATASETS_PATH"] / random_name
 
@@ -96,12 +95,34 @@ class DatasetJob(BaseJob):
                 ) from e
 
             try:
-                log.debug("Storing dataset in %s", folder_path)
-                new_dataset = dataloader.load_data(
-                    filepath_or_buffer=str(file_path) if file_path is not None else url,
-                    temp_path=str(temp_dir),
-                    params=parsed_params.model_dump(),
-                )
+                print("Notebook ID:", notebook_id)
+                if notebook_id is not None:
+                    log.debug(f"Copying dataset from notebook id {notebook_id}.")
+                    with session_factory() as db:
+                        notebook_dataset = (
+                            db.query(Notebook)
+                            .filter(Notebook.id == notebook_id)
+                            .first()
+                        )
+                        if not notebook_dataset:
+                            raise JobError(
+                                f"Notebook with ID {notebook_id} has no associated dataset."
+                            )
+                        new_dataset = load_dataset(
+                            os.path.join(notebook_dataset.file_path, "dataset")
+                        )
+
+                else:
+                    parsed_params = parse_params(DatasetParams, json.dumps(params))
+                    dataloader = component_registry[parsed_params.dataloader]["class"]()
+                    log.debug("Storing dataset in %s", folder_path)
+                    new_dataset = dataloader.load_data(
+                        filepath_or_buffer=(
+                            str(file_path) if file_path is not None else url
+                        ),
+                        temp_path=str(temp_dir),
+                        params=parsed_params.model_dump(),
+                    )
                 gc.collect()
                 dataset_save_path = folder_path / "dataset"
                 log.debug("Saving dataset in %s", str(dataset_save_path))

--- a/DashAI/front/src/api/job.ts
+++ b/DashAI/front/src/api/job.ts
@@ -23,25 +23,27 @@ export const enqueueRunnerJob = async (runId: number): Promise<object> => {
 
 export const enqueueDatasetJob = async (
   dataset_id: number,
-  file: File,
+  file: File | null,
   url: string,
   params: object,
+  notebook_id: number | null = null,
 ): Promise<object> => {
   const formData = new FormData();
   const kwargs = {
     dataset_id: dataset_id,
+    notebook_id: notebook_id,
     url: url,
     params: params,
   };
 
   formData.append("job_type", "DatasetJob");
   formData.append("kwargs", JSON.stringify(kwargs));
-  formData.append("file", file);
+  if (file) formData.append("file", file);
 
   const response = await api.post<object>("/v1/job/", formData, {
     headers: {
       "Content-Type": "multipart/form-data",
-      filename: encodeURIComponent(file.name),
+      filename: file ? encodeURIComponent(file.name) : "",
     },
   });
   return response.data;

--- a/DashAI/front/src/api/notebook.ts
+++ b/DashAI/front/src/api/notebook.ts
@@ -43,17 +43,6 @@ export const deleteNotebook = async (id: number): Promise<void> => {
   await api.delete(`${notebookEndpoint}/${id}`);
 };
 
-export const createDatasetFromNotebook = async (
-  notebookId: string,
-  name: string,
-): Promise<IDataset> => {
-  const response = await api.post(`${notebookEndpoint}/${notebookId}/dataset`, {
-    name: name,
-  });
-
-  return response.data;
-};
-
 export const updateNotebook = async (
   id: number,
   formData: object,

--- a/DashAI/front/src/pages/datasets/Datasets.jsx
+++ b/DashAI/front/src/pages/datasets/Datasets.jsx
@@ -182,6 +182,8 @@ export default function DatasetsPage() {
     deleteNotebook(id);
   };
 
+  const timerId = useRef(null);
+
   const checkDatasetReady = async (newDataset) => {
     try {
       const freshDatasets = await getDatasets();
@@ -209,7 +211,7 @@ export default function DatasetsPage() {
           variant: "error",
         });
       } else {
-        timerId.current = setTimeout(checkDatasetReady, 1000);
+        timerId.current = setTimeout(checkDatasetReady, 1000, newDataset);
       }
     } catch (error) {
       console.error("Error checking dataset readiness:", error);
@@ -220,11 +222,10 @@ export default function DatasetsPage() {
     if (selectedNotebook) {
       try {
         const data = await createDataset(name);
-        console.log("Posting job for dataset:", data);
-        await enqueueDatasetJob(data.id, null, "", {}, selectedNotebook.id);
         enqueueSnackbar("Dataset creation started", {
           variant: "success",
         });
+        await enqueueDatasetJob(data.id, null, "", {}, selectedNotebook.id);
 
         checkDatasetReady(data);
       } catch (error) {
@@ -244,9 +245,8 @@ export default function DatasetsPage() {
     setSelectedDatasetId(null);
   };
 
-  const timerId = useRef(null);
-
   const handleDatasetCreated = async (newDataset) => {
+    console.log("New dataset created:", newDataset);
     setDatasets((prevDatasets) => [...prevDatasets, newDataset]);
     setSelectedDatasetId(newDataset.id);
 

--- a/DashAI/front/src/pages/datasets/Datasets.jsx
+++ b/DashAI/front/src/pages/datasets/Datasets.jsx
@@ -20,6 +20,8 @@ import {
   createDatasetFromNotebook,
   updateNotebook,
 } from "../../api/notebook";
+
+import { enqueueDatasetJob } from "../../api/job";
 import { useSnackbar } from "notistack";
 import { ExplorersAndConvertersProvider } from "../../components/notebooks/context/ExplorersAndConvertersContext";
 import { getDatasetStatus } from "../../utils/datasetStatus";
@@ -180,23 +182,51 @@ export default function DatasetsPage() {
     deleteNotebook(id);
   };
 
+  const checkDatasetReady = async (newDataset) => {
+    try {
+      const freshDatasets = await getDatasets();
+
+      const dataset = freshDatasets.find((d) => d.id === newDataset.id);
+      if (!dataset) {
+        console.error("Dataset not found in response:", newDataset.id);
+        return;
+      }
+
+      if (getDatasetStatus(dataset.status) === "Finished") {
+        // Get current datasets and enrich with preserved data
+        enqueueSnackbar("Dataset uploaded successfully!", {
+          variant: "success",
+        });
+        setDatasets((currentDatasets) => {
+          enrichDatasetsWithInfo(freshDatasets, currentDatasets).then(
+            setDatasets,
+          );
+          return currentDatasets;
+        });
+      } else if (getDatasetStatus(dataset.status) === "Error") {
+        console.error("Dataset creation failed:", dataset.error);
+        enqueueSnackbar("Dataset creation failed:", {
+          variant: "error",
+        });
+      } else {
+        timerId.current = setTimeout(checkDatasetReady, 1000);
+      }
+    } catch (error) {
+      console.error("Error checking dataset readiness:", error);
+    }
+  };
+
   const handleAddDatasetFromNotebook = async (name) => {
     if (selectedNotebook) {
       try {
         const data = await createDatasetFromNotebook(selectedNotebook.id, name);
+        console.log("Posting job for dataset:", data);
+        await enqueueDatasetJob(data.id, null, "", {}, selectedNotebook.id);
+        enqueueSnackbar("Dataset creation started", {
+          variant: "success",
+        });
 
-        if (data) {
-          enqueueSnackbar("Dataset created successfully", {
-            variant: "success",
-          });
-          const enrichedDatasets = await enrichDatasetsWithInfo(
-            [data],
-            datasets,
-          );
-          const enrichedNewDataset = enrichedDatasets[0];
-
-          setDatasets((prevDatasets) => [...prevDatasets, enrichedNewDataset]);
-        }
+        checkDatasetReady(data);
       } catch (error) {
         enqueueSnackbar("Failed to create dataset from notebook:", {
           variant: "error",
@@ -225,38 +255,7 @@ export default function DatasetsPage() {
     setSelectedNotebookId(null);
 
     // Check and wait for new dataset to be ready:
-    const checkDatasetReady = async () => {
-      try {
-        const freshDatasets = await getDatasets();
-
-        const dataset = freshDatasets.find((d) => d.id === newDataset.id);
-        if (!dataset) {
-          console.error("Dataset not found in response:", newDataset.id);
-          return;
-        }
-
-        if (getDatasetStatus(dataset.status) === "Finished") {
-          // Get current datasets and enrich with preserved data
-          setDatasets((currentDatasets) => {
-            enrichDatasetsWithInfo(freshDatasets, currentDatasets).then(
-              setDatasets,
-            );
-            return currentDatasets;
-          });
-        } else if (getDatasetStatus(dataset.status) === "Error") {
-          console.error("Dataset creation failed:", dataset.error);
-          enqueueSnackbar("Dataset creation failed:", {
-            variant: "error",
-          });
-        } else {
-          timerId.current = setTimeout(checkDatasetReady, 1000);
-        }
-      } catch (error) {
-        console.error("Error checking dataset readiness:", error);
-      }
-    };
-
-    checkDatasetReady();
+    checkDatasetReady(newDataset);
   };
 
   useEffect(() => {

--- a/DashAI/front/src/pages/datasets/Datasets.jsx
+++ b/DashAI/front/src/pages/datasets/Datasets.jsx
@@ -246,7 +246,6 @@ export default function DatasetsPage() {
   };
 
   const handleDatasetCreated = async (newDataset) => {
-    console.log("New dataset created:", newDataset);
     setDatasets((prevDatasets) => [...prevDatasets, newDataset]);
     setSelectedDatasetId(newDataset.id);
 

--- a/DashAI/front/src/pages/datasets/Datasets.jsx
+++ b/DashAI/front/src/pages/datasets/Datasets.jsx
@@ -13,11 +13,11 @@ import {
   deleteDataset,
   getDatasetInfo,
   updateDataset,
+  createDataset,
 } from "../../api/datasets";
 import {
   getNotebooks,
   deleteNotebook,
-  createDatasetFromNotebook,
   updateNotebook,
 } from "../../api/notebook";
 
@@ -219,7 +219,7 @@ export default function DatasetsPage() {
   const handleAddDatasetFromNotebook = async (name) => {
     if (selectedNotebook) {
       try {
-        const data = await createDatasetFromNotebook(selectedNotebook.id, name);
+        const data = await createDataset(name);
         console.log("Posting job for dataset:", data);
         await enqueueDatasetJob(data.id, null, "", {}, selectedNotebook.id);
         enqueueSnackbar("Dataset creation started", {


### PR DESCRIPTION
This pull request refactors and streamlines the process for creating a dataset from a notebook in DashAI. The main changes include removing the old API endpoint for dataset creation from notebooks, updating the job logic to support notebook-based dataset creation, and modifying the frontend to use the new workflow. These updates improve maintainability and unify dataset creation under the job system.

**Backend API and Job System Updates:**

* Removed the `/notebook/{notebook_id}/dataset` API endpoint and its associated logic for creating datasets directly from notebooks, shifting this functionality to the job system. [[1]](diffhunk://#diff-a3509b2f4f0ab2ec84684ef8440b23d31ac906ab8bfb0608f45269ada13ef436L311-L351) [[2]](diffhunk://#diff-efadff2b56e49f0d47a7a0f177e9ee048fb65bcd90954928bef93dd9688c58daL46-L56)
* Enhanced the dataset job (`DatasetJob`) to support an optional `notebook_id` parameter. If provided, the job loads the dataset from the notebook's file path instead of using a dataloader. [[1]](diffhunk://#diff-c87cb49194c7b089768cf4a88739476ba8ddbe3188f6c8214152462dc96d91c6R69) [[2]](diffhunk://#diff-c87cb49194c7b089768cf4a88739476ba8ddbe3188f6c8214152462dc96d91c6R98-R125)
* Updated the dataset job API to accept a `notebook_id` and handle cases where the file input may be null, supporting notebook-based dataset creation.

**Frontend Workflow and API Usage:**

* Refactored the frontend to remove direct calls to the old notebook dataset creation API, and now uses the dataset creation job with the `notebook_id` parameter. [[1]](diffhunk://#diff-b282719b20b0f77801d27c2295f1dce9d7bd1582581b4b205c94415742f80d2cR16-R24) [[2]](diffhunk://#diff-b282719b20b0f77801d27c2295f1dce9d7bd1582581b4b205c94415742f80d2cL183-R229)
* Improved the dataset readiness polling logic to work with the new job-based workflow, ensuring the UI updates appropriately as the dataset is processed.
