### PR TITLE
Fix parameter unpacking in FANOVA importance evaluation

### DIFF
--- a/DashAI/back/optimizers/base_optimizer.py
+++ b/DashAI/back/optimizers/base_optimizer.py
@@ -311,7 +311,7 @@ class BaseOptimizer(ConfigObject, metaclass=ABCMeta):
             importances = evaluator.evaluate(study)
         except RuntimeError:
             importances = {
-                param: 1.0 / len(self.parameters) for _, param, _ in self.parameters
+                param: 1.0 / len(self.parameters) for _, param, _, _ in self.parameters
             }
             log.warning(
                 "Could not calculate parameter importance using FANOVA. "


### PR DESCRIPTION
This pull request makes a minor fix to the parameter unpacking logic in the `importance_plot` method of `base_optimizer.py`. The change ensures that the code correctly unpacks each item in `self.parameters` when calculating parameter importance if FANOVA evaluation fails.