### PR TITLE
Fix regression models

### DIFF
--- a/DashAI/back/metrics/regression/rmse.py
+++ b/DashAI/back/metrics/regression/rmse.py
@@ -28,4 +28,4 @@ class RMSE(RegressionMetric):
             RMSE score between true values and predicted values
         """
         true_values, pred_values = prepare_to_metric(true_values, predicted_values)
-        return mean_squared_error(true_values, pred_values, squared=False)
+        return mean_squared_error(true_values, pred_values)

--- a/DashAI/back/metrics/regression/rmse.py
+++ b/DashAI/back/metrics/regression/rmse.py
@@ -1,7 +1,7 @@
 """DashAI RMSE regression metric implementation."""
 
 import numpy as np
-from sklearn.metrics import mean_squared_error
+from sklearn.metrics import root_mean_squared_error
 
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 from DashAI.back.metrics.regression_metric import RegressionMetric, prepare_to_metric
@@ -28,4 +28,4 @@ class RMSE(RegressionMetric):
             RMSE score between true values and predicted values
         """
         true_values, pred_values = prepare_to_metric(true_values, predicted_values)
-        return mean_squared_error(true_values, pred_values)
+        return root_mean_squared_error(true_values, pred_values)

--- a/DashAI/back/models/scikit_learn/gradient_boosting_regression.py
+++ b/DashAI/back/models/scikit_learn/gradient_boosting_regression.py
@@ -4,6 +4,7 @@ from DashAI.back.core.schema_fields import (
     BaseSchema,
     bool_field,
     enum_field,
+    float_field,
     none_type,
     optimizer_float_field,
     optimizer_int_field,
@@ -24,7 +25,7 @@ class GradientBoostingRSchema(BaseSchema):
     )  # type: ignore
 
     learning_rate: schema_field(
-        optimizer_float_field(gt=0.0),
+        optimizer_float_field(ge=0.01),
         placeholder={
             "optimize": False,
             "fixed_value": 0.1,
@@ -46,7 +47,7 @@ class GradientBoostingRSchema(BaseSchema):
     )  # type: ignore
 
     subsample: schema_field(
-        optimizer_float_field(gt=0.0, le=1.0),
+        optimizer_float_field(ge=0.1, le=1.0),
         placeholder={
             "optimize": False,
             "fixed_value": 1.0,
@@ -86,13 +87,8 @@ class GradientBoostingRSchema(BaseSchema):
     )  # type: ignore
 
     min_weight_fraction_leaf: schema_field(
-        optimizer_float_field(ge=0.0, le=0.5),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.0,
-            "lower_bound": 0.0,
-            "upper_bound": 0.5,
-        },
+        float_field(ge=0.0, le=0.5),
+        placeholder=0.0,
         description="The minimum weighted fraction of the sum total of weights"
         " (of all the input samples) required to be at a leaf node.",
     )  # type: ignore
@@ -104,13 +100,8 @@ class GradientBoostingRSchema(BaseSchema):
     )  # type: ignore
 
     min_impurity_decrease: schema_field(
-        optimizer_float_field(ge=0.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.0,
-            "lower_bound": 0.0,
-            "upper_bound": 0.5,
-        },
+        float_field(ge=0.0),
+        placeholder=0.0,
         description="A node will be split if this split induces a decrease of "
         "the impurity greater than or equal to this value.",
     )  # type: ignore

--- a/DashAI/back/models/scikit_learn/linearSVR.py
+++ b/DashAI/back/models/scikit_learn/linearSVR.py
@@ -41,11 +41,11 @@ class LinearSVRSchema(BaseSchema):
     )  # type: ignore
 
     C: schema_field(
-        optimizer_float_field(gt=0.0),
+        optimizer_float_field(ge=1.0),
         placeholder={
             "optimize": False,
             "fixed_value": 1.0,
-            "lower_bound": 0.1,
+            "lower_bound": 1.0,
             "upper_bound": 10,
         },
         description="Regularization parameter. The strength of the regularization "
@@ -66,11 +66,11 @@ class LinearSVRSchema(BaseSchema):
     )  # type: ignore
 
     intercept_scaling: schema_field(
-        optimizer_float_field(gt=0.0),
+        optimizer_float_field(ge=1.0),
         placeholder={
             "optimize": False,
             "fixed_value": 1.0,
-            "lower_bound": 0.1,
+            "lower_bound": 1.0,
             "upper_bound": 10,
         },
         description="When fit_intercept is True, instance vector x becomes "

--- a/DashAI/back/models/scikit_learn/linearSVR.py
+++ b/DashAI/back/models/scikit_learn/linearSVR.py
@@ -41,11 +41,11 @@ class LinearSVRSchema(BaseSchema):
     )  # type: ignore
 
     C: schema_field(
-        optimizer_float_field(ge=1.0),
+        optimizer_int_field(ge=1),
         placeholder={
             "optimize": False,
-            "fixed_value": 1.0,
-            "lower_bound": 1.0,
+            "fixed_value": 1,
+            "lower_bound": 1,
             "upper_bound": 10,
         },
         description="Regularization parameter. The strength of the regularization "

--- a/DashAI/back/models/scikit_learn/random_forest_regression.py
+++ b/DashAI/back/models/scikit_learn/random_forest_regression.py
@@ -4,6 +4,7 @@ from DashAI.back.core.schema_fields import (
     BaseSchema,
     bool_field,
     enum_field,
+    float_field,
     none_type,
     optimizer_float_field,
     optimizer_int_field,
@@ -63,13 +64,8 @@ class RandomForestRegressionSchema(BaseSchema):
     )  # type: ignore
 
     min_weight_fraction_leaf: schema_field(
-        optimizer_float_field(ge=0.0, le=0.5),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.0,
-            "lower_bound": 0.0,
-            "upper_bound": 0.5,
-        },
+        float_field(ge=0.0, le=0.5),
+        placeholder=0.0,
         description="The minimum weighted fraction of the sum total of weights"
         " required to be at a leaf node.",
     )  # type: ignore
@@ -91,13 +87,8 @@ class RandomForestRegressionSchema(BaseSchema):
     )  # type: ignore
 
     min_impurity_decrease: schema_field(
-        optimizer_float_field(ge=0.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.0,
-            "lower_bound": 0.0,
-            "upper_bound": 0.5,
-        },
+        float_field(ge=0.0),
+        placeholder=0.0,
         description="A node will be split if this split induces a decrease of"
         " the impurity greater than or equal to this value.",
     )  # type: ignore

--- a/DashAI/back/models/scikit_learn/ridge_regression.py
+++ b/DashAI/back/models/scikit_learn/ridge_regression.py
@@ -18,12 +18,12 @@ class RidgeRegressionSchema(BaseSchema):
     """Ridge regression is a linear model that includes L2 regularization."""
 
     alpha: schema_field(
-        optimizer_float_field(ge=0.0),
+        optimizer_int_field(ge=1),
         placeholder={
             "optimize": False,
-            "fixed_value": 1.0,
-            "lower_bound": 0.1,
-            "upper_bound": 10.0,
+            "fixed_value": 1,
+            "lower_bound": 1,
+            "upper_bound": 10,
         },
         description="Regularization strength; must be a positive float. "
         "Larger values specify stronger regularization.",
@@ -44,11 +44,11 @@ class RidgeRegressionSchema(BaseSchema):
     )  # type: ignore
 
     max_iter: schema_field(
-        optimizer_int_field(ge=1),
+        optimizer_int_field(ge=10),
         placeholder={
             "optimize": False,
-            "fixed_value": 1000,
-            "lower_bound": 100,
+            "fixed_value": 100,
+            "lower_bound": 10,
             "upper_bound": 10000,
         },
         description="Maximum number of iterations for conjugate gradient solver.",

--- a/DashAI/front/src/pages/results/components/ResultsTabHyperparameters.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsTabHyperparameters.jsx
@@ -4,6 +4,7 @@ import Plot from "react-plotly.js";
 import { FormControl, InputLabel, Grid, MenuItem, Select } from "@mui/material";
 import { getHyperparameterPlot as getHyperparameterPlotRequest } from "../../../api/run";
 import { enqueueSnackbar } from "notistack";
+import { checkIfHaveOptimazers } from "../../../utils/schema";
 
 function ResultsTabHyperparameters({ runData }) {
   const [displayMode, setDisplayMode] = useState("nested-list");
@@ -17,12 +18,10 @@ function ResultsTabHyperparameters({ runData }) {
     const layout = formattedPlot.layout;
     return formattedPlot;
   }
-  const optimizables = Object.keys(runData.parameters).filter(
-    (key) => runData.parameters[key].optimize === true,
-  ).length;
+  const optimizables = checkIfHaveOptimazers(runData.parameters);
   const getHyperparameterPlot = async () => {
     try {
-      if (optimizables >= 2) {
+      if (optimizables) {
         const historicalPlot = await getHyperparameterPlotRequest(
           runData.id,
           1,
@@ -91,7 +90,7 @@ function ResultsTabHyperparameters({ runData }) {
           config={{ staticPlot: false }}
         />
       </Grid>
-      {optimizables >= 2 && (
+      {optimizables && (
         <>
           <Grid container direction="column">
             <Plot

--- a/DashAI/front/src/pages/results/components/ResultsTabHyperparameters.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsTabHyperparameters.jsx
@@ -4,7 +4,7 @@ import Plot from "react-plotly.js";
 import { FormControl, InputLabel, Grid, MenuItem, Select } from "@mui/material";
 import { getHyperparameterPlot as getHyperparameterPlotRequest } from "../../../api/run";
 import { enqueueSnackbar } from "notistack";
-import { checkIfHaveOptimazers } from "../../../utils/schema";
+import { checkHowManyOptimazers } from "../../../utils/schema";
 
 function ResultsTabHyperparameters({ runData }) {
   const [displayMode, setDisplayMode] = useState("nested-list");
@@ -18,12 +18,13 @@ function ResultsTabHyperparameters({ runData }) {
     const layout = formattedPlot.layout;
     return formattedPlot;
   }
-  const optimizables = checkIfHaveOptimazers({
+  const optimizables = checkHowManyOptimazers({
     params: runData.parameters,
   });
+
   const getHyperparameterPlot = async () => {
     try {
-      if (optimizables) {
+      if (optimizables >= 2) {
         const historicalPlot = await getHyperparameterPlotRequest(
           runData.id,
           1,
@@ -92,7 +93,7 @@ function ResultsTabHyperparameters({ runData }) {
           config={{ staticPlot: false }}
         />
       </Grid>
-      {optimizables && (
+      {optimizables >= 2 && (
         <>
           <Grid container direction="column">
             <Plot

--- a/DashAI/front/src/pages/results/components/ResultsTabHyperparameters.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsTabHyperparameters.jsx
@@ -18,7 +18,9 @@ function ResultsTabHyperparameters({ runData }) {
     const layout = formattedPlot.layout;
     return formattedPlot;
   }
-  const optimizables = checkIfHaveOptimazers(runData.parameters);
+  const optimizables = checkIfHaveOptimazers({
+    params: runData.parameters,
+  });
   const getHyperparameterPlot = async () => {
     try {
       if (optimizables) {

--- a/DashAI/front/src/utils/schema.js
+++ b/DashAI/front/src/utils/schema.js
@@ -257,6 +257,32 @@ export const checkIfHaveOptimazers = (values) => {
   return false;
 };
 
+export const checkHowManyOptimazers = (values) => {
+  let count = 0;
+
+  if (!values?.params) {
+    return count;
+  }
+
+  for (let key in values.params) {
+    const param = values.params[key];
+    if (!param) continue;
+
+    if (param.optimize) {
+      count += 1;
+    }
+
+    if (
+      param.properties &&
+      checkIfHaveOptimazers(param.properties.params.comp.params)
+    ) {
+      count += checkHowManyOptimazers(param.properties.params.comp.params);
+    }
+  }
+
+  return count;
+};
+
 export const getParamsFromSubform = (subform) => {
   if (!subform) {
     return null;


### PR DESCRIPTION
This pull request updates several regression model schemas and utility functions to improve parameter validation, consistency, and code clarity in both backend and frontend components. The main changes involve refining the types and constraints for model hyperparameters, updating metric computation to use the latest scikit-learn API, and enhancing frontend logic for handling optimizable hyperparameters.

**Backend: Model Schema and Metric Updates**

*Regression model schema improvements:*
- Changed `min_weight_fraction_leaf` and `min_impurity_decrease` in both `RandomForestRegressionSchema` and `GradientBoostingRSchema` to use `float_field` instead of `optimizer_float_field`, simplifying these fields and updating their placeholders accordingly. [[1]](diffhunk://#diff-74397a3d75ddb28217dbfd69ceed3cc0bde6b18f61c8442d078ff557ca09ddceL66-R68) [[2]](diffhunk://#diff-74397a3d75ddb28217dbfd69ceed3cc0bde6b18f61c8442d078ff557ca09ddceL94-R91) [[3]](diffhunk://#diff-d8431200beff51a833d70f1f5131c85cb71f07d97f717cf4e061b37f94b112ecL89-R91) [[4]](diffhunk://#diff-d8431200beff51a833d70f1f5131c85cb71f07d97f717cf4e061b37f94b112ecL107-R104)
- Adjusted constraints for several hyperparameters:
  - `learning_rate` now requires a minimum value of 0.01, and `subsample` a minimum of 0.1 in `GradientBoostingRSchema`. [[1]](diffhunk://#diff-d8431200beff51a833d70f1f5131c85cb71f07d97f717cf4e061b37f94b112ecL27-R28) [[2]](diffhunk://#diff-d8431200beff51a833d70f1f5131c85cb71f07d97f717cf4e061b37f94b112ecL49-R50)
  - `C` in `LinearSVRSchema` and `alpha` in `RidgeRegressionSchema` now use `optimizer_int_field` with a minimum of 1, and their placeholders were updated for integer values. [[1]](diffhunk://#diff-6c31fa00025909477bf96729b1d7363eea9f1741564c47802651db9e65f8f8edL44-R48) [[2]](diffhunk://#diff-0a4a48a60b6253631cb3446398bb3c10db2f0555722d96a33f278d312e7ec1fbL21-R26)
  - `intercept_scaling` in `LinearSVRSchema` now uses a minimum value of 1.0.
  - `max_iter` in `RidgeRegressionSchema` now requires a minimum of 10.

*Regression metric update:*
- Updated the RMSE metric implementation to use `root_mean_squared_error` from scikit-learn instead of computing RMSE via `mean_squared_error(..., squared=False)`, aligning with the latest scikit-learn API. [[1]](diffhunk://#diff-d55ed7601065aa498268c760c39ab902ca5254de3161e2de94df775b826045eeL4-R4) [[2]](diffhunk://#diff-d55ed7601065aa498268c760c39ab902ca5254de3161e2de94df775b826045eeL31-R31)

**Frontend: Hyperparameter Optimization Utilities**

*Hyperparameter optimizers logic:*
- Added a new utility function `checkHowManyOptimazers` in `schema.js` to recursively count optimizable hyperparameters, including nested parameters.
- Updated `ResultsTabHyperparameters.jsx` to use the new `checkHowManyOptimazers` function for determining the number of optimizable hyperparameters, improving reliability for complex parameter schemas. [[1]](diffhunk://#diff-ad332d659fc0f69b7968930b6b68476a124f360460697ba2e059fedc1afb5f9fR7) [[2]](diffhunk://#diff-ad332d659fc0f69b7968930b6b68476a124f360460697ba2e059fedc1afb5f9fL20-R24)
