### PR TITLE
Fix dataset name for experiment tutorial

### DIFF
--- a/DashAI/front/src/components/experiments/NewExperimentModal.jsx
+++ b/DashAI/front/src/components/experiments/NewExperimentModal.jsx
@@ -190,7 +190,7 @@ export default function NewExperimentModal({
       if (tourContext && tourContext.run) {
         setTimeout(() => {
           tourContext.nextStep();
-        }, 300);
+        }, 500);
       }
       return;
     }

--- a/DashAI/front/src/components/experiments/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/experiments/SelectDatasetStep.jsx
@@ -108,11 +108,9 @@ function SelectDatasetStep({ newExp, setNewExp, setNextEnabled }) {
       setNewExp({ ...newExp, dataset });
       setNextEnabled(true);
       if (tourContext && tourContext.run) {
-        if (dataset.name === "Clean Personality Dataset") {
-          setTimeout(() => {
-            tourContext.nextStep();
-          }, 300);
-        }
+        setTimeout(() => {
+          tourContext.nextStep();
+        }, 300);
       }
     }
   }, [datasetsSelected]);

--- a/DashAI/front/src/components/experiments/SetNameAndTaskStep.jsx
+++ b/DashAI/front/src/components/experiments/SetNameAndTaskStep.jsx
@@ -134,7 +134,7 @@ function SetNameAndTaskStep({
     if (tourContext && tourContext.run) {
       setNewExp((prev) => ({
         ...prev,
-        name: "Personality Classification Experiment",
+        name: "Exp actividad 2",
       }));
       setExpNameOk(true);
     } else if (defaultExperimentName && !newExp?.name) {

--- a/DashAI/front/src/constants/tours/experimentsTour.js
+++ b/DashAI/front/src/constants/tours/experimentsTour.js
@@ -113,10 +113,6 @@ export const experimentsTourSteps = [
       <div>
         <h3>Choose Your Dataset</h3>
         <p>Select the dataset you want to use for training your models.</p>
-        <p>
-          <strong>Find and select "Clean Personality Dataset"</strong> – the
-          dataset you processed earlier in the Notebook.
-        </p>
       </div>
     ),
     placement: "top",
@@ -220,7 +216,6 @@ export const experimentsTourSteps = [
         </p>
       </div>
     ),
-    placement: "top",
     disableBeacon: true,
     spotlightClicks: true,
   },


### PR DESCRIPTION
This pull request updates the experiment creation tour and onboarding flow to make it more general and less tied to specific datasets or names. The changes focus on removing hardcoded references to the "Clean Personality Dataset" and "Personality Classification Experiment," generalizing the experience for users, and making minor timing and UI improvements.

**Generalization of experiment tour and onboarding:**

* Removed the instruction to specifically select the "Clean Personality Dataset" from the dataset selection tour step, making the tour applicable to any dataset.
* Changed the default experiment name set during the tour from "Personality Classification Experiment" to a more generic "Exp actividad 2".
* Removed the conditional logic that only advanced the tour if the "Clean Personality Dataset" was selected, allowing the tour to proceed regardless of dataset choice.

**Tour experience improvements:**

* Increased the delay before advancing the tour step in `NewExperimentModal` to 500ms for smoother transitions.
* Minor adjustment to the tour step configuration by removing redundant `placement: "top"` property.## Summary

