### PR TITLE
Feat: differentiate notebook view

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetVisualization.jsx
@@ -184,9 +184,7 @@ export default function DatasetVisualization({
           alignItems="center"
           sx={{ mb: 4 }}
         >
-          <Typography variant="h5" component="h2">
-            {dataset.name}
-          </Typography>
+          <Typography variant="h6">{dataset.name}</Typography>
           <Grid sx={{ height: "35px" }}>
             <Button
               variant="contained"

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -44,6 +44,15 @@ export default function DatasetPreviewNotebook({
   const [converters, setConverters] = useState([]);
   const { explorersAndConverters } = useExplorersAndConverters();
 
+  // Find the associated dataset name
+  const getDatasetName = () => {
+    if (!notebook.dataset_id || !existingDatasets.length) {
+      return "Dataset";
+    }
+    const dataset = existingDatasets.find((d) => d.id === notebook.dataset_id);
+    return dataset ? dataset.name : "Dataset";
+  };
+
   const fetchDatasetPage = useCallback(
     async (page, pageSize) => {
       const data = await getDatasetFile(notebook.file_path, page, pageSize);
@@ -115,7 +124,9 @@ export default function DatasetPreviewNotebook({
             },
           }}
         >
-          <Typography variant="h6">Dataset Preview</Typography>
+          <Typography variant="h6">
+            Notebook: {getDatasetName()} Preview
+          </Typography>
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             {/* Save Dataset Button */}
             <Button


### PR DESCRIPTION
# Summary

Improve visual differentiation between dataset and notebook views by displaying the associated dataset name in the notebook preview title. This change helps users quickly identify which dataset a notebook is linked to, reducing confusion between similar-looking views.

## Type of change

- Front end new feature.

## Changes

- Modified `DatasetPreviewNotebook` component to display dataset name instead of generic "Dataset Preview"
- Added `getDatasetName()` function to resolve dataset name from `notebook.dataset_id`
- Updated Typography to show "[Dataset Name] Preview" format
- Improved contextual clarity for notebook-dataset relationships

## How to Test

1. Navigate to Notebooks page
2. Select any notebook that has an associated dataset
3. Verify the preview title shows "[Dataset Name] Preview" instead of generic "Dataset Preview"
4. Confirm the dataset name displayed matches the actual associated dataset
5. Test with notebooks linked to different datasets to ensure correct name resolution

## Notes

This enhancement addresses user confusion between dataset and notebook views by providing immediate visual context about which dataset the notebook is processing. The title now clearly indicates the relationship between the notebook and its source dataset.