### PR TITLE
Refactor QualityAlerts component to use missing values instead of ratio

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetVisualization.jsx
@@ -273,6 +273,7 @@ export default function DatasetVisualization({
               <QualityAlerts
                 qualityInfo={datasetInfo?.quality_info}
                 generalInfo={datasetInfo?.general_info}
+                missingValues={datasetInfo?.nan}
               />
             </Box>
             {/* Tabs */}

--- a/DashAI/front/src/components/notebooks/dataset/QualityAlerts.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/QualityAlerts.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Alert } from "@mui/material";
 import CheckIcon from "@mui/icons-material/Check";
 
-export const QualityAlerts = ({ qualityInfo, generalInfo }) => {
+export const QualityAlerts = ({ qualityInfo, generalInfo, missingValues }) => {
   if (!qualityInfo) return null;
 
   const alerts = [];
@@ -16,15 +16,15 @@ export const QualityAlerts = ({ qualityInfo, generalInfo }) => {
     );
   }
 
-  // High missing values
-  const highNanColumns = Object.entries(qualityInfo.nan_ratio_per_column || {})
-    .filter(([_, ratio]) => ratio > 0.1)
-    .map(([col]) => col);
-
-  if (highNanColumns.length > 0) {
+  // Missing values
+  if (Object.values(missingValues).some((value) => value > 0)) {
     alerts.push(
       <Alert severity="warning" sx={{ mb: 1 }} key="nan">
-        High missing values in: {highNanColumns.join(", ")}
+        Missing values detected in columns:{" "}
+        {Object.entries(missingValues)
+          .filter(([_, value]) => value > 0)
+          .map(([key, _]) => key)
+          .join(", ")}
       </Alert>,
     );
   }


### PR DESCRIPTION
This pull request updates the dataset quality alert logic to improve how missing values are detected and displayed in the notebook dataset visualization. The main changes involve passing missing value information directly and updating the alert message to be more accurate and user-friendly.

**Improvements to missing values detection and display:**

* The `DatasetVisualization` component now passes the `nan` field from `datasetInfo` as the `missingValues` prop to the `QualityAlerts` component, ensuring missing value data is available for alerts.
* The `QualityAlerts` component is updated to accept the new `missingValues` prop.
* The logic for displaying missing value alerts is simplified: instead of only warning for columns with a high missing value ratio, an alert is now shown for any column with missing values, and the alert message lists all affected columns.

<img width="1912" height="956" alt="image" src="https://github.com/user-attachments/assets/401139ad-95ca-4782-b7d1-6f51ba8ab3e7" />
