### PR TITLE
Fix type detection to only allow "integer" when included in parameter options

### DIFF
--- a/DashAI/front/src/components/shared/FormSchemaFieldWithOptions.jsx
+++ b/DashAI/front/src/components/shared/FormSchemaFieldWithOptions.jsx
@@ -21,12 +21,15 @@ const typesLabels = {
   null: "Null",
 };
 
-const getType = (value) => {
+const getType = (value, options) => {
   if (value === null || value === undefined) {
     return "null";
   }
   if (typeof value === "number") {
-    if (Number.isInteger(value)) {
+    if (
+      Number.isInteger(value) &&
+      options.some((opt) => opt.type === "integer")
+    ) {
       return "integer";
     }
     return "number";
@@ -79,7 +82,7 @@ function FormSchemaFieldsWithOptions({
 
   useEffect(() => {
     if (field.value !== undefined && selectedType === null) {
-      setSelectedType(getType(field.value));
+      setSelectedType(getType(field.value, options));
     }
 
     if (selectedType && selectedType !== "null" && fieldProps.paramJsonSchema) {


### PR DESCRIPTION
## Summary
This pull request improves the type-detection logic in `FormSchemaFieldWithOptions` to ensure that the `"integer"` type is only selected when it is explicitly allowed in the field's `options`. This prevents mismatches between detected value types and permitted schema types.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `FormSchemaFieldWithOptions.jsx`:  
  - Updated `getType` to return `"integer"` only if it is included in the field's `options`.  
  - Updated `useEffect` call to pass `options` into `getType` to ensure consistent type validation.

---

## Testing
- Verify that numeric values no longer default to `"integer"` when the field does not allow the `"integer"` type. This used to cause the next error:

https://github.com/user-attachments/assets/bf952eb8-9793-4931-a87d-438699b5898c

- Check that fields with `"integer"` in their options still behave correctly and detect integer values.