### PR TITLE
Integrate DashAI types into dataset metadata

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -368,10 +368,6 @@ class DashAIDataset(Dataset):
                 "median_length": float(lengths.median()),
                 "min_length": int(lengths.min()),
                 "max_length": int(lengths.max()),
-                "empty_count": int(
-                    (dataset_df[col].isna() | (dataset_df[col] == "")).sum()
-                ),
-                "whitespace_only": int(series.str.strip().eq("").sum()),
                 "unique_count": int(series.nunique()),
                 "unique_ratio": float(series.nunique() / len(series)),
                 "avg_word_count": float(series.str.split().str.len().mean()),

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -23,6 +23,7 @@ from DashAI.back.types.utils import (
     save_types_in_arrow_metadata,
     to_arrow_types,
 )
+from DashAI.back.types.value_types import Decimal, Float, Integer, Text
 
 log = logging.getLogger(__name__)
 
@@ -180,24 +181,96 @@ class DashAIDataset(Dataset):
 
         dataset_df = self.to_pandas()
 
+        if self.types is None:
+            raise ValueError("Dataset types are not defined.")
+
         # --- Base ---
         self.splits["column_names"] = dataset_df.columns.tolist()
         self.splits["total_rows"] = len(dataset_df)
         self.splits["nan"] = dataset_df.isna().sum().to_dict()
 
-        # --- General info ---
-        general_info = {
+        # --- Compute all metadata components ---
+        self.splits["general_info"] = self._compute_general_info(dataset_df)
+        self.splits["numeric_stats"] = self._compute_numeric_metadata(dataset_df)
+        self.splits["categorical_stats"] = self._compute_categorical_metadata(
+            dataset_df
+        )
+        self.splits["text_stats"] = self._compute_text_metadata(dataset_df)
+        self.splits["quality_info"] = self._compute_quality_metadata(dataset_df)
+        self.splits["correlations"] = self._compute_correlations(dataset_df)
+
+        return self
+
+    def _compute_general_info(self, dataset_df) -> dict:
+        """Compute general dataset information.
+
+        Parameters
+        ----------
+        dataset_df : pd.DataFrame
+            The dataset as a pandas DataFrame.
+
+        Returns
+        -------
+        dict
+            General information including rows, columns, memory usage, and dtypes.
+        """
+        return {
             "n_rows": len(dataset_df),
             "n_columns": len(dataset_df.columns),
             "memory_usage_mb": float(dataset_df.memory_usage(deep=True).sum() / 1e6),
             "duplicate_rows": int(dataset_df.duplicated().sum()),
-            "dtypes": dataset_df.dtypes.astype(str).to_dict(),
+            "dtypes": {k: v.to_string().get("type") for k, v in self.types.items()},
         }
 
-        # --- Numeric columns stats ---
-        # TODO: Replace with categorical type from DashAI types when available
-        numeric_cols = dataset_df.select_dtypes(include=[np.number])
+    def _get_numeric_columns(self) -> list:
+        """Get list of numeric column names based on DashAI types.
+
+        Returns
+        -------
+        list
+            List of numeric column names.
+        """
+        return [
+            k for k, v in self.types.items() if isinstance(v, (Integer, Float, Decimal))
+        ]
+
+    def _get_categorical_columns(self) -> list:
+        """Get list of categorical column names based on DashAI types.
+
+        Returns
+        -------
+        list
+            List of categorical column names.
+        """
+        return [k for k, v in self.types.items() if isinstance(v, Categorical)]
+
+    def _get_text_columns(self) -> list:
+        """Get list of text column names based on DashAI types.
+
+        Returns
+        -------
+        list
+            List of text column names.
+        """
+        return [k for k, v in self.types.items() if isinstance(v, Text)]
+
+    def _compute_numeric_metadata(self, dataset_df) -> dict:
+        """Compute statistics for numeric columns.
+
+        Parameters
+        ----------
+        dataset_df : pd.DataFrame
+            The dataset as a pandas DataFrame.
+
+        Returns
+        -------
+        dict
+            Dictionary with statistics for each numeric column.
+        """
+        numeric_keys = self._get_numeric_columns()
+        numeric_cols = dataset_df[numeric_keys]
         numeric_stats = {}
+
         for col in numeric_cols.columns:
             series = numeric_cols[col].dropna()
             if series.empty:
@@ -229,10 +302,25 @@ class DashAIDataset(Dataset):
                 "outliers_count": outliers_count,
             }
 
-        # --- Categorical columns stats ---
-        # TODO: Replace with categorical type from DashAI types when available
-        categorical_cols = dataset_df.select_dtypes(include=["object", "category"])
+        return numeric_stats
+
+    def _compute_categorical_metadata(self, dataset_df) -> dict:
+        """Compute statistics for categorical columns.
+
+        Parameters
+        ----------
+        dataset_df : pd.DataFrame
+            The dataset as a pandas DataFrame.
+
+        Returns
+        -------
+        dict
+            Dictionary with statistics for each categorical column.
+        """
+        categorical_keys = self._get_categorical_columns()
+        categorical_cols = dataset_df[categorical_keys]
         categorical_stats = {}
+
         for col in categorical_cols.columns:
             series = categorical_cols[col].dropna()
             if series.empty:
@@ -252,22 +340,59 @@ class DashAIDataset(Dataset):
                 "top_5": top_5,
             }
 
-        # --- Text columns stats ---
-        # TODO: Replace with categorical type from DashAI types when available
+        return categorical_stats
+
+    def _compute_text_metadata(self, dataset_df) -> dict:
+        """Compute statistics for text columns.
+
+        Parameters
+        ----------
+        dataset_df : pd.DataFrame
+            The dataset as a pandas DataFrame.
+
+        Returns
+        -------
+        dict
+            Dictionary with statistics for each text column.
+        """
+        text_keys = self._get_text_columns()
         text_stats = {}
-        for col in categorical_cols.columns:
+
+        for col in text_keys:
+            if col not in dataset_df.columns:
+                continue
             series = dataset_df[col].astype(str)
             lengths = series.str.len()
             text_stats[col] = {
                 "avg_length": float(lengths.mean()),
+                "median_length": float(lengths.median()),
                 "min_length": int(lengths.min()),
                 "max_length": int(lengths.max()),
                 "empty_count": int(
                     (dataset_df[col].isna() | (dataset_df[col] == "")).sum()
                 ),
+                "whitespace_only": int(series.str.strip().eq("").sum()),
+                "unique_count": int(series.nunique()),
+                "unique_ratio": float(series.nunique() / len(series)),
+                "avg_word_count": float(series.str.split().str.len().mean()),
             }
 
-        # --- Quality indicators ---
+        return text_stats
+
+    def _compute_quality_metadata(self, dataset_df) -> dict:
+        """Compute data quality indicators.
+
+        Parameters
+        ----------
+        dataset_df : pd.DataFrame
+            The dataset as a pandas DataFrame.
+
+        Returns
+        -------
+        dict
+            Dictionary with quality indicators including completeness,
+            constant columns, high cardinality columns, and quality score.
+        """
         # Count rows with missing values
         rows_with_any_nan = int(dataset_df.isna().any(axis=1).sum())
         rows_with_multiple_nan = int((dataset_df.isna().sum(axis=1) > 1).sum())
@@ -277,14 +402,18 @@ class DashAIDataset(Dataset):
         completeness = 1 - (
             dataset_df.isna().sum().sum() / (len(dataset_df) * len(dataset_df.columns))
         )
-        uniqueness = 1 - (general_info["duplicate_rows"] / len(dataset_df))
+        duplicate_rows = int(dataset_df.duplicated().sum())
+        uniqueness = 1 - (duplicate_rows / len(dataset_df))
         data_quality_score = float((completeness * 0.7 + uniqueness * 0.3) * 100)
 
         # Compute unique counts
         nunique_series = dataset_df.nunique(dropna=False)
+
+        categorical_keys = self._get_categorical_columns()
+        categorical_cols = dataset_df[categorical_keys]
         nunique_categorical = categorical_cols.nunique(dropna=False)
 
-        quality_info = {
+        return {
             "constant_columns": [
                 c for c in dataset_df.columns if int(nunique_series[c]) == 1
             ],
@@ -302,37 +431,39 @@ class DashAIDataset(Dataset):
             "data_quality_score": data_quality_score,
         }
 
-        # --- Correlations ---
-        if not numeric_cols.empty:
-            corr_matrix = numeric_cols.corr(numeric_only=True)
-            # Drop columns and rows from correlation matrix that are all NaN
-            corr_matrix = corr_matrix.dropna(axis=0, how="all").dropna(
-                axis=1, how="all"
-            )
-            correlations = {}
-            for col1 in corr_matrix.columns:
-                col_corrs = {}
-                for col2 in corr_matrix.columns:
-                    corr_val = float(corr_matrix.loc[col1, col2])
-                    col_corrs[col2] = round(corr_val, 4)
-                if col_corrs:
-                    correlations[col1] = col_corrs
-        else:
-            correlations = {}
+    def _compute_correlations(self, dataset_df) -> dict:
+        """Compute correlation matrix for numeric columns.
 
-        # --- Combine everything ---
-        self.splits.update(
-            {
-                "general_info": general_info,
-                "numeric_stats": numeric_stats,
-                "categorical_stats": categorical_stats,
-                "text_stats": text_stats,
-                "quality_info": quality_info,
-                "correlations": correlations,
-            }
-        )
+        Parameters
+        ----------
+        dataset_df : pd.DataFrame
+            The dataset as a pandas DataFrame.
 
-        return self
+        Returns
+        -------
+        dict
+            Nested dictionary representing the correlation matrix.
+        """
+        numeric_keys = self._get_numeric_columns()
+        numeric_cols = dataset_df[numeric_keys]
+
+        if numeric_cols.empty:
+            return {}
+
+        corr_matrix = numeric_cols.corr(numeric_only=True)
+        # Drop columns and rows from correlation matrix that are all NaN
+        corr_matrix = corr_matrix.dropna(axis=0, how="all").dropna(axis=1, how="all")
+
+        correlations = {}
+        for col1 in corr_matrix.columns:
+            col_corrs = {}
+            for col2 in corr_matrix.columns:
+                corr_val = float(corr_matrix.loc[col1, col2])
+                col_corrs[col2] = round(corr_val, 4)
+            if col_corrs:
+                correlations[col1] = col_corrs
+
+        return correlations
 
     @beartype
     def remove_columns(self, column_names: Union[str, List[str]]) -> "DashAIDataset":

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -12,7 +12,11 @@ from sqlalchemy.orm import sessionmaker
 
 from DashAI.back.api.api_v1.schemas.datasets_params import DatasetParams
 from DashAI.back.api.utils import parse_params
-from DashAI.back.dataloaders.classes.dashai_dataset import load_dataset, save_dataset
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    load_dataset,
+    save_dataset,
+    transform_dataset_with_schema,
+)
 from DashAI.back.dependencies.database.models import Dataset, Notebook
 from DashAI.back.job.base_job import BaseJob, JobError
 from DashAI.back.types.inf.type_inference import infer_types
@@ -166,17 +170,21 @@ class DatasetJob(BaseJob):
                         n_sample=n_sample,
                     )
 
-                # Calculate metadata
-                new_dataset.compute_metadata()
-                gc.collect()
                 if "inferred_types" in params:
                     schema = params["inferred_types"]
                 else:
                     schema = infer_types(new_dataset.to_pandas(), method="DashAIPtype")
 
+                # Cast dataset to inferred types
+                new_dataset = transform_dataset_with_schema(new_dataset, schema)
+
+                # Calculate metadata
+                new_dataset.compute_metadata()
+                gc.collect()
+
                 dataset_save_path = folder_path / "dataset"
                 log.debug("Saving dataset in %s", str(dataset_save_path))
-                save_dataset(new_dataset, dataset_save_path, schema)
+                save_dataset(new_dataset, dataset_save_path)
             except Exception as e:
                 log.exception(e)
                 shutil.rmtree(folder_path, ignore_errors=True)

--- a/DashAI/front/src/components/notebooks/dataset/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetVisualization.jsx
@@ -38,6 +38,7 @@ import { CategoricalTab } from "./tabs/CategoricalTab";
 import QualityTab from "./tabs/QualityTab";
 import CorrelationsTab from "./tabs/CorrelationsTab";
 import { QualityAlerts } from "./QualityAlerts";
+import { TextTab } from "./tabs/TextTab";
 
 export default function DatasetVisualization({
   dataset,
@@ -333,6 +334,13 @@ export default function DatasetVisualization({
                   Object.keys(datasetInfo.categorical_stats).length === 0
                 }
               />
+              <Tab
+                label="Text"
+                disabled={
+                  !datasetInfo?.text_stats ||
+                  Object.keys(datasetInfo.text_stats).length === 0
+                }
+              />
               <Tab label="Data Quality" disabled={!datasetInfo?.quality_info} />
               <Tab
                 label="Correlations"
@@ -364,13 +372,14 @@ export default function DatasetVisualization({
                 categoricalStats={datasetInfo?.categorical_stats}
               />
             )}
-            {tab === 3 && (
+            {tab === 3 && <TextTab textStats={datasetInfo?.text_stats} />}
+            {tab === 4 && (
               <QualityTab
                 qualityInfo={datasetInfo?.quality_info}
                 totalRows={datasetInfo?.total_rows}
               />
             )}
-            {tab === 4 && (
+            {tab === 5 && (
               <CorrelationsTab correlations={datasetInfo?.correlations} />
             )}
           </Box>

--- a/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
@@ -32,18 +32,14 @@ const OverviewTab = ({
     percentage: ((count / total_rows) * 100).toFixed(1),
   }));
 
-  const typeCounts = Object.entries(
-    Object.values(dtypes ?? {}).reduce((acc, type) => {
-      const category =
-        type.includes("float") || type.includes("int")
-          ? "Numeric"
-          : type.includes("object")
-            ? "Text"
-            : "Other";
-      acc[category] = (acc[category] || 0) + 1;
-      return acc;
-    }, {}),
-  );
+  // Get all unique dtype values
+  const dtypeValues = new Set(Object.values(dtypes ?? {}));
+
+  // Count occurrences of each dtype
+  const typeCounts = Array.from(dtypeValues).map((dtype) => [
+    dtype,
+    Object.values(dtypes).filter((v) => v === dtype).length,
+  ]);
 
   return (
     <Box display="flex" flexDirection="column" gap={4}>

--- a/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
@@ -57,8 +57,8 @@ export const TextTab = ({ textStats }) => (
                         uniquePercentage > 90
                           ? "#4caf50"
                           : uniquePercentage > 30
-                          ? "#ff9800"
-                          : "#f44336",
+                            ? "#ff9800"
+                            : "#f44336",
                       color: "white",
                       cursor: "default",
                     }}

--- a/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
@@ -61,9 +61,10 @@ export const TextTab = ({ textStats }) => (
                         uniquePercentage > 90
                           ? "#4caf50"
                           : uniquePercentage > 30
-                          ? "#ff9800"
-                          : "#f44336",
+                            ? "#ff9800"
+                            : "#f44336",
                       color: "white",
+                      cursor: "default",
                     }}
                   />
                 </Tooltip>

--- a/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
@@ -1,0 +1,196 @@
+import React from "react";
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Alert,
+  Tooltip,
+} from "@mui/material";
+import TextFieldsIcon from "@mui/icons-material/TextFields";
+import {
+  ResponsiveContainer,
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip as RechartsTooltip,
+  Bar,
+  Cell,
+} from "recharts";
+import { StatBox } from "../StatBox";
+import { MetricRow } from "../MetricRow";
+
+export const TextTab = ({ textStats }) => (
+  <Box display="flex" flexDirection="column" gap={4}>
+    {Object.entries(textStats).map(([column, stats]) => {
+      const lengthData = [
+        { label: "Min", value: stats.min_length, color: "#82ca9d" },
+        { label: "Median", value: stats.median_length, color: "#8884d8" },
+        { label: "Avg", value: stats.avg_length, color: "#ffc658" },
+        { label: "Max", value: stats.max_length, color: "#ff7c7c" },
+      ];
+
+      const totalCount = stats.total_count || 0;
+      const validCount =
+        totalCount - (stats.empty_count || 0) - (stats.whitespace_only || 0);
+
+      const uniquePercentage = stats.unique_ratio
+        ? (stats.unique_ratio * 100).toFixed(1)
+        : null;
+
+      return (
+        <Card key={column} sx={{ borderRadius: 2 }}>
+          <CardContent sx={{ bgcolor: "#2C2C2C" }}>
+            {/* Title */}
+            <Box display="flex" alignItems="center" mb={2}>
+              <TextFieldsIcon sx={{ color: "primary.main", mr: 1 }} />
+              <Typography variant="h6" fontWeight="bold">
+                {column}
+              </Typography>
+
+              {uniquePercentage && (
+                <Tooltip title={"Uniqueness = (Unique ÷ Total) × 100"} arrow>
+                  <Chip
+                    label={`${uniquePercentage}% unique`}
+                    size="small"
+                    sx={{
+                      ml: 2,
+                      bgcolor:
+                        uniquePercentage > 90
+                          ? "#4caf50"
+                          : uniquePercentage > 30
+                          ? "#ff9800"
+                          : "#f44336",
+                      color: "white",
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </Box>
+
+            {parseFloat(uniquePercentage) <= 30 && (
+              <Alert severity="error" sx={{ mb: 3 }}>
+                Warning: This text column has a very low uniqueness ratio. This
+                may be a categorical variable misclassified as text, which could
+                lead to analysis issues.
+              </Alert>
+            )}
+
+            {/* Summary Stats (StatBoxes) */}
+            <Box display="flex" flexWrap="wrap" gap={2} mb={3}>
+              <Box flex="1 1 200px" minWidth="150px">
+                <StatBox
+                  label="Avg Length"
+                  value={Math.round(stats.avg_length)}
+                />
+              </Box>
+
+              <Box flex="1 1 200px" minWidth="150px">
+                <StatBox label="Median Length" value={stats.median_length} />
+              </Box>
+
+              {stats.avg_word_count && (
+                <Box flex="1 1 200px" minWidth="150px">
+                  <StatBox
+                    label="Avg Word Count"
+                    value={Math.round(stats.avg_word_count)}
+                  />
+                </Box>
+              )}
+
+              <Box flex="1 1 200px" minWidth="150px">
+                <StatBox label="Unique Values" value={stats.unique_count} />
+              </Box>
+            </Box>
+
+            {/* Two-column metric grouping (like NumericTab) */}
+            <Box display="flex" flexWrap="wrap" gap={4}>
+              {/* Length Metrics */}
+              <Box flex="1 1 300px" minWidth="250px">
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  Length Metrics
+                </Typography>
+                <Box display="flex" flexDirection="column" gap={1}>
+                  <MetricRow label="Min Length" value={stats.min_length} />
+                  <MetricRow label="Median" value={stats.median_length} />
+                  <MetricRow
+                    label="Mean"
+                    value={stats.avg_length?.toFixed(1)}
+                  />
+                  <MetricRow label="Max Length" value={stats.max_length} />
+                  <MetricRow
+                    label="Range"
+                    value={stats.max_length - stats.min_length}
+                  />
+                </Box>
+              </Box>
+
+              {/* Data Quality Metrics */}
+              <Box flex="1 1 300px" minWidth="250px">
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  Data Quality
+                </Typography>
+                <Box display="flex" flexDirection="column" gap={1}>
+                  <MetricRow label="Empty" value={stats.empty_count || 0} />
+                  {stats.whitespace_only !== undefined && (
+                    <MetricRow
+                      label="Whitespace Only"
+                      value={stats.whitespace_only}
+                    />
+                  )}
+                  <MetricRow label="Valid" value={validCount} />
+
+                  {stats.duplicate_count !== undefined && (
+                    <MetricRow
+                      label="Duplicates"
+                      value={stats.duplicate_count}
+                    />
+                  )}
+                </Box>
+              </Box>
+            </Box>
+
+            {/* Plot: Length Distribution */}
+            <Box mt={4}>
+              <Typography
+                variant="subtitle2"
+                color="text.secondary"
+                gutterBottom
+              >
+                Length Distribution
+              </Typography>
+              <Box sx={{ width: "100%", height: 250 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={lengthData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="label" />
+                    <YAxis />
+                    <RechartsTooltip
+                      contentStyle={{
+                        backgroundColor: "#121212",
+                        borderRadius: 4,
+                        color: "#ffffff",
+                      }}
+                      labelStyle={{ color: "#ffffff" }}
+                    />
+                    <Bar dataKey="value" fill="rgba(136, 132, 216, 0.7)" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </Box>
+            </Box>
+          </CardContent>
+        </Card>
+      );
+    })}
+  </Box>
+);

--- a/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
@@ -32,10 +32,6 @@ export const TextTab = ({ textStats }) => (
         { label: "Max", value: stats.max_length, color: "#ff7c7c" },
       ];
 
-      const totalCount = stats.total_count || 0;
-      const validCount =
-        totalCount - (stats.empty_count || 0) - (stats.whitespace_only || 0);
-
       const uniquePercentage = stats.unique_ratio
         ? (stats.unique_ratio * 100).toFixed(1)
         : null;
@@ -61,8 +57,8 @@ export const TextTab = ({ textStats }) => (
                         uniquePercentage > 90
                           ? "#4caf50"
                           : uniquePercentage > 30
-                            ? "#ff9800"
-                            : "#f44336",
+                          ? "#ff9800"
+                          : "#f44336",
                       color: "white",
                       cursor: "default",
                     }}
@@ -106,9 +102,8 @@ export const TextTab = ({ textStats }) => (
               </Box>
             </Box>
 
-            {/* Two-column metric grouping (like NumericTab) */}
+            {/* Two-column metric grouping */}
             <Box display="flex" flexWrap="wrap" gap={4}>
-              {/* Length Metrics */}
               <Box flex="1 1 300px" minWidth="250px">
                 <Typography
                   variant="subtitle2"
@@ -117,46 +112,26 @@ export const TextTab = ({ textStats }) => (
                 >
                   Length Metrics
                 </Typography>
-                <Box display="flex" flexDirection="column" gap={1}>
-                  <MetricRow label="Min Length" value={stats.min_length} />
-                  <MetricRow label="Median" value={stats.median_length} />
-                  <MetricRow
-                    label="Mean"
-                    value={stats.avg_length?.toFixed(1)}
-                  />
-                  <MetricRow label="Max Length" value={stats.max_length} />
-                  <MetricRow
-                    label="Range"
-                    value={stats.max_length - stats.min_length}
-                  />
-                </Box>
-              </Box>
 
-              {/* Data Quality Metrics */}
-              <Box flex="1 1 300px" minWidth="250px">
-                <Typography
-                  variant="subtitle2"
-                  color="text.secondary"
-                  gutterBottom
-                >
-                  Data Quality
-                </Typography>
-                <Box display="flex" flexDirection="column" gap={1}>
-                  <MetricRow label="Empty" value={stats.empty_count || 0} />
-                  {stats.whitespace_only !== undefined && (
+                <Box display="flex" gap={4}>
+                  {/* Column 1 */}
+                  <Box display="flex" flexDirection="column" gap={1} flex="1">
+                    <MetricRow label="Min Length" value={stats.min_length} />
+                    <MetricRow label="Median" value={stats.median_length} />
                     <MetricRow
-                      label="Whitespace Only"
-                      value={stats.whitespace_only}
+                      label="Mean"
+                      value={stats.avg_length?.toFixed(1)}
                     />
-                  )}
-                  <MetricRow label="Valid" value={validCount} />
+                  </Box>
 
-                  {stats.duplicate_count !== undefined && (
+                  {/* Column 2 */}
+                  <Box display="flex" flexDirection="column" gap={1} flex="1">
+                    <MetricRow label="Max Length" value={stats.max_length} />
                     <MetricRow
-                      label="Duplicates"
-                      value={stats.duplicate_count}
+                      label="Range"
+                      value={stats.max_length - stats.min_length}
                     />
-                  )}
+                  </Box>
                 </Box>
               </Box>
             </Box>

--- a/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
@@ -72,7 +72,7 @@ export const TextTab = ({ textStats }) => (
             </Box>
 
             {parseFloat(uniquePercentage) <= 30 && (
-              <Alert severity="error" sx={{ mb: 3 }}>
+              <Alert severity="warning" sx={{ mb: 3 }}>
                 Warning: This text column has a very low uniqueness ratio. This
                 may be a categorical variable misclassified as text, which could
                 lead to analysis issues.


### PR DESCRIPTION
## Summary
This pull request improves the accuracy, structure, and usability of dataset metadata in DashAI. It refactors backend metadata computation using DashAI's type system, modularizes metadata generation, and introduces a new Text tab on the frontend.

---

## Type of Change

- [x] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [ ] Bug fix  
- [ ] Documentation

---

## Changes (by file)

### Backend
- `DashAIDataset`:
  - Refactored `compute_metadata` into modular metadata calculation methods (general, numeric, categorical, text, quality, correlations).
  - Integrated DashAI type classes for more reliable and extensible column metadata.
  - Added safety checks for undefined dataset types before computing metadata.
  - Updated job pipeline to always cast datasets to inferred types before metadata computation.

### Frontend
- `TextTab.tsx`:
  - Added a new tab showing text statistics (avg/median/min/max length, uniqueness ratio, word count, warnings for low uniqueness).
- Updated Overview tab to display type counts based on backend-provided dtypes.
- UI and utility improvements for text metadata rendering.

<img width="1910" height="950" alt="image" src="https://github.com/user-attachments/assets/24a2571b-a3ba-42d3-bf25-16e78948e059" />

<img width="1913" height="959" alt="image" src="https://github.com/user-attachments/assets/238aa48f-9fd3-48d1-be91-bb84390fa754" />

---

## Testing
- Verify metadata generation works for datasets with text columns

