### PR TITLE
Set default placeholder for max_features in DecisionTreeClassifier schema

### DIFF
--- a/DashAI/back/models/scikit_learn/decision_tree_classifier.py
+++ b/DashAI/back/models/scikit_learn/decision_tree_classifier.py
@@ -58,7 +58,7 @@ class DecisionTreeClassifierSchema(BaseSchema):
     )  # type: ignore
     max_features: schema_field(
         enum_field(enum=["auto", "sqrt", "log2"]),
-        placeholder=None,
+        placeholder="auto",
         description="The number of features to consider when looking for the best "
         "split.",
     )  # type: ignore


### PR DESCRIPTION
This pull request makes a minor fix to the `DecisionTreeClassifierSchema` in `decision_tree_classifier.py` by setting the default placeholder value for the `max_features` field to `"auto"`. 