### PR TITLE
Update PermutationFeatureImportance to select samples using fraction

### DIFF
--- a/DashAI/back/explainability/explainers/permutation_feature_importance.py
+++ b/DashAI/back/explainability/explainers/permutation_feature_importance.py
@@ -11,6 +11,7 @@ from sklearn.metrics import accuracy_score, balanced_accuracy_score, make_scorer
 from DashAI.back.core.schema_fields import (
     BaseSchema,
     enum_field,
+    float_field,
     int_field,
     schema_field,
 )
@@ -35,7 +36,7 @@ class PermutationFeatureImportanceSchema(BaseSchema):
 
     n_repeats: schema_field(
         int_field(ge=1),
-        placeholder=10,
+        placeholder=20,
         description="Number of times to permute a feature.",
     )  # type: ignore
 
@@ -46,10 +47,10 @@ class PermutationFeatureImportanceSchema(BaseSchema):
         "permutations of each feature.",
     )  # type: ignore
 
-    max_samples: schema_field(
-        int_field(ge=1),
-        placeholder=100,
-        description="The number of samples to draw from the dataset to "
+    max_samples_fraction: schema_field(
+        float_field(ge=0.0, le=1.0),
+        placeholder=1.0,
+        description="The fraction of samples to draw from the test set to "
         "calculate feature importance at each repetition.",
     )  # type: ignore
 
@@ -69,7 +70,7 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
         scoring: Union[str, List[str], None] = None,
         n_repeats: int = 5,
         random_state: Union[int, None] = None,
-        max_samples: int = 1,
+        max_samples_fraction: float = 0.5,
     ):
         """Initialize a new instance of PermutationFeatureImportance explainer.
 
@@ -85,8 +86,8 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
         random_state: Union[int, None]
             Seed for  the random number generator to control the
             permutations of each feature
-        max_samples: int
-            The number of samples to draw from the dataset to calculate
+        max_samples_fraction: float
+            The fraction of samples to draw from the test set to calculate
             feature importance at each repetition
         """
 
@@ -100,7 +101,7 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
         self.scoring = metrics[scoring]
         self.n_repeats = n_repeats
         self.random_state = random_state
-        self.max_samples = max_samples
+        self.max_samples_fraction = max_samples_fraction
 
     def explain(self, dataset: Tuple[DatasetDict, DatasetDict]):
         """Method for calculating the importance of features in the model
@@ -134,6 +135,8 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
         def patched_metric(y_true, y_pred_probas):
             return self.scoring(y_true, np.argmax(y_pred_probas, axis=1))
 
+        max_samples = max(int(len(x_test) * self.max_samples_fraction), 1)
+
         # TODO: binary and multi-label scorer
         pfi = permutation_importance(
             estimator=self.model,
@@ -142,7 +145,7 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
             scoring=make_scorer(patched_metric),
             n_repeats=self.n_repeats,
             random_state=self.random_state,
-            max_samples=self.max_samples,
+            max_samples=max_samples,
         )
 
         return {

--- a/tests/back/explainers/test_explainers.py
+++ b/tests/back/explainers/test_explainers.py
@@ -7,10 +7,7 @@ from DashAI.back.dataloaders.classes.dashai_dataset import (
     split_dataset,
     split_indexes,
 )
-from DashAI.back.explainability import (
-    PartialDependence,
-    PermutationFeatureImportance,
-)
+from DashAI.back.explainability import PartialDependence, PermutationFeatureImportance
 from DashAI.back.models.base_model import BaseModel
 from DashAI.back.models.scikit_learn.decision_tree_classifier import (
     DecisionTreeClassifier,
@@ -117,7 +114,7 @@ def test_permutation_feature_importance(trained_model: BaseModel, dataset: Datas
         "scoring": "accuracy",
         "n_repeats": 5,
         "random_state": None,
-        "max_samples": 1,
+        "max_samples_fraction": 1.0,
     }
     explainer = PermutationFeatureImportance(trained_model, **parameters)
     explanation = explainer.explain(dataset)
@@ -136,7 +133,7 @@ def test_permutation_feature_importance(trained_model: BaseModel, dataset: Datas
         "scoring": "balanced_accuracy",
         "n_repeats": 5,
         "random_state": None,
-        "max_samples": 1,
+        "max_samples_fraction": 1.0,
     }
     explainer = PermutationFeatureImportance(trained_model, **parameters)
     explanation = explainer.explain(dataset)


### PR DESCRIPTION
This pull request updates the `PermutationFeatureImportance` explainer to use a fractional value for the number of samples drawn from the test set, instead of an absolute count. This makes the explainer more flexible and better suited for datasets of varying sizes. The parameter and its usage are renamed and refactored throughout the code and schema.

**Parameter and schema changes:**

* Changed the parameter from `max_samples` (absolute integer) to `max_samples_fraction` (float between 0.0 and 1.0) in the `PermutationFeatureImportanceSchema` and throughout the explainer class. 
* Updated the placeholder for `n_repeats` from 10 to 20 for more robust permutation calculations.