### PR TITLE
Fix CI failure by pinning scikit-learn version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ joblib
 pydantic
 pydantic-settings
 starlette
-scikit-learn
+scikit-learn<1.8.0
 datasets
 diffusers
 evaluate


### PR DESCRIPTION
Recent releases of scikit-learn introduced changes that break compatibility with our current codebase and cause the CI pipeline to fail during setup and test execution. By pinning the version below 1.8.0, we ensure consistent and stable behavior across all CI runs until full compatibility with newer versions is implemented.