### PR TITLE
feat: Display column types in dataset preparation step

### DIFF
--- a/DashAI/front/src/components/experiments/DivideDatasetColumns.jsx
+++ b/DashAI/front/src/components/experiments/DivideDatasetColumns.jsx
@@ -8,6 +8,7 @@ import {
   Box,
   Chip,
 } from "@mui/material";
+import { getColorByColumnType } from "../../utils";
 
 function DivideDatasetColumns({
   allColumnNames,
@@ -41,15 +42,30 @@ function DivideDatasetColumns({
   const renderColumnOption = (props, option) => {
     const { key, ...otherProps } = props;
     const columnType = columnTypes[option];
+    const typeColor = columnType?.type
+      ? getColorByColumnType(columnType.type)
+      : null;
+
     return (
-      <Box component="li" key={key} {...otherProps}>
+      <Box
+        component="li"
+        key={key}
+        {...otherProps}
+        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+      >
         <span>{option}</span>
         {columnType && columnType.type && (
-          <span
-            style={{ marginLeft: "8px", fontSize: "0.85em", color: "#757575" }}
-          >
-            ({columnType.type})
-          </span>
+          <Chip
+            label={columnType.type}
+            size="small"
+            sx={{
+              backgroundColor: typeColor,
+              color: "#fff",
+              fontWeight: 600,
+              fontSize: "0.7rem",
+              height: "20px",
+            }}
+          />
         )}
       </Box>
     );
@@ -59,20 +75,26 @@ function DivideDatasetColumns({
     return value.map((option, index) => {
       const { key, ...tagProps } = getTagProps({ index });
       const columnType = columnTypes[option];
+      const typeColor = columnType?.type
+        ? getColorByColumnType(columnType.type)
+        : null;
+
       const label =
         columnType && columnType.type ? (
-          <span>
-            {option}
-            <span
-              style={{
-                marginLeft: "4px",
-                fontSize: "0.85em",
-                color: "#9e9e9e",
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <span>{option}</span>
+            <Chip
+              label={columnType.type}
+              size="small"
+              sx={{
+                backgroundColor: typeColor,
+                color: "#fff",
+                fontWeight: 600,
+                fontSize: "0.65rem",
+                height: "16px",
               }}
-            >
-              ({columnType.type})
-            </span>
-          </span>
+            />
+          </Box>
         ) : (
           option
         );

--- a/DashAI/front/src/components/experiments/DivideDatasetColumns.jsx
+++ b/DashAI/front/src/components/experiments/DivideDatasetColumns.jsx
@@ -1,9 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Grid, Typography, Autocomplete, TextField } from "@mui/material";
+import {
+  Grid,
+  Typography,
+  Autocomplete,
+  TextField,
+  Box,
+  Chip,
+} from "@mui/material";
 
 function DivideDatasetColumns({
   allColumnNames,
+  columnTypes = {},
   selectedInputColumnNames,
   onInputColumnNamesChange,
   selectedOutputColumnNames,
@@ -20,6 +28,57 @@ function DivideDatasetColumns({
 
   const handleOutputAutocompleteChange = (event, newValue) => {
     onOutputColumnNamesChange(newValue);
+  };
+
+  const getColumnLabel = (columnName) => {
+    const columnType = columnTypes[columnName];
+    if (columnType && columnType.type) {
+      return `${columnName} (${columnType.type})`;
+    }
+    return columnName;
+  };
+
+  const renderColumnOption = (props, option) => {
+    const { key, ...otherProps } = props;
+    const columnType = columnTypes[option];
+    return (
+      <Box component="li" key={key} {...otherProps}>
+        <span>{option}</span>
+        {columnType && columnType.type && (
+          <span
+            style={{ marginLeft: "8px", fontSize: "0.85em", color: "#757575" }}
+          >
+            ({columnType.type})
+          </span>
+        )}
+      </Box>
+    );
+  };
+
+  const renderTags = (value, getTagProps) => {
+    return value.map((option, index) => {
+      const { key, ...tagProps } = getTagProps({ index });
+      const columnType = columnTypes[option];
+      const label =
+        columnType && columnType.type ? (
+          <span>
+            {option}
+            <span
+              style={{
+                marginLeft: "4px",
+                fontSize: "0.85em",
+                color: "#9e9e9e",
+              }}
+            >
+              ({columnType.type})
+            </span>
+          </span>
+        ) : (
+          option
+        );
+
+      return <Chip key={key} label={label} size="small" {...tagProps} />;
+    });
   };
 
   return (
@@ -47,7 +106,9 @@ function DivideDatasetColumns({
         options={allColumnNames}
         value={selectedInputColumnNames}
         onChange={handleInputAutocompleteChange}
-        getOptionLabel={(option) => option} // Assuming allColumnNames are strings
+        getOptionLabel={(option) => option}
+        renderOption={renderColumnOption}
+        renderTags={renderTags}
         filterSelectedOptions
         disableCloseOnSelect
         fullWidth
@@ -77,6 +138,8 @@ function DivideDatasetColumns({
         value={selectedOutputColumnNames}
         onChange={handleOutputAutocompleteChange}
         getOptionLabel={(option) => option}
+        renderOption={renderColumnOption}
+        renderTags={renderTags}
         filterSelectedOptions
         fullWidth
         renderInput={(params) => (
@@ -102,6 +165,7 @@ function DivideDatasetColumns({
 
 DivideDatasetColumns.propTypes = {
   allColumnNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  columnTypes: PropTypes.object,
   selectedInputColumnNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   onInputColumnNamesChange: PropTypes.func.isRequired,
   selectedOutputColumnNames: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/DashAI/front/src/components/experiments/DivideDatasetColumns.jsx
+++ b/DashAI/front/src/components/experiments/DivideDatasetColumns.jsx
@@ -77,7 +77,7 @@ function DivideDatasetColumns({
           option
         );
 
-      return <Chip key={key} label={label} size="small" {...tagProps} />;
+      return <Chip key={key} label={label} {...tagProps} />;
     });
   };
 

--- a/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
+++ b/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
@@ -4,7 +4,10 @@ import PropTypes from "prop-types";
 import { Grid, CircularProgress, Box, Alert, AlertTitle } from "@mui/material";
 import DivideDatasetColumns from "./DivideDatasetColumns";
 import SplitDatasetRows from "./SplitDatasetRows";
-import { getDatasetInfo as getDatasetInfoRequest } from "../../api/datasets";
+import {
+  getDatasetInfo as getDatasetInfoRequest,
+  getDatasetTypes as getDatasetTypesRequest,
+} from "../../api/datasets";
 import { getComponents as getComponentsRequest } from "../../api/component";
 import { validateColumns as validateColumnsRequest } from "../../api/experiment";
 import { useSnackbar } from "notistack";
@@ -17,6 +20,7 @@ import { useSnackbar } from "notistack";
  */
 function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
   const [datasetInfo, setDatasetInfo] = useState({});
+  const [datasetTypes, setDatasetTypes] = useState({});
   const { enqueueSnackbar } = useSnackbar();
   const [infoLoading, setInfoLoading] = useState(true);
 
@@ -74,8 +78,12 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
   const getDatasetInfo = async () => {
     setInfoLoading(true);
     try {
-      const fetchedDatasetInfo = await getDatasetInfoRequest(newExp.dataset.id);
+      const [fetchedDatasetInfo, fetchedDatasetTypes] = await Promise.all([
+        getDatasetInfoRequest(newExp.dataset.id),
+        getDatasetTypesRequest(newExp.dataset.id),
+      ]);
       setDatasetInfo(fetchedDatasetInfo);
+      setDatasetTypes(fetchedDatasetTypes);
 
       if (fetchedDatasetInfo) {
         setDatasetPartitionsIndex({
@@ -345,6 +353,7 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
         <Grid container spacing={1}>
           <DivideDatasetColumns
             allColumnNames={datasetInfo.column_names || []}
+            columnTypes={datasetTypes}
             selectedInputColumnNames={inputColumnNames}
             onInputColumnNamesChange={setInputColumnNames}
             selectedOutputColumnNames={outputColumnNames}

--- a/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
+++ b/DashAI/front/src/components/experiments/PrepareDatasetStep.jsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
-import { Grid, CircularProgress, Box, Alert, AlertTitle } from "@mui/material";
+import {
+  Grid,
+  CircularProgress,
+  Box,
+  Alert,
+  AlertTitle,
+  Chip,
+} from "@mui/material";
 import DivideDatasetColumns from "./DivideDatasetColumns";
 import SplitDatasetRows from "./SplitDatasetRows";
 import {
@@ -11,6 +18,7 @@ import {
 import { getComponents as getComponentsRequest } from "../../api/component";
 import { validateColumns as validateColumnsRequest } from "../../api/experiment";
 import { useSnackbar } from "notistack";
+import { getColorByColumnType } from "../../utils";
 /**
  * Step of the experiment modal: Set the input and output columns to use for clasification
  * and the splits for training, validation and testing
@@ -298,6 +306,43 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
     return stringsList.join(" or ");
   };
 
+  const renderTypesAsChips = (typesList) => {
+    if (!typesList || typesList.length === 0) {
+      return <span>any</span>;
+    }
+
+    return (
+      <Box
+        component="span"
+        sx={{
+          display: "inline-flex",
+          gap: 0.5,
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
+        {typesList.map((type, index) => (
+          <React.Fragment key={type}>
+            <Chip
+              label={type}
+              size="small"
+              sx={{
+                backgroundColor: getColorByColumnType(type),
+                color: "#fff",
+                fontWeight: 600,
+                fontSize: "0.75rem",
+                height: "22px",
+              }}
+            />
+            {index < typesList.length - 1 && (
+              <span style={{ margin: "0 4px" }}>or</span>
+            )}
+          </React.Fragment>
+        ))}
+      </Box>
+    );
+  };
+
   return (
     <React.Fragment>
       <Alert severity={columnsAreValid ? "success" : "error"} sx={{ mb: 1 }}>
@@ -309,20 +354,42 @@ function PrepareDatasetStep({ newExp, setNewExp, setNextEnabled }) {
         </AlertTitle>
         <Grid container spacing={2}>
           <Grid size={{ xs: 12 }}>
-            The input columns must be of the types{" "}
-            {taskRequirements
-              ? parseListOfStrings(taskRequirements.metadata.inputs_types)
-              : null}
-            , and they should have a cardinality of{" "}
-            {taskRequirements.metadata.inputs_cardinality}.
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                flexWrap: "wrap",
+              }}
+            >
+              <span>The input columns must be of the types</span>
+              {taskRequirements
+                ? renderTypesAsChips(taskRequirements.metadata.inputs_types)
+                : null}
+              <span>
+                , and they should have a cardinality of{" "}
+                {taskRequirements.metadata.inputs_cardinality}.
+              </span>
+            </Box>
           </Grid>
           <Grid size={{ xs: 12 }}>
-            The output columns must be of the types{" "}
-            {taskRequirements
-              ? parseListOfStrings(taskRequirements.metadata.outputs_types)
-              : null}
-            , and they should have a cardinality of{" "}
-            {taskRequirements.metadata.outputs_cardinality}.
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                flexWrap: "wrap",
+              }}
+            >
+              <span>The output columns must be of the types</span>
+              {taskRequirements
+                ? renderTypesAsChips(taskRequirements.metadata.outputs_types)
+                : null}
+              <span>
+                , and they should have a cardinality of{" "}
+                {taskRequirements.metadata.outputs_cardinality}.
+              </span>
+            </Box>
           </Grid>
         </Grid>
       </Alert>

--- a/DashAI/front/src/utils/index.js
+++ b/DashAI/front/src/utils/index.js
@@ -35,3 +35,36 @@ export const getColorByStatus = (status) => {
   }
   return color;
 };
+
+export const getColorByColumnType = (type) => {
+  if (!type) return "#757575";
+
+  const typeColors = {
+    numerical: "#00BEBB",
+    float: "#00BEBB",
+    integer: "#3e68ff",
+    int: "#3e68ff",
+    number: "#00BEBB",
+
+    categorical: "#9c27b0",
+    category: "#9c27b0",
+
+    text: "#f1ae61",
+    string: "#f1ae61",
+
+    boolean: "#43A047",
+    bool: "#43A047",
+
+    datetime: "#e91e63",
+    date: "#e91e63",
+    time: "#e91e63",
+    timestamp: "#e91e63",
+
+    image: "#6E86E8",
+
+    default: "#757575",
+  };
+
+  const normalizedType = type.toLowerCase();
+  return typeColors[normalizedType] || typeColors.default;
+};


### PR DESCRIPTION
## Summary
Added visual display of column value types (Integer, Float, Text, Categorical, etc.) alongside column names in the dataset preparation step. This helps users identify the data type of each column when selecting input and output columns for experiments.

The type information appears in a smaller, gray font next to the column name in both the dropdown options and selected chips.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/experiments/PrepareDatasetStep.jsx`: Added fetch for dataset types using `getDatasetTypesRequest` and passed `columnTypes` prop to `DivideDatasetColumns`
- `DashAI/front/src/components/experiments/DivideDatasetColumns.jsx`: Implemented custom `renderOption` and `renderTags` to display column types with differentiated styling (smaller, gray text)

---

## Testing (optional)
1. Navigate to the experiment creation flow
2. Select a dataset and proceed to the "Prepare Dataset" step
3. Verify that column types appear next to column names in the Input/Output dropdowns
4. Verify that selected columns show the type in the chips

---

## Notes (optional)
Before
<img width="1600" height="805" alt="image" src="https://github.com/user-attachments/assets/3116c814-fcae-4ef7-98b3-e125647b8b8b" />
After
<img width="1907" height="962" alt="image" src="https://github.com/user-attachments/assets/9b9c0449-e397-42c9-8ba5-2b4acff1f4a1" />
