### PR TITLE
Add dataset split and percentage selection for local explanations, update KernelShap sampling to use fractions

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/explainers.py
+++ b/DashAI/back/api/api_v1/endpoints/explainers.py
@@ -520,6 +520,7 @@ async def upload_local_explainer(
                 dataset_id=params.dataset_id,
                 parameters=params.parameters,
                 fit_parameters=params.fit_parameters,
+                scope=params.scope,
             )
 
             db.add(explainer)

--- a/DashAI/back/api/api_v1/schemas/explainers_params.py
+++ b/DashAI/back/api/api_v1/schemas/explainers_params.py
@@ -15,6 +15,7 @@ class LocalExplainerParams(BaseModel):
     dataset_id: int
     parameters: dict
     fit_parameters: dict
+    scope: dict
 
 
 class ValidateDatasetParams(BaseModel):

--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -256,6 +256,7 @@ class LocalExplainer(Base):
     plots_path: Mapped[str] = mapped_column(String, nullable=True)
     parameters: Mapped[JSON] = mapped_column(JSON)
     fit_parameters: Mapped[JSON] = mapped_column(JSON)
+    scope: Mapped[JSON] = mapped_column(JSON)
     created: Mapped[DateTime] = mapped_column(DateTime, default=datetime.now)
     status: Mapped[Enum] = mapped_column(
         Enum(ExplainerStatus), nullable=False, default=ExplainerStatus.NOT_STARTED

--- a/DashAI/back/explainability/explainers/kernel_shap.py
+++ b/DashAI/back/explainability/explainers/kernel_shap.py
@@ -11,7 +11,7 @@ from DashAI.back.core.schema_fields import (
     BaseSchema,
     bool_field,
     enum_field,
-    int_field,
+    float_field,
     schema_field,
 )
 from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
@@ -35,18 +35,18 @@ class KernelShapSchema(BaseSchema):
 
     fit_parameter_sample_background_data: schema_field(
         bool_field(),
-        placeholder=False,
+        placeholder=True,
         description="Parameter to fit the explainer. 'true' if the background "
         "data must be sampled, otherwise the entire train data set is used. "
         "Smaller datasets speed up the algorithm run time.",
     )  # type: ignore
 
-    fit_parameter_n_background_samples: schema_field(
-        int_field(ge=1),
-        placeholder=1,
+    fit_parameter_background_fraction: schema_field(
+        float_field(ge=0, le=1),
+        placeholder=0.2,
         description="Parameter to fit the explainer. If the parameter "
-        "'sample_background_data' is 'true', the number of background "
-        "data samples to be drawn.",
+        "'sample_background_data' is 'true', the proportion of background "
+        "data samples to be drawn from the training data set.",
     )  # type: ignore
 
     fit_parameter_sampling_method: schema_field(
@@ -91,7 +91,7 @@ class KernelShap(BaseLocalExplainer):
     def _sample_background_data(
         self,
         background_data: np.array,
-        n_background_samples: int,
+        background_fraction: float,
         sampling_method: str = "shuffle",
         categorical_features: bool = False,
     ):
@@ -103,8 +103,8 @@ class KernelShap(BaseLocalExplainer):
         background_data: np.array
             Data used to estimate feature attributions and establish a baseline for
             the calculation of SHAP values.
-        n_background_samples: int
-            Number of background data samples used to estimate of SHAP values. By
+        background_fraction: float
+            Proportion of background data samples used to estimate of SHAP values. By
             default, the entire train dataset is used, but this option limits the
             samples to reduce run times.
         sampling_method: str
@@ -124,6 +124,8 @@ class KernelShap(BaseLocalExplainer):
 
         samplers = {"shuffle": shap.sample, "kmeans": shap.kmeans}
 
+        n_background_samples = int(background_fraction * background_data.shape[0])
+
         if categorical_features:
             data = samplers["shuffle"](background_data, n_background_samples)
         else:
@@ -135,7 +137,7 @@ class KernelShap(BaseLocalExplainer):
         self,
         background_dataset: Tuple[DatasetDict, DatasetDict],
         sample_background_data: str = "false",
-        n_background_samples: Union[int, None] = None,
+        background_fraction: Union[float, None] = None,
         sampling_method: Union[str, None] = None,
     ):
         """Method to train the KernelShap explainer.
@@ -149,9 +151,9 @@ class KernelShap(BaseLocalExplainer):
         sample_background_data: bool
             True if the background data must be sampled. Smaller data sets speed up
             the algorithm run time. False by default.
-        n_background_samples: int
-            Number of background data samples used to estimate of SHAP values if
-            ``sample_background_data=True``.
+        background_fraction: float
+            Proportion of background data from the training samples used to estimate
+            SHAP values if ``sample_background_data=True``.
         sampling_method: str
             Sampling method used to select the background samples if
             ``sample_background_data=True``. Options are 'shuffle' to select random
@@ -178,7 +180,7 @@ class KernelShap(BaseLocalExplainer):
         if sample_background_data:
             background_data = self._sample_background_data(
                 background_data.to_numpy(),
-                n_background_samples,
+                background_fraction,
                 sampling_method,
                 categorical_features,
             )

--- a/DashAI/back/job/explainer_job.py
+++ b/DashAI/back/job/explainer_job.py
@@ -13,7 +13,6 @@ from DashAI.back.dataloaders.classes.dashai_dataset import (
     load_dataset,
     select_columns,
     split_dataset,
-    to_dashai_dataset,
 )
 from DashAI.back.dependencies.database.models import (
     Dataset,
@@ -152,7 +151,6 @@ class ExplainerJob(BaseJob):
 
             prepared_instance = prepared_instance.select(
                 range(
-                    0,
                     max(
                         1,
                         int(

--- a/DashAI/back/job/explainer_job.py
+++ b/DashAI/back/job/explainer_job.py
@@ -13,6 +13,7 @@ from DashAI.back.dataloaders.classes.dashai_dataset import (
     load_dataset,
     select_columns,
     split_dataset,
+    to_dashai_dataset,
 )
 from DashAI.back.dependencies.database.models import (
     Dataset,
@@ -110,6 +111,7 @@ class ExplainerJob(BaseJob):
         self,
         explainer: BaseLocalExplainer,
         dataset: Tuple[DatasetDict, DatasetDict],
+        splits: Dict[str, Any],
         task: BaseTask,
         config: Dict[str, Any] = lambda di: di["config"],
     ) -> None:
@@ -135,6 +137,33 @@ class ExplainerJob(BaseJob):
             prepared_instance = task.prepare_for_task(
                 loaded_instance, outputs_columns=self.output_columns
             )
+
+            split = self.explainer_db.scope.get("split")
+            if split not in ["train", "test", "val", "all"]:
+                raise JobError(f"{split} is not a valid split")
+
+            if split != "all":
+                prepared_instance = split_dataset(
+                    prepared_instance,
+                    train_indexes=splits["train_indexes"],
+                    test_indexes=splits["test_indexes"],
+                    val_indexes=splits["val_indexes"],
+                )[split]
+
+            prepared_instance = prepared_instance.select(
+                range(
+                    0,
+                    max(
+                        1,
+                        int(
+                            prepared_instance.num_rows
+                            * self.explainer_db.scope.get("percentage")
+                            / 100
+                        ),
+                    ),
+                )
+            )
+
             prepared_instance = DatasetDict({"train": prepared_instance})
             X, _ = select_columns(
                 prepared_instance,
@@ -323,6 +352,7 @@ class ExplainerJob(BaseJob):
                 self._generate_local_explanation(
                     explainer=explainer,
                     dataset=(data_x, data_y),
+                    splits=splits,
                     task=task,
                 )
             else:

--- a/DashAI/back/job/explainer_job.py
+++ b/DashAI/back/job/explainer_job.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from DashAI.back.dataloaders.classes.dashai_dataset import (
     load_dataset,
+    prepare_for_experiment,
     select_columns,
     split_dataset,
 )
@@ -112,6 +113,7 @@ class ExplainerJob(BaseJob):
         dataset: Tuple[DatasetDict, DatasetDict],
         splits: Dict[str, Any],
         task: BaseTask,
+        same_dataset: bool,
         config: Dict[str, Any] = lambda di: di["config"],
     ) -> None:
         explainer_id: int = self.kwargs["explainer_id"]
@@ -142,6 +144,13 @@ class ExplainerJob(BaseJob):
                 raise JobError(f"{split} is not a valid split")
 
             if split != "all":
+                if not same_dataset:
+                    prepared_instance, splits = prepare_for_experiment(
+                        dataset=prepared_instance,
+                        splits=splits,
+                        output_columns=self.output_columns,
+                    )
+
                 prepared_instance = split_dataset(
                     prepared_instance,
                     train_indexes=splits["train_indexes"],
@@ -347,11 +356,16 @@ class ExplainerJob(BaseJob):
                 )
 
             elif explainer_scope == "local":
+                same_dataset = experiment.dataset_id == self.explainer_db.dataset_id
+                if not same_dataset:
+                    splits = experiment.splits
+
                 self._generate_local_explanation(
                     explainer=explainer,
                     dataset=(data_x, data_y),
                     splits=splits,
                     task=task,
+                    same_dataset=same_dataset,
                 )
             else:
                 raise JobError(f"{explainer_scope} is an invalid explainer type")

--- a/DashAI/front/src/api/explainer.ts
+++ b/DashAI/front/src/api/explainer.ts
@@ -60,10 +60,6 @@ export const createLocalExplainer = async (
     fit_parameters: fitParameters,
     scope,
   };
-
-  console.log("data explainer");
-  console.log(data);
-
   const response = await api.post<IExplainer>("/v1/explainer/local", data);
   return response.data;
 };

--- a/DashAI/front/src/api/explainer.ts
+++ b/DashAI/front/src/api/explainer.ts
@@ -49,6 +49,7 @@ export const createLocalExplainer = async (
   datasetId: string,
   parameters: object,
   fitParameters: object,
+  scope: object,
 ): Promise<IExplainer> => {
   const data = {
     name,
@@ -57,7 +58,11 @@ export const createLocalExplainer = async (
     explainer_name: explainerName,
     parameters,
     fit_parameters: fitParameters,
+    scope,
   };
+
+  console.log("data explainer");
+  console.log(data);
 
   const response = await api.post<IExplainer>("/v1/explainer/local", data);
   return response.data;

--- a/DashAI/front/src/components/explainers/NewLocalExplainerModal.jsx
+++ b/DashAI/front/src/components/explainers/NewLocalExplainerModal.jsx
@@ -63,6 +63,7 @@ export default function NewLocalExplainerModal({
     name: "",
     run_id: runId,
     explainer_name: null,
+    scope: { split: "test", percentage: 20 },
     dataset_id: null,
     parameters: null,
     fit_parameters: null,
@@ -120,6 +121,7 @@ export default function NewLocalExplainerModal({
         newLocalExpl.dataset_id,
         newLocalExpl.parameters,
         newLocalExpl.fit_parameters,
+        newLocalExpl.scope,
       );
       const explainerId = response.id;
       await enqueueLocalExplainerJob(explainerId);

--- a/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
@@ -16,6 +16,8 @@ import { Link as RouterLink } from "react-router-dom";
 import { getDatasets as getDatasetsRequest } from "../../api/datasets";
 import { validateDataset as validateDatasetRequest } from "../../api/explainer";
 import { formatDate } from "../../utils";
+import { SplitSelector } from "./SplitSelector";
+import NoteBox from "../notebooks/NoteBox";
 
 const columns = [
   {
@@ -120,13 +122,16 @@ export default function SelectDatasetStep({
   }, [selectedDatasetId]);
 
   useEffect(() => {
-    if (isValidDataset) {
-      setNewExpl({ ...newExpl, dataset_id: selectedDatasetId });
+    if (isValidDataset && selectedDatasetId) {
+      setNewExpl((prevExpl) => ({
+        ...prevExpl,
+        dataset_id: selectedDatasetId,
+      }));
       setNextEnabled(true);
     } else {
       setNextEnabled(false);
     }
-  }, [isValidDataset]);
+  }, [isValidDataset, selectedDatasetId]);
 
   return (
     <React.Fragment>
@@ -180,6 +185,21 @@ export default function SelectDatasetStep({
           hideFooterSelectedRowCount
         />
       </Paper>
+
+      {selectedDatasetId && isValidDataset && (
+        <>
+          <SplitSelector
+            onSelectionChange={(scope) => {
+              setNewExpl((prevExpl) => ({ ...prevExpl, scope }));
+            }}
+          />
+          <NoteBox
+            message={
+              "The dataset selected here will be used to compute the explanations. If you chose the same dataset that was used to train the model, you may want to use a sample of your test set instead. Keep in mind that some explainers can take a long time to generate explanations, depending on the number of instances selected."
+            }
+          />
+        </>
+      )}
     </React.Fragment>
   );
 }

--- a/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
@@ -13,8 +13,13 @@ import { DataGrid } from "@mui/x-data-grid";
 import { useSnackbar } from "notistack";
 import { Link as RouterLink } from "react-router-dom";
 
-import { getDatasets as getDatasetsRequest } from "../../api/datasets";
+import {
+  getDatasets as getDatasetsRequest,
+  getDatasetInfo,
+} from "../../api/datasets";
 import { validateDataset as validateDatasetRequest } from "../../api/explainer";
+import { getRunById } from "../../api/run";
+import { getExperimentById } from "../../api/experiment";
 import { formatDate } from "../../utils";
 import { SplitSelector } from "./SplitSelector";
 import NoteBox from "../notebooks/NoteBox";
@@ -57,6 +62,13 @@ export default function SelectDatasetStep({
   const [selectedDatasetId, setSelectedDatasetId] = useState(false);
   const [isValidDataset, setIsValidDataset] = useState(false);
   const [requestError, setRequestError] = useState(false);
+  const [totalRows, setTotalRows] = useState(0);
+  const [splits, setSplits] = useState({
+    train: 0,
+    test: 0,
+    validation: 0,
+    all: 1,
+  });
 
   const getDatasets = async () => {
     setLoading(true);
@@ -100,10 +112,47 @@ export default function SelectDatasetStep({
     }
   };
 
+  const getTotalRows = async () => {
+    if (selectedDatasetId) {
+      try {
+        const datasetInfo = await getDatasetInfo(selectedDatasetId);
+        setTotalRows(datasetInfo.total_rows);
+      } catch {
+        console.error(`Error fetching dataset info for ${selectedDatasetId}`);
+      }
+    }
+  };
+
   // fetch datasets when the component is mounting
   useEffect(() => {
     getDatasets();
   }, []);
+
+  useEffect(() => {
+    getTotalRows();
+  }, [selectedDatasetId]);
+
+  const getRuninfo = async () => {
+    if (newExpl.run_id) {
+      try {
+        const run = await getRunById(newExpl.run_id);
+        const experiment = await getExperimentById(run.experiment_id);
+        const splitsExperiment = JSON.parse(experiment.splits);
+        setSplits((prev) => ({
+          ...prev,
+          train: splitsExperiment["train"],
+          test: splitsExperiment["test"],
+          validation: splitsExperiment["validation"],
+        }));
+      } catch {
+        console.error(`Error fetching run info for ${newExpl.run_id}`);
+      }
+    }
+  };
+
+  useEffect(() => {
+    getRuninfo();
+  }, [newExpl.run_id]);
 
   useEffect(() => {
     if (rowSelectedDataset.length > 0) {
@@ -189,6 +238,8 @@ export default function SelectDatasetStep({
       {selectedDatasetId && isValidDataset && (
         <>
           <SplitSelector
+            totalRows={totalRows}
+            splits={splits}
             onSelectionChange={(scope) => {
               setNewExpl((prevExpl) => ({ ...prevExpl, scope }));
             }}

--- a/DashAI/front/src/components/explainers/SplitSelector.jsx
+++ b/DashAI/front/src/components/explainers/SplitSelector.jsx
@@ -1,0 +1,122 @@
+import { useState, useEffect } from "react";
+import {
+  Typography,
+  Button,
+  Slider,
+  TextField,
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Box,
+  Stack,
+  Divider,
+} from "@mui/material";
+
+export function SplitSelector({
+  onSelectionChange,
+  initialSplit,
+  initialPercentage,
+}) {
+  const [selectedSplit, setSelectedSplit] = useState(initialSplit || "test");
+  const [percentage, setPercentage] = useState(initialPercentage ?? 20);
+
+  // Propagate changes
+  useEffect(() => {
+    onSelectionChange({ split: selectedSplit, percentage });
+  }, [selectedSplit, percentage]);
+
+  const handleSelectAll = () => {
+    setSelectedSplit("all");
+    setPercentage(100);
+  };
+
+  const handleSliderChange = (_, newValue) => {
+    setPercentage(newValue);
+  };
+
+  const handleInputChange = (e) => {
+    const val = e.target.value === "" ? "" : Number(e.target.value);
+    if (val === "" || (val >= 0 && val <= 100)) {
+      setPercentage(val);
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <FormControl component="fieldset" sx={{ mb: 3, width: "100%" }}>
+        <FormLabel component="legend">Dataset Split</FormLabel>
+
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          sx={{ mt: 1 }}
+        >
+          <RadioGroup
+            row
+            value={selectedSplit}
+            onChange={(e) => setSelectedSplit(e.target.value)}
+          >
+            <FormControlLabel value="train" control={<Radio />} label="Train" />
+            <FormControlLabel value="test" control={<Radio />} label="Test" />
+            <FormControlLabel
+              value="validation"
+              control={<Radio />}
+              label="Validation"
+            />
+            <FormControlLabel value="all" control={<Radio />} label="All" />
+          </RadioGroup>
+
+          <Button variant="outlined" size="small" onClick={handleSelectAll}>
+            Select All
+          </Button>
+        </Stack>
+      </FormControl>
+
+      <Stack spacing={2} mb={2}>
+        <Typography gutterBottom>Percentage of Split to Use</Typography>
+
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Slider
+            value={typeof percentage === "number" ? percentage : 0}
+            onChange={handleSliderChange}
+            aria-labelledby="percentage-slider"
+            valueLabelDisplay="auto"
+            step={1}
+            marks={[
+              { value: 0, label: "0%" },
+              { value: 25, label: "25%" },
+              { value: 50, label: "50%" },
+              { value: 75, label: "75%" },
+              { value: 100, label: "100%" },
+            ]}
+            min={0}
+            max={100}
+            sx={{ flex: 1 }}
+          />
+
+          <TextField
+            label="%"
+            type="number"
+            size="small"
+            value={percentage}
+            onChange={handleInputChange}
+            inputProps={{ min: 0, max: 100 }}
+            sx={{ width: "80px" }}
+          />
+        </Stack>
+      </Stack>
+
+      <Divider sx={{ my: 1 }} />
+
+      <Box mt={1}>
+        <Typography variant="caption" color="text.secondary">
+          Selected split: <strong>{selectedSplit}</strong> | Percentage:{" "}
+          {percentage}%
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/DashAI/front/src/components/explainers/SplitSelector.jsx
+++ b/DashAI/front/src/components/explainers/SplitSelector.jsx
@@ -15,6 +15,8 @@ import {
 } from "@mui/material";
 
 export function SplitSelector({
+  totalRows,
+  splits,
   onSelectionChange,
   initialSplit,
   initialPercentage,
@@ -114,7 +116,13 @@ export function SplitSelector({
       <Box mt={1}>
         <Typography variant="caption" color="text.secondary">
           Selected split: <strong>{selectedSplit}</strong> | Percentage:{" "}
-          {percentage}%
+          {percentage}% | Rows selected:{" "}
+          {percentage != 0
+            ? Math.round(
+                (percentage / 100) * (totalRows * splits[selectedSplit]),
+              )
+            : 1}{" "}
+          / {Math.round(totalRows * splits[selectedSplit])}
         </Typography>
       </Box>
     </Box>

--- a/tests/back/api/test_explainer_jobs.py
+++ b/tests/back/api/test_explainer_jobs.py
@@ -224,6 +224,7 @@ def create_local_explainer(client: TestClient, run_id: int, dataset_id: int):
             run_id=run_id,
             explainer_name="DummyLocalExplainer",
             dataset_id=dataset_id,
+            scope={"split": "test", "percentage": 20},
             parameters={},
             fit_parameters={},
         )

--- a/tests/back/api/test_explanations_api.py
+++ b/tests/back/api/test_explanations_api.py
@@ -195,6 +195,7 @@ def test_create_local_explainer(client: TestClient, dataset_id: int, run_id_1: i
                 "parameters": {
                     "link": "identity",
                 },
+                "scope": {"split": "test", "percentage": 20},
                 "fit_parameters": {
                     "sample_background_data": True,
                     "n_background_samples": 50,
@@ -296,6 +297,7 @@ def test_get_local_explainers_by_run_id(
                 "parameters": {
                     "link": "identity",
                 },
+                "scope": {"split": "test", "percentage": 20},
                 "fit_parameters": {
                     "sample_background_data": True,
                     "n_background_samples": 50,
@@ -377,6 +379,7 @@ def test_get_local_explanation(client: TestClient, dataset_id: int, run_id_1: in
                 "parameters": {
                     "link": "identity",
                 },
+                "scope": {"split": "test", "percentage": 20},
                 "fit_parameters": {
                     "sample_background_data": True,
                     "n_background_samples": 50,
@@ -432,6 +435,7 @@ def test_delete_local_explainer(client: TestClient, dataset_id: int, run_id_1: i
             "parameters": {
                 "link": "identity",
             },
+            "scope": {"split": "test", "percentage": 20},
             "fit_parameters": {
                 "sample_background_data": False,
                 "categorical_features": True,


### PR DESCRIPTION
This pull request introduces support for selecting a dataset split (train, test, validation, or all) and a percentage of that split to use when generating local explanations in the DashAI platform. This allows users to control which subset of the data is used for explainability, improving flexibility and efficiency, especially for large datasets. The changes span both the backend and frontend, including schema updates, API modifications, UI enhancements, and logic for handling splits and percentages in the explanation process.

**Backend changes:**

* Added a new `scope` field (as a JSON object) to the local explainer schema, database model, API endpoint, and job logic to specify which split and percentage of the dataset to use. [[1]](diffhunk://#diff-5f5ed5c889e58d77c5cbb8c7f910c4f3c4c365d7e3e97aa65fee0c5d92793dcdR18) [[2]](diffhunk://#diff-af25d7f37b8ad917d413011f6f57ec0569e3c94ccdd9ecfe25a062e5507ef3e7R259) [[3]](diffhunk://#diff-9fe5d05e793f20cf7d6ce5a92a2b4732f979f403b8d35da52d17d868bf6c440eR523)
* Updated the local explainer job logic to use the specified split and percentage from `scope`, including validation and sample selection. [[1]](diffhunk://#diff-1c211861ae269605e1ff26bf78619cc9e2824c470034af3f4c3a4e35bbeae0c1R114-R116) [[2]](diffhunk://#diff-1c211861ae269605e1ff26bf78619cc9e2824c470034af3f4c3a4e35bbeae0c1R141-R173) [[3]](diffhunk://#diff-1c211861ae269605e1ff26bf78619cc9e2824c470034af3f4c3a4e35bbeae0c1R359-R368)

**Frontend changes:**

* Added a `SplitSelector` UI component that allows users to choose the dataset split and percentage, displaying the number of rows selected. [[1]](diffhunk://#diff-6ef598d594b8c44f2bb4918f86e123cf9400fd080a7a84e2b639eb585257a406R1-R130) [[2]](diffhunk://#diff-5d4c338ab1a5e6f2ea95a39df16717616688899bb3b67d7863a0432349949165R237-R253)
* Integrated the split/percentage selection into the local explainer creation flow, including default values and state management. [[1]](diffhunk://#diff-ceaead161c316a8bd46a6249479066be552548bac89abce50198fbee33a25d3aR66) [[2]](diffhunk://#diff-ceaead161c316a8bd46a6249479066be552548bac89abce50198fbee33a25d3aR124) [[3]](diffhunk://#diff-5d4c338ab1a5e6f2ea95a39df16717616688899bb3b67d7863a0432349949165R65-R71) [[4]](diffhunk://#diff-5d4c338ab1a5e6f2ea95a39df16717616688899bb3b67d7863a0432349949165R115-R156) [[5]](diffhunk://#diff-5d4c338ab1a5e6f2ea95a39df16717616688899bb3b67d7863a0432349949165L123-R183)
* Updated the API calls and modal logic to send the `scope` field when creating a local explainer. [[1]](diffhunk://#diff-fe578e481a2a8ac23f30e698dbaaa514c45ad08be62de7807e28ac4ed4c57f64R52) [[2]](diffhunk://#diff-fe578e481a2a8ac23f30e698dbaaa514c45ad08be62de7807e28ac4ed4c57f64R61-L61)

<img width="1914" height="962" alt="image" src="https://github.com/user-attachments/assets/aeddce1c-e7d5-4b0b-856b-2b775ab13399" />

**KernelShap explainer improvements:**

* Changed background data sampling parameters from an absolute number (`n_background_samples`) to a fraction (`background_fraction`), making the sampling proportional to the dataset size and more intuitive for users. [[1]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L14-R14) [[2]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L38-R49) [[3]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L94-R94) [[4]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L106-R107) [[5]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197R127-R128) [[6]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L138-R140) [[7]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L152-R156) [[8]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L181-R183)

<img width="1916" height="957" alt="image" src="https://github.com/user-attachments/assets/47233045-e839-42e0-b06d-e65c10350170" />
