### PR TITLE
Fix/dataset table refresh

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/converters.py
+++ b/DashAI/back/api/api_v1/endpoints/converters.py
@@ -221,11 +221,14 @@ async def delete_converter_list(
                 dirs_exist_ok=True,
             )
 
-            # Enqueue all previous converters usando el sistema Huey existente
+            # Enqueue all previous converters
+            job_ids = []
             for converter in previous_converters:
                 # Crear instancia de ConverterListJob y encolarlo directamente
                 job = ConverterListJob(converter_list_id=converter.id)
                 job_queue.put(job)
+                if hasattr(job, "id"):
+                    job_ids.append(job.id)
 
             # Delete all the converters after the current one
             for converter in next_converters:
@@ -238,6 +241,9 @@ async def delete_converter_list(
             # Delete the current converter
             db.delete(converter_list)
             db.commit()
+
+            last_job_id = job_ids[-1] if job_ids else None
+            return {"jobId": last_job_id}
 
         except exc.SQLAlchemyError as e:
             logger.exception(e)

--- a/DashAI/front/src/api/converter.ts
+++ b/DashAI/front/src/api/converter.ts
@@ -35,6 +35,11 @@ export const getConverterById = async (id: number): Promise<IConverter> => {
   return response.data;
 };
 
-export const deleteConverterById = async (id: number): Promise<void> => {
-  await api.delete(`${converterEndpoint}/${id}`);
+export const deleteConverterById = async (
+  id: number,
+): Promise<string | null> => {
+  const response = await api.delete<{ jobId: string | null }>(
+    `${converterEndpoint}/${id}`,
+  );
+  return response.data.jobId;
 };

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -13,6 +13,7 @@ import ItemsToDeleteList from "../converter/ItemsToDeleteList";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
 import { deleteExplorer } from "../../../api/explorer";
 import { deleteConverterById } from "../../../api/converter";
+import { startJobPolling } from "../../../utils/jobPoller";
 
 const RowItem = React.memo(function RowItem({
   item,
@@ -108,7 +109,6 @@ export default function NotebookView({ notebook }) {
 
       if (converterIndex === -1) return [];
 
-      // Todos los items desde el converter en adelante (incluyendo el converter)
       return explorersAndConverters.slice(converterIndex);
     },
     [explorersAndConverters],
@@ -167,21 +167,26 @@ export default function NotebookView({ notebook }) {
   }, [explorerToDelete, setExplorersAndConverters]);
 
   const handleConfirmConverterDelete = useCallback(async () => {
-    if (converterToDelete) {
-      try {
-        await deleteConverterById(converterToDelete.id);
-
-        await fetchExplorersAndConverters();
-
-        setOpenDeleteConverterConfirmation(false);
-        setConverterToDelete(null);
-        setDeleteModalContent("");
-        setItemsToDelete([]);
-      } catch (error) {
-        console.error("Failed to delete converter:", error);
+    if (!converterToDelete) return;
+    try {
+      const jobId = await deleteConverterById(converterToDelete.id);
+      setOpenDeleteConverterConfirmation(false);
+      setConverterToDelete(null);
+      setDeleteModalContent("");
+      setItemsToDelete([]);
+      if (jobId) {
+        startJobPolling(
+          jobId,
+          () => fetchExplorersAndConverters(),
+          () => fetchExplorersAndConverters(),
+        );
+      } else {
+        fetchExplorersAndConverters();
       }
+    } catch (error) {
+      console.error("Failed to delete converter:", error);
     }
-  }, [converterToDelete, setExplorersAndConverters]);
+  }, [converterToDelete, fetchExplorersAndConverters]);
 
   const handleCancelDelete = useCallback(() => {
     setOpenDeleteExplorerConfirmation(false);


### PR DESCRIPTION
# Summary

This PR fixes an issue where the converters/explorers table in the notebook view was not updating consistently after deleting a converter. Now, the table waits for the backend job to finish before refreshing, ensuring the UI always reflects the correct state. The approach mirrors the strategy used for dataset creation and deletion.

## Type of change

- Bug fix.

## Changes

- Fixed inconsistent table updates after deleting a converter in the notebook view.
- Implemented job polling after converter deletion, updating the table only when the backend job completes.
- Ensured UI consistency by reusing the dataset job-waiting strategy.

## How to Test

1. Open a notebook with multiple converters applied.
2. Delete the last (or any) converter.
3. Observe that the table only updates after the backend job finishes, always showing the correct state.
4. Reloading the page should not change the displayed data (no more inconsistencies).

## Screenshots

<!-- Add screenshots here if the UI changed. -->

## Notes

- This fix uses the same polling logic as dataset operations for consistency.
- No new dependencies were added.