### PR TITLE
Fix default values in RBFSamplerSchema

### DIFF
--- a/DashAI/back/converters/scikit_learn/rbf_sampler.py
+++ b/DashAI/back/converters/scikit_learn/rbf_sampler.py
@@ -16,7 +16,7 @@ from DashAI.back.core.schema_fields.base_schema import BaseSchema
 class RBFSamplerSchema(BaseSchema):
     gamma: schema_field(
         union_type(enum_field(["scale"]), float_field(gt=0)),
-        1.0,
+        "scale",
         "Parameter of the RBF kernel.",
     )  # type: ignore
     n_components: schema_field(
@@ -28,7 +28,7 @@ class RBFSamplerSchema(BaseSchema):
         none_type(
             union_type(int_field(), enum_field(["RandomState"]))
         ),  # int, RandomState instance or None
-        None,
+        0,
         (
             "Pseudo-random number generator to control the generation of the "
             "random weights and random offset when fitting the training data. "


### PR DESCRIPTION
This pull request updates the default parameter values in the `RBFSamplerSchema` class to better align with expected usage and improve consistency.

Parameter defaults update in `RBFSamplerSchema`:

* Changed the default value of the `gamma` parameter from `1.0` to `"scale"`.
* Changed the default value of the random state parameter from `None` to `0`.