### PR TITLE
Update tokenization from BOW model to remove all specified columns instead of just 'text'

### DIFF
--- a/DashAI/back/models/scikit_learn/bow_text_classification_model.py
+++ b/DashAI/back/models/scikit_learn/bow_text_classification_model.py
@@ -203,7 +203,7 @@ class BagOfWordsTextClassificationModel(TextClassificationModel, SklearnLikeMode
         input_column = x.column_names[0]
         self.vectorizer.fit(x[input_column])
         tokenizer_func = self.get_vectorizer(input_column)
-        tokenized_dataset = x.map(tokenizer_func, remove_columns="text")
+        tokenized_dataset = x.map(tokenizer_func, remove_columns=x.column_names)
         tokenized_dataset = to_dashai_dataset(tokenized_dataset)
 
         self.classifier.fit(tokenized_dataset, y)
@@ -212,7 +212,7 @@ class BagOfWordsTextClassificationModel(TextClassificationModel, SklearnLikeMode
         input_column = x.column_names[0]
 
         tokenizer_func = self.get_vectorizer(input_column)
-        tokenized_dataset = x.map(tokenizer_func, remove_columns="text")
+        tokenized_dataset = x.map(tokenizer_func, remove_columns=x.column_names)
         tokenized_dataset = to_dashai_dataset(tokenized_dataset)
 
         return self.classifier.predict(tokenized_dataset)


### PR DESCRIPTION
This pull request updates how columns are removed during tokenization in the `fit` and `predict` methods of the `bow_text_classification_model.py` file. Instead of removing only the `"text"` column, it now removes all columns present in the dataset, making the tokenization process more robust and less dependent on hardcoded column names.

**Tokenization improvements:**

* Updated both the `fit` and `predict` methods to remove all columns (`x.column_names`) during tokenization rather than just the `"text"` column, ensuring compatibility with datasets that may have different or multiple column names. [[1]](diffhunk://#diff-e365bc76750c3d480b2bf0dd787fb15ba89539aa6308958ce0d8e934a06fb487L206-R206) [[2]](diffhunk://#diff-e365bc76750c3d480b2bf0dd787fb15ba89539aa6308958ce0d8e934a06fb487L215-R215)