### PR TITLE
Update DashAIDataset to accept InMemoryTable in constructor

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -11,6 +11,7 @@ import pyarrow.ipc as ipc
 from beartype import beartype
 from beartype.typing import Dict, List, Literal, Optional, Tuple, Union
 from datasets import ClassLabel, Dataset, DatasetDict, Value, concatenate_datasets
+from datasets.table import InMemoryTable
 from pandas import DataFrame
 from sklearn.model_selection import train_test_split
 
@@ -55,7 +56,7 @@ class DashAIDataset(Dataset):
     @beartype
     def __init__(
         self,
-        table: pa.Table,
+        table: Union[pa.Table, InMemoryTable],
         splits: dict = None,
         types: Optional[Dict[str, DashAIDataType]] = None,
         *args,


### PR DESCRIPTION
## Summary
This pull request enhances dataset compatibility by allowing the `DashAIDataset` class to accept both `pa.Table` and `InMemoryTable` instances. This resolves issues in translation task that relies on `InMemoryTable`.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `dashai/data/dataset.py`:
  - Added import for `InMemoryTable` from `datasets.table`.
  - Updated the `DashAIDataset` constructor to accept `Union[pa.Table, InMemoryTable]` for the `table` parameter.

---

## Testing 
- Verify that translation task works

---
