### PR TITLE
Fix optimizer direction (minimum or maximum)

### DIFF
--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -277,7 +277,10 @@ class ModelJob(BaseJob):
                         # Generate hyperparameter plot
                         trials = optimizer.get_trials_values()
                         plot_filenames, plots = optimizer.create_plots(
-                            trials, run_id, n_params=len(run_optimizable_parameters)
+                            trials,
+                            run_id,
+                            n_params=len(run_optimizable_parameters),
+                            goal_metric=goal_metric,
                         )
                         for filename, plot in zip(plot_filenames, plots):
                             plot_path = os.path.join(config["RUNS_PATH"], filename)

--- a/DashAI/back/metrics/base_metric.py
+++ b/DashAI/back/metrics/base_metric.py
@@ -1,9 +1,26 @@
 """Base Metric abstract class."""
 
-from typing import Final
+from typing import Any, Dict, Final
 
 
 class BaseMetric:
     """Abstract class of all metrics."""
 
     TYPE: Final[str] = "Metric"
+    MAXIMIZE: Final[bool] = False
+    metadata: Dict[str, Any] = {}
+
+    @classmethod
+    def get_metadata(cls) -> Dict[str, Any]:
+        """
+        Get metadata values for the current metric.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary with the metadata
+        """
+        meta: Dict[str, Any] = dict(getattr(cls, "metadata", {}) or {})
+        meta["maximize"] = cls.MAXIMIZE
+
+        return meta

--- a/DashAI/back/metrics/classification_metric.py
+++ b/DashAI/back/metrics/classification_metric.py
@@ -9,6 +9,8 @@ from DashAI.back.metrics.base_metric import BaseMetric
 class ClassificationMetric(BaseMetric):
     """Class for metrics associated to classification models."""
 
+    MAXIMIZE: bool = True
+
     COMPATIBLE_COMPONENTS = [
         "TabularClassificationTask",
         "ImageClassificationTask",

--- a/DashAI/back/metrics/regression_metric.py
+++ b/DashAI/back/metrics/regression_metric.py
@@ -9,6 +9,7 @@ from DashAI.back.metrics.base_metric import BaseMetric
 class RegressionMetric(BaseMetric):
     """Class for metrics associated with regression models."""
 
+    MAXIMIZE: bool = False
     COMPATIBLE_COMPONENTS = ["RegressionTask"]
 
 

--- a/DashAI/back/metrics/translation/bleu.py
+++ b/DashAI/back/metrics/translation/bleu.py
@@ -18,6 +18,8 @@ class Bleu(TranslationMetric):
     [1] https://en.wikipedia.org/wiki/BLEU
     """
 
+    MAXIMIZE: bool = True
+
     @staticmethod
     def score(source_sentences: DashAIDataset, target_sentences: np.ndarray):
         """Calculate the BLEU score between source and target sentences.

--- a/DashAI/back/metrics/translation/ter.py
+++ b/DashAI/back/metrics/translation/ter.py
@@ -18,6 +18,8 @@ class Ter(TranslationMetric):
     [1] https://huggingface.co/spaces/evaluate-metric/ter
     """
 
+    MAXIMIZE: bool = False
+
     @staticmethod
     def score(source_sentences: DashAIDataset, target_sentences: np.ndarray):
         """Calculate the TER score between source and target sentences.

--- a/DashAI/back/models/model_factory.py
+++ b/DashAI/back/models/model_factory.py
@@ -138,6 +138,7 @@ class ModelFactory:
         elif isinstance(value, dict) and value.get("optimize") is True:
             lower, upper = value.get("lower_bound"), value.get("upper_bound")
             fixed_value = value.get("fixed_value")
+            print(value)
 
             setattr(obj, key, fixed_value)
             local_refs.append((obj, key, (lower, upper)))

--- a/DashAI/back/models/model_factory.py
+++ b/DashAI/back/models/model_factory.py
@@ -138,7 +138,6 @@ class ModelFactory:
         elif isinstance(value, dict) and value.get("optimize") is True:
             lower, upper = value.get("lower_bound"), value.get("upper_bound")
             fixed_value = value.get("fixed_value")
-            print(value)
 
             setattr(obj, key, fixed_value)
             local_refs.append((obj, key, (lower, upper)))

--- a/DashAI/back/models/scikit_learn/logistic_regression.py
+++ b/DashAI/back/models/scikit_learn/logistic_regression.py
@@ -25,12 +25,12 @@ class LogisticRegressionSchema(BaseSchema):
         description="Specify the norm of the penalty",
     )  # type: ignore
     tol: schema_field(
-        optimizer_float_field(gt=0.0),
+        optimizer_float_field(ge=0.0),
         placeholder={
             "optimize": False,
-            "fixed_value": 0.001,
-            "lower_bound": 0.001,
-            "upper_bound": 5,
+            "fixed_value": 0.0,
+            "lower_bound": 0.0,
+            "upper_bound": 5.0,
         },
         description="Tolerance for stopping criteria.",
     )  # type: ignore

--- a/DashAI/back/optimizers/base_optimizer.py
+++ b/DashAI/back/optimizers/base_optimizer.py
@@ -275,7 +275,7 @@ class BaseOptimizer(ConfigObject, metaclass=ABCMeta):
         )
         return plotly.io.to_json(fig)
 
-    def importance_plot(self, trials):
+    def importance_plot(self, trials, goal_metric):
         """
         Plot to obtain the importance between all the hyperparameters
         involved in hyperparameter optimization.
@@ -295,7 +295,8 @@ class BaseOptimizer(ConfigObject, metaclass=ABCMeta):
             elif isinstance(low, float):
                 distributions[param] = optuna.distributions.FloatDistribution(low, high)
 
-        study = optuna.create_study(direction="maximize")
+        direction = "maximize" if goal_metric["metadata"]["maximize"] else "minimize"
+        study = optuna.create_study(direction=direction)
         for trial in trials:
             study.add_trial(
                 optuna.trial.create_trial(
@@ -343,7 +344,7 @@ class BaseOptimizer(ConfigObject, metaclass=ABCMeta):
 
         return plotly.io.to_json(fig)
 
-    def create_plots(self, trials, run_id, n_params):
+    def create_plots(self, trials, run_id, n_params, goal_metric):
         """
         List of available plots.
 
@@ -354,6 +355,7 @@ class BaseOptimizer(ConfigObject, metaclass=ABCMeta):
                             from the experiment.
             n_params (int): Number of the different hyperparameters involved
                             in the process of hyperparameter optimization
+            goal_metric (dict): Metric optimized in the process.
 
         Returns
         -------
@@ -370,7 +372,7 @@ class BaseOptimizer(ConfigObject, metaclass=ABCMeta):
                 self.history_objective_plot(trials),
                 self.slice_plot(trials),
                 self.contour_plot(trials),
-                self.importance_plot(trials),
+                self.importance_plot(trials, goal_metric),
             ]
             return plots_filenames, plots_list
         else:

--- a/DashAI/back/optimizers/hyperopt_optimizer.py
+++ b/DashAI/back/optimizers/hyperopt_optimizer.py
@@ -107,7 +107,7 @@ class HyperOptOptimizer(BaseOptimizer):
             self.model.fit(self.input_dataset["train"], self.output_dataset["train"])
             y_pred = self.model.predict(input_dataset["validation"])
             score = self.metric.score(output_dataset["validation"], y_pred)
-            return score
+            return -score if metric["metadata"]["maximize"] else score
 
         trials = Trials()
         fmin(

--- a/DashAI/back/optimizers/optuna_optimizer.py
+++ b/DashAI/back/optimizers/optuna_optimizer.py
@@ -75,15 +75,10 @@ class OptunaOptimizer(BaseOptimizer):
         self.input_dataset = input_dataset
         self.output_dataset = output_dataset
         self.parameters = parameters
-
-        if metric["name"] in ["Accuracy", "F1", "Precision", "Recall"]:
-            study = optuna.create_study(
-                direction="maximize", sampler=self.sampler(), pruner=self.pruner
-            )
-        else:
-            study = optuna.create_study(
-                direction="minimize", sampler=self.sampler(), pruner=self.pruner
-            )
+        direction = "maximize" if metric["metadata"]["maximize"] else "minimize"
+        study = optuna.create_study(
+            direction=direction, sampler=self.sampler(), pruner=self.pruner
+        )
 
         self.metric = metric["class"]
 


### PR DESCRIPTION
This pull request introduces improvements to how metrics are handled and used in optimization processes, ensuring that whether a metric should be maximized or minimized is consistently respected throughout the codebase. It adds metadata support to metrics, refactors optimizer logic to use this metadata, and makes minor corrections to schema definitions.

### Metric metadata and maximization/minimization handling

* Added a `MAXIMIZE` attribute and `get_metadata` method to the `BaseMetric` class, enabling each metric to specify if it should be maximized or minimized and exposing this via metadata. (`DashAI/back/metrics/base_metric.py`)
* Set the `MAXIMIZE` attribute appropriately for classification, regression, and translation metrics, ensuring correct optimization direction for each metric type. 

### Optimizer logic refactoring

* Refactored optimizer classes (`OptunaOptimizer`, `HyperoptOptimizer`, and base optimizer) to use the metric's metadata for determining optimization direction, replacing hardcoded checks and ensuring consistency. 
