### PR TITLE
Remove invalid hook usage inside loops in FormSchemaRenderFields

### DIFF
--- a/DashAI/back/models/hugging_face/qwen_model.py
+++ b/DashAI/back/models/hugging_face/qwen_model.py
@@ -30,7 +30,7 @@ class QwenSchema(BaseSchema):
             enum=[
                 "Qwen/Qwen2.5-0.5B-Instruct-GGUF",
                 "Qwen/Qwen2.5-1.5B-Instruct-GGUF",
-                "Qwen/Qwen3-4B-GGUF ",
+                "Qwen/Qwen3-4B-GGUF",
             ]
         ),
         placeholder="Qwen/Qwen2.5-1.5B-Instruct-GGUF",

--- a/DashAI/front/src/components/shared/FormSchemaRenderFields.jsx
+++ b/DashAI/front/src/components/shared/FormSchemaRenderFields.jsx
@@ -42,15 +42,11 @@ function FormSchemaRenderFields({
       const error = formik?.errors?.[objName];
       const isOptimizable = fieldSchema.placeholder?.optimize !== undefined;
 
-      // Memoize the field object to avoid unnecessary re-renders
-      const baseField = useMemo(
-        () => ({
-          value,
-          error,
-          onChange: handleChange(objName),
-        }),
-        [value, error, objName, handleChange],
-      );
+      const baseField = {
+        value,
+        error,
+        onChange: handleChange(objName),
+      };
 
       if ("anyOf" in fieldSchema) {
         fields.push(


### PR DESCRIPTION
This branch fixes a React hooks violation in `FormSchemaRenderFields` that caused the error "Rendered more hooks than during the previous render". 
The issue was due to useMemo being called inside loops and maps. 
Replaced these hook calls with plain object definitions to ensure consistent hook order and stable renders.
