### PR TITLE
fix: update default dataset name to use in SaveDatasetModal

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -30,13 +30,13 @@ export function SaveDatasetModal({
 
   const { defaultName } = useMemo(() => {
     if (tourContext && tourContext.run) {
-      return { defaultName: "Clean personality dataset" };
+      return { defaultName: "Clean Personality Dataset" };
     }
     return generateSequentialName({
       base: "Dataset",
       items: existingDatasets,
     });
-  }, [existingDatasets]);
+  }, [existingDatasets, tourContext]);
 
   useEffect(() => {
     if (open && defaultName) {


### PR DESCRIPTION
This pull request makes a small change to the default dataset name shown in the `SaveDatasetModal` component when the tour is running, updating it from "Clean personality dataset" to "Clean Personality Dataset" for consistency in capitalization. It also adds `tourContext` as a dependency to the relevant `useMemo` hook to ensure the default name updates correctly when the tour context changes.
