### PR TITLE
Update dependencies in RightBar to include explorersAndConverters

### DIFF
--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -20,6 +20,7 @@ import FormConverterSection from "./converterCreation/FormConverterSection";
 import { getComponents } from "../../api/component";
 import { getDatasetTypesByFilePath } from "../../api/datasets";
 import { useSnackbar } from "notistack";
+import { useExplorersAndConverters } from "./context/ExplorersAndConvertersContext";
 
 export default function RightBar({ notebook }) {
   const [activeTab, setActiveTab] = useState(0);
@@ -31,6 +32,7 @@ export default function RightBar({ notebook }) {
   const [datasetColumns, setDatasetColumns] = useState([]);
   const [viewMode, setViewMode] = useState("list");
   const { enqueueSnackbar } = useSnackbar();
+  const { explorersAndConverters } = useExplorersAndConverters();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -86,7 +88,7 @@ export default function RightBar({ notebook }) {
     return () => {
       isMounted = false;
     };
-  }, [notebook?.file_path]);
+  }, [notebook?.file_path, explorersAndConverters]);
 
   // Validate explorers based on dataset columns
   const validateExplorer = (explorer) => {


### PR DESCRIPTION
This pull request updates the `RightBar` component to integrate the `ExplorersAndConvertersContext` and ensure that changes to explorers and converters trigger relevant updates.

**Integration of explorers and converters context:**

* Imported `useExplorersAndConverters` from the local context and used it to access `explorersAndConverters` within the `RightBar` component. [[1]](diffhunk://#diff-711647abd9237f7984867e4544ede07fcf00a688129ce0f7ae4dd2c752781c81R23) [[2]](diffhunk://#diff-711647abd9237f7984867e4544ede07fcf00a688129ce0f7ae4dd2c752781c81R35)

**Reactivity improvements:**

* Updated the dependency array of the main `useEffect` to include `explorersAndConverters`, ensuring that the dataset columns update when explorers or converters change.