### PR TITLE
Move run finished status update to the end of the job

### DIFF
--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -303,14 +303,6 @@ class ModelJob(BaseJob):
                     raise JobError(
                         f"Hyperparameter plot path saving failed {e}",
                     ) from e
-                try:
-                    run.set_status_as_finished()
-                    db.commit()
-                except exc.SQLAlchemyError as e:
-                    log.exception(e)
-                    raise JobError(
-                        "Connection with the database failed",
-                    ) from e
 
                 try:
                     model_metrics = factory.evaluate(x, y, metrics)
@@ -340,6 +332,14 @@ class ModelJob(BaseJob):
                     log.exception(e)
                     run.set_status_as_error()
                     db.commit()
+                    raise JobError(
+                        "Connection with the database failed",
+                    ) from e
+                try:
+                    run.set_status_as_finished()
+                    db.commit()
+                except exc.SQLAlchemyError as e:
+                    log.exception(e)
                     raise JobError(
                         "Connection with the database failed",
                     ) from e


### PR DESCRIPTION
This pull request refactors the order of database operations in the `run` function within `model_job.py` to improve error handling and ensure that the model evaluation step occurs before marking the job as finished. The main change is moving the code that sets the job status as finished and commits to the database after the model evaluation step, rather than before.

Error handling and workflow improvements:

* Moved the call to `run.set_status_as_finished()` and `db.commit()` to occur after the model evaluation step, ensuring that the job is only marked as finished if evaluation succeeds. [[1]](diffhunk://#diff-3593445c1176d9b163ffebc14f49dce7bd7bf04169a87e905fca2f486310fbcdL306-L313) [[2]](diffhunk://#diff-3593445c1176d9b163ffebc14f49dce7bd7bf04169a87e905fca2f486310fbcdR338-R345)