### PR TITLE
Update missing_values placeholder in KNNImputerSchema to "np.nan"

### DIFF
--- a/DashAI/back/converters/scikit_learn/knn_imputer.py
+++ b/DashAI/back/converters/scikit_learn/knn_imputer.py
@@ -20,7 +20,7 @@ class KNNImputerSchema(BaseSchema):
         none_type(
             union_type(int_field(), union_type(float_field(), string_field()))
         ),  # int, float, str, np.nan or None
-        None,  # np.nan,
+        "np.nan",
         "The placeholder for the missing values.",
     )  # type: ignore
     n_neighbors: schema_field(


### PR DESCRIPTION
This pull request updates the `KNNImputerSchema` to fix the placeholder value for missing data. Instead of using `None` to represent `np.nan`, the string `"np.nan"` is now explicitly used as the placeholder.

- Schema improvement:
  * Updated the `KNNImputerSchema` in `knn_imputer.py` to use the string `"np.nan"` as the placeholder for missing values instead of `None`.