### PR TITLE
Fix and add tour button in datasets

### DIFF
--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -113,7 +113,6 @@ export default function FormConverterSection({
         flexGrow: 1,
         maxHeight: "100%",
       }}
-      data-tour="column-selector-converter-container"
     >
       {step === 0 && (
         <ScopeStepConverter

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -83,6 +83,7 @@ export default function ScopeStepConverter({
         height: "100%",
         gap: 1,
       }}
+      data-tour="column-selector-converter-container"
     >
       {/* Content */}
       <Box

--- a/DashAI/front/src/components/notebooks/notebook/NotebookVisualization.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookVisualization.jsx
@@ -18,7 +18,10 @@ export default function NotebookVisualization({
         data-notebook-container
       >
         {/* Dataset View */}
-        <Box sx={{ flexGrow: 0, position: "sticky" }}>
+        <Box
+          sx={{ flexGrow: 0, position: "sticky" }}
+          data-tour="dataset-preview-section"
+        >
           <DatasetPreviewNotebook
             notebook={notebook}
             handleAddDatasetFromNotebook={handleAddDatasetFromNotebook}

--- a/DashAI/front/src/components/notebooks/tool/ToolList.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolList.jsx
@@ -27,32 +27,11 @@ export default function ToolList({ tools, notebook, FormComponent }) {
   const handleToolClick = (tool) => {
     setSelectedTool(tool);
     setOpen(true);
-
     if (tourContext && tourContext.run) {
-      const shouldAdvance =
-        tool.name === "HistogramPlotExplorer" ||
-        tool.name === "LabelEncoder" ||
-        tool.name === "NanRemover";
-
-      if (shouldAdvance) {
-        setTimeout(() => {
-          tourContext.nextStep();
-        }, 500);
-      }
+      setTimeout(() => {
+        tourContext.nextStep();
+      }, 500);
     }
-  };
-
-  const getTourAttribute = (toolName) => {
-    if (toolName === "HistogramPlotExplorer") {
-      return "histogram-explorer";
-    }
-    if (toolName === "LabelEncoder") {
-      return "label-encoder-converter";
-    }
-    if (toolName === "NanRemover") {
-      return "nan-remover-converter";
-    }
-    return undefined;
   };
 
   if (!tools || tools.length === 0) {
@@ -136,7 +115,6 @@ export default function ToolList({ tools, notebook, FormComponent }) {
                       tool={tool}
                       disabled={tool.disabled}
                       onClick={() => handleToolClick(tool)}
-                      data-tour={getTourAttribute(tool.name)}
                     />
                   ))}
               </Box>

--- a/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
@@ -4,7 +4,12 @@ import HoverToolInfo from "./HoverToolInfo";
 import api from "../../../api/api";
 import { CategoryIcon } from "./CategoryIcon";
 
-export default function ToolListItem({ tool, disabled = false, onClick }) {
+export default function ToolListItem({
+  tool,
+  disabled = false,
+  onClick,
+  ...props
+}) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [hoveredTool, setHoveredTool] = useState(null);
 
@@ -61,6 +66,7 @@ export default function ToolListItem({ tool, disabled = false, onClick }) {
         <Box
           key={tool.id}
           data-tour={getTourAttribute()}
+          {...props}
           onMouseEnter={(e) => handleMouseEnter(e, tool)}
           onMouseLeave={handleMouseLeave}
           onClick={disabled ? null : onClick}

--- a/DashAI/front/src/constants/tours/notebookTour.js
+++ b/DashAI/front/src/constants/tours/notebookTour.js
@@ -17,7 +17,7 @@ export const notebookTourSteps = [
     disableBeacon: true,
   },
   {
-    target: ".dataset-preview-section",
+    target: '[data-tour="dataset-preview-section"]',
     content: (
       <div>
         <h3>Dataset Preview</h3>
@@ -83,8 +83,8 @@ export const notebookTourSteps = [
           histogram.
         </p>
         <p>
-          For this example, you can select any numeric column. Try selecting one
-          column from the list.
+          For this example, you can <strong> select any numeric column </strong>
+          . Try selecting one column from the list.
         </p>
         <p>
           <strong>Click "Next" when you've selected a column.</strong>
@@ -212,6 +212,7 @@ export const notebookTourSteps = [
     ),
     disableBeacon: true,
     spotlightClicks: true,
+    disableOverlay: true,
     hideFooter: true,
   },
   {
@@ -262,6 +263,7 @@ export const notebookTourSteps = [
     ),
     disableBeacon: true,
     spotlightClicks: true,
+    disableOverlay: true,
     hideFooter: true,
   },
 
@@ -324,7 +326,6 @@ export const notebookTourSteps = [
         </div>
       </div>
     ),
-    placement: "auto",
     disableBeacon: true,
     spotlightClicks: true,
     disableScrolling: true,

--- a/DashAI/front/src/pages/datasets/DatasetsContent.jsx
+++ b/DashAI/front/src/pages/datasets/DatasetsContent.jsx
@@ -26,6 +26,9 @@ import {
 } from "../../api/notebook";
 import { enqueueDatasetJob } from "../../api/job";
 import { ExplorersAndConvertersProvider } from "../../components/notebooks/context/ExplorersAndConvertersContext";
+import { TourProvider } from "../../components/tour/TourProvider";
+import { TourButton } from "../../components/tour/TourButton";
+import { TOUR_KEYS } from "../../constants/tours";
 
 export default function DatasetsContent() {
   const [step, setStep] = useState(0);
@@ -45,11 +48,38 @@ export default function DatasetsContent() {
   const tourContext = useTourContext();
   const { enqueueSnackbar } = useSnackbar();
 
-  const goToNextStep = (option = selectedOption) => {
-    setStep((prevStep) => prevStep + 1);
-    setSelectedOption(option);
-    setSelectedNotebookId(null);
-    setSelectedDatasetId(null);
+  const menuOptions = [
+    {
+      name: "dataset",
+      display_name: "Upload Dataset",
+      description: "Import your data from various sources and formats.",
+      Icon: null,
+      "data-tour": "dataset-option",
+    },
+    {
+      name: "notebook",
+      display_name: "Create a New Notebook",
+      description: "Start a new analysis session with an existing dataset.",
+      Icon: null,
+      "data-tour": "notebook-option",
+    },
+  ];
+
+  const goToNextStep = (option) => {
+    if (option === "dataset" && tourContext?.run) {
+      setStep((prevStep) => prevStep + 1);
+      setSelectedOption(option);
+      setSelectedNotebookId(null);
+      setSelectedDatasetId(null);
+      setTimeout(() => {
+        tourContext.nextStep();
+      }, 600);
+    } else {
+      setStep((prevStep) => prevStep + 1);
+      setSelectedOption(option);
+      setSelectedNotebookId(null);
+      setSelectedDatasetId(null);
+    }
   };
 
   const enrichDatasetsWithInfo = async (newDatasets, existingDatasets = []) => {
@@ -248,12 +278,9 @@ export default function DatasetsContent() {
     maxAttempts = 10,
   ) => {
     if (jobId && attempt === 1) {
-      console.log(`Setting up job polling for dataset creation job: ${jobId}`);
-
       startJobPolling(
         jobId,
         async (result) => {
-          console.log(`Dataset job completed successfully`);
           enqueueSnackbar(`Dataset "${datasetName}" created successfully`, {
             variant: "success",
           });
@@ -270,17 +297,11 @@ export default function DatasetsContent() {
               setDatasets(enrichedDatasets);
               setSelectedDatasetId(datasetId);
             } else {
-              console.log(
-                "Dataset job completed but couldn't find real dataset",
-              );
               await fetchDatasets();
               setSelectedDatasetId(datasetId);
             }
           } catch (error) {
-            console.error(
-              "Error fetching datasets after job completion:",
-              error,
-            );
+            console.error("Error fetching datasets:", error);
             await fetchDatasets();
             setSelectedDatasetId(datasetId);
           }
@@ -441,212 +462,55 @@ export default function DatasetsContent() {
   const selectedNotebook = notebooks.find((n) => n.id === selectedNotebookId);
 
   return (
-    <Box
-      height="calc(100vh - 74px)"
-      width="100%"
-      p={1.5}
-      pb={1}
-      display="flex"
-      data-container="datasets"
-    >
-      {/* Left Panel */}
+    <>
       <Box
-        width={leftBarVisible ? `${leftBarWidth}%` : "0%"}
-        mr={leftBarVisible ? 0.5 : 0}
-        position="relative"
-        className="datasets-list"
-        sx={{
-          transition: isTogglingLeft
-            ? "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease"
-            : "none",
-          opacity: leftBarVisible ? 1 : 0,
-          overflow: "hidden",
-        }}
+        height="calc(100vh - 74px)"
+        width="100%"
+        p={1.5}
+        pb={1}
+        display="flex"
+        data-container="datasets"
       >
-        {leftBarVisible && (
-          <>
-            <LeftBar
-              datasets={datasets}
-              notebooks={notebooks}
-              selectedDatasetId={selectedDatasetId}
-              selectedNotebookId={selectedNotebookId}
-              onDatasetClick={handleDatasetClick}
-              onDatasetDelete={handleDatasetDelete}
-              onDatasetEdit={handleEditDataset}
-              onNotebookClick={handleNotebookClick}
-              onNotebookDelete={handleNotebookDelete}
-              onNotebookEdit={handleEditNotebook}
-              handleNewSessionButton={handleNewSessionButton}
-              onToggle={handleToggleLeft}
-            />
-            {/* Resize Handle */}
-            <Box
-              onMouseDown={() => {
-                isResizingLeft.current = true;
-                document.body.style.cursor = "col-resize";
-                document.body.style.userSelect = "none";
-              }}
-              sx={{
-                position: "absolute",
-                right: -2,
-                top: 0,
-                bottom: 0,
-                width: "5px",
-                cursor: "col-resize",
-                bgcolor: "transparent",
-                transition: "background-color 0.2s ease",
-                "&:hover": {
-                  bgcolor: "primary.main",
-                },
-                zIndex: 10,
-              }}
-            />
-          </>
-        )}
-      </Box>
-
-      {/* Toggle button when left panel is hidden */}
-      {!leftBarVisible && (
-        <IconButton
-          onClick={handleToggleLeft}
-          sx={{
-            position: "absolute",
-            left: 8,
-            top: "50%",
-            transform: "translateY(-50%)",
-            bgcolor: "background.paper",
-            zIndex: 10,
-            transition: "all 0.2s ease",
-            "&:hover": {
-              bgcolor: "action.hover",
-              transform: "translateY(-50%) scale(1.1)",
-            },
-          }}
-        >
-          <ChevronRight />
-        </IconButton>
-      )}
-
-      {/* Center Panel */}
-      <ExplorersAndConvertersProvider>
+        {/* Left Panel */}
         <Box
-          width={`${centerWidth}%`}
-          mx={0.5}
-          sx={{
-            transition:
-              isTogglingLeft || isTogglingRight
-                ? "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
-                : "none",
-          }}
-        >
-          <CenterBox>
-            {selectedDatasetId ? (
-              <DatasetVisualization
-                dataset={selectedDataset}
-                onNotebookCreated={handleNotebookCreated}
-                existingNotebooks={notebooks}
-              />
-            ) : selectedNotebookId ? (
-              <NotebookVisualization
-                notebook={selectedNotebook}
-                handleAddDatasetFromNotebook={handleAddDatasetFromNotebook}
-                existingDatasets={datasets}
-              />
-            ) : step === 0 ? (
-              <SelectOptionMenu
-                title="Dataset Module"
-                subtitle="Upload your datasets: Explore, analyze, and transform your data with advanced exploratory analysis tools. Create interactive notebooks, generate visualizations, and apply data transformations intuitively."
-                options={[
-                  {
-                    name: "dataset",
-                    display_name: "Upload Dataset",
-                    description:
-                      "Import your data from various sources and formats.",
-                    Icon: null,
-                  },
-                  {
-                    name: "notebook",
-                    display_name: "Create a New Notebook",
-                    description:
-                      "Start a new analysis session with an existing dataset.",
-                    Icon: null,
-                  },
-                ]}
-                searchBar={false}
-                goToNextStep={goToNextStep}
-              />
-            ) : step === 1 && selectedOption === "dataset" ? (
-              <UploadDatasetSteps
-                backHome={() => {
-                  setStep(0);
-                  setSelectedOption(null);
-                  fetchDatasets();
-                }}
-                handleDatasetCreated={handleDatasetCreated}
-                existingDatasets={datasets}
-              />
-            ) : step === 1 && selectedOption === "notebook" ? (
-              <UploadNotebookSteps
-                backHome={() => {
-                  setStep(0);
-                  setSelectedOption(null);
-                  fetchNotebooks();
-                }}
-                datasets={datasets}
-                handleNotebookCreated={handleNotebookCreated}
-                existingNotebooks={notebooks}
-              />
-            ) : null}
-          </CenterBox>
-        </Box>
-
-        {/* Toggle button when right panel is hidden */}
-        {!rightBarVisible && (
-          <IconButton
-            onClick={handleToggleRight}
-            sx={{
-              position: "absolute",
-              right: 8,
-              top: "50%",
-              transform: "translateY(-50%)",
-              bgcolor: "background.paper",
-              zIndex: 10,
-              transition: "all 0.2s ease",
-              "&:hover": {
-                bgcolor: "action.hover",
-                transform: "translateY(-50%) scale(1.1)",
-              },
-            }}
-          >
-            <ChevronLeft />
-          </IconButton>
-        )}
-
-        {/* Right Panel */}
-        <Box
-          width={rightBarVisible ? `${rightBarWidth}%` : "0%"}
-          ml={rightBarVisible ? 0.5 : 0}
+          width={leftBarVisible ? `${leftBarWidth}%` : "0%"}
+          mr={leftBarVisible ? 0.5 : 0}
           position="relative"
+          className="datasets-list"
           sx={{
-            transition: isTogglingRight
+            transition: isTogglingLeft
               ? "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease"
               : "none",
-            opacity: rightBarVisible ? 1 : 0,
+            opacity: leftBarVisible ? 1 : 0,
             overflow: "hidden",
           }}
         >
-          {rightBarVisible && (
+          {leftBarVisible && (
             <>
+              <LeftBar
+                datasets={datasets}
+                notebooks={notebooks}
+                selectedDatasetId={selectedDatasetId}
+                selectedNotebookId={selectedNotebookId}
+                onDatasetClick={handleDatasetClick}
+                onDatasetDelete={handleDatasetDelete}
+                onDatasetEdit={handleEditDataset}
+                onNotebookClick={handleNotebookClick}
+                onNotebookDelete={handleNotebookDelete}
+                onNotebookEdit={handleEditNotebook}
+                handleNewSessionButton={handleNewSessionButton}
+                onToggle={handleToggleLeft}
+              />
               {/* Resize Handle */}
               <Box
                 onMouseDown={() => {
-                  isResizingRight.current = true;
+                  isResizingLeft.current = true;
                   document.body.style.cursor = "col-resize";
                   document.body.style.userSelect = "none";
                 }}
                 sx={{
                   position: "absolute",
-                  left: -2,
+                  right: -2,
                   top: 0,
                   bottom: 0,
                   width: "5px",
@@ -659,14 +523,265 @@ export default function DatasetsContent() {
                   zIndex: 10,
                 }}
               />
-              <RightBar
-                notebook={selectedNotebook}
-                onToggle={handleToggleRight}
-              />
             </>
           )}
         </Box>
-      </ExplorersAndConvertersProvider>
-    </Box>
+
+        {/* Toggle button when left panel is hidden */}
+        {!leftBarVisible && (
+          <IconButton
+            onClick={handleToggleLeft}
+            sx={{
+              position: "absolute",
+              left: 8,
+              top: "50%",
+              transform: "translateY(-50%)",
+              bgcolor: "background.paper",
+              zIndex: 10,
+              transition: "all 0.2s ease",
+              "&:hover": {
+                bgcolor: "action.hover",
+                transform: "translateY(-50%) scale(1.1)",
+              },
+            }}
+          >
+            <ChevronRight />
+          </IconButton>
+        )}
+
+        {/* Center and Right Panels */}
+        <ExplorersAndConvertersProvider>
+          {selectedDatasetId ? (
+            <>
+              {/* Center Panel - Dataset */}
+              <Box
+                width={`${centerWidth}%`}
+                mx={0.5}
+                sx={{
+                  transition:
+                    isTogglingLeft || isTogglingRight
+                      ? "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
+                      : "none",
+                }}
+              >
+                <CenterBox>
+                  <DatasetVisualization
+                    dataset={selectedDataset}
+                    onNotebookCreated={handleNotebookCreated}
+                    existingNotebooks={notebooks}
+                  />
+                </CenterBox>
+              </Box>
+
+              {/* Toggle button when right panel is hidden - Dataset view */}
+              {!rightBarVisible && (
+                <IconButton
+                  onClick={handleToggleRight}
+                  sx={{
+                    position: "absolute",
+                    right: 8,
+                    top: "50%",
+                    transform: "translateY(-50%)",
+                    bgcolor: "background.paper",
+                    zIndex: 10,
+                    transition: "all 0.2s ease",
+                    "&:hover": {
+                      bgcolor: "action.hover",
+                      transform: "translateY(-50%) scale(1.1)",
+                    },
+                  }}
+                >
+                  <ChevronLeft />
+                </IconButton>
+              )}
+
+              {/* Right Panel - Dataset view */}
+              <Box
+                width={rightBarVisible ? `${rightBarWidth}%` : "0%"}
+                ml={rightBarVisible ? 0.5 : 0}
+                position="relative"
+                sx={{
+                  transition: isTogglingRight
+                    ? "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease"
+                    : "none",
+                  opacity: rightBarVisible ? 1 : 0,
+                  overflow: "hidden",
+                }}
+              >
+                {rightBarVisible && (
+                  <>
+                    {/* Resize Handle */}
+                    <Box
+                      onMouseDown={() => {
+                        isResizingRight.current = true;
+                        document.body.style.cursor = "col-resize";
+                        document.body.style.userSelect = "none";
+                      }}
+                      sx={{
+                        position: "absolute",
+                        left: -2,
+                        top: 0,
+                        bottom: 0,
+                        width: "5px",
+                        cursor: "col-resize",
+                        bgcolor: "transparent",
+                        transition: "background-color 0.2s ease",
+                        "&:hover": {
+                          bgcolor: "primary.main",
+                        },
+                        zIndex: 10,
+                      }}
+                    />
+                    <RightBar notebook={null} onToggle={handleToggleRight} />
+                  </>
+                )}
+              </Box>
+            </>
+          ) : selectedNotebookId ? (
+            // ✅ TourProvider envuelve TANTO el centro COMO el panel derecho
+            <TourProvider tourKey={TOUR_KEYS.NOTEBOOK}>
+              <>
+                {/* Center Panel - Notebook */}
+                <Box
+                  width={`${centerWidth}%`}
+                  mx={0.5}
+                  sx={{
+                    transition:
+                      isTogglingLeft || isTogglingRight
+                        ? "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
+                        : "none",
+                  }}
+                >
+                  <CenterBox>
+                    <NotebookVisualization
+                      notebook={selectedNotebook}
+                      handleAddDatasetFromNotebook={
+                        handleAddDatasetFromNotebook
+                      }
+                      existingDatasets={datasets}
+                    />
+                  </CenterBox>
+                </Box>
+
+                {/* Toggle button when right panel is hidden - Notebook view */}
+                {!rightBarVisible && (
+                  <IconButton
+                    onClick={handleToggleRight}
+                    sx={{
+                      position: "absolute",
+                      right: 8,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      bgcolor: "background.paper",
+                      zIndex: 10,
+                      transition: "all 0.2s ease",
+                      "&:hover": {
+                        bgcolor: "action.hover",
+                        transform: "translateY(-50%) scale(1.1)",
+                      },
+                    }}
+                  >
+                    <ChevronLeft />
+                  </IconButton>
+                )}
+
+                {/* Right Panel - Notebook view */}
+                <Box
+                  width={rightBarVisible ? `${rightBarWidth}%` : "0%"}
+                  ml={rightBarVisible ? 0.5 : 0}
+                  position="relative"
+                  sx={{
+                    transition: isTogglingRight
+                      ? "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease"
+                      : "none",
+                    opacity: rightBarVisible ? 1 : 0,
+                    overflow: "hidden",
+                  }}
+                >
+                  {rightBarVisible && (
+                    <>
+                      {/* Resize Handle */}
+                      <Box
+                        onMouseDown={() => {
+                          isResizingRight.current = true;
+                          document.body.style.cursor = "col-resize";
+                          document.body.style.userSelect = "none";
+                        }}
+                        sx={{
+                          position: "absolute",
+                          left: -2,
+                          top: 0,
+                          bottom: 0,
+                          width: "5px",
+                          cursor: "col-resize",
+                          bgcolor: "transparent",
+                          transition: "background-color 0.2s ease",
+                          "&:hover": {
+                            bgcolor: "primary.main",
+                          },
+                          zIndex: 10,
+                        }}
+                      />
+                      <RightBar
+                        notebook={selectedNotebook}
+                        onToggle={handleToggleRight}
+                      />
+                    </>
+                  )}
+                </Box>
+
+                <TourButton tourKey={TOUR_KEYS.NOTEBOOK} />
+              </>
+            </TourProvider>
+          ) : (
+            // Menu and upload steps
+            <Box
+              width={`${centerWidth}%`}
+              mx={0.5}
+              sx={{
+                transition:
+                  isTogglingLeft || isTogglingRight
+                    ? "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
+                    : "none",
+              }}
+            >
+              <CenterBox>
+                {step === 0 ? (
+                  <SelectOptionMenu
+                    title="Dataset Module"
+                    subtitle="Upload your datasets: Explore, analyze, and transform your data with advanced exploratory analysis tools. Create interactive notebooks, generate visualizations, and apply data transformations intuitively."
+                    options={menuOptions}
+                    searchBar={false}
+                    goToNextStep={goToNextStep}
+                  />
+                ) : step === 1 && selectedOption === "dataset" ? (
+                  <UploadDatasetSteps
+                    backHome={() => {
+                      setStep(0);
+                      setSelectedOption(null);
+                      fetchDatasets();
+                    }}
+                    handleDatasetCreated={handleDatasetCreated}
+                    existingDatasets={datasets}
+                  />
+                ) : step === 1 && selectedOption === "notebook" ? (
+                  <UploadNotebookSteps
+                    backHome={() => {
+                      setStep(0);
+                      setSelectedOption(null);
+                      fetchNotebooks();
+                    }}
+                    datasets={datasets}
+                    handleNotebookCreated={handleNotebookCreated}
+                    existingNotebooks={notebooks}
+                  />
+                ) : null}
+              </CenterBox>
+            </Box>
+          )}
+        </ExplorersAndConvertersProvider>
+      </Box>
+      {!selectedNotebookId && <TourButton tourKey={TOUR_KEYS.DATASETS} />}
+    </>
   );
 }


### PR DESCRIPTION
This pull request significantly improves the user tour experience and refactors the main datasets/notebooks page for better maintainability and clarity. The main changes include enhancing the guided tour with more robust selectors and step controls, restructuring the layout rendering logic in `DatasetsContent.jsx`, and making the codebase more modular and readable.

**User Tour Improvements**
* Updated tour step selectors to use `data-tour` attributes for more robust targeting, and added new `data-tour` markers to relevant components such as the dataset preview and converter column selector (`NotebookVisualization.jsx`, `ScopeStepConverter.jsx`, `FormConverterSection.jsx`, `notebookTour.js`). [[1]](diffhunk://#diff-0def202b58b6b02d0d4b20a58ca0695f9d6ffc660ec6b8e1356a267cfdfddef6L21-R24) [[2]](diffhunk://#diff-b2a383a9624be950258619b2b78f249dcf1619c925e6d14e75bc9e05bc37a54fR86) [[3]](diffhunk://#diff-8eeff4f0e04538ba9cb4faba8e7e8748aec4a299e61132e3a20730c24248ea76L116) [[4]](diffhunk://#diff-52836de3913eda413cd3b4c2235820f2c993a3e4b520ff23a352833516d349f5L20-R20)
* Enhanced tour step behavior by adding options like `disableOverlay` and improved content formatting for clarity in `notebookTour.js`. [[1]](diffhunk://#diff-52836de3913eda413cd3b4c2235820f2c993a3e4b520ff23a352833516d349f5R215) [[2]](diffhunk://#diff-52836de3913eda413cd3b4c2235820f2c993a3e4b520ff23a352833516d349f5R266) [[3]](diffhunk://#diff-52836de3913eda413cd3b4c2235820f2c993a3e4b520ff23a352833516d349f5L86-R87) [[4]](diffhunk://#diff-52836de3913eda413cd3b4c2235820f2c993a3e4b520ff23a352833516d349f5L327)

**Main Page Refactoring (`DatasetsContent.jsx`)**
* Refactored the main rendering logic to clearly separate views for dataset, notebook, and menu/upload steps, and wrapped the notebook view in a `TourProvider` to enable context-specific tours. [[1]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70R465) [[2]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70L530-R556) [[3]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70L543-R666) [[4]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70L625-R688) [[5]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70R732-R785)
* Introduced a `menuOptions` array for the main menu, with `data-tour` attributes for tour integration, and improved the `goToNextStep` logic to advance the tour programmatically.
* Added `TourButton` components to allow users to trigger tours for both datasets and notebooks. [[1]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70R29-R31) [[2]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70R732-R785)

**Component and Prop Improvements**
* Updated `ToolListItem` to accept and spread extra props, allowing easier integration of tour attributes and improving reusability. [[1]](diffhunk://#diff-d1b1bd8a90727b9555bd6451ea5e67bf1f13ff1935af33267fd210eb03e9d685L7-R12) [[2]](diffhunk://#diff-d1b1bd8a90727b9555bd6451ea5e67bf1f13ff1935af33267fd210eb03e9d685R69)
* Simplified tool click handling and removed hardcoded tour logic from `ToolList.jsx`, delegating tour advancement more cleanly. [[1]](diffhunk://#diff-4fb406cb196fa12cf14adae0a689092534a88ad1f65d2e2820a620e8e0f0ad56L30-L55) [[2]](diffhunk://#diff-4fb406cb196fa12cf14adae0a689092534a88ad1f65d2e2820a620e8e0f0ad56L139)

**Code Cleanliness**
* Removed unnecessary console logs and improved error handling for dataset job polling. [[1]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70L251-L256) [[2]](diffhunk://#diff-6f12dd7a70cb2d3c063d7541cf3f23e8250821031eb0b31da8be8cb39b775c70L273-R304)

These changes together make the tour experience more robust, the codebase more modular, and the main datasets/notebooks page easier to maintain and extend.