### PR TITLE
Feat: prevent modal close

### DIFF
--- a/DashAI/front/src/components/datasets/DatasetModal.jsx
+++ b/DashAI/front/src/components/datasets/DatasetModal.jsx
@@ -12,7 +12,10 @@ import {
   Grid,
   Typography,
   StepButton,
+  IconButton,
+  Box,
 } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 import SelectDataloaderStep from "./SelectDataloaderStep";
 import ConfigureAndUploadDataset from "./ConfigureAndUploadDataset";
 import { useSnackbar } from "notistack";
@@ -113,7 +116,8 @@ function DatasetModal({ open, setOpen, updateDatasets }) {
   return (
     <Dialog
       open={open}
-      onClose={handleCloseDialog}
+      onClose={() => {}}
+      disableEscapeKeyDown
       fullWidth
       maxWidth={"lg"}
       scroll="paper"
@@ -125,7 +129,7 @@ function DatasetModal({ open, setOpen, updateDatasets }) {
     >
       {/* Title */}
       <DialogTitle id="new-experiment-dialog-title">
-        <Grid container direction={"row"} alignItems={"center"}>
+        <Grid container direction={"row"} alignItems={"center"} spacing={1}>
           <Grid size={{ xs: 12, md: 3 }}>
             <Typography
               variant="h6"
@@ -135,7 +139,7 @@ function DatasetModal({ open, setOpen, updateDatasets }) {
               New dataset
             </Typography>
           </Grid>
-          <Grid size={{ xs: 12, md: 9 }}>
+          <Grid size={{ xs: 12, md: 8 }}>
             <Stepper
               nonLinear
               activeStep={activeStep}
@@ -153,6 +157,22 @@ function DatasetModal({ open, setOpen, updateDatasets }) {
                 </Step>
               ))}
             </Stepper>
+          </Grid>
+          <Grid
+            size={{ xs: 12, md: 1 }}
+            display="flex"
+            justifyContent="flex-end"
+          >
+            <IconButton
+              onClick={handleCloseDialog}
+              sx={{
+                position: { xs: "absolute", md: "static" },
+                right: { xs: 8, md: "auto" },
+                top: { xs: 8, md: "auto" },
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
           </Grid>
         </Grid>
       </DialogTitle>

--- a/DashAI/front/src/components/experiments/NewExperimentModal.jsx
+++ b/DashAI/front/src/components/experiments/NewExperimentModal.jsx
@@ -214,7 +214,8 @@ export default function NewExperimentModal({
       fullScreen={screenSm}
       fullWidth
       maxWidth={"lg"}
-      onClose={handleCloseDialog}
+      onClose={() => {}} // No cerrar automáticamente
+      disableEscapeKeyDown // Evitar cierre con Escape
       aria-labelledby="new-experiment-dialog-title"
       aria-describedby="new-experiment-dialog-description"
       scroll="paper"
@@ -276,6 +277,19 @@ export default function NewExperimentModal({
             </Stepper>
           </Grid>
         </Grid>
+        {/* Close button for larger screens */}
+        <IconButton
+          onClick={handleCloseDialog}
+          sx={{
+            position: "absolute",
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500],
+            display: { xs: "none", sm: "flex" },
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
       </DialogTitle>
       {/* Main content - steps */}
       <DialogContent dividers>

--- a/DashAI/front/src/components/experiments/RunnerDialog.jsx
+++ b/DashAI/front/src/components/experiments/RunnerDialog.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import {
   PlayArrow as PlayArrowIcon,
   Check as CheckIcon,
+  Close as CloseIcon,
 } from "@mui/icons-material";
 import { DataGrid, GridActionsCellItem } from "@mui/x-data-grid";
 import {
@@ -15,6 +16,7 @@ import {
   DialogTitle,
   Paper,
   Typography,
+  IconButton,
 } from "@mui/material";
 import { getRuns as getRunsRequest } from "../../api/run";
 import { enqueueRunnerJob as enqueueRunnerJobRequest } from "../../api/job";
@@ -213,7 +215,25 @@ function RunnerDialog({ experiment, expRunning, setExpRunning }) {
         fullWidth
         maxWidth={"md"}
       >
-        <DialogTitle>{`Runs in ${experiment.name}`}</DialogTitle>
+        <DialogTitle>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            {`Runs in ${experiment.name}`}
+            <IconButton
+              onClick={() => setOpen(false)}
+              sx={{
+                color: (theme) => theme.palette.grey[500],
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
         <DialogContent>
           <Paper
             sx={{ px: 3, py: 2 }}

--- a/DashAI/front/src/components/explainers/NewGlobalExplainerModal.jsx
+++ b/DashAI/front/src/components/explainers/NewGlobalExplainerModal.jsx
@@ -15,6 +15,7 @@ import {
   Grid,
   Typography,
   IconButton,
+  Box,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { useTheme } from "@mui/material/styles";
@@ -187,7 +188,8 @@ export default function NewGlobalExplainerModal({
       fullScreen={screenSm}
       fullWidth
       maxWidth={"lg"}
-      onClose={handleCloseDialog}
+      onClose={() => {}}
+      disableEscapeKeyDown
       aria-labelledby="new-global-explainer-dialog-title"
       aria-describedby="new-global-explainer-dialog-description"
       scroll="paper"
@@ -229,7 +231,7 @@ export default function NewGlobalExplainerModal({
               </Grid>
             </Grid>
           </Grid>
-          <Grid size={{ xs: 12, md: 9 }}>
+          <Grid size={{ xs: 12, md: 8 }}>
             <Stepper
               nonLinear
               activeStep={activeStep}
@@ -247,6 +249,22 @@ export default function NewGlobalExplainerModal({
                 </Step>
               ))}
             </Stepper>
+          </Grid>
+          <Grid
+            size={{ xs: 12, md: 1 }}
+            sx={{
+              display: { xs: "none", sm: "flex" },
+              justifyContent: "flex-end",
+            }}
+          >
+            <IconButton
+              onClick={handleCloseDialog}
+              sx={{
+                color: (theme) => theme.palette.grey[500],
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
           </Grid>
         </Grid>
       </DialogTitle>

--- a/DashAI/front/src/components/explainers/NewLocalExplainerModal.jsx
+++ b/DashAI/front/src/components/explainers/NewLocalExplainerModal.jsx
@@ -15,6 +15,7 @@ import {
   Grid,
   Typography,
   IconButton,
+  Box,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { useTheme } from "@mui/material/styles";
@@ -196,7 +197,8 @@ export default function NewLocalExplainerModal({
       fullScreen={screenSm}
       fullWidth
       maxWidth={"lg"}
-      onClose={handleCloseDialog}
+      onClose={() => {}}
+      disableEscapeKeyDown
       aria-labelledby="new-local-explainer-dialog-title"
       aria-describedby="new-local-explainer-dialog-description"
       scroll="paper"
@@ -238,7 +240,7 @@ export default function NewLocalExplainerModal({
               </Grid>
             </Grid>
           </Grid>
-          <Grid size={{ xs: 12, md: 9 }}>
+          <Grid size={{ xs: 12, md: 8 }}>
             <Stepper
               nonLinear
               activeStep={activeStep}
@@ -256,6 +258,22 @@ export default function NewLocalExplainerModal({
                 </Step>
               ))}
             </Stepper>
+          </Grid>
+          <Grid
+            size={{ xs: 12, md: 1 }}
+            sx={{
+              display: { xs: "none", sm: "flex" },
+              justifyContent: "flex-end",
+            }}
+          >
+            <IconButton
+              onClick={handleCloseDialog}
+              sx={{
+                color: (theme) => theme.palette.grey[500],
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
           </Grid>
         </Grid>
       </DialogTitle>

--- a/DashAI/front/src/components/notebooks/ConfigureToolModal.jsx
+++ b/DashAI/front/src/components/notebooks/ConfigureToolModal.jsx
@@ -46,14 +46,14 @@ export default function ConfigureToolModal({
   return (
     <Dialog
       open={open}
-      onClose={handleClose}
+      onClose={() => {}}
       slotProps={{
         paper: {
           sx: {
             width: { xs: "95%", sm: "1200px" },
             maxWidth: "100%",
             borderRadius: 2,
-            height: "90vh", // fixed modal height
+            height: "90vh",
             display: "flex",
             flexDirection: "column",
           },

--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -77,7 +77,7 @@ export function SaveDatasetModal({
   const nameError = getNameError();
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={() => {}} maxWidth="sm" fullWidth>
       <DialogTitle>
         Save Processed Dataset
         <IconButton

--- a/DashAI/front/src/components/notebooks/notebookCreation/CreateNotebookModal.jsx
+++ b/DashAI/front/src/components/notebooks/notebookCreation/CreateNotebookModal.jsx
@@ -99,7 +99,7 @@ export function CreateNotebookModal({
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={() => {}} maxWidth="sm" fullWidth>
       <DialogTitle>
         Create a New Notebook
         <IconButton

--- a/DashAI/front/src/components/pipelines/nodes/ExplorationModal.jsx
+++ b/DashAI/front/src/components/pipelines/nodes/ExplorationModal.jsx
@@ -5,6 +5,7 @@ import {
   DialogContent,
   DialogActions,
   Button,
+  ButtonGroup,
   IconButton,
   useMediaQuery,
   useTheme,
@@ -89,7 +90,8 @@ function ConfigureExplorersModal({ open, onClose, onSave, savedConfig }) {
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClose={() => {}}
+      disableEscapeKeyDown
       fullScreen={fullScreen}
       maxWidth="lg"
       fullWidth
@@ -119,9 +121,18 @@ function ConfigureExplorersModal({ open, onClose, onSave, savedConfig }) {
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleSave} variant="contained" disabled={!valid}>
-          Save
-        </Button>
+        <ButtonGroup size="large">
+          <Button onClick={onClose}>Cancel</Button>
+          <Button
+            onClick={handleSave}
+            variant="contained"
+            disabled={!valid}
+            autoFocus
+            color="primary"
+          >
+            Save
+          </Button>
+        </ButtonGroup>
       </DialogActions>
     </Dialog>
   );

--- a/DashAI/front/src/components/pipelines/nodes/TrainNode.jsx
+++ b/DashAI/front/src/components/pipelines/nodes/TrainNode.jsx
@@ -279,10 +279,6 @@ const Train = ({ open, onClose, onSave, savedConfig, prevNodes }) => {
   return (
     <>
       <DialogContent>
-        <Typography variant="h5" gutterBottom>
-          Select Train Parameters
-        </Typography>
-
         <Grid container>
           <Grid size={{ xs: 12 }}>
             <Typography variant="body1">Split Data:</Typography>
@@ -481,6 +477,7 @@ const Train = ({ open, onClose, onSave, savedConfig, prevNodes }) => {
           </Button>
         </Box>
       </DialogContent>
+
       <ParamsSettings
         open={openSettings}
         modelSchema={modelSchema}

--- a/DashAI/front/src/components/predictions/EditPredictionModal.jsx
+++ b/DashAI/front/src/components/predictions/EditPredictionModal.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { GridActionsCellItem } from "@mui/x-data-grid";
 import EditIcon from "@mui/icons-material/Edit";
+import CloseIcon from "@mui/icons-material/Close";
 import {
   Button,
   Dialog,
@@ -11,6 +12,8 @@ import {
   Grid,
   TextField,
   Typography,
+  IconButton,
+  Box,
 } from "@mui/material";
 import { rename_prediction as renamePredictionRequest } from "../../api/predict";
 import { useSnackbar } from "notistack";
@@ -64,7 +67,25 @@ function EditPredictionModal({ predictName, updatePredictions }) {
         fullWidth
         maxWidth={"md"}
       >
-        <DialogTitle>Edit prediction</DialogTitle>
+        <DialogTitle>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            Edit prediction
+            <IconButton
+              onClick={() => setOpen(false)}
+              sx={{
+                color: (theme) => theme.palette.grey[500],
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
         <DialogContent>
           <Grid
             container

--- a/DashAI/front/src/components/predictions/PredictionModal.jsx
+++ b/DashAI/front/src/components/predictions/PredictionModal.jsx
@@ -12,6 +12,7 @@ import {
   Grid,
   Typography,
   IconButton,
+  Box,
 } from "@mui/material";
 import PropTypes from "prop-types";
 import CloseIcon from "@mui/icons-material/Close";
@@ -198,7 +199,7 @@ function PredictionModal({
       fullScreen={screenSm}
       fullWidth
       maxWidth={"lg"}
-      onClose={handleCloseDialog}
+      onClose={() => {}} // No cerrar automáticamente
       aria-labelledby="new-predict-dialog-title"
       aria-describedby="new-predict-dialog-description"
       scroll="paper"
@@ -209,56 +210,77 @@ function PredictionModal({
       }}
     >
       <DialogTitle>
-        <Grid container direction={"row"} alignItems={"center"}>
-          <Grid size={{ xs: 12, md: 3 }}>
-            <Grid
-              container
-              direction="row"
-              alignItems="center"
-              justifyContent="space-between"
-            >
-              <Grid size={{ xs: 1 }}>
-                <IconButton
-                  edge="start"
-                  color="inherit"
-                  onClick={handleCloseDialog}
-                  sx={{ display: { xs: "flex", sm: "none" } }}
-                >
-                  <CloseIcon />
-                </IconButton>
-              </Grid>
-              <Grid size={{ xs: 11 }}>
-                <Typography
-                  variant="h6"
-                  component="h3"
-                  align={matches ? "center" : "left"}
-                  sx={{ mb: { sm: 2, md: 0 } }}
-                >
-                  Create a New Prediction
-                </Typography>
+        <Box sx={{ position: "relative" }}>
+          <Grid container direction={"row"} alignItems={"center"}>
+            <Grid size={{ xs: 12, md: 3 }}>
+              <Grid
+                container
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Grid size={{ xs: 1 }}>
+                  <IconButton
+                    edge="start"
+                    color="inherit"
+                    onClick={handleCloseDialog}
+                    sx={{ display: { xs: "flex", sm: "none" } }}
+                  >
+                    <CloseIcon />
+                  </IconButton>
+                </Grid>
+                <Grid size={{ xs: 11 }}>
+                  <Typography
+                    variant="h6"
+                    component="h3"
+                    align={matches ? "center" : "left"}
+                    sx={{ mb: { sm: 2, md: 0 } }}
+                  >
+                    Create a New Prediction
+                  </Typography>
+                </Grid>
               </Grid>
             </Grid>
-          </Grid>
-          <Grid size={{ xs: 12, md: 9 }}>
-            <Stepper
-              nonLinear
-              activeStep={activeStep}
-              sx={{ maxWidth: "100%" }}
+            <Grid size={{ xs: 12, md: 8 }}>
+              <Stepper
+                nonLinear
+                activeStep={activeStep}
+                sx={{ maxWidth: "100%" }}
+              >
+                {steps.map((step, index) => (
+                  <Step
+                    key={`${step.name}`}
+                    completed={activeStep > index}
+                    disabled={activeStep < index}
+                  >
+                    <StepButton
+                      color="inherit"
+                      onClick={handleStepButton(index)}
+                    >
+                      {step.label}
+                    </StepButton>
+                  </Step>
+                ))}
+              </Stepper>
+            </Grid>
+            <Grid
+              size={{ xs: 12, md: 1 }}
+              sx={{
+                display: { xs: "none", sm: "flex" },
+                justifyContent: "flex-end",
+              }}
             >
-              {steps.map((step, index) => (
-                <Step
-                  key={`${step.name}`}
-                  completed={activeStep > index}
-                  disabled={activeStep < index}
-                >
-                  <StepButton color="inherit" onClick={handleStepButton(index)}>
-                    {step.label}
-                  </StepButton>
-                </Step>
-              ))}
-            </Stepper>
+              <IconButton
+                onClick={handleCloseDialog}
+                sx={{
+                  color: (theme) => theme.palette.grey[500],
+                }}
+              >
+                <CloseIcon />
+              </IconButton>
+            </Grid>
           </Grid>
-        </Grid>
+        </Box>
       </DialogTitle>
       <DialogContent dividers>
         {renderStep(

--- a/DashAI/front/src/components/predictions/PredictionSummaryModal.jsx
+++ b/DashAI/front/src/components/predictions/PredictionSummaryModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Search } from "@mui/icons-material";
+import { Search, Close } from "@mui/icons-material";
 import { GridActionsCellItem } from "@mui/x-data-grid";
 import {
   Dialog,
@@ -9,6 +9,8 @@ import {
   Typography,
   Tabs,
   Tab,
+  IconButton,
+  Box,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
 import PredictionSummaryTab from "./PredictionSummaryTab";
@@ -74,11 +76,25 @@ function PredictionSummaryModal({ predictName }) {
         maxWidth={"md"}
       >
         <DialogTitle>
-          <Grid container direction="row" justifyContent="space-between">
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
             <Typography variant="h5" component="h2">
               Prediction Summary
             </Typography>
-          </Grid>
+            <IconButton
+              onClick={() => setOpen(false)}
+              sx={{
+                color: (theme) => theme.palette.grey[500],
+              }}
+            >
+              <Close />
+            </IconButton>
+          </Box>
         </DialogTitle>
         <DialogContent>
           <Grid

--- a/DashAI/front/src/pages/pipelines/NewPipeline.jsx
+++ b/DashAI/front/src/pages/pipelines/NewPipeline.jsx
@@ -1,5 +1,12 @@
 import React, { useRef } from "react";
-import { Box, Typography, Dialog } from "@mui/material";
+import {
+  Box,
+  Typography,
+  Dialog,
+  DialogTitle,
+  IconButton,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 import { ReactFlowProvider } from "reactflow";
 import CustomLayout from "../../components/custom/CustomLayout";
 import { Results as PipelineResults } from "../../components/pipelines";
@@ -154,7 +161,34 @@ function NewPipeline() {
               </Box>
 
               {renderNodeDialogContent() && (
-                <Dialog open={true} onClose={handleCloseDialog}>
+                <Dialog
+                  open={true}
+                  onClose={() => {}}
+                  disableEscapeKeyDown
+                  maxWidth="md"
+                  fullWidth
+                >
+                  <DialogTitle>
+                    <Box
+                      display="flex"
+                      justifyContent="space-between"
+                      alignItems="center"
+                    >
+                      <Typography variant="h6">
+                        {selectedNode?.type === "Train"
+                          ? "Select Train Parameters"
+                          : selectedNode?.type === "Exploration"
+                            ? "Exploration Configuration"
+                            : `Configure ${selectedNode?.type || "Node"}`}
+                      </Typography>
+                      <IconButton
+                        onClick={handleCloseDialog}
+                        sx={{ position: "absolute", right: 8, top: 8 }}
+                      >
+                        <CloseIcon />
+                      </IconButton>
+                    </Box>
+                  </DialogTitle>
                   {renderNodeDialogContent()}
                 </Dialog>
               )}

--- a/DashAI/front/src/pages/results/components/ResultsDialogLayout.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsDialogLayout.jsx
@@ -1,6 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Dialog, DialogTitle, Divider, Grid } from "@mui/material";
+import {
+  Dialog,
+  DialogTitle,
+  Divider,
+  Grid,
+  IconButton,
+  Box,
+} from "@mui/material";
+import { Close } from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import CustomLayout from "../../../components/custom/CustomLayout";
@@ -46,7 +54,25 @@ function ResultsDialogLayout({
         },
       }}
     >
-      <DialogTitle>{`Experiment ${experiment.name} results`}</DialogTitle>
+      <DialogTitle>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          {`Experiment ${experiment.name} results`}
+          <IconButton
+            onClick={handleOnClose}
+            sx={{
+              color: (theme) => theme.palette.grey[500],
+            }}
+          >
+            <Close />
+          </IconButton>
+        </Box>
+      </DialogTitle>
       <Divider />
       <ResultsDialogViews
         showTable={showTable}


### PR DESCRIPTION
# Summary

This PR improves user experience by preventing accidental modal closures in DashAI. Previously, modals would close automatically when users clicked outside them (backdrop click), causing data loss and frustration. Now modals only close through explicit user actions via close buttons.

## Type of change

- Front end new feature.
- Bug fix.

## Changes

- Disabled automatic modal closure on backdrop click for 13 critical modals
- Disabled ESC key closure (`disableEscapeKeyDown`)
- Added visible close buttons (X icon) in modal headers
- Implemented consistent Cancel/Save button patterns
- Applied responsive design for different screen sizes

## How to Test

1. Open any modal (Dataset creation, New Experiment, Predictions, etc.)
2. Try clicking outside the modal - it should NOT close
3. Verify close button (X) works properly
4. Confirm Cancel/Save buttons function as expected

## Notes

Affects 13 modals across the platform including DatasetModal, NewExperimentModal, PredictionModal, and explainer modals. This change prevents accidental data loss while maintaining full user control over modal interactions.