### PR TITLE
Improve dataset upload error

### DIFF
--- a/DashAI/front/src/pages/datasets/Datasets.jsx
+++ b/DashAI/front/src/pages/datasets/Datasets.jsx
@@ -287,7 +287,28 @@ export default function DatasetsPage() {
             `Error creating dataset: ${result.error || "Unknown error"}`,
             { variant: "error" },
           );
-          fetchDatasets();
+
+          // Check if dataset exists in state before attempting deletion
+          setDatasets((prevDatasets) => {
+            const datasetExists = prevDatasets.some((d) => d.id === datasetId);
+
+            if (datasetExists) {
+              // Only call deleteDataset API if the dataset exists in state
+              deleteDataset(datasetId).catch((error) => {
+                console.error("Error deleting failed dataset:", error);
+              });
+
+              // Remove from state
+              return prevDatasets.filter((d) => d.id !== datasetId);
+            }
+
+            // Dataset already removed, no action needed
+            return prevDatasets;
+          });
+
+          setSelectedDatasetId(null);
+          setStep(0);
+          setSelectedOption(null);
         },
       );
     }


### PR DESCRIPTION
This pull request improves error handling and state management when a dataset creation fails in the `DatasetsPage` component. Instead of always refetching datasets, the code now checks if the failed dataset exists in local state and ensures it is properly deleted both from the backend and the UI. This makes the user experience smoother and avoids unnecessary API calls.

Error handling and state management improvements:

* Added a check to see if the failed dataset exists in local state before attempting to delete it, ensuring the `deleteDataset` API is only called when necessary. (`DashAI/front/src/pages/datasets/Datasets.jsx`)
* Updated local state to remove the failed dataset and reset selection and step values, preventing stale data from being shown to the user. (`DashAI/front/src/pages/datasets/Datasets.jsx`)