### PR TITLE
Fix the windows error "LLVMPY_AddSymbol"  

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,5 @@ wordcloud
 opencv-python
 protobuf
 imblearn
+numba==0.58.1
+llvmlite==0.41.1


### PR DESCRIPTION
Added specific versions for numba and llvmlite in requirements:
numba==0.58.1
llvmlite==0.41.1