### PR TITLE
Ensure hover effect for NewItemButton background color

### DIFF
--- a/DashAI/front/src/components/threeSectionLayout/NewItemButton.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/NewItemButton.jsx
@@ -18,6 +18,7 @@ export default function NewItemButton({ onClick, title = "New Item" }) {
           height: "35px",
           width: "100%",
           textTransform: "none",
+          "&:hover": { bgcolor: "primary.dark" },
         }}
         onClick={onClick}
         endIcon={<AddIcon />}


### PR DESCRIPTION
This pull request introduces a small UI improvement to the `NewItemButton` component by updating its hover styling.

- Added a hover effect to the button, changing its background color to `primary.dark` when hovered.
<img width="412" height="262" alt="image" src="https://github.com/user-attachments/assets/4e61ff3f-b2a8-4e31-b5d9-549458794266" />
<img width="432" height="283" alt="image" src="https://github.com/user-attachments/assets/f65c22c9-a558-4b04-8189-cc477bc71bc4" />
