### PR TITLE
Fix split experiment

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -472,11 +472,33 @@ def split_indexes(
     if seed is None:
         seed = 42
     indexes = np.arange(total_rows)
+    stratify_labels = np.array(labels) if stratify else None
+
+    if test_size == 0 and val_size == 0:
+        return indexes.tolist(), [], []
+
+    if test_size == 0:
+        train_indexes, val_indexes = train_test_split(
+            indexes,
+            train_size=train_size,
+            random_state=seed,
+            shuffle=shuffle,
+            stratify=stratify_labels,
+        )
+        return train_indexes.tolist(), [], val_indexes.tolist()
+
+    if val_size == 0:
+        train_indexes, test_indexes = train_test_split(
+            indexes,
+            train_size=train_size,
+            random_state=seed,
+            shuffle=shuffle,
+            stratify=stratify_labels,
+        )
+        return train_indexes.tolist(), test_indexes.tolist(), []
 
     test_val = test_size + val_size
     val_proportion = test_size / test_val
-
-    stratify_labels = np.array(labels) if stratify else None
 
     train_indexes, test_val_indexes = train_test_split(
         indexes,
@@ -927,9 +949,9 @@ def prepare_for_experiment(
 
         train_indexes, test_indexes, val_indexes = split_indexes(
             n,
-            splits["train"],
-            splits["test"],
-            splits["validation"],
+            float(splits["train"]),
+            float(splits["test"]),
+            float(splits["validation"]),
             shuffle=splits.get("shuffle", False),
             seed=splits.get("seed"),
             stratify=splits.get("stratify", False),

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -897,6 +897,9 @@ def prepare_for_experiment(
             test_indexes=splits_index["test"],
             val_indexes=splits_index["validation"],
         )
+        train_indexes = splits_index["train"]
+        test_indexes = splits_index["test"]
+        val_indexes = splits_index["validation"]
     else:
         n = len(dataset)
         labels = None

--- a/DashAI/back/models/model_factory.py
+++ b/DashAI/back/models/model_factory.py
@@ -122,6 +122,10 @@ class ModelFactory:
         results = {}
         for split in ["train", "validation", "test"]:
             split_results = {}
+            if x[split].shape[0] == 0:
+                split_results = {metric.__name__: None for metric in metrics}
+                results[split] = split_results
+                continue
             predictions = self.model.predict(x[split])
             for metric in metrics:
                 if (

--- a/DashAI/front/src/components/experiments/SplitDatasetRows.jsx
+++ b/DashAI/front/src/components/experiments/SplitDatasetRows.jsx
@@ -44,7 +44,9 @@ function SplitDatasetRows({
     testDatasetPercentage > 0;
 
   const checkSplit = (train, validation, test) => {
-    return train + validation + test === 1;
+    const sum = train + validation + test;
+    const tolerance = 0.0001; // Allow small floating point errors
+    return Math.abs(sum - 1) < tolerance;
   };
 
   // handle rows numbers change state
@@ -56,79 +58,137 @@ function SplitDatasetRows({
       color: "#bbb",
     },
   };
-  const [rowsPartitionsError, setRowsPartitionsError] = useState(false);
-  const [rowsPartitionsErrorText, setRowsPartitionsErrorText] = useState("");
+  const [randomSplitError, setRandomSplitError] = useState(false);
+  const [randomSplitErrorText, setRandomSplitErrorText] = useState("");
+  const [manualSplitError, setManualSplitError] = useState(false);
+  const [manualSplitErrorText, setManualSplitErrorText] = useState("");
 
   const handleSplitTypeChange = (event) => {
     const newType = event.target.value;
     setSplitType(newType);
 
     if (newType === SPLIT_TYPES.PREDEFINED) {
-      setRowsPartitionsError(false);
       setSplitsReady(true);
     }
     if (newType === SPLIT_TYPES.RANDOM) {
-      setSplitType(newType);
-      setRowsPartitionsPercentage({ train: 0.6, test: 0.2, validation: 0.2 });
+      const newSplit = { train: 0.6, test: 0.2, validation: 0.2 };
+      setRowsPartitionsPercentage(newSplit);
+
+      // Validate the random split
+      const hasZero =
+        newSplit.train === 0 ||
+        newSplit.validation === 0 ||
+        newSplit.test === 0;
+      const sumsToOne = checkSplit(
+        newSplit.train,
+        newSplit.validation,
+        newSplit.test,
+      );
+
+      if (hasZero) {
+        setRandomSplitErrorText("All splits must be greater than 0");
+        setRandomSplitError(true);
+      } else if (!sumsToOne) {
+        setRandomSplitErrorText("Splits must sum to 1");
+        setRandomSplitError(true);
+      } else {
+        setRandomSplitError(false);
+      }
     }
     if (newType === SPLIT_TYPES.MANUAL) {
-      setSplitType(newType);
-      setRowsPartitionsIndex({ train: [], test: [], validation: [] });
+      const newIndex = { train: [], test: [], validation: [] };
+      setRowsPartitionsIndex(newIndex);
+
+      // Validate the manual split
+      if (
+        newIndex.train.length === 0 ||
+        newIndex.validation.length === 0 ||
+        newIndex.test.length === 0
+      ) {
+        setManualSplitErrorText("All splits must have at least one row");
+        setManualSplitError(true);
+      } else {
+        setManualSplitError(false);
+      }
     }
   };
 
   const handleRowsChange = (event) => {
     const value = event.target.value;
-    const id = event.target.id; // TODO: check that the training, validation and testing rows dont overlap
+    const id = event.target.id;
+
     if (splitType === SPLIT_TYPES.MANUAL) {
       try {
         const rowsIndex = parseRangeToIndex(value, totalRows);
+        let updatedIndex = { ...rowsPartitionsIndex };
+
         switch (id) {
           case "train":
-            setRowsPartitionsIndex({
-              ...rowsPartitionsIndex,
-              train: rowsIndex,
-            });
+            updatedIndex.train = rowsIndex;
             break;
           case "validation":
-            setRowsPartitionsIndex({
-              ...rowsPartitionsIndex,
-              validation: rowsIndex,
-            });
+            updatedIndex.validation = rowsIndex;
             break;
           case "test":
-            setRowsPartitionsIndex({
-              ...rowsPartitionsIndex,
-              test: rowsIndex,
-            });
+            updatedIndex.test = rowsIndex;
             break;
         }
-        setRowsPartitionsError(false);
+        console.log("Updated Index:", updatedIndex);
+
+        setRowsPartitionsIndex(updatedIndex);
+
+        // Validate after update
+        if (
+          updatedIndex.train.length === 0 ||
+          updatedIndex.validation.length === 0 ||
+          updatedIndex.test.length === 0
+        ) {
+          setManualSplitErrorText("All splits must have at least one row");
+          setManualSplitError(true);
+        } else {
+          setManualSplitError(false);
+        }
       } catch (error) {
-        setRowsPartitionsErrorText(error.message);
-        setRowsPartitionsError(true);
+        setManualSplitErrorText(error.message);
+        setManualSplitError(true);
       }
     } else {
-      let newSplit = rowsPartitionsPercentage;
+      let newSplit = { ...rowsPartitionsPercentage };
+      const numValue = parseFloat(value) || 0;
+
       switch (id) {
         case "train":
-          newSplit = { ...newSplit, train: parseFloat(value) };
+          newSplit = { ...newSplit, train: numValue };
           break;
         case "validation":
-          newSplit = { ...newSplit, validation: parseFloat(value) };
+          newSplit = { ...newSplit, validation: numValue };
           break;
         case "test":
-          newSplit = { ...newSplit, test: parseFloat(value) };
+          newSplit = { ...newSplit, test: numValue };
           break;
       }
+
       setRowsPartitionsPercentage(newSplit);
-      if (!checkSplit(newSplit.train, newSplit.validation, newSplit.test)) {
-        setRowsPartitionsErrorText(
-          "Splits should be numbers between 0 and 1 and should add 1 in total",
-        );
-        setRowsPartitionsError(true);
+
+      // Check if any value is 0 or if sum is not 1
+      const hasZero =
+        newSplit.train === 0 ||
+        newSplit.validation === 0 ||
+        newSplit.test === 0;
+      const sumsToOne = checkSplit(
+        newSplit.train,
+        newSplit.validation,
+        newSplit.test,
+      );
+
+      if (hasZero) {
+        setRandomSplitErrorText("All splits must be greater than 0");
+        setRandomSplitError(true);
+      } else if (!sumsToOne) {
+        setRandomSplitErrorText("Splits must sum to 1");
+        setRandomSplitError(true);
       } else {
-        setRowsPartitionsError(false);
+        setRandomSplitError(false);
       }
     }
   };
@@ -167,7 +227,7 @@ function SplitDatasetRows({
       setSplitsReady(true);
     } else if (
       splitType === SPLIT_TYPES.MANUAL &&
-      !rowsPartitionsError &&
+      !manualSplitError &&
       rowsPartitionsIndex.train.length >= 1 &&
       rowsPartitionsIndex.validation.length >= 1 &&
       rowsPartitionsIndex.test.length >= 1
@@ -175,7 +235,7 @@ function SplitDatasetRows({
       setSplitsReady(true);
     } else if (
       splitType === SPLIT_TYPES.RANDOM &&
-      !rowsPartitionsError &&
+      !randomSplitError &&
       rowsPartitionsPercentage.train > 0 &&
       rowsPartitionsPercentage.validation > 0 &&
       rowsPartitionsPercentage.test > 0
@@ -187,7 +247,8 @@ function SplitDatasetRows({
   }, [
     rowsPartitionsIndex,
     rowsPartitionsPercentage,
-    rowsPartitionsError,
+    randomSplitError,
+    manualSplitError,
     splitType,
   ]);
 
@@ -263,8 +324,8 @@ function SplitDatasetRows({
           label="Use random rows by specifying which portion of the dataset you want to use for each subset"
           sx={{ my: 1 }}
         />
-        <React.Fragment>
-          {splitType === SPLIT_TYPES.RANDOM && (
+        {splitType === SPLIT_TYPES.RANDOM && (
+          <>
             <Grid container direction="row" spacing={4}>
               <Grid size={{ xs: 4 }}>
                 <TextField
@@ -273,9 +334,10 @@ function SplitDatasetRows({
                   autoComplete="off"
                   type="number"
                   size="small"
-                  error={rowsPartitionsError}
-                  defaultValue={rowsPartitionsPercentage.train}
+                  error={randomSplitError}
+                  value={rowsPartitionsPercentage.train}
                   onChange={handleRowsChange}
+                  InputLabelProps={{ shrink: true }}
                 />
               </Grid>
               <Grid size={{ xs: 4 }}>
@@ -285,9 +347,10 @@ function SplitDatasetRows({
                   autoComplete="off"
                   type="number"
                   size="small"
-                  error={rowsPartitionsError}
-                  defaultValue={rowsPartitionsPercentage.validation}
+                  error={randomSplitError}
+                  value={rowsPartitionsPercentage.validation}
                   onChange={handleRowsChange}
+                  InputLabelProps={{ shrink: true }}
                 />
               </Grid>
               <Grid size={{ xs: 4 }}>
@@ -297,11 +360,17 @@ function SplitDatasetRows({
                   type="number"
                   size="small"
                   autoComplete="off"
-                  error={rowsPartitionsError}
-                  defaultValue={rowsPartitionsPercentage.test}
+                  error={randomSplitError}
+                  value={rowsPartitionsPercentage.test}
                   onChange={handleRowsChange}
+                  InputLabelProps={{ shrink: true }}
                 />
               </Grid>
+              {randomSplitError && (
+                <Grid size={{ xs: 12 }}>
+                  <FormHelperText error>{randomSplitErrorText}</FormHelperText>
+                </Grid>
+              )}
               <Grid size={{ xs: 12 }} sx={{ ml: 3 }}>
                 <BooleanInput
                   name="shuffle"
@@ -329,22 +398,16 @@ function SplitDatasetRows({
                 />
               </Grid>
             </Grid>
-          )}
-          {rowsPartitionsError ? (
-            <FormHelperText>{rowsPartitionsErrorText}</FormHelperText>
-          ) : (
-            <React.Fragment />
-          )}
-        </React.Fragment>
-        <React.Fragment />
+          </>
+        )}
         <FormControlLabel
           value={SPLIT_TYPES.MANUAL}
           control={<Radio />}
           label="Use manual splitting by specifying the row indexes of each subset"
           sx={{ my: 1 }}
         />
-        <React.Fragment>
-          {splitType === SPLIT_TYPES.MANUAL && (
+        {splitType === SPLIT_TYPES.MANUAL && (
+          <>
             <Grid container direction="row" spacing={4}>
               <Grid size={{ xs: 4 }}>
                 <TextField
@@ -352,7 +415,7 @@ function SplitDatasetRows({
                   label="Train"
                   autoComplete="off"
                   size="small"
-                  error={rowsPartitionsError}
+                  error={manualSplitError}
                   onChange={handleRowsChange}
                 />
               </Grid>
@@ -362,7 +425,7 @@ function SplitDatasetRows({
                   label="Validation"
                   autoComplete="off"
                   size="small"
-                  error={rowsPartitionsError}
+                  error={manualSplitError}
                   onChange={handleRowsChange}
                 />
               </Grid>
@@ -372,19 +435,18 @@ function SplitDatasetRows({
                   label="Test"
                   autoComplete="off"
                   size="small"
-                  error={rowsPartitionsError}
+                  error={manualSplitError}
                   onChange={handleRowsChange}
                 />
               </Grid>
+              {manualSplitError && (
+                <Grid size={{ xs: 12 }}>
+                  <FormHelperText error>{manualSplitErrorText}</FormHelperText>
+                </Grid>
+              )}
             </Grid>
-          )}
-          {rowsPartitionsError ? (
-            <FormHelperText>{rowsPartitionsErrorText}</FormHelperText>
-          ) : (
-            <React.Fragment />
-          )}
-        </React.Fragment>
-        <React.Fragment />
+          </>
+        )}
       </RadioGroup>
     </React.Fragment>
   );
@@ -418,5 +480,8 @@ SplitDatasetRows.propTypes = {
   setShuffle: PropTypes.func.isRequired,
   stratify: PropTypes.bool.isRequired,
   setStratify: PropTypes.func.isRequired,
+  seed: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  setSeed: PropTypes.func.isRequired,
 };
+
 export default SplitDatasetRows;

--- a/DashAI/front/src/components/experiments/SplitDatasetRows.jsx
+++ b/DashAI/front/src/components/experiments/SplitDatasetRows.jsx
@@ -38,6 +38,10 @@ function SplitDatasetRows({
   ).toFixed(2);
   const testDatasetPercentage = (datasetInfo.test_size / totalRows).toFixed(2);
 
+  useEffect(() => {
+    console.log(rowsPartitionsIndex);
+  }, [rowsPartitionsIndex]);
+
   const hasPredefinedSplits =
     trainDatasetPercentage > 0 ||
     validationDatasetPercentage > 0 ||
@@ -75,10 +79,7 @@ function SplitDatasetRows({
       setRowsPartitionsPercentage(newSplit);
 
       // Validate the random split
-      const hasZero =
-        newSplit.train === 0 ||
-        newSplit.validation === 0 ||
-        newSplit.test === 0;
+      const hasZero = newSplit.train === 0;
       const sumsToOne = checkSplit(
         newSplit.train,
         newSplit.validation,
@@ -86,7 +87,7 @@ function SplitDatasetRows({
       );
 
       if (hasZero) {
-        setRandomSplitErrorText("All splits must be greater than 0");
+        setRandomSplitErrorText("Train splits must be greater than 0");
         setRandomSplitError(true);
       } else if (!sumsToOne) {
         setRandomSplitErrorText("Splits must sum to 1");
@@ -100,12 +101,8 @@ function SplitDatasetRows({
       setRowsPartitionsIndex(newIndex);
 
       // Validate the manual split
-      if (
-        newIndex.train.length === 0 ||
-        newIndex.validation.length === 0 ||
-        newIndex.test.length === 0
-      ) {
-        setManualSplitErrorText("All splits must have at least one row");
+      if (newIndex.train.length === 0) {
+        setManualSplitErrorText("Train split must have at least one row");
         setManualSplitError(true);
       } else {
         setManualSplitError(false);
@@ -138,12 +135,8 @@ function SplitDatasetRows({
         setRowsPartitionsIndex(updatedIndex);
 
         // Validate after update
-        if (
-          updatedIndex.train.length === 0 ||
-          updatedIndex.validation.length === 0 ||
-          updatedIndex.test.length === 0
-        ) {
-          setManualSplitErrorText("All splits must have at least one row");
+        if (updatedIndex.train.length === 0) {
+          setManualSplitErrorText("Train split must have at least one row");
           setManualSplitError(true);
         } else {
           setManualSplitError(false);
@@ -171,10 +164,7 @@ function SplitDatasetRows({
       setRowsPartitionsPercentage(newSplit);
 
       // Check if any value is 0 or if sum is not 1
-      const hasZero =
-        newSplit.train === 0 ||
-        newSplit.validation === 0 ||
-        newSplit.test === 0;
+      const hasZero = newSplit.train === 0;
       const sumsToOne = checkSplit(
         newSplit.train,
         newSplit.validation,
@@ -182,7 +172,7 @@ function SplitDatasetRows({
       );
 
       if (hasZero) {
-        setRandomSplitErrorText("All splits must be greater than 0");
+        setRandomSplitErrorText("Train splits must be greater than 0");
         setRandomSplitError(true);
       } else if (!sumsToOne) {
         setRandomSplitErrorText("Splits must sum to 1");
@@ -228,17 +218,13 @@ function SplitDatasetRows({
     } else if (
       splitType === SPLIT_TYPES.MANUAL &&
       !manualSplitError &&
-      rowsPartitionsIndex.train.length >= 1 &&
-      rowsPartitionsIndex.validation.length >= 1 &&
-      rowsPartitionsIndex.test.length >= 1
+      rowsPartitionsIndex.train.length >= 1
     ) {
       setSplitsReady(true);
     } else if (
       splitType === SPLIT_TYPES.RANDOM &&
       !randomSplitError &&
-      rowsPartitionsPercentage.train > 0 &&
-      rowsPartitionsPercentage.validation > 0 &&
-      rowsPartitionsPercentage.test > 0
+      rowsPartitionsPercentage.train > 0
     ) {
       setSplitsReady(true);
     } else {


### PR DESCRIPTION
This pull request improves the dataset splitting workflow in both the backend and frontend, with a focus on better error handling, validation, and user feedback for dataset splits in experiments. The main changes are the introduction of more precise validation and clearer error messages for both random and manual splits, as well as a minor backend fix to dataset index handling.

**Frontend validation and user experience improvements:**

* Added separate error states and messages for random and manual dataset splits, providing clearer feedback to users about split requirements and validation errors.
* Improved validation logic for random splits to allow for small floating point errors and require all splits to be greater than zero and sum to one.
* Enhanced manual split validation to ensure each split has at least one row, with immediate feedback when editing indices.
* Updated UI components to display error states and helper text directly under the relevant inputs for both split types, improving clarity and usability.

**Backend fix:**

* Refactored the backend to explicitly assign train, test, and validation indexes from the split configuration.