### PR TITLE
Enhance explorer and converter filtering to include short description

### DIFF
--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -160,8 +160,16 @@ export default function RightBar({ notebook }) {
 
   useEffect(() => {
     const filteredAndValidatedExplorers = explorers
-      .filter((item) =>
-        item.name.toLowerCase().includes(searchQuery.toLowerCase()),
+      .filter(
+        (item) =>
+          item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          (item.metadata.short_description
+            ? item.metadata.short_description
+                .toLowerCase()
+                .includes(searchQuery.toLowerCase())
+            : item.description
+                .toLowerCase()
+                .includes(searchQuery.toLowerCase())),
       )
       .map((explorer) => {
         const validation = validateExplorer(explorer);
@@ -176,11 +184,17 @@ export default function RightBar({ notebook }) {
 
     setFilteredExplorers(filteredAndValidatedExplorers);
 
-    setFilteredConverters(
-      converters.filter((item) =>
-        item.name.toLowerCase().includes(searchQuery.toLowerCase()),
-      ),
+    const filteredConverters = converters.filter(
+      (item) =>
+        item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        (item.metadata.short_description
+          ? item.metadata.short_description
+              .toLowerCase()
+              .includes(searchQuery.toLowerCase())
+          : item.description.toLowerCase().includes(searchQuery.toLowerCase())),
     );
+
+    setFilteredConverters(filteredConverters);
   }, [searchQuery, explorers, converters, datasetColumns, notebook]);
 
   return (


### PR DESCRIPTION
This pull request enhances the search functionality in the `RightBar` component by expanding the fields that are searched for both explorers and converters. Previously, only the `name` field was considered; now, both the `short_description` (if present) and the `description` fields are also included in the search.