### PR TITLE
fix: update dependency in SaveDatasetModal useMemo to include 'open'

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -36,7 +36,7 @@ export function SaveDatasetModal({
       base: "Dataset",
       items: existingDatasets,
     });
-  }, [existingDatasets, tourContext]);
+  }, [existingDatasets, open]);
 
   useEffect(() => {
     if (open && defaultName) {


### PR DESCRIPTION
## Summary
Updates the dependency array of a `useMemo` hook in `SaveDatasetModal` so that dataset default name refresh correctly whenever the modal is opened.

---

## Type of Change
- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)
- `DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx`: Replaced `tourContext` in the `useMemo` dependency array with `open` to ensure dataset options reload when the modal becomes visible.

---

## Testing (optional)
- Confirm that opening the modal always triggers a refreshed dataset list.  
- Verify that no unnecessary re-renders occur when unrelated context values change.

---

## Notes (optional)
None.
