### PR TITLE
Fix trained model view when using it for predictions

### DIFF
--- a/DashAI/back/job/predict_job.py
+++ b/DashAI/back/job/predict_job.py
@@ -26,20 +26,6 @@ class PredictJob(BaseJob):
 
     def set_status_as_delivered(self) -> None:
         """Set the status of the job as delivered."""
-        run_id: int = self.kwargs["run_id"]
-        db: Session = self.kwargs["db"]
-
-        run: Run = db.get(Run, run_id)
-        if not run:
-            raise JobError(f"Run {run_id} does not exist in DB.")
-        try:
-            run.set_status_as_delivered()
-            db.commit()
-        except exc.SQLAlchemyError as e:
-            log.exception(e)
-            raise JobError(
-                "Internal database error",
-            ) from e
 
     @inject
     async def run(


### PR DESCRIPTION
This pull request fixes an issue in the `PredictJob` class in `predict_job.py` by removing the unused `set_status_as_delivered` method. The method, which previously updated the run status in the database and handled related errors, was causing inconsistencies. Removing it resolves the issue and simplifies the class.

* Fixed issue by removing the `set_status_as_delivered` method from `PredictJob`.
