### PR TITLE
fix: remove default column selection in ColumnSelector

### DIFF
--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -99,34 +99,9 @@ function ColumnSelector({
     };
   }, [file_path]);
 
-  // Handle automatic column selection based on cardinality
   useEffect(() => {
-    // Auto-select only once at start if no initial selection provided
     if (rows.length > 0 && rowSelectionModel.length === 0) {
-      const validIds = getValidColumnIds();
-      let autoSelection = [];
-
-      if (inputCardinality.exact && validIds.length >= inputCardinality.exact) {
-        autoSelection = validIds.slice(0, inputCardinality.exact);
-      } else if (inputCardinality.max && validIds.length > 0) {
-        autoSelection = validIds.slice(
-          0,
-          Math.min(validIds.length, inputCardinality.max),
-        );
-      } else if (
-        inputCardinality.min &&
-        validIds.length >= inputCardinality.min
-      ) {
-        autoSelection = inputCardinality.max
-          ? validIds.slice(0, inputCardinality.min)
-          : validIds;
-      } else {
-        autoSelection = validIds;
-      }
-
-      if (autoSelection.length > 0) {
-        setRowSelectionModel(autoSelection);
-      }
+      setRowSelectionModel([]);
     }
   }, [rows.length]);
 

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -99,15 +99,13 @@ function ColumnSelector({
     };
   }, [file_path]);
 
-  useEffect(() => {
-    if (rows.length > 0 && rowSelectionModel.length === 0) {
-      setRowSelectionModel([]);
-    }
-  }, [rows.length]);
-
   // Validate current selection
   const isValidSelection = useCallback(
     (selection) => {
+      if (selection.length === 0) {
+        return false;
+      }
+
       if (
         inputCardinality.exact &&
         selection.length !== inputCardinality.exact

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -24,6 +24,7 @@ export default function ScopeStepConverter({
 }) {
   const [datasetInfo, setDatasetInfo] = useState(0);
   const [datasetColumns, setDatasetColumns] = useState([]);
+  const [isColumnSelectionValid, setIsColumnSelectionValid] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -100,7 +101,7 @@ export default function ScopeStepConverter({
             }));
             setColumns(processedColumns);
           }}
-          onValidationChange={() => {}}
+          onValidationChange={(isValid) => setIsColumnSelectionValid(isValid)}
         />
         <Typography variant="body2" color="text.secondary">
           Here you will configure which rows to apply the converter to.
@@ -153,7 +154,9 @@ export default function ScopeStepConverter({
 
         <FormSchemaButtonGroup
           onFormSubmit={nextStep}
-          error={supervised ? !targetColumn : false}
+          error={
+            !isColumnSelectionValid || (supervised ? !targetColumn : false)
+          }
           saveButtonText={
             Object.values(tool.schema.properties).length > 0
               ? "Next"


### PR DESCRIPTION
# Fix: Remove Default Column Selection in ColumnSelector

## Summary

This PR removes the automatic column selection behavior in the `ColumnSelector` component used during the explorer creation workflow.  
Now, no columns are selected by default — users must manually select them.

## Changes

### ColumnSelector.jsx
- Updated logic to prevent automatic selection of valid columns.
- Ensures initial selection state is always empty (`[]`).
- Maintains all existing cardinality validation (`min`, `max`, `exact`).

### ScopeStepConverter.jsx
- Added: State `isColumnSelectionValid` for tracking column validation.
- Connected: Callback `onValidationChange` to propagate validation state.
- Improved: Button logic now includes column validation before proceeding.

## Result

- No columns are pre-selected when the step loads.  
- User must select columns manually.  
- Cardinality validation (`min`, `max`, `exact`) still applies.  
- Button “Next/Save” remains disabled until selection is valid.  

## Testing Steps

1. Open the explorer creation workflow.  
2. Go to **Step 1: Select Scope**.  
3. Confirm that no columns are selected initially.  
4. Verify that the button “Next” is disabled until valid selection.  

## Type of Change

- [x] Bug fix (non-breaking change)