### PR TITLE
Fix dataset name duplication crash and improve validation error handling

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -12,7 +12,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 from kink import di, inject
-from sqlalchemy import exc
+from sqlalchemy import exc, select
 from sqlalchemy.orm.session import sessionmaker
 
 from DashAI.back.api.api_v1.schemas import datasets_params as schemas
@@ -621,19 +621,44 @@ async def update_dataset(
         A dictionary containing the updated dataset record.
     """
     with session_factory() as db:
+        dataset = db.get(Dataset, dataset_id)
+        if dataset is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
+            )
+
+        if not params.name or params.name.strip() == dataset.name:
+            return dataset
+
+        new_name = params.name.strip()
+        if not new_name:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Name cannot be empty",
+            )
+
+        exists = db.execute(
+            select(Dataset.id).where(Dataset.name == new_name, Dataset.id != dataset_id)
+        ).scalar()
+        if exists:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Dataset name already exists",
+            )
+
+        dataset.name = new_name
         try:
-            dataset = db.get(Dataset, dataset_id)
-            if params.name and params.name != dataset.name:
-                setattr(dataset, "name", params.name)
-                db.commit()
-                db.refresh(dataset)
-                return dataset
-            else:
-                raise HTTPException(
-                    status_code=status.HTTP_304_NOT_MODIFIED,
-                    detail="Record not modified",
-                )
+            db.commit()
+            db.refresh(dataset)
+            return dataset
+        except exc.IntegrityError as e:
+            db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Dataset name already exists",
+            ) from e
         except exc.SQLAlchemyError as e:
+            db.rollback()
             logger.exception(e)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -627,15 +627,16 @@ async def update_dataset(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
             )
 
-        if not params.name or params.name.strip() == dataset.name:
-            return dataset
-
-        new_name = params.name.strip()
-        if not new_name:
+        if not params.name or not params.name.strip():
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="Name cannot be empty",
             )
+
+        new_name = params.name.strip()
+
+        if new_name == dataset.name:
+            return dataset
 
         exists = db.execute(
             select(Dataset.id).where(Dataset.name == new_name, Dataset.id != dataset_id)

--- a/DashAI/back/api/api_v1/endpoints/notebook.py
+++ b/DashAI/back/api/api_v1/endpoints/notebook.py
@@ -376,27 +376,34 @@ async def update_notebook(
         A dictionary containing the updated dataset record.
     """
     with session_factory() as db:
-        try:
-            notebook = db.get(Notebook, notebook_id)
-            if not notebook:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Notebook not found",
-                )
-            if not params.name or params.name == notebook.name:
-                raise HTTPException(
-                    status_code=status.HTTP_304_NOT_MODIFIED,
-                    detail="No fields to update",
-                )
+        notebook = db.get(Notebook, notebook_id)
+        if not notebook:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Notebook not found",
+            )
 
-            setattr(notebook, "name", params.name)
+        if not params.name or not params.name.strip():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Name cannot be empty",
+            )
+
+        new_name = params.name.strip()
+
+        if new_name == notebook.name:
+            return notebook
+
+        notebook.name = new_name
+        try:
             db.commit()
             db.refresh(notebook)
-        except Exception as e:
-            log.error(f"Error updating notebook {notebook_id}: {e}")
+        except exc.SQLAlchemyError as e:
+            db.rollback()
+            log.error(f"Database error updating notebook {notebook_id}: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to update notebook",
+                detail="Internal database error",
             ) from e
 
     return notebook

--- a/DashAI/front/src/components/threeSectionLayout/ItemBox.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/ItemBox.jsx
@@ -26,12 +26,17 @@ export default function ItemBox({
     setIsEditing(true);
   };
 
-  const handleKeyDown = (e) => {
+  const handleKeyDown = async (e) => {
     if (e.key === "Enter") {
-      setIsEditing(false);
       if (editedName.trim() !== name && editedName.trim() !== "") {
-        onEdit(editedName);
+        try {
+          await onEdit(editedName.trim());
+          setIsEditing(false);
+        } catch (error) {
+          setEditedName(name);
+        }
       } else {
+        setIsEditing(false);
         setEditedName(name);
       }
     }
@@ -41,7 +46,7 @@ export default function ItemBox({
     }
   };
 
-  const handleBlur = (e) => {
+  const handleBlur = async (e) => {
     const next = e.relatedTarget;
 
     if (
@@ -51,8 +56,18 @@ export default function ItemBox({
       return;
     }
 
-    setIsEditing(false);
-    setEditedName(name);
+    if (editedName.trim() !== name && editedName.trim() !== "") {
+      try {
+        await onEdit(editedName.trim());
+        setIsEditing(false);
+      } catch (error) {
+        setEditedName(name);
+        setIsEditing(false);
+      }
+    } else {
+      setIsEditing(false);
+      setEditedName(name);
+    }
   };
 
   return (

--- a/DashAI/front/src/components/threeSectionLayout/ItemBox.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/ItemBox.jsx
@@ -28,12 +28,13 @@ export default function ItemBox({
 
   const handleKeyDown = async (e) => {
     if (e.key === "Enter") {
-      if (editedName.trim() !== name && editedName.trim() !== "") {
+      if (editedName.trim() !== name) {
         try {
           await onEdit(editedName.trim());
           setIsEditing(false);
         } catch (error) {
           setEditedName(name);
+          setIsEditing(false);
         }
       } else {
         setIsEditing(false);
@@ -56,11 +57,12 @@ export default function ItemBox({
       return;
     }
 
-    if (editedName.trim() !== name && editedName.trim() !== "") {
+    if (editedName.trim() !== name) {
       try {
         await onEdit(editedName.trim());
         setIsEditing(false);
       } catch (error) {
+        // If edit fails, restore original name and exit editing mode
         setEditedName(name);
         setIsEditing(false);
       }

--- a/DashAI/front/src/pages/datasets/Datasets.jsx
+++ b/DashAI/front/src/pages/datasets/Datasets.jsx
@@ -269,33 +269,65 @@ export default function DatasetsPage() {
 
   const handleEditDataset = async (id, newName) => {
     try {
-      updateDataset(id, { name: newName }).then(async (updatedDataset) => {
-        setDatasets((prevDatasets) =>
-          prevDatasets.map((dataset) =>
-            dataset.id === id
-              ? { ...dataset, name: updatedDataset.name }
-              : dataset,
-          ),
-        );
+      const updatedDataset = await updateDataset(id, { name: newName });
+      setDatasets((prevDatasets) =>
+        prevDatasets.map((dataset) =>
+          dataset.id === id
+            ? { ...dataset, name: updatedDataset.name }
+            : dataset,
+        ),
+      );
+      enqueueSnackbar("Dataset updated successfully", {
+        variant: "success",
       });
     } catch (error) {
       console.error("Failed to update dataset:", error);
+      if (error.response?.status === 409) {
+        enqueueSnackbar("A dataset with this name already exists", {
+          variant: "error",
+        });
+      } else if (error.response?.status === 422) {
+        enqueueSnackbar("Dataset name cannot be empty", {
+          variant: "error",
+        });
+      } else {
+        enqueueSnackbar("Failed to update dataset", {
+          variant: "error",
+        });
+      }
+      throw error;
     }
   };
 
   const handleEditNotebook = async (id, newName) => {
     try {
-      await updateNotebook(id, { name: newName }).then((updatedNotebook) => {
-        setNotebooks((prevNotebooks) =>
-          prevNotebooks.map((notebook) =>
-            notebook.id === id
-              ? { ...notebook, name: updatedNotebook.name }
-              : notebook,
-          ),
-        );
+      const updatedNotebook = await updateNotebook(id, { name: newName });
+      setNotebooks((prevNotebooks) =>
+        prevNotebooks.map((notebook) =>
+          notebook.id === id
+            ? { ...notebook, name: updatedNotebook.name }
+            : notebook,
+        ),
+      );
+      enqueueSnackbar("Notebook updated successfully", {
+        variant: "success",
       });
     } catch (error) {
       console.error("Failed to update notebook:", error);
+      if (error.response?.status === 422) {
+        enqueueSnackbar("Notebook name cannot be empty", {
+          variant: "error",
+        });
+      } else if (error.response?.status === 304) {
+        enqueueSnackbar("No changes were made", {
+          variant: "info",
+        });
+      } else {
+        enqueueSnackbar("Failed to update notebook", {
+          variant: "error",
+        });
+      }
+      throw error;
     }
   };
 


### PR DESCRIPTION
# Summary

Fixed critical application crash when users attempted to edit dataset names with duplicate values. The issue was caused by improper validation logic ordering in backend endpoints and inadequate error handling in frontend components. This PR resolves the crash, improves validation consistency between datasets and notebooks, and provides clear error messages to users.

## Type of change

- Bug fix.

## Changes

- **Fixed app crash on duplicate dataset names**: Reordered validation logic in backend to properly handle duplicate name detection before database operations
- **Improved empty name validation**: Fixed validation logic that was incorrectly allowing empty names to pass through initial checks  
- **Enhanced error handling consistency**: Replaced generic 500 errors in notebook endpoints with specific HTTP status codes (422 for validation errors)
- **Strengthened frontend error handling**: Improved async/await error propagation in ItemBox component and added specific error messages for different validation scenarios
- **Standardized validation flow**: Applied consistent validation logic across both dataset and notebook endpoints (datasets require unique names, notebooks allow duplicates but both reject empty names)

## How to Test

1. **Test duplicate dataset name validation:**
   - Navigate to datasets page
   - Try to edit a dataset name to match an existing dataset name
   - Verify: Should show "A dataset with this name already exists" error instead of crashing

2. **Test empty name validation:**
   - Try to edit a dataset or notebook name to be completely empty
   - Verify: Should show "Name cannot be empty" error message

3. **Test notebook name editing:**
   - Edit notebook names (including duplicates - should be allowed)
   - Verify: No 500 errors, proper validation messages for empty names

4. **Test UI state consistency:**
   - When validation fails, verify the original name is restored and editing mode exits properly
   - Check that no UI inconsistencies occur during failed edit
...

## Screenshots

<!--
In the case of modifying a view in the front-end, include screenshots with the changes.
Optional, delete this section if not needed.-->
...

## Notes

<!--
Include any additional information that would be useful to the reviewer.
Optional, delete this section if not needed.
-->
...
