### PR TITLE
fix: update upload instructions to clarify file selection method

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
@@ -97,7 +97,7 @@ function Upload({ onFileUpload }) {
               <React.Fragment>
                 <Grid>
                   <Typography variant="subtitle1">
-                    Drag and drop a file here, or
+                    Click to upload your dataset file
                   </Typography>
                 </Grid>
                 <Grid>

--- a/DashAI/front/src/constants/tours/datasetsTour.js
+++ b/DashAI/front/src/constants/tours/datasetsTour.js
@@ -148,13 +148,9 @@ export const datasetsTourSteps = [
       <div>
         <h3>Upload Your File</h3>
         <p>Now it's time to upload the file you just downloaded!</p>
-        <p>You can either:</p>
         <ul>
           <li>
-            <strong>Drag and drop</strong> the file here
-          </li>
-          <li>
-            Or click <strong>"Upload a file"</strong> to browse for it
+            Click <strong>"Upload a file"</strong> to browse for it
           </li>
         </ul>
         <p style={{ fontSize: "0.9em", color: "#666", marginTop: "10px" }}>


### PR DESCRIPTION
## Summary
This pull request updates the dataset upload interface and tour instructions to make the file upload process clearer. The emphasis is shifted from drag-and-drop to a simple click-to-upload action.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx`: Updated the upload prompt to instruct users to "Click to upload your dataset file" instead of suggesting drag-and-drop.
- `DashAI/front/src/constants/tours/datasetsTour.js`: Updated tour instructions to remove drag-and-drop references and describe only the click-to-upload method.

---

## Testing (optional)
N/A — visual change only; verify the updated text appears correctly in the UI and tour.

---

## Notes (optional)
None.
