### PR TITLE
Fix excel dataloader

### DIFF
--- a/DashAI/back/dataloaders/classes/excel_dataloader.py
+++ b/DashAI/back/dataloaders/classes/excel_dataloader.py
@@ -48,7 +48,7 @@ class ExcelDataloaderSchema(BaseSchema):
     )  # type: ignore
     header: schema_field(
         none_type(int_field(ge=0)),
-        placeholder=None,
+        placeholder=0,
         description="""
         The row number where the column names are located, indexed from 0.
         If null, the file will be considered to have no column names.

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ imblearn
 numba
 llvmlite
 huey
+xlrd


### PR DESCRIPTION
This pull request makes a minor update to the `ExcelDataloaderSchema` in the `excel_dataloader.py` file and `requirements.txt` file. The default placeholder value for the `header` field is changed from `None` to `0`, clarifying that the default behavior assumes column names are present in the first row.

- Changed the `header` field's `placeholder` from `None` to `0` in `ExcelDataloaderSchema`, making the default behavior more explicit for users.
- Added `xlrd` library to support older `.xls` files.