### PR TITLE
Enhance parameter type handling in OptunaOptimizer

### DIFF
--- a/DashAI/back/optimizers/optuna_optimizer.py
+++ b/DashAI/back/optimizers/optuna_optimizer.py
@@ -90,7 +90,16 @@ class OptunaOptimizer(BaseOptimizer):
             def objective(trial):
                 classifier_trial = self.model.classifier
                 for hyperparameter, values in self.parameters.items():
-                    value = trial.suggest_int(hyperparameter, values[0], values[-1])
+                    if any(isinstance(i, float) for i in values):
+                        value = trial.suggest_float(
+                            hyperparameter, values[0], values[-1]
+                        )
+                    elif any(isinstance(i, int) for i in values):
+                        value = trial.suggest_int(hyperparameter, values[0], values[-1])
+                    else:
+                        raise ValueError(
+                            f"Unsupported parameter type for {hyperparameter}"
+                        )
                     setattr(classifier_trial, hyperparameter, value)
 
                 model_trial = self.model
@@ -108,7 +117,16 @@ class OptunaOptimizer(BaseOptimizer):
             def objective(trial):
                 model_trial = self.model
                 for hyperparameter, values in self.parameters.items():
-                    value = trial.suggest_int(hyperparameter, values[0], values[-1])
+                    if any(isinstance(i, float) for i in values):
+                        value = trial.suggest_float(
+                            hyperparameter, values[0], values[-1]
+                        )
+                    elif any(isinstance(i, int) for i in values):
+                        value = trial.suggest_int(hyperparameter, values[0], values[-1])
+                    else:
+                        raise ValueError(
+                            f"Unsupported parameter type for {hyperparameter}"
+                        )
                     setattr(model_trial, hyperparameter, value)
 
                 model_trial.fit(


### PR DESCRIPTION
This pull request improves the robustness of hyperparameter optimization in the Optuna optimizer by adding explicit type checks for hyperparameter values. Now, the optimizer distinguishes between float and integer hyperparameters and raises an error for unsupported types, making the optimization process more reliable.

Hyperparameter type handling improvements:

* Updated both the `classifier_trial` and `model_trial` hyperparameter assignment logic in `optimize` to:
  * Use `trial.suggest_float` for hyperparameters with float values. [[1]](diffhunk://#diff-54771a1229fa6d3bc0ef6c9e7e3c6197c213e0eeae0be990f073bcccff89edb5R93-R102) [[2]](diffhunk://#diff-54771a1229fa6d3bc0ef6c9e7e3c6197c213e0eeae0be990f073bcccff89edb5R120-R129)
  * Use `trial.suggest_int` for hyperparameters with integer values. [[1]](diffhunk://#diff-54771a1229fa6d3bc0ef6c9e7e3c6197c213e0eeae0be990f073bcccff89edb5R93-R102) [[2]](diffhunk://#diff-54771a1229fa6d3bc0ef6c9e7e3c6197c213e0eeae0be990f073bcccff89edb5R120-R129)
  * Raise a `ValueError` if a hyperparameter value is neither float nor int, ensuring unsupported types are caught early. [[1]](diffhunk://#diff-54771a1229fa6d3bc0ef6c9e7e3c6197c213e0eeae0be990f073bcccff89edb5R93-R102) [[2]](diffhunk://#diff-54771a1229fa6d3bc0ef6c9e7e3c6197c213e0eeae0be990f073bcccff89edb5R120-R129)