### PR TITLE
Align min_samples_split placeholder values with expected float range

### DIFF
--- a/DashAI/back/models/scikit_learn/gradient_boosting_regression.py
+++ b/DashAI/back/models/scikit_learn/gradient_boosting_regression.py
@@ -68,9 +68,9 @@ class GradientBoostingRSchema(BaseSchema):
         optimizer_float_field(gt=0.0, le=1.0),
         placeholder={
             "optimize": False,
-            "fixed_value": 2,
-            "lower_bound": 2,
-            "upper_bound": 20,
+            "fixed_value": 0.5,
+            "lower_bound": 0.1,
+            "upper_bound": 1.0,
         },
         description="The minimum number of samples required to split an internal node.",
     )  # type: ignore


### PR DESCRIPTION
## Summary
Updated the placeholder values for `min_samples_split` parameter in the `GradientBoostingRSchema` class so they correctly reflect the expected float range and default for the minimum number of samples required to split an internal node.

---

## Type of Change

- [x] Backend change  
- [ ] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [ ] Bug fix  
- [ ] Documentation  

---

## Changes (by file)

- `DashAI/back/models/scikit_learn/gradient_boosting_regression.py`: Updated the optimizer field's `fixed_value`, `lower_bound`, and `upper_bound` from integer placeholders (2, 2, 20) to float placeholders (0.5, 0.1, 1.0) to align with the parameter’s expected type and valid range.

---