### PR TITLE
Fix problem between hueyqueue and plugins

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/plugins.py
+++ b/DashAI/back/api/api_v1/endpoints/plugins.py
@@ -17,7 +17,9 @@ from DashAI.back.dependencies.database.utils import (
     add_plugin_to_db,
     upgrade_plugin_info_in_db,
 )
+from DashAI.back.dependencies.job_queues import BaseJobQueue
 from DashAI.back.dependencies.registry import ComponentRegistry
+from DashAI.back.job.sync_components_job import SyncComponentsJob
 from DashAI.back.plugins.utils import (
     get_plugin_by_name_from_pypi,
     get_plugins_from_pypi,
@@ -223,6 +225,7 @@ async def update_plugin(
     params: PluginUpdateParams,
     session_factory: sessionmaker = Depends(lambda: di["session_factory"]),
     component_registry: ComponentRegistry = Depends(lambda: di["component_registry"]),
+    job_queue: BaseJobQueue = Depends(lambda: di["job_queue"]),
 ):
     """Updates the status of a plugin with the provided ID.
 
@@ -271,12 +274,15 @@ async def update_plugin(
                 # else the new components should be registered
                 else:
                     register_plugin_components(installed_components, component_registry)
+                    job_queue.put(SyncComponentsJob())
             elif (
                 plugin.status == PluginStatus.INSTALLED
                 and params.new_status == PluginStatus.REGISTERED
             ):
                 uninstalled_components = uninstall_plugin(plugin_name)
                 unregister_plugin_components(uninstalled_components, component_registry)
+                job_queue.put(SyncComponentsJob())
+
             setattr(plugin, "status", params.new_status)
             db.commit()
             db.refresh(plugin)
@@ -295,6 +301,7 @@ async def upgrade_plugin(
     plugin_id: int,
     session_factory: sessionmaker = Depends(lambda: di["session_factory"]),
     component_registry: ComponentRegistry = Depends(lambda: di["component_registry"]),
+    job_queue: BaseJobQueue = Depends(lambda: di["job_queue"]),
 ):
     """
     Upgrade the plugin version prvided in pyPI.
@@ -326,12 +333,14 @@ async def upgrade_plugin(
             if plugin.status == PluginStatus.INSTALLED:
                 uninstalled_components = uninstall_plugin(plugin_name)
                 unregister_plugin_components(uninstalled_components, component_registry)
+                job_queue.put(SyncComponentsJob())
 
             plugin_info = get_plugin_by_name_from_pypi(plugin_name)
             new_plugin_params = PluginParams.model_validate(plugin_info)
 
             installed_components = install_plugin(plugin_name)
             register_plugin_components(installed_components, component_registry)
+            job_queue.put(SyncComponentsJob())
             plugin = upgrade_plugin_info_in_db(new_plugin_params)
 
             if plugin is None:

--- a/DashAI/back/job/sync_components_job.py
+++ b/DashAI/back/job/sync_components_job.py
@@ -1,0 +1,51 @@
+import logging
+
+from kink import inject
+
+from DashAI.back.job.base_job import BaseJob
+from DashAI.back.plugins.utils import (
+    get_available_plugins,
+    register_plugin_components,
+    unregister_plugin_components,
+)
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+
+class SyncComponentsJob(BaseJob):
+    DESCRIPTION = "Sync consumer ComponentRegistry with installed DashAI plugins"
+
+    def set_status_as_delivered(self):
+        log.debug("Prediction job marked as delivered")
+
+    def set_status_as_error(self):
+        log.debug("Sync components job failed")
+
+    @inject
+    def get_job_name(self):
+        return "Adding/removing plugins"
+
+    @inject
+    def run(self):
+        from kink import di
+
+        component_registry = di["component_registry"]
+        available = set(get_available_plugins())
+        registered = set(
+            component_registry[comp]["class"]
+            for comp in [
+                c["name"] for c in component_registry.get_components_by_types()
+            ]
+        )
+        to_add = list(available - registered)
+        to_remove = list(registered - available)
+        if to_add:
+            register_plugin_components(to_add, component_registry)
+        if to_remove:
+            unregister_plugin_components(to_remove, component_registry)
+
+        return {
+            "added": [cls.__name__ for cls in to_add],
+            "removed": [cls.__name__ for cls in to_remove],
+        }

--- a/DashAI/back/job/sync_components_job.py
+++ b/DashAI/back/job/sync_components_job.py
@@ -32,14 +32,14 @@ class SyncComponentsJob(BaseJob):
 
         component_registry = di["component_registry"]
         available = set(get_available_plugins())
-        registered = set(
-            component_registry[comp]["class"]
-            for comp in [
-                c["name"] for c in component_registry.get_components_by_types()
-            ]
-        )
+        registered = {
+            component_registry[c["name"]]["class"]
+            for c in component_registry.get_components_by_types()
+        }
+
         to_add = list(available - registered)
         to_remove = list(registered - available)
+
         if to_add:
             register_plugin_components(to_add, component_registry)
         if to_remove:

--- a/DashAI/back/job/sync_components_job.py
+++ b/DashAI/back/job/sync_components_job.py
@@ -17,7 +17,7 @@ class SyncComponentsJob(BaseJob):
     DESCRIPTION = "Sync consumer ComponentRegistry with installed DashAI plugins"
 
     def set_status_as_delivered(self):
-        log.debug("Prediction job marked as delivered")
+        log.debug("Sync components job marked as delivered")
 
     def set_status_as_error(self):
         log.debug("Sync components job failed")
@@ -30,15 +30,20 @@ class SyncComponentsJob(BaseJob):
     def run(self):
         from kink import di
 
+        from DashAI.back.initial_components import get_initial_components
+
         component_registry = di["component_registry"]
-        available = set(get_available_plugins())
-        registered = {
+
+        basic_components = set(get_initial_components())
+        available_plugins = set(get_available_plugins())
+
+        all_registered = {
             component_registry[c["name"]]["class"]
             for c in component_registry.get_components_by_types()
         }
-
-        to_add = list(available - registered)
-        to_remove = list(registered - available)
+        registered_plugins = all_registered - basic_components
+        to_add = list(available_plugins - registered_plugins)
+        to_remove = list(registered_plugins - available_plugins)
 
         if to_add:
             register_plugin_components(to_add, component_registry)


### PR DESCRIPTION
This pull request introduces a new job class for synchronizing plugin components and integrates it into the plugin management endpoints. The main goal is to ensure that the `ComponentRegistry` stays in sync with the actual installed plugins whenever plugins are updated, registered, unregistered, or upgraded. The changes improve the reliability and consistency of plugin component management in the backend.

**Plugin component synchronization:**

* Added a new `SyncComponentsJob` class in `DashAI/back/job/sync_components_job.py`, which checks for discrepancies between installed plugins and registered components, and updates the `ComponentRegistry` accordingly.

**API endpoint integration:**

* Modified the `update_plugin` and `upgrade_plugin` endpoints in `DashAI/back/api/api_v1/endpoints/plugins.py` to inject a `job_queue` dependency and enqueue the `SyncComponentsJob` whenever plugin components are registered or unregistered. This ensures the registry is automatically synchronized after plugin changes. [[1]](diffhunk://#diff-4c7e9a2f7ecd7a253818ba48637e9a201088b4dd1c3502501d9e31c965075810R20-R22) [[2]](diffhunk://#diff-4c7e9a2f7ecd7a253818ba48637e9a201088b4dd1c3502501d9e31c965075810R228) [[3]](diffhunk://#diff-4c7e9a2f7ecd7a253818ba48637e9a201088b4dd1c3502501d9e31c965075810R277-R285) [[4]](diffhunk://#diff-4c7e9a2f7ecd7a253818ba48637e9a201088b4dd1c3502501d9e31c965075810R304) [[5]](diffhunk://#diff-4c7e9a2f7ecd7a253818ba48637e9a201088b4dd1c3502501d9e31c965075810R336-R343)