### PR TITLE
Add margin-bottom to layout in ScopeStepConverter component

### DIFF
--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -139,6 +139,7 @@ export default function ScopeStepConverter({
           alignItems: "center",
           justifyContent: "flex-end",
           gap: 1,
+          mb: 4,
         }}
       >
         {supervised && (


### PR DESCRIPTION
## Summary
Fixed spacing issue in converter scope configuration modal where buttons were stuck to the content with no visual separation. Added bottom margin to the button container.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx`: Added `mb: 4` to button container Box to create proper spacing between RowSelector content and action buttons

---

## Testing (optional)
Open a converter configuration modal and verify that there is visible spacing between the scope step content (RowSelector) and the bottom buttons.

---

## Notes (optional)
Before
<img width="1917" height="963" alt="image" src="https://github.com/user-attachments/assets/3968289f-df32-4412-b257-bcedc70b99ae" />

After
<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/b12e2461-fc5e-445b-abe6-2e5d30902c0b" />

