### PR TITLE
Display dataset name instead of ID in experiments table

### DIFF
--- a/DashAI/front/src/components/experiments/ExperimentsTable.jsx
+++ b/DashAI/front/src/components/experiments/ExperimentsTable.jsx
@@ -26,6 +26,10 @@ function ExperimentsTable({
   const { enqueueSnackbar } = useSnackbar();
   const [expRunning, setExpRunning] = useState({});
 
+  const datasetMap = React.useMemo(() => {
+    return new Map(datasets.map((dataset) => [dataset.id, dataset.name]));
+  }, [datasets]);
+
   const deleteExperiment = async (id) => {
     try {
       await deleteExperimentRequest(id);
@@ -77,8 +81,8 @@ function ExperimentsTable({
         minWidth: 200,
         editable: false,
         valueFormatter: (params) => {
-          const dataset = datasets.find((d) => d.id === params.value);
-          return dataset ? dataset.name : `Dataset ID: ${params.value}`;
+          const datasetName = datasetMap.get(params.value);
+          return datasetName || `Dataset ID: ${params.value}`;
         },
       },
       {
@@ -115,7 +119,7 @@ function ExperimentsTable({
         ],
       },
     ],
-    [handleDeleteExperiment, datasets],
+    [handleDeleteExperiment, datasetMap],
   );
 
   return (

--- a/DashAI/front/src/components/experiments/ExperimentsTable.jsx
+++ b/DashAI/front/src/components/experiments/ExperimentsTable.jsx
@@ -19,6 +19,7 @@ import DeleteItemModal from "../custom/DeleteItemModal";
 function ExperimentsTable({
   handleOpenNewExperimentModal,
   experiments = [],
+  datasets = [],
   loading = false,
   onUpdateExperiments,
 }) {
@@ -75,6 +76,10 @@ function ExperimentsTable({
         headerName: "Dataset",
         minWidth: 200,
         editable: false,
+        valueFormatter: (params) => {
+          const dataset = datasets.find((d) => d.id === params.value);
+          return dataset ? dataset.name : `Dataset ID: ${params.value}`;
+        },
       },
       {
         field: "created",
@@ -110,7 +115,7 @@ function ExperimentsTable({
         ],
       },
     ],
-    [handleDeleteExperiment],
+    [handleDeleteExperiment, datasets],
   );
 
   return (
@@ -181,6 +186,7 @@ ExperimentsTable.propTypes = {
   updateTableFlag: PropTypes.bool,
   setUpdateTableFlag: PropTypes.func,
   experiments: PropTypes.array,
+  datasets: PropTypes.array,
   loading: PropTypes.bool,
   onUpdateExperiments: PropTypes.func.isRequired,
 };

--- a/DashAI/front/src/pages/experiments/Experiments.jsx
+++ b/DashAI/front/src/pages/experiments/Experiments.jsx
@@ -21,7 +21,7 @@ function ExperimentsPage() {
       const experimentsData = await getExperimentsRequest();
       setExperiments(experimentsData);
     } catch (error) {
-      enqueueSnackbar("Error while trying to obtain experiments.");
+      enqueueSnackbar("Error while trying to get experiments.");
       console.error(error);
     } finally {
       setLoading(false);
@@ -33,7 +33,7 @@ function ExperimentsPage() {
       const datasetsData = await getDatasets();
       setDatasets(datasetsData);
     } catch (error) {
-      enqueueSnackbar("Error while trying to obtain datasets.");
+      enqueueSnackbar("Error while trying to get datasets.");
       console.error(error);
     }
   };

--- a/DashAI/front/src/pages/experiments/Experiments.jsx
+++ b/DashAI/front/src/pages/experiments/Experiments.jsx
@@ -5,11 +5,13 @@ import NewExperimentModal from "../../components/experiments/NewExperimentModal"
 import ExperimentsTable from "../../components/experiments/ExperimentsTable";
 import CustomLayout from "../../components/custom/CustomLayout";
 import { getExperiments as getExperimentsRequest } from "../../api/experiment";
+import { getDatasets } from "../../api/datasets";
 
 function ExperimentsPage() {
   const [showNewExperimentModal, setShowNewExperimentModal] = useState(false);
   const [updateTableFlag, setUpdateTableFlag] = useState(false);
   const [experiments, setExperiments] = useState([]);
+  const [datasets, setDatasets] = useState([]);
   const [loading, setLoading] = useState(true);
   const { enqueueSnackbar } = useSnackbar();
 
@@ -26,8 +28,19 @@ function ExperimentsPage() {
     }
   };
 
+  const fetchDatasets = async () => {
+    try {
+      const datasetsData = await getDatasets();
+      setDatasets(datasetsData);
+    } catch (error) {
+      enqueueSnackbar("Error while trying to obtain datasets.");
+      console.error(error);
+    }
+  };
+
   useEffect(() => {
     getExperiments();
+    fetchDatasets();
   }, []);
 
   // Update experiments when table is updated
@@ -57,6 +70,7 @@ function ExperimentsPage() {
         updateTableFlag={updateTableFlag}
         setUpdateTableFlag={setUpdateTableFlag}
         experiments={experiments}
+        datasets={datasets}
         loading={loading}
         onUpdateExperiments={getExperiments}
       />


### PR DESCRIPTION
# Summary

Improved user experience in the experiments table by displaying readable dataset names instead of numeric IDs. This enhancement makes it easier for users to identify which dataset is associated with each experiment without needing to memorize or cross-reference ID numbers.

## Type of change

- Frontend fix.

## Changes

- **Enhanced experiments table display**: Modified the dataset column to show dataset names instead of IDs using a valueFormatter that maps IDs to their corresponding names
- **Added dataset data integration**: Implemented dataset fetching in the Experiments page to provide the necessary data for name mapping
- **Improved data flow**: Added datasets as a prop to ExperimentsTable component with proper PropTypes validation
- **Robust fallback handling**: Added fallback display for cases where dataset lookup fails, showing descriptive text with the ID

## How to Test

1. **Navigate to experiments page**:
   - Go to the experiments section of the application
   - Verify that the experiments table loads correctly

2. **Verify dataset name display**:
   - Check that the "Dataset" column shows readable names (e.g., "Customer Analysis", "Sales Data") instead of numeric IDs
   - Confirm that all experiments show their associated dataset names properly

3. **Test fallback behavior**:
   - If possible, create a scenario where a dataset ID doesn't have a corresponding name
   - Verify that it displays "Dataset ID: [number]" as fallback
   
## Screenshots

...

## Notes

...