### PR TITLE
fix: close radar chart shape by adding first value and label at the end

### DIFF
--- a/DashAI/front/src/pages/results/constants/graphsMaking.jsx
+++ b/DashAI/front/src/pages/results/constants/graphsMaking.jsx
@@ -12,13 +12,16 @@ function graphsMaking(
   graphsToView.bar = graphsToView.bar || [];
   graphsToView.pie = graphsToView.pie || [];
 
+  const radarTheta = showCustomMetrics ? selectedParameters : generalParameters;
+  const radarR = relevantNumericValues;
+
   // Radar Graph
   graphsToView.radar.push({
     type: "scatterpolar",
     name: item.name,
     automargin: true,
-    r: relevantNumericValues,
-    theta: showCustomMetrics ? selectedParameters : generalParameters,
+    r: [...radarR, radarR[0]], // Add first value at the end to close the shape
+    theta: [...radarTheta, radarTheta[0]], // Add first label at the end
     fill: "toself",
   });
 


### PR DESCRIPTION
## Summary
Fixes radar chart not closing properly by adding first point at the end.

## Changes
- Duplicates first value in `r` and `theta` arrays to close radar polygon

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation
