### PR TITLE
Add max_features field with support for percentage and None type for DecisionTreeClassifier

### DIFF
--- a/DashAI/back/models/scikit_learn/decision_tree_classifier.py
+++ b/DashAI/back/models/scikit_learn/decision_tree_classifier.py
@@ -3,8 +3,11 @@ from sklearn.tree import DecisionTreeClassifier as _DecisionTreeClassifier
 from DashAI.back.core.schema_fields import (
     BaseSchema,
     enum_field,
+    float_field,
+    none_type,
     optimizer_int_field,
     schema_field,
+    union_type,
 )
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
     SklearnLikeClassifier,
@@ -57,10 +60,13 @@ class DecisionTreeClassifierSchema(BaseSchema):
         description="The minimum number of samples required to be at a leaf node.",
     )  # type: ignore
     max_features: schema_field(
-        enum_field(enum=["auto", "sqrt", "log2"]),
-        placeholder="auto",
+        none_type(
+            union_type(enum_field(enum=["sqrt", "log2"]), float_field(gt=0.0, le=1.0))
+        ),
+        placeholder=None,
         description="The number of features to consider when looking for the best "
-        "split.",
+        "split. If float, then max_features is a percentage of "
+        "the total number of features.",
     )  # type: ignore
 
 


### PR DESCRIPTION
This pull request updates the schema for the `DecisionTreeClassifier` model to enhance the flexibility of the `max_features` parameter. The main change allows `max_features` to accept `None`, a float between 0 and 1, or specific string values, aligning the schema with scikit-learn's options.

Schema improvements for `DecisionTreeClassifier`:

* Updated the `max_features` field in `DecisionTreeClassifierSchema` to accept `None`, a float (as a percentage), or the strings `"sqrt"` and `"log2"`, and improved its description.
* Imported new schema field helpers (`float_field`, `none_type`, `union_type`) to support the expanded types for `max_features`.