### PR TITLE
Fix explainer navigation by passing model and task context

### DIFF
--- a/DashAI/front/src/pages/results/components/ResultsTable.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsTable.jsx
@@ -58,7 +58,12 @@ function ResultsTable({
   };
 
   const handleExplainer = (run) => {
-    navigate(`../app/explainers/runs/${run.id}`);
+    navigate(`../app/explainers/runs/${run.id}`, {
+      state: {
+        modelName: run.name,
+        taskName: experiment.task_name,
+      },
+    });
   };
 
   const processRuns = () => {


### PR DESCRIPTION
## Summary
This pull request fixes the navigation logic in the `ResultsTable` component. It now passes `modelName` and `taskName` through the navigation state when opening the explainer page, allowing that page to access needed context.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)
- `DashAI/front/src/components/results/ResultsTable.jsx`: Updated `handleExplainer` to include `modelName` and `taskName` in the navigation state when redirecting to the explainer page.

---

## Testing
- Confirm that navigating to the explainer page correctly receives `modelName` and `taskName` through `location.state`.
- Verify that the explainer page shows model name and fetches properly explainers available for the task.
