### PR TITLE
Fix column replacement logic in converter job

### DIFF
--- a/DashAI/back/job/converter_job.py
+++ b/DashAI/back/job/converter_job.py
@@ -64,10 +64,15 @@ def _rebuild_dataset_with_transformed_columns(
     original_without_scope = base.remove_columns(scope_column_names)
 
     transformed_cols = transformed.column_names
-    replacement_cols = transformed_cols[: len(scope_column_indexes)]
-    new_cols = transformed_cols[len(scope_column_indexes) :]
 
-    index_to_replacement = dict(zip(scope_column_indexes, replacement_cols))
+    index_to_replacement = dict(zip(scope_column_indexes, scope_column_names))
+    index_to_replacement = {
+        key: value
+        for key, value in index_to_replacement.items()
+        if value in transformed_cols and value in original_columns
+    }
+    new_cols = [col for col in transformed_cols if col not in scope_column_names]
+
     new_columns_order = []
     for i, col in enumerate(original_columns):
         if i in index_to_replacement:


### PR DESCRIPTION
This pull request updates the logic for rebuilding datasets with transformed columns in the `converter_job.py` file. The main focus is on improving how replacement and new columns are determined when transforming scoped columns.

Column replacement and filtering logic:

* The mapping for column replacement now uses `scope_column_names` directly instead of sliced transformed columns, ensuring replacements are based on actual column names.
* The replacement mapping is further filtered to include only columns present in both the transformed and original columns, improving robustness.
* The identification of new columns is updated to select columns from `transformed_cols` that are not in `scope_column_names`, making the logic clearer and more accurate.