### PR TITLE
Change Annotated import from typing to typing extensions

### DIFF
--- a/DashAI/back/core/schema_fields/optimizer_float_field.py
+++ b/DashAI/back/core/schema_fields/optimizer_float_field.py
@@ -1,6 +1,7 @@
-from typing import Annotated, Optional, Type
+from typing import Optional, Type
 
 from pydantic import Field
+from typing_extensions import Annotated
 
 
 def optimizer_float_field(

--- a/DashAI/back/core/schema_fields/optimizer_int_field.py
+++ b/DashAI/back/core/schema_fields/optimizer_int_field.py
@@ -1,6 +1,7 @@
-from typing import Annotated, Optional, Type
+from typing import Optional, Type
 
 from pydantic import Field
+from typing_extensions import Annotated
 
 
 def optimizer_int_field(


### PR DESCRIPTION
This pull request updates the import statements for `Annotated` in two schema field modules to fix compatibility. The main change is switching the import of `Annotated` from the standard `typing` module to `typing_extensions`.

Dependency import updates:

* Changed the import of `Annotated` from `typing` to `typing_extensions` in both `optimizer_float_field.py` and `optimizer_int_field.py` for better compatibility, especially with Python versions where `Annotated` is not available in the standard library. 