### PR TITLE
Add NaN detection and user warnings for experiment creation

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -150,7 +150,8 @@ class DashAIDataset(Dataset):
 
         Returns
         -------
-        None
+        DashAIDataset
+            The dataset with the updated metadata.
         """
         dataset_df = self.to_pandas()
         # Calculate the number of NaN values per column

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -152,9 +152,9 @@ class DashAIDataset(Dataset):
         -------
         None
         """
-        df = self.to_pandas()
+        dataset_df = self.to_pandas()
         # Calculate the number of NaN values per column
-        nan_count = df.isna().sum().to_dict()
+        nan_count = dataset_df.isna().sum().to_dict()
         self.splits.update({"nan": nan_count})
 
         return self

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -140,6 +140,25 @@ class DashAIDataset(Dataset):
         dataset = self.cast(new_features)
         return dataset
 
+    def nan_per_column(self) -> "DashAIDataset":
+        """Calculate the number of NaN values per column in the dataset and
+        add it to the metadata under the 'nan' key.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        df = self.to_pandas()
+        # Calculate the number of NaN values per column
+        nan_count = df.isna().sum().to_dict()
+        self.splits.update({"nan": nan_count})
+
+        return self
+
     @beartype
     def remove_columns(self, column_names: Union[str, List[str]]) -> "DashAIDataset":
         """Remove one or several column(s) in the dataset and the features
@@ -790,6 +809,7 @@ def get_dataset_info(dataset_path: str) -> object:
         "total_rows": total_rows,
         "total_columns": len(column_names),
         "column_names": column_names,
+        "nan": splits_data.get("nan", {}),
         "train_size": len(train_indices),
         "test_size": len(test_indices),
         "val_size": len(val_indices),

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -102,7 +102,10 @@ class DatasetJob(BaseJob):
                     temp_path=str(temp_dir),
                     params=parsed_params.model_dump(),
                 )
+                # Calculate nan per column
+                new_dataset.nan_per_column()
                 gc.collect()
+
                 dataset_save_path = folder_path / "dataset"
                 log.debug("Saving dataset in %s", str(dataset_save_path))
                 save_dataset(new_dataset, dataset_save_path)

--- a/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
+++ b/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
@@ -367,6 +367,29 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
           </Grid>
         </Grid>
       </Alert>
+      {!infoLoading ? (
+        Object.values(datasetInfo.nan).some((v) => v > 0) &&
+        Object.values(datasetInfo.nan).length !== 0 ? (
+          <Alert severity="warning" sx={{ mb: 1 }}>
+            <AlertTitle>
+              The dataset contains missing values (NaN) in the columns:
+            </AlertTitle>
+            <Grid container spacing={2}>
+              {Object.entries(datasetInfo.nan)
+                .filter(([_, count]) => count > 0)
+                .map(([col, count]) => (
+                  <Grid item xs={12} key={col}>
+                    - {col}: {count} missing values
+                  </Grid>
+                ))}
+            </Grid>
+            <p>
+              It's recommended to preprocess the dataset to handle these missing
+              values before training a model.
+            </p>
+          </Alert>
+        ) : null
+      ) : null}
 
       {!infoLoading ? (
         <Grid container spacing={1}>

--- a/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
+++ b/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
@@ -367,9 +367,8 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
           </Grid>
         </Grid>
       </Alert>
-      {!infoLoading ? (
-        Object.values(datasetInfo.nan).some((v) => v > 0) &&
-        Object.values(datasetInfo.nan).length !== 0 ? (
+      {!infoLoading && datasetInfo.nan ? (
+        Object.values(datasetInfo.nan).some((v) => v > 0) ? (
           <Alert severity="warning" sx={{ mb: 1 }}>
             <AlertTitle>
               The dataset contains missing values (NaN) in the columns:


### PR DESCRIPTION
This pull request adds functionality to detect and report missing values (NaNs) in datasets, making it easier for users to identify columns with incomplete data before proceeding with model training. The changes include backend updates to calculate and store NaN counts per column, expose this information in the dataset metadata, and frontend improvements to display warnings when missing values are present.

**Backend enhancements for NaN detection:**

* Added a new method `nan_per_column` to `DashAIDataset` that calculates the number of NaN values per column and stores the result in the dataset's metadata under the `nan` key.
* Updated the dataset information returned by `get_dataset_info` to include the per-column NaN counts from the metadata.
* Modified the dataset job workflow to call `nan_per_column` after dataset creation, ensuring NaN statistics are available for downstream use.

**Frontend improvements for user awareness:**

* In `PrepareDatasetStep.jsx`, added a warning alert that lists columns containing missing values and recommends preprocessing the dataset before model training. The alert is shown only when NaNs are detected.

If contains NaN:
<img width="1904" height="959" alt="image" src="https://github.com/user-attachments/assets/1b510d54-236c-44b2-a785-ff1928f09524" />

If not:
<img width="1910" height="960" alt="image" src="https://github.com/user-attachments/assets/29adb815-893c-48f0-859e-3f7818cfab5a" />
