### PR TITLE
Refactor prediction dataset filtering to allow datasets without target column

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/predict.py
+++ b/DashAI/back/api/api_v1/endpoints/predict.py
@@ -3,15 +3,12 @@ import logging
 import os
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from fastapi.exceptions import HTTPException
 from kink import di, inject
 from sqlalchemy.orm import sessionmaker
 
-from DashAI.back.api.api_v1.schemas.predict_params import (
-    FilterDatasetParams,
-    RenameRequest,
-)
+from DashAI.back.api.api_v1.schemas.predict_params import RenameRequest
 from DashAI.back.dataloaders.classes.dashai_dataset import get_columns_spec
 from DashAI.back.dependencies.database.models import Dataset, Experiment, Run
 
@@ -237,9 +234,9 @@ async def get_predict_summary(
     return summary
 
 
-@router.post("/filter_datasets")
+@router.get("/filter_datasets")
 async def filter_datasets_endpoint(
-    params: FilterDatasetParams,
+    run_id: int = Query(..., description="The ID of the trained model/run"),
     session_factory: sessionmaker = Depends(lambda: di["session_factory"]),
 ):
     """
@@ -247,10 +244,8 @@ async def filter_datasets_endpoint(
 
     Parameters
     ----------
-    train_dataset_id : int
-        The ID of the train dataset.
-    datasets : List[str]
-        List of datasets paths to filter.
+    run_id : int
+        The ID of the trained model/run.
 
     Returns
     -------
@@ -259,26 +254,30 @@ async def filter_datasets_endpoint(
     """
     try:
         with session_factory() as db:
-            train_dataset_id = params.train_dataset_id
-            datasets_paths = params.datasets
-            filtered_list = []
-            file_path = Path(db.get(Dataset, train_dataset_id).file_path, "dataset")
-            if not file_path:
+            run: Run = db.get(Run, run_id)
+            if not run:
                 raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Dataset not found",
+                    status_code=status.HTTP_404_NOT_FOUND, detail="Run not found"
                 )
-            train_dataset_spec = get_columns_spec(str(file_path))
-            for dataset_path in datasets_paths:
-                dataset_spec = get_columns_spec(str(Path(dataset_path, "dataset")))
-                if train_dataset_spec == dataset_spec:
-                    dataset = (
-                        db.query(Dataset)
-                        .filter(Dataset.file_path == dataset_path)
-                        .first()
-                    )
-                    filtered_list.append(dataset)
-            return filtered_list
+
+            exp: Experiment = db.get(Experiment, run.experiment_id)
+            if not exp:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND, detail="Experiment not found"
+                )
+            input_columns = list(exp.input_columns)
+
+            datasets = db.query(Dataset).all()
+            datasets_filtered = []
+            for dataset in datasets:
+                dataset_path = Path(f"{dataset.file_path}/dataset/")
+                if dataset_path.exists():
+                    columns_spec = get_columns_spec(str(dataset_path))
+                    if all(col in columns_spec for col in input_columns):
+                        datasets_filtered.append(dataset)
+                else:
+                    logger.warning("Dataset path does not exist: %s", dataset_path)
+            return datasets_filtered
     except Exception as e:
         logger.exception("Error filtering datasets: %s", str(e))
         raise HTTPException(

--- a/DashAI/back/api/api_v1/schemas/predict_params.py
+++ b/DashAI/back/api/api_v1/schemas/predict_params.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 
@@ -12,5 +10,4 @@ class RenameRequest(BaseModel):
 
 
 class FilterDatasetParams(BaseModel):
-    train_dataset_id: int
-    datasets: List[str]
+    run_id: int

--- a/DashAI/front/src/api/predict.ts
+++ b/DashAI/front/src/api/predict.ts
@@ -37,10 +37,9 @@ export const rename_prediction = async (
 };
 
 export const filter_datasets = async (requestData: IParamsFilter) => {
-  const response = await api.post(
-    `${predictEndpoint}/filter_datasets/`,
-    requestData,
-  );
+  const response = await api.get(`${predictEndpoint}/filter_datasets`, {
+    params: requestData,
+  });
   return response.data;
 };
 

--- a/DashAI/front/src/components/predictions/PredictionModal.jsx
+++ b/DashAI/front/src/components/predictions/PredictionModal.jsx
@@ -240,6 +240,7 @@ function PredictionModal({
       <DialogContent dividers>
         {renderStep(
           steps[activeStep].name,
+          selectedModelId,
           preselectedModelId,
           setSelectedModelId,
           setSelectedDatasetId,

--- a/DashAI/front/src/components/predictions/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/predictions/SelectDatasetStep.jsx
@@ -45,6 +45,7 @@ const columns = [
 ];
 
 function SelectDatasetStep({
+  selectedModelId,
   preselectedModelId,
   setSelectedDatasetId,
   setNextEnabled,
@@ -58,21 +59,14 @@ function SelectDatasetStep({
   const [loading, setLoading] = useState(true);
   const [datasetsSelected, setDatasetsSelected] = useState([]);
   const [requestError, setRequestError] = useState(false);
-  const [datasetPaths, setDatasetPaths] = useState([]);
   const [isNameValid, setIsNameValid] = useState(false);
 
   const getDatasets = async () => {
     setLoading(true);
     try {
-      const datasets = await getDatasetsRequest();
-      const paths = datasets.map((dataset) => dataset.file_path);
-      setDatasetPaths(paths);
-
       const requestData = {
-        train_dataset_id: Number(trainDataset),
-        datasets: paths,
+        run_id: preselectedModelId ?? selectedModelId,
       };
-
       const filteredDatasets = await filterDatasetsRequest(requestData);
       setDatasets(filteredDatasets);
     } catch (error) {

--- a/DashAI/front/src/components/predictions/renderStep.js
+++ b/DashAI/front/src/components/predictions/renderStep.js
@@ -4,6 +4,7 @@ import SelectDatasetStep from "./SelectDatasetStep";
 
 export function renderStep(
   stepName,
+  selectedModelId,
   preselectedModelId,
   setSelectedModelId,
   setSelectedDatasetId,
@@ -28,6 +29,7 @@ export function renderStep(
     case "selectDataset":
       return (
         <SelectDatasetStep
+          selectedModelId={selectedModelId}
           preselectedModelId={preselectedModelId}
           handlePredictNameInput={handlePredictNameInput}
           setSelectedDatasetId={setSelectedDatasetId}

--- a/DashAI/front/src/types/predict.ts
+++ b/DashAI/front/src/types/predict.ts
@@ -7,6 +7,5 @@ export interface IPredict {
 }
 
 export interface IParamsFilter {
-  train_dataset_id: number;
-  datasets: string[];
+  run_id: number;
 }

--- a/tests/back/api/test_predict_api.py
+++ b/tests/back/api/test_predict_api.py
@@ -330,20 +330,19 @@ def test_predict_summary(client: TestClient, prediction_name: str):
 
 
 def test_filter_datasets_endpoint(
-    client: TestClient, dataset: Dataset, dataset_2: Dataset
+    client: TestClient, trained_run_id: int, dataset: Dataset, dataset_2: Dataset
 ):
-    list_datasets = [dataset["file_path"], dataset_2["file_path"]]
-    params = {
-        "train_dataset_id": 1,
-        "datasets": list_datasets,
-    }
-    response = client.post("/api/v1/predict/filter_datasets", json=params)
+    response = client.get(
+        "/api/v1/predict/filter_datasets",
+        params={"run_id": trained_run_id},
+    )
     assert response.status_code == 200, response.text
-    filtered_datasets = response.json()
-    assert len(filtered_datasets) == 1
-    assert (
-        filtered_datasets[0]["id"] == 1
-    )  # only the first dataset is used to train the model
+    datasets = response.json()
+    assert isinstance(datasets, list)
+    assert len(datasets) == 1
+    dataset_names = [ds["name"] for ds in datasets]
+    assert dataset["name"] in dataset_names
+    assert dataset_2["name"] not in dataset_names
 
 
 @pytest.fixture(name="json_data")


### PR DESCRIPTION
This pull request refactors the dataset filtering logic in the prediction API to simplify the interface and improve consistency between the backend and frontend. The main change is switching the `/filter_datasets` endpoint from a POST request with a complex payload to a GET request that filters datasets based solely on the `run_id` parameter. This streamlines the process and updates related types, request logic, and tests across the codebase.

**Backend API changes:**

* The `/filter_datasets` endpoint in `predict.py` now accepts only a `run_id` as a query parameter via GET, replacing the previous POST method and payload structure. The filtering logic now matches datasets based on the input columns of the experiment associated with the run, rather than requiring explicit dataset paths in the request. [[1]](diffhunk://#diff-b65e9a8af6a71dec16d74da9721b14c93ce9a70d8e890ef7df3bcfac7721d9ecL240-R248) [[2]](diffhunk://#diff-b65e9a8af6a71dec16d74da9721b14c93ce9a70d8e890ef7df3bcfac7721d9ecL262-R280)
* The `FilterDatasetParams` schema is updated to only require `run_id`, removing the previous fields for `train_dataset_id` and dataset paths.

**Testing updates:**

* The test for the filter endpoint is updated to reflect the new API contract, validating correct filtering based on `run_id` and dataset properties.