### PR TITLE
Ensure proper initialization of superclass in TruncatedSVD

### DIFF
--- a/DashAI/back/converters/scikit_learn/truncated_svd.py
+++ b/DashAI/back/converters/scikit_learn/truncated_svd.py
@@ -76,3 +76,4 @@ class TruncatedSVD(SklearnWrapper, TruncatedSVDOperation):
         if self.random_state == "RandomState":
             self.random_state = create_random_state()
         kwargs["random_state"] = self.random_state
+        super().__init__(**kwargs)


### PR DESCRIPTION
This pull request makes a small update to the `TruncatedSVDConverter` initialization logic by ensuring the superclass's `__init__` method is called with the correct keyword arguments. This change helps maintain proper initialization and inheritance behavior.

* Added a call to `super().__init__(**kwargs)` in the `__init__` method of `TruncatedSVDConverter` to ensure the parent class is properly initialized.