### PR TITLE
Fix column select experiment/Refactor input and output columns

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/experiments.py
+++ b/DashAI/back/api/api_v1/endpoints/experiments.py
@@ -124,14 +124,14 @@ async def validate_columns(
 
             column_names = minimal_dataset.column_names
 
-            if max(params.inputs_columns + params.outputs_columns) > len(column_names):
+            if len(params.inputs_columns + params.outputs_columns) > len(column_names):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Column index out of range",
                 )
 
-            inputs_names = [column_names[i - 1] for i in params.inputs_columns]
-            outputs_names = [column_names[i - 1] for i in params.outputs_columns]
+            inputs_names = params.inputs_columns
+            outputs_names = params.outputs_columns
 
         except exc.SQLAlchemyError as e:
             log.exception(e)
@@ -208,20 +208,18 @@ async def create_experiment(
                 schema = reader.schema
                 column_names = schema.names
 
-            if max(params.input_columns + params.output_columns) > len(column_names):
+            if len(params.input_columns + params.output_columns) > len(column_names):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Column index out of range",
                 )
 
-            inputs_columns = [column_names[i - 1] for i in params.input_columns]
-            outputs_columns = [column_names[i - 1] for i in params.output_columns]
             experiment = Experiment(
                 dataset_id=params.dataset_id,
                 task_name=params.task_name,
                 name=params.name,
-                input_columns=inputs_columns,
-                output_columns=outputs_columns,
+                input_columns=params.input_columns,
+                output_columns=params.output_columns,
                 splits=params.splits,
             )
             db.add(experiment)

--- a/DashAI/back/api/api_v1/schemas/experiments_params.py
+++ b/DashAI/back/api/api_v1/schemas/experiments_params.py
@@ -7,13 +7,13 @@ class ExperimentParams(BaseModel):
     dataset_id: int
     task_name: str
     name: str
-    input_columns: List[int]
-    output_columns: List[int]
+    input_columns: List[str]
+    output_columns: List[str]
     splits: str
 
 
 class ColumnsValidationParams(BaseModel):
     task_name: str
     dataset_id: int
-    inputs_columns: List[int]
-    outputs_columns: List[int]
+    inputs_columns: List[str]
+    outputs_columns: List[str]

--- a/DashAI/front/src/api/experiment.ts
+++ b/DashAI/front/src/api/experiment.ts
@@ -17,8 +17,8 @@ export const createExperiment = async (
   datasetId: number,
   taskName: string,
   expName: string,
-  inputColumns: number[],
-  outputColumns: number[],
+  inputColumns: string[],
+  outputColumns: string[],
   splitsValue: JSON,
 ): Promise<IExperiment> => {
   const data = {
@@ -53,8 +53,8 @@ export const deleteExperiment = async (id: string): Promise<object> => {
 export const validateColumns = async (
   taskName: string,
   datasetId: number,
-  inputColumns: number[],
-  outputColumns: number[],
+  inputColumns: string[],
+  outputColumns: string[],
 ): Promise<object> => {
   const formData = {
     task_name: taskName,

--- a/DashAI/front/src/components/experiments/ConfigureModelsStep.jsx
+++ b/DashAI/front/src/components/experiments/ConfigureModelsStep.jsx
@@ -218,8 +218,8 @@ ConfigureModelsStep.propTypes = {
     name: PropTypes.string,
     dataset: PropTypes.object,
     task_name: PropTypes.string,
-    input_columns: PropTypes.arrayOf(PropTypes.number),
-    output_columns: PropTypes.arrayOf(PropTypes.number),
+    input_columns: PropTypes.arrayOf(PropTypes.string),
+    output_columns: PropTypes.arrayOf(PropTypes.string),
     splits: PropTypes.shape({
       training: PropTypes.number,
       validation: PropTypes.number,

--- a/DashAI/front/src/components/experiments/ModelsTable.jsx
+++ b/DashAI/front/src/components/experiments/ModelsTable.jsx
@@ -208,8 +208,8 @@ ModelsTable.propTypes = {
     name: PropTypes.string,
     dataset: PropTypes.object,
     task_name: PropTypes.string,
-    input_columns: PropTypes.arrayOf(PropTypes.number),
-    output_columns: PropTypes.arrayOf(PropTypes.number),
+    input_columns: PropTypes.arrayOf(PropTypes.string),
+    output_columns: PropTypes.arrayOf(PropTypes.string),
     splits: PropTypes.shape({
       training: PropTypes.number,
       validation: PropTypes.number,

--- a/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
+++ b/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
@@ -30,8 +30,13 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
     },
   });
 
-  const [inputColumnNames, setInputColumnNames] = useState([]);
-  const [outputColumnNames, setOutputColumnNames] = useState([]);
+  const [inputColumnNames, setInputColumnNames] = useState(
+    newExp.input_columns,
+  );
+  const [outputColumnNames, setOutputColumnNames] = useState(
+    newExp.output_columns,
+  );
+
   const [columnsReady, setColumnsReady] = useState(false);
   const [columnsAreValid, setColumnsAreValid] = useState(false);
   const [shuffle, setShuffle] = useState(true);
@@ -95,16 +100,6 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
           } else if (allNames.length === 1) {
             setInputColumnNames([allNames[0]]);
           }
-        } else if (
-          newExp.input_columns &&
-          newExp.input_columns.length > 0 &&
-          allNames.length > 0
-        ) {
-          setInputColumnNames(
-            newExp.input_columns
-              .map((index) => allNames[index])
-              .filter((name) => name !== undefined),
-          );
         }
 
         if (
@@ -114,16 +109,6 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
           if (allNames.length > 0) {
             setOutputColumnNames([allNames[allNames.length - 1]]);
           }
-        } else if (
-          newExp.output_columns &&
-          newExp.output_columns.length > 0 &&
-          allNames.length > 0
-        ) {
-          setOutputColumnNames(
-            newExp.output_columns
-              .map((index) => allNames[index])
-              .filter((name) => name !== undefined),
-          );
         }
       }
     } catch (error) {
@@ -175,22 +160,6 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
     }
   };
 
-  const getIndicesFromNames = (selectedNames, allNames) => {
-    if (
-      !allNames ||
-      allNames.length === 0 ||
-      !selectedNames ||
-      selectedNames.length === 0
-    )
-      return [];
-    return selectedNames
-      .map((name) => {
-        const index = allNames.indexOf(name);
-        return index !== -1 ? index + 1 : -1;
-      })
-      .filter((index) => index !== -1);
-  };
-
   const validateColumns = async () => {
     if (
       !datasetInfo ||
@@ -201,16 +170,7 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
       return;
     }
 
-    const inputIndices = getIndicesFromNames(
-      inputColumnNames,
-      datasetInfo.column_names,
-    );
-    const outputIndices = getIndicesFromNames(
-      outputColumnNames,
-      datasetInfo.column_names,
-    );
-
-    if (inputIndices.length === 0 || outputIndices.length === 0) {
+    if (inputColumnNames.length === 0 || outputColumnNames.length === 0) {
       setColumnsAreValid(false);
       return;
     }
@@ -219,8 +179,8 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
       const validation = await validateColumnsRequest(
         newExp.task_name,
         newExp.dataset.id,
-        inputIndices,
-        outputIndices,
+        inputColumnNames,
+        outputColumnNames,
       );
       setColumnsAreValid(validation.dataset_status === "valid");
     } catch (error) {
@@ -245,19 +205,10 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
       return;
     }
 
-    const inputIndices = getIndicesFromNames(
-      inputColumnNames,
-      datasetInfo.column_names,
-    );
-    const outputIndices = getIndicesFromNames(
-      outputColumnNames,
-      datasetInfo.column_names,
-    );
-
     const updatedExpData = {
       ...newExp,
-      input_columns: inputIndices,
-      output_columns: outputIndices,
+      input_columns: inputColumnNames,
+      output_columns: outputColumnNames,
     };
 
     if (splitType === SPLIT_TYPES.MANUAL) {
@@ -436,8 +387,8 @@ PrepareDatasetStep.propTypes = {
     name: PropTypes.string,
     dataset: PropTypes.object,
     task_name: PropTypes.string,
-    input_columns: PropTypes.arrayOf(PropTypes.number),
-    output_columns: PropTypes.arrayOf(PropTypes.number),
+    input_columns: PropTypes.arrayOf(PropTypes.string),
+    output_columns: PropTypes.arrayOf(PropTypes.string),
     splits: PropTypes.object,
     step: PropTypes.string,
     created: PropTypes.instanceOf(Date),

--- a/DashAI/front/src/components/experiments/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/experiments/SelectDatasetStep.jsx
@@ -50,6 +50,10 @@ function SelectDatasetStep({ newExp, setNewExp, setNextEnabled }) {
   const [datasetsSelected, setDatasetsSelected] = useState([]);
   const [requestError, setRequestError] = useState(false);
 
+  useEffect(() => {
+    setNewExp({ ...newExp, input_columns: [], output_columns: [] });
+  }, []);
+
   const getDatasets = async () => {
     setLoading(true);
     try {
@@ -166,8 +170,8 @@ SelectDatasetStep.propTypes = {
     name: PropTypes.string,
     dataset: PropTypes.object,
     task_name: PropTypes.string,
-    input_columns: PropTypes.arrayOf(PropTypes.number),
-    output_columns: PropTypes.arrayOf(PropTypes.number),
+    input_columns: PropTypes.arrayOf(PropTypes.string),
+    output_columns: PropTypes.arrayOf(PropTypes.string),
     splits: PropTypes.shape({
       training: PropTypes.number,
       validation: PropTypes.number,

--- a/DashAI/front/src/components/experiments/SetNameAndTaskStep.jsx
+++ b/DashAI/front/src/components/experiments/SetNameAndTaskStep.jsx
@@ -195,8 +195,8 @@ SetNameAndTaskStep.propTypes = {
     name: PropTypes.string,
     dataset: PropTypes.object,
     task_name: PropTypes.string,
-    input_columns: PropTypes.arrayOf(PropTypes.number),
-    output_columns: PropTypes.arrayOf(PropTypes.number),
+    input_columns: PropTypes.arrayOf(PropTypes.string),
+    output_columns: PropTypes.arrayOf(PropTypes.string),
     splits: PropTypes.shape({
       training: PropTypes.number,
       validation: PropTypes.number,

--- a/tests/back/api/test_experiments_api.py
+++ b/tests/back/api/test_experiments_api.py
@@ -35,8 +35,13 @@ def create_experiment_1(client: TestClient, dataset_id: int):
             "dataset_id": dataset_id,
             "task_name": "TabularClassificationTask",
             "name": "ExperimentA",
-            "input_columns": [1, 2, 3, 4],
-            "output_columns": [5],
+            "input_columns": [
+                "SepalLengthCm",
+                "SepalWidthCm",
+                "PetalLengthCm",
+                "PetalWidthCm",
+            ],
+            "output_columns": ["Species"],
             "splits": splits,
         },
     )
@@ -51,8 +56,8 @@ def create_experiment_2(client: TestClient, dataset_id: int):
             "dataset_id": dataset_id,
             "task_name": "TabularClassificationTask",
             "name": "ExperimentB",
-            "input_columns": [1, 4],
-            "output_columns": [5],
+            "input_columns": ["SepalLengthCm", "PetalWidthCm"],
+            "output_columns": ["Species"],
             "splits": splits,
         },
     )
@@ -152,8 +157,13 @@ def test_get_columns_validation_valid(client: TestClient, dataset_id: int):
         json={
             "task_name": "TabularClassificationTask",
             "dataset_id": dataset_id,
-            "inputs_columns": [1, 2, 3, 4],
-            "outputs_columns": [5],
+            "inputs_columns": [
+                "SepalLengthCm",
+                "SepalWidthCm",
+                "PetalLengthCm",
+                "PetalWidthCm",
+            ],
+            "outputs_columns": ["Species"],
         },
     )
     assert response.status_code == 200, response.text
@@ -167,8 +177,13 @@ def test_get_columns_validation_invalid(client: TestClient, dataset_id: int):
         json={
             "task_name": "ImageClassificationTask",
             "dataset_id": dataset_id,
-            "inputs_columns": [1, 2, 3, 4],
-            "outputs_columns": [5],
+            "inputs_columns": [
+                "SepalLengthCm",
+                "SepalWidthCm",
+                "PetalLengthCm",
+                "PetalWidthCm",
+            ],
+            "outputs_columns": ["Species"],
         },
     )
     assert response.status_code == 200, response.text
@@ -182,8 +197,13 @@ def test_get_columns_validation_wrong_task_name(client: TestClient, dataset_id: 
         json={
             "task_name": "TabularClassTask",
             "dataset_id": dataset_id,
-            "inputs_columns": [1, 2, 3, 4],
-            "outputs_columns": [5],
+            "inputs_columns": [
+                "SepalLengthCm",
+                "SepalWidthCm",
+                "PetalLengthCm",
+                "PetalWidthCm",
+            ],
+            "outputs_columns": ["Species"],
         },
     )
     assert response.status_code == 404, response.text
@@ -198,8 +218,13 @@ def test_get_columns_validation_wrong_dataset(client: TestClient):
         json={
             "task_name": "TabularClassificationTask",
             "dataset_id": 127,
-            "inputs_columns": [1, 2, 3, 4],
-            "outputs_columns": [5],
+            "inputs_columns": [
+                "SepalLengthCm",
+                "SepalWidthCm",
+                "PetalLengthCm",
+                "PetalWidthCm",
+            ],
+            "outputs_columns": ["Species"],
         },
     )
     assert response.status_code == 404, response.text

--- a/tests/back/api/test_runs_api.py
+++ b/tests/back/api/test_runs_api.py
@@ -21,8 +21,13 @@ def create_experiment(client: TestClient, dataset_id):
             "dataset_id": dataset_id,
             "task_name": "TabularClassificationTask",
             "name": "Test Experiment",
-            "input_columns": [1, 2, 3, 4],
-            "output_columns": [5],
+            "input_columns": [
+                "SepalLengthCm",
+                "SepalWidthCm",
+                "PetalLengthCm",
+                "PetalWidthCm",
+            ],
+            "output_columns": ["Species"],
             "splits": json.dumps(
                 {
                     "train": 0.5,


### PR DESCRIPTION
This pull request updates how input and output columns are handled throughout the experiment creation workflow, switching from using column indices (numbers) to using column names (strings). This change affects both backend and frontend code, improving clarity and reducing errors related to column indexing. The update includes changes to API schemas, validation logic, experiment creation, and React component props.

**Backend changes:**

* The `ExperimentParams` and `ColumnsValidationParams` schemas now expect lists of column names (`List[str]`) instead of indices (`List[int]`).
* Validation and experiment creation logic in `experiments.py` now works directly with column names, removing the need to map indices to names and updating the out-of-range check accordingly. 

**State initialization and management:**

* When a new dataset is selected, input and output columns are reset to empty arrays to ensure the correct state for subsequent steps.
