### PR TITLE
Implement live metrics for model training

### DIFF
--- a/DashAI/back/api/api_v1/api.py
+++ b/DashAI/back/api/api_v1/api.py
@@ -10,6 +10,7 @@ from DashAI.back.api.api_v1.endpoints import (
     generative_process,
     generative_session,
     jobs,
+    metrics,
     notebook,
     pipelines,
     plugins,
@@ -32,3 +33,4 @@ api_router_v1.include_router(generative_process.router, prefix="/generative-proc
 api_router_v1.include_router(pipelines.router, prefix="/pipelines")
 api_router_v1.include_router(plugins.router, prefix="/plugin")
 api_router_v1.include_router(notebook.router, prefix="/notebook")
+api_router_v1.include_router(metrics.router, prefix="/metrics")

--- a/DashAI/back/api/api_v1/endpoints/experiments.py
+++ b/DashAI/back/api/api_v1/endpoints/experiments.py
@@ -215,6 +215,9 @@ async def create_experiment(
                 name=params.name,
                 input_columns=params.input_columns,
                 output_columns=params.output_columns,
+                train_metrics=params.train_metrics,
+                validation_metrics=params.validation_metrics,
+                test_metrics=params.test_metrics,
                 splits=params.splits,
             )
             db.add(experiment)

--- a/DashAI/back/api/api_v1/endpoints/metrics.py
+++ b/DashAI/back/api/api_v1/endpoints/metrics.py
@@ -1,0 +1,62 @@
+import asyncio
+import json
+import logging
+
+from fastapi import APIRouter, Depends, WebSocket
+from fastapi.websockets import WebSocketDisconnect
+from kink import di, inject
+from sqlalchemy.orm import sessionmaker
+
+from DashAI.back.core.enums.status import RunStatus
+from DashAI.back.dependencies.database.models import Metric, Run
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.websocket("/ws/{run_id}")
+@inject
+async def live_metrics_websocket(
+    websocket: WebSocket,
+    run_id: int,
+    session_factory: sessionmaker = Depends(lambda: di["session_factory"]),
+):
+
+    await websocket.accept()
+
+    try:
+        while True:
+            with session_factory() as db:
+                metrics = db.query(Metric).filter_by(run_id=run_id).all()
+                run = db.get(Run, run_id)
+
+                payload: dict[str, dict[str, dict]] = {}
+
+                for metric in metrics:
+                    split = metric.split.name
+                    level = metric.level.name
+
+                    payload.setdefault(split, {})
+                    payload[split][level] = metric.results
+
+                if run:
+                    payload["run_status"] = run.status.name
+
+            # Send update
+            await websocket.send_text(json.dumps(payload))
+
+            # If run finished or errored → close cleanly
+            if run and run.status in {RunStatus.FINISHED, RunStatus.ERROR}:
+                await websocket.close(code=1000)
+                break
+
+            await asyncio.sleep(1)
+
+    except WebSocketDisconnect:
+        logger.info(f"WebSocket disconnected for run_id: {run_id}")
+
+    except Exception:
+        logger.exception("WebSocket error")
+        await websocket.close(code=1011)

--- a/DashAI/back/api/api_v1/endpoints/metrics.py
+++ b/DashAI/back/api/api_v1/endpoints/metrics.py
@@ -23,7 +23,6 @@ async def live_metrics_websocket(
     run_id: int,
     session_factory: sessionmaker = Depends(lambda: di["session_factory"]),
 ):
-
     await websocket.accept()
 
     try:

--- a/DashAI/back/api/api_v1/endpoints/runs.py
+++ b/DashAI/back/api/api_v1/endpoints/runs.py
@@ -19,6 +19,60 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def get_metrics_for_run(db, run_id: int):
+    """Retrieve metrics associated with a specific run.
+
+    Parameters
+    ----------
+    db : Session
+        SQLAlchemy session to interact with the database.
+    run_id : int
+        ID of the run for which to retrieve metrics.
+
+    Returns
+    -------
+    dict
+        A dictionary containing train, validation, and test metrics for the run.
+    """
+    train_metrics = (
+        db.query(Metric)
+        .filter(
+            Metric.run_id == run_id,
+            Metric.split == "TRAIN",
+            Metric.level == "LAST",
+        )
+        .first()
+    )
+
+    validation_metrics = (
+        db.query(Metric)
+        .filter(
+            Metric.run_id == run_id,
+            Metric.split == "VALIDATION",
+            Metric.level == "LAST",
+        )
+        .first()
+    )
+
+    test_metrics = (
+        db.query(Metric)
+        .filter(
+            Metric.run_id == run_id,
+            Metric.split == "TEST",
+            Metric.level == "LAST",
+        )
+        .first()
+    )
+
+    return {
+        "train_metrics": train_metrics.results if train_metrics else None,
+        "validation_metrics": (
+            validation_metrics.results if validation_metrics else None
+        ),
+        "test_metrics": test_metrics.results if test_metrics else None,
+    }
+
+
 @router.get("/")
 @inject
 async def get_runs(
@@ -59,6 +113,13 @@ async def get_runs(
                         status_code=status.HTTP_404_NOT_FOUND,
                         detail="Runs associated with Experiment not found",
                     )
+
+                # Add metrics to each run
+                for run in runs:
+                    metrics = get_metrics_for_run(db, run.id)
+                    run.train_metrics = metrics["train_metrics"]
+                    run.validation_metrics = metrics["validation_metrics"]
+                    run.test_metrics = metrics["test_metrics"]
             else:
                 runs = db.query(Run).all()
         except exc.SQLAlchemyError as e:
@@ -104,6 +165,12 @@ async def get_run_by_id(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="Run not found",
                 )
+            # Add metrics to the run
+            metrics = get_metrics_for_run(db, run_id)
+            run.train_metrics = metrics["train_metrics"]
+            run.validation_metrics = metrics["validation_metrics"]
+            run.test_metrics = metrics["test_metrics"]
+
         except exc.SQLAlchemyError as e:
             log.exception(e)
             raise HTTPException(

--- a/DashAI/back/api/api_v1/endpoints/runs.py
+++ b/DashAI/back/api/api_v1/endpoints/runs.py
@@ -11,7 +11,7 @@ from sqlalchemy import exc, select
 from sqlalchemy.orm import sessionmaker
 
 from DashAI.back.api.api_v1.schemas.runs_params import RunParams, UpdateRunParams
-from DashAI.back.dependencies.database.models import Experiment, Run, RunStatus
+from DashAI.back.dependencies.database.models import Experiment, Metric, Run, RunStatus
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
@@ -402,6 +402,11 @@ def reset_run(run):
     setattr(run, "start_time", None)
     setattr(run, "delivery_time", None)
     setattr(run, "end_time", None)
+
+    # Delete metrics from DB
+    with di["session_factory"]() as db:
+        db.query(Metric).filter(Metric.run_id == run.id).delete()
+        db.commit()
 
     # Delete files
     if run.run_path and os.path.exists(run.run_path):

--- a/DashAI/back/api/api_v1/schemas/experiments_params.py
+++ b/DashAI/back/api/api_v1/schemas/experiments_params.py
@@ -9,6 +9,9 @@ class ExperimentParams(BaseModel):
     name: str
     input_columns: List[str]
     output_columns: List[str]
+    train_metrics: List[str]
+    validation_metrics: List[str]
+    test_metrics: List[str]
     splits: str
 
 

--- a/DashAI/back/core/enums/metrics.py
+++ b/DashAI/back/core/enums/metrics.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class SplitEnum(Enum):
+    TRAIN = "train"
+    VALIDATION = "validation"
+    TEST = "test"
+
+
+class LevelEnum(Enum):
+    LAST = "last"
+    TRIAL = "trial"
+    STEP = "step"
+    EPOCH = "epoch"

--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -93,6 +93,12 @@ class Experiment(Base):
     task_name: Mapped[str] = mapped_column(String, nullable=False)
     input_columns: Mapped[str] = mapped_column(JSON, nullable=False)
     output_columns: Mapped[str] = mapped_column(JSON, nullable=False)
+
+    # Metrics per split
+    train_metrics: Mapped[list[str]] = mapped_column(JSON, nullable=True)
+    validation_metrics: Mapped[list[str]] = mapped_column(JSON, nullable=True)
+    test_metrics: Mapped[list[str]] = mapped_column(JSON, nullable=True)
+
     splits: Mapped[str] = mapped_column(JSON, nullable=False)
     created: Mapped[DateTime] = mapped_column(DateTime, default=datetime.now)
     last_modified: Mapped[DateTime] = mapped_column(

--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import JSON, Boolean, DateTime, Enum, ForeignKey, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
 from DashAI.back.core.enums.plugin_tags import PluginTag
 from DashAI.back.core.enums.status import (
     ConverterListStatus,
@@ -134,10 +135,6 @@ class Run(Base):
     plot_importance_path: Mapped[str] = mapped_column(String, nullable=True)
     # goal metrics
     goal_metric: Mapped[str] = mapped_column(String)
-    # metrics
-    train_metrics: Mapped[JSON] = mapped_column(JSON, nullable=True)
-    test_metrics: Mapped[JSON] = mapped_column(JSON, nullable=True)
-    validation_metrics: Mapped[JSON] = mapped_column(JSON, nullable=True)
     # artifacts
     artifacts: Mapped[str] = mapped_column(JSON, nullable=True)
     # metadata
@@ -221,6 +218,18 @@ class Prediction(Base):
     def set_status_as_error(self) -> None:
         """Update the status of the prediction to error."""
         self.status = PredictionStatus.ERROR
+
+
+class Metric(Base):
+    __tablename__ = "metric"
+    """
+    Table to store all the information related to a metric
+    """
+    id: Mapped[int] = mapped_column(primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("run.id", ondelete="CASCADE"))
+    split: Mapped[SplitEnum] = mapped_column(Enum(SplitEnum), nullable=False)
+    level: Mapped[LevelEnum] = mapped_column(Enum(LevelEnum), nullable=False)
+    results: Mapped[Dict[str, list[float]]] = mapped_column(JSON, nullable=False)
 
 
 class Plugin(Base):

--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -9,6 +9,7 @@ from kink import inject
 from sqlalchemy import exc
 from sqlalchemy.orm import sessionmaker
 
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
 from DashAI.back.dataloaders.classes.dashai_dataset import (
     DashAIDataset,
     load_dataset,
@@ -16,7 +17,7 @@ from DashAI.back.dataloaders.classes.dashai_dataset import (
     select_columns,
     split_dataset,
 )
-from DashAI.back.dependencies.database.models import Dataset, Experiment, Run
+from DashAI.back.dependencies.database.models import Dataset, Experiment, Metric, Run
 from DashAI.back.job.base_job import BaseJob, JobError
 from DashAI.back.metrics import BaseMetric
 from DashAI.back.models import BaseModel
@@ -221,7 +222,15 @@ class ModelJob(BaseJob):
                     ) from e
                 try:
                     factory = ModelFactory(
-                        run_model_class, run.parameters, n_labels=n_labels
+                        run_model_class,
+                        run.parameters,
+                        run_id,
+                        x,
+                        y,
+                        metrics,
+                        metrics,
+                        metrics,
+                        n_labels=n_labels,
                     )
                     model: BaseModel = factory.model
                     run_optimizable_parameters = factory.optimizable_parameters
@@ -265,7 +274,9 @@ class ModelJob(BaseJob):
                     # Hyperparameter Tunning
                     plot_paths = []
                     if not run_optimizable_parameters:
-                        model.fit(x["train"], y["train"])
+                        model.train(
+                            x["train"], y["train"], x["validation"], y["validation"]
+                        )
                     else:
                         optimizer.optimize(
                             model,
@@ -309,17 +320,43 @@ class ModelJob(BaseJob):
                         f"Hyperparameter plot path saving failed {e}",
                     ) from e
 
+                # Calculate metrics at the end of training if not done already
                 try:
-                    model_metrics = factory.evaluate(x, y, metrics)
+                    last_train_metric = (
+                        db.query(Metric)
+                        .filter_by(run_id=run.id, split="TRAIN", level="LAST")
+                        .first()
+                    )
+                    if not last_train_metric:
+                        model.calculate_metrics(
+                            split=SplitEnum.TRAIN,
+                            level=LevelEnum.LAST,
+                        )
+                    last_val_metric = (
+                        db.query(Metric)
+                        .filter_by(run_id=run.id, split="VALIDATION", level="LAST")
+                        .first()
+                    )
+                    if not last_val_metric:
+                        model.calculate_metrics(
+                            split=SplitEnum.VALIDATION,
+                            level=LevelEnum.LAST,
+                        )
+                    last_test_metric = (
+                        db.query(Metric)
+                        .filter_by(run_id=run.id, split="TEST", level="LAST")
+                        .first()
+                    )
+                    if not last_test_metric:
+                        model.calculate_metrics(
+                            split=SplitEnum.TEST,
+                            level=LevelEnum.LAST,
+                        )
                 except Exception as e:
                     log.exception(e)
                     raise JobError(
-                        "Metrics calculation failed",
+                        f"Metric calculation failed {e}",
                     ) from e
-
-                run.train_metrics = model_metrics["train"]
-                run.validation_metrics = model_metrics["validation"]
-                run.test_metrics = model_metrics["test"]
 
                 try:
                     run_path = os.path.join(config["RUNS_PATH"], str(run.id))

--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -98,10 +98,6 @@ class ModelJob(BaseJob):
     ) -> None:
         from kink import di
 
-        from DashAI.back.api.api_v1.endpoints.components import (
-            _intersect_component_lists,
-        )
-
         component_registry = di["component_registry"]
         session_factory = di["session_factory"]
         config = di["config"]
@@ -148,23 +144,18 @@ class ModelJob(BaseJob):
                     ) from e
 
                 try:
-                    # Get all the metrics
-                    components_by_type = component_registry.get_components_by_types(
-                        select="Metric"
-                    )
-                    all_metrics = {
-                        component_dict["name"]: component_dict
-                        for component_dict in components_by_type
-                    }
-                    # Get the intersection between the metrics and the task
-                    # related components
-                    selected_metrics = _intersect_component_lists(
-                        all_metrics,
-                        component_registry.get_related_components(experiment.task_name),
-                    )
-                    metrics: List[BaseMetric] = [
-                        metric["class"] for metric in selected_metrics.values()
+                    # Get metrics from experiment
+                    train_metrics: List[BaseMetric] = [
+                        component_registry[m]["class"] for m in experiment.train_metrics
                     ]
+                    validation_metrics: List[BaseMetric] = [
+                        component_registry[m]["class"]
+                        for m in experiment.validation_metrics
+                    ]
+                    test_metrics: List[BaseMetric] = [
+                        component_registry[m]["class"] for m in experiment.test_metrics
+                    ]
+
                 except Exception as e:
                     log.exception(e)
                     raise JobError(
@@ -227,9 +218,9 @@ class ModelJob(BaseJob):
                         run_id,
                         x,
                         y,
-                        metrics,
-                        metrics,
-                        metrics,
+                        train_metrics,
+                        validation_metrics,
+                        test_metrics,
                         n_labels=n_labels,
                     )
                     model: BaseModel = factory.model
@@ -242,7 +233,7 @@ class ModelJob(BaseJob):
                     ) from e
                 try:
                     if run_optimizable_parameters:
-                        goal_metric = selected_metrics[run.goal_metric]
+                        goal_metric = component_registry[run.goal_metric]
                 except Exception as e:
                     log.exception(e)
                     raise JobError(

--- a/DashAI/back/metrics/regression/mae.py
+++ b/DashAI/back/metrics/regression/mae.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.metrics import mean_absolute_error
 
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
-from DashAI.back.metrics.regression_metric import RegressionMetric
+from DashAI.back.metrics.regression_metric import RegressionMetric, prepare_to_metric
 
 
 class MAE(RegressionMetric):
@@ -27,4 +27,5 @@ class MAE(RegressionMetric):
         float
             MAE score between true values and predicted values
         """
+        true_values, pred_values = prepare_to_metric(true_values, pred_values)
         return mean_absolute_error(true_values, pred_values)

--- a/DashAI/back/metrics/regression/rmse.py
+++ b/DashAI/back/metrics/regression/rmse.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.metrics import root_mean_squared_error
 
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
-from DashAI.back.metrics.regression_metric import RegressionMetric
+from DashAI.back.metrics.regression_metric import RegressionMetric, prepare_to_metric
 
 
 class RMSE(RegressionMetric):
@@ -27,7 +27,5 @@ class RMSE(RegressionMetric):
         float
             RMSE score between true values and predicted values
         """
-        true_values, pred_values = super().prepare_to_metric(
-            true_values, predicted_values
-        )
+        true_values, pred_values = prepare_to_metric(true_values, predicted_values)
         return root_mean_squared_error(true_values, pred_values)

--- a/DashAI/back/metrics/regression_metric.py
+++ b/DashAI/back/metrics/regression_metric.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 from DashAI.back.metrics.base_metric import BaseMetric
 
 
@@ -6,3 +9,28 @@ class RegressionMetric(BaseMetric):
 
     MAXIMIZE: bool = False
     COMPATIBLE_COMPONENTS = ["RegressionTask"]
+
+
+def prepare_to_metric(
+    y: DashAIDataset,
+    y_pred: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Prepare true and predicted values for metric calculation.
+
+    Parameters
+    ----------
+    y : DashAIDataset
+        True values.
+    y_pred : np.ndarray
+        Predicted values by the model.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Tuple containing true values and predicted values as numpy arrays.
+    """
+    true_values = np.array(y.to_pandas().to_numpy().flatten())
+    pred_values = np.array(y_pred).flatten()
+
+    return true_values, pred_values

--- a/DashAI/back/models/base_model.py
+++ b/DashAI/back/models/base_model.py
@@ -156,6 +156,8 @@ class BaseModel(ConfigObject, metaclass=ABCMeta):
 
         # Load data if not provided
         if x_data is None or y_data is None:
+            if self.x_data is None or self.y_data is None:
+                return
             x_data = self.x_data[split.value]
             y_data = self.y_data[split.value]
 

--- a/DashAI/back/models/base_model.py
+++ b/DashAI/back/models/base_model.py
@@ -1,16 +1,21 @@
 """Base Model abstract class."""
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Final
+from typing import Any, Dict, Final, final
+
+from kink import di
 
 from DashAI.back.config_object import ConfigObject
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+from DashAI.back.dependencies.database.models import Metric
 
 
 class BaseModel(ConfigObject, metaclass=ABCMeta):
     """Abstract class of all machine learning models.
 
-    All models must extend this class and implement save and load methods.
+    All models must extend this class
+    and implement save, load, train and predict methods.
     """
 
     TYPE: Final[str] = "Model"
@@ -32,6 +37,144 @@ class BaseModel(ConfigObject, metaclass=ABCMeta):
         filename (Str): Indicates where the model was stored.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def train(
+        self,
+        x_train: DashAIDataset,
+        y_train: DashAIDataset,
+        x_validation: DashAIDataset = None,
+        y_validation: DashAIDataset = None,
+    ) -> "BaseModel":
+        """Train the model with the provided data.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            The input features for training.
+        y_train : DashAIDataset
+            The target labels for training.
+        x_validation : DashAIDataset, optional
+            The input features for validation.
+        y_validation : DashAIDataset, optional
+            The target labels for validation.
+
+        Returns
+        -------
+        BaseModel
+            The trained model instance.
+        """
+        raise NotImplementedError
+
+    @final
+    def _save_metrics(
+        self, split: SplitEnum, level: LevelEnum, results: Dict[str, float]
+    ):
+        """
+        Save metrics to the database, appending to existing metrics
+        if they exist.
+
+        Parameters
+        ----------
+        split : SplitEnum
+            The data split (TRAIN, VALIDATION, TEST)
+        level : LevelEnum
+            The metric level (LAST, TRIAL, STEP, BATCH)
+        results : Dict[str, float]
+            Dictionary mapping metric names to their scores
+        """
+        with di["session_factory"]() as db:
+            # Try to find existing metric entry for this run, split, and level
+            existing_metric = (
+                db.query(Metric)
+                .filter_by(run_id=self.run_id, split=split, level=level)
+                .first()
+            )
+
+            if existing_metric:
+                # Append new scores to existing lists
+                for metric_name, score in results.items():
+                    # If metric already exists, append or override,
+                    # otherwise create new list
+                    if metric_name in existing_metric.results:
+                        # If last override the last value,
+                        # else, append to the list
+                        if level == LevelEnum.LAST:
+                            existing_metric.results[metric_name][-1] = score
+                        else:
+                            existing_metric.results[metric_name].append(score)
+                    else:
+                        existing_metric.results[metric_name] = [score]
+
+                # Mark as modified for SQLAlchemy to detect the change
+                from sqlalchemy.orm.attributes import flag_modified
+
+                flag_modified(existing_metric, "results")
+            else:
+                # Create new metric entry with lists
+                metric_entry = Metric(
+                    run_id=self.run_id,
+                    split=split,
+                    level=level,
+                    results={name: [score] for name, score in results.items()},
+                )
+                db.add(metric_entry)
+
+            db.commit()
+
+    @final
+    def calculate_metrics(
+        self,
+        split: SplitEnum = SplitEnum.VALIDATION,
+        level: LevelEnum = LevelEnum.LAST,
+        x_data: DashAIDataset = None,
+        y_data: DashAIDataset = None,
+    ):
+        """
+        Calculate and save metrics for a given data split and level.
+
+        Parameters
+        ----------
+        split : SplitEnum, default=SplitEnum.VALIDATION
+            The data split (TRAIN, VALIDATION, TEST).
+        level : LevelEnum, default=LevelEnum.LAST
+            The metric level (LAST, TRIAL, STEP, BATCH).
+        x_data : DashAIDataset, optional
+            The input features for the split. If None, the stored dataset
+            associated with the split is used.
+        y_data : DashAIDataset, optional
+            The target labels for the split. If None, the stored labels
+            associated with the split are used.
+        """
+        # Get the appropriate metrics based on split
+        metrics_attr = f"{split.value}_metrics"
+        metrics = getattr(self, metrics_attr, None)
+
+        # If no metrics or run_id, skip calculation
+        if not metrics or not self.run_id:
+            return
+
+        # Load data if not provided
+        if x_data is None or y_data is None:
+            x_data = self.x_data[split.value]
+            y_data = self.y_data[split.value]
+
+        # If data is empty after retrieval, skip calculation
+        if x_data is None or y_data is None:
+            return
+
+        # Make predictions and transform outputs
+        y_pred = self.predict(x_data)
+        y_transformed = self.prepare_output(y_data, is_fit=False)
+
+        # Calculate metric scores
+        results = {}
+        for metric in metrics:
+            score = metric.score(y_transformed, y_pred)
+            results[metric.__name__] = score
+
+        # Save to database
+        self._save_metrics(split=split, level=level, results=results)
 
     def prepare_dataset(
         self, dataset: DashAIDataset, is_fit: bool = False

--- a/DashAI/back/models/hugging_face/distilbert_transformer.py
+++ b/DashAI/back/models/hugging_face/distilbert_transformer.py
@@ -28,6 +28,7 @@ from DashAI.back.dataloaders.classes.dashai_dataset_utils import (
     apply_categorical_label_encoder,
     categorical_label_encoder,
 )
+from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
 from DashAI.back.models.text_classification_model import TextClassificationModel
 from DashAI.back.types.categorical import Categorical
 
@@ -130,17 +131,7 @@ class DistilBertTransformer(TextClassificationModel):
         self.fitted = False
         self.encodings = {}  # Store encodings for categorical columns
 
-    def fit(self, x_train: DashAIDataset, y_train: DashAIDataset):
-        """Fine-tune the pre-trained model.
-
-        Parameters
-        ----------
-        x_train : Dataset
-            Dataset with input training data.
-        y_train : Dataset
-            Dataset with output training data.
-
-        """
+    def train(self, x_train, y_train, x_validation, y_validation):
         output_column_name = y_train.column_names[0]
 
         if self.num_labels is None:
@@ -154,10 +145,22 @@ class DistilBertTransformer(TextClassificationModel):
                 self.model_name, config=config
             )
 
-        x_train = self.prepare_dataset(x_train, is_fit=True)
-        y_train = self.prepare_dataset(y_train, is_fit=True)
+        # Train dataset preparation
+        x_train_prepared = self.prepare_dataset(x_train, is_fit=True)
+        y_train_prepared = self.prepare_dataset(y_train, is_fit=True)
+        train_dataset = x_train_prepared.add_column(
+            "label", y_train_prepared[output_column_name]
+        )
 
-        train_dataset = x_train.add_column("label", y_train[output_column_name])
+        # Validation dataset preparation
+        x_validation_prepared = self.prepare_dataset(x_validation)
+        y_validation_prepared = self.prepare_dataset(y_validation)
+        validation_dataset = x_validation_prepared.add_column(
+            "label", y_validation_prepared[output_column_name]
+        )
+
+        # Get number of epochs from training args
+        num_epochs = self.training_args_params.get("num_train_epochs", 2)
 
         can_use_fp16 = torch.cuda.is_available() and self.device == "gpu"
         training_args_obj = TrainingArguments(
@@ -166,21 +169,37 @@ class DistilBertTransformer(TextClassificationModel):
             logging_steps=20,
             save_strategy="epoch",
             per_device_train_batch_size=self.batch_size,
+            per_device_eval_batch_size=self.batch_size,
+            eval_strategy="epoch",
             use_cpu=self.device != "gpu",
             fp16=can_use_fp16,
             **self.training_args_params,
         )
 
         data_collator = DataCollatorWithPadding(tokenizer=self.tokenizer)
+
+        # Initialize the custom callback with epoch information
+        metrics_callback = MetricsCallback(
+            model_instance=self,
+            x_train=x_train,
+            y_train=y_train,
+            x_val=x_validation,
+            y_val=y_validation,
+            total_epochs=num_epochs,
+        )
+
         trainer = Trainer(
             model=self.model,
             args=training_args_obj,
             train_dataset=train_dataset,
+            eval_dataset=validation_dataset,
             data_collator=data_collator,
+            callbacks=[metrics_callback],
         )
 
-        trainer.train()
         self.fitted = True
+        trainer.train()
+
         shutil.rmtree(
             "DashAI/back/user_models/temp_checkpoints_distilbert", ignore_errors=True
         )

--- a/DashAI/back/models/hugging_face/metrics_callback.py
+++ b/DashAI/back/models/hugging_face/metrics_callback.py
@@ -34,18 +34,4 @@ class MetricsCallback(TrainerCallback):
         )
 
     def on_step_end(self, args, state, control, **kwargs):
-        # Optional: Calculate metrics every N steps for more granular tracking
-        # Uncomment if you want step-level metrics
-        # self.model_instance.calculate_metrics(
-        #     split=SplitEnum.TRAIN,
-        #     level=LevelEnum.STEP,
-        #     x_data=self.x_train,
-        #     y_data=self.y_train,
-        # )
-        # self.model_instance.calculate_metrics(
-        #     split=SplitEnum.VALIDATION,
-        #     level=LevelEnum.STEP,
-        #     x_data=self.x_val,
-        #     y_data=self.y_val,
-        # )
         pass

--- a/DashAI/back/models/hugging_face/metrics_callback.py
+++ b/DashAI/back/models/hugging_face/metrics_callback.py
@@ -1,0 +1,51 @@
+from transformers import TrainerCallback
+
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
+from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+
+
+class MetricsCallback(TrainerCallback):
+    def __init__(self, model_instance, x_train, y_train, x_val, y_val, total_epochs):
+        self.model_instance = model_instance
+        self.x_train = to_dashai_dataset(x_train)
+        self.y_train = to_dashai_dataset(y_train)
+        self.x_val = to_dashai_dataset(x_val)
+        self.y_val = to_dashai_dataset(y_val)
+        self.total_epochs = total_epochs
+        self.current_epoch = 0
+
+    def on_epoch_end(self, args, state, control, **kwargs):
+        self.current_epoch += 1
+
+        # Calculate training metrics
+        self.model_instance.calculate_metrics(
+            split=SplitEnum.TRAIN,
+            level=LevelEnum.EPOCH,
+            x_data=self.x_train,
+            y_data=self.y_train,
+        )
+
+        # Calculate validation metrics
+        self.model_instance.calculate_metrics(
+            split=SplitEnum.VALIDATION,
+            level=LevelEnum.EPOCH,
+            x_data=self.x_val,
+            y_data=self.y_val,
+        )
+
+    def on_step_end(self, args, state, control, **kwargs):
+        # Optional: Calculate metrics every N steps for more granular tracking
+        # Uncomment if you want step-level metrics
+        # self.model_instance.calculate_metrics(
+        #     split=SplitEnum.TRAIN,
+        #     level=LevelEnum.STEP,
+        #     x_data=self.x_train,
+        #     y_data=self.y_train,
+        # )
+        # self.model_instance.calculate_metrics(
+        #     split=SplitEnum.VALIDATION,
+        #     level=LevelEnum.STEP,
+        #     x_data=self.x_val,
+        #     y_data=self.y_val,
+        # )
+        pass

--- a/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
@@ -21,6 +21,7 @@ from DashAI.back.core.schema_fields import (
     schema_field,
 )
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
 from DashAI.back.models.translation_model import TranslationModel
 from DashAI.back.models.utils import GPU_OR_CPU, GPU_OR_CPU_PLACEHOLDER
 
@@ -90,6 +91,7 @@ class OpusMtEnESTransformer(TranslationModel):
             if model is not None
             else AutoModelForSeq2SeqLM.from_pretrained(self.model_name)
         )
+        self.num_train_epochs = kwargs.get("num_train_epochs", 2)
         self.fitted = model is not None
 
     def tokenize_data(
@@ -142,18 +144,13 @@ class OpusMtEnESTransformer(TranslationModel):
             dataset.append(sample)
         return DashAIDataset.from_list(dataset)
 
-    def fit(self, x_train: DashAIDataset, y_train: DashAIDataset):
-        """Fine-tune the pre-trained model.
-
-        Parameters
-        ----------
-        x_train : Dataset
-            Dataset with input training data.
-        y_train : Dataset
-            Dataset with output training data.
-
-        """
-
+    def train(
+        self,
+        x_train: DashAIDataset,
+        y_train: DashAIDataset,
+        x_validation: DashAIDataset = None,
+        y_validation: DashAIDataset = None,
+    ) -> "OpusMtEnESTransformer":
         dataset = self.tokenize_data(x_train, y_train)
         dataset.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
 
@@ -167,14 +164,25 @@ class OpusMtEnESTransformer(TranslationModel):
             **self.training_args,
         )
 
+        # Initialize the custom callback with epoch information
+        metrics_callback = MetricsCallback(
+            model_instance=self,
+            x_train=x_train,
+            y_train=y_train,
+            x_val=x_validation,
+            y_val=y_validation,
+            total_epochs=self.num_train_epochs,
+        )
+
         trainer = Seq2SeqTrainer(
             model=self.model,
             args=training_args,
             train_dataset=dataset,
+            callbacks=[metrics_callback],
         )
 
-        trainer.train()
         self.fitted = True
+        trainer.train()
         shutil.rmtree(
             "DashAI/back/user_models/temp_checkpoints_opus-mt-en-es", ignore_errors=True
         )

--- a/DashAI/back/models/model_factory.py
+++ b/DashAI/back/models/model_factory.py
@@ -1,5 +1,6 @@
 from kink import di
 
+from DashAI.back.metrics.base_metric import BaseMetric
 from DashAI.back.metrics.classification_metric import ClassificationMetric
 
 
@@ -23,10 +24,34 @@ class ModelFactory:
         Extracts fixed and optimizable parameters from a dictionary.
     """
 
-    def __init__(self, model, params: dict, n_labels=None):
+    def __init__(
+        self,
+        model,
+        params: dict,
+        run_id: id = None,
+        x_data: dict = None,
+        y_data: dict = None,
+        train_metrics: list[BaseMetric] = None,
+        validation_metrics: list[BaseMetric] = None,
+        test_metrics: list[BaseMetric] = None,
+        n_labels=None,
+    ):
         self.model, self.fixed_parameters, self.optimizable_parameters = (
             self._extract_parameters(model, params)
         )
+
+        # Set run id
+        self.model.run_id = run_id
+
+        # Set data for the model
+        self.model.x_data = x_data
+        self.model.y_data = y_data
+
+        # Set metrics
+        self.model.train_metrics = train_metrics
+        self.model.validation_metrics = validation_metrics
+        self.model.test_metrics = test_metrics
+
         self.num_labels = n_labels
         self.fitted = False
 

--- a/DashAI/back/models/scikit_learn/bow_text_classification_model.py
+++ b/DashAI/back/models/scikit_learn/bow_text_classification_model.py
@@ -137,14 +137,20 @@ class BagOfWordsTextClassificationModel(TextClassificationModel, SklearnLikeMode
 
         return _vectorize
 
-    def fit(self, x: Dataset, y: Dataset):
+    def train(
+        self,
+        x: Dataset,
+        y: Dataset,
+        x_validation: Dataset = None,
+        y_validation: Dataset = None,
+    ):
         input_column = x.column_names[0]
         self.vectorizer.fit(x[input_column])
         tokenizer_func = self.get_vectorizer(input_column)
         tokenized_dataset = x.map(tokenizer_func, remove_columns=x.column_names)
         tokenized_dataset = to_dashai_dataset(tokenized_dataset)
 
-        self.classifier.fit(tokenized_dataset, y)
+        self.classifier.train(tokenized_dataset, y)
 
     def predict(self, x: Dataset):
         input_column = x.column_names[0]

--- a/DashAI/back/models/scikit_learn/bow_text_classification_model.py
+++ b/DashAI/back/models/scikit_learn/bow_text_classification_model.py
@@ -17,7 +17,6 @@ from DashAI.back.dataloaders.classes.dashai_dataset import (
     DashAIDataset,
     to_dashai_dataset,
 )
-from DashAI.back.models.scikit_learn.sklearn_like_model import SklearnLikeModel
 from DashAI.back.models.text_classification_model import TextClassificationModel
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float

--- a/DashAI/back/models/scikit_learn/bow_text_classification_model.py
+++ b/DashAI/back/models/scikit_learn/bow_text_classification_model.py
@@ -57,7 +57,7 @@ class BagOfWordsTextClassificationModelSchema(BaseSchema):
     )  # type: ignore
 
 
-class BagOfWordsTextClassificationModel(TextClassificationModel, SklearnLikeModel):
+class BagOfWordsTextClassificationModel(TextClassificationModel):
     """Text classification meta-model.
 
     The metamodel has two main components:
@@ -215,3 +215,6 @@ class BagOfWordsTextClassificationModel(TextClassificationModel, SklearnLikeMode
             return dataset
         except Exception as e:
             print(f"Couldn't apply transformations to the dataset for the model: {e}")
+
+    def prepare_output(self, dataset, is_fit=False):
+        return self.classifier.prepare_output(dataset, is_fit)

--- a/DashAI/back/models/scikit_learn/mlp_regression.py
+++ b/DashAI/back/models/scikit_learn/mlp_regression.py
@@ -165,14 +165,31 @@ class MLPRegression(RegressionModel):
         x_proc = self.prepare_dataset(x, is_fit=False).to_pandas().values
         x_tensor = torch.tensor(x_proc, dtype=torch.float32).to(self.device)
         with torch.no_grad():
-            return self.model(x_tensor).cpu().numpy()
+            return self.model(x_tensor).cpu().numpy().flatten()
 
     def save(self, filename: str) -> None:
-        torch.save({"state": self.model.state_dict(), "params": self.params}, filename)
+        torch.save(
+            {
+                "state": self.model.state_dict(),
+                "params": self.params,
+                "input_dim": self.model.model[0].in_features,
+            },
+            filename,
+        )
 
     @staticmethod
     def load(filename: str) -> "MLPRegression":
         data = torch.load(filename)
         instance = MLPRegression(**data["params"])
-        # Logic to rebuild and load state_dict would go here
+
+        # Rebuild the model architecture using saved input_dim
+        instance.model = MLP(
+            input_dim=data["input_dim"],
+            hidden_size=instance.params.get("hidden_size", 5),
+            activation_name=instance.params.get("activation", "relu"),
+        ).to(instance.device)
+
+        # Load the trained weights
+        instance.model.load_state_dict(data["state"])
+
         return instance

--- a/DashAI/back/models/scikit_learn/mlp_regression.py
+++ b/DashAI/back/models/scikit_learn/mlp_regression.py
@@ -1,228 +1,178 @@
-from sklearn.neural_network import MLPRegressor as _MLPregressor
+import numpy as np
+import torch
+import torch.nn as nn
 
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
 from DashAI.back.core.schema_fields import (
     BaseSchema,
-    bool_field,
     enum_field,
-    none_type,
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
+from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+from DashAI.back.models.utils import DEVICE_ENUM, DEVICE_PLACEHOLDER, DEVICE_TO_IDX
 
 
 class MLPRegressorSchema(BaseSchema):
-    """MLP Regressor for DashAI."""
+    """PyTorch MLP Regressor Schema."""
 
-    activation: schema_field(
-        enum_field(enum=["identity", "logistic", "tanh", "relu"]),
-        placeholder="relu",
-        description="Activation function for the hidden layer.",
-    )  # type: ignore
-
-    solver: schema_field(
-        enum_field(enum=["lbfgs", "sgd", "adam"]),
-        placeholder="adam",
-        description="The solver for weight optimization.",
-    )  # type: ignore
-
-    alpha: schema_field(
-        optimizer_float_field(ge=0.0),
+    hidden_size: schema_field(
+        optimizer_int_field(ge=1),
         placeholder={
             "optimize": False,
-            "fixed_value": 0.0001,
-            "lower_bound": 1e-6,
-            "upper_bound": 1e-1,
+            "fixed_value": 5,
+            "lower_bound": 1,
+            "upper_bound": 15,
         },
-        description="L2 penalty (regularization term) parameter.",
+        description="Number of neurons in the hidden layer.",
     )  # type: ignore
 
-    batch_size: schema_field(
-        union_type(optimizer_int_field(ge=1), enum_field(enum=["auto"])),
-        placeholder="auto",
-        description="Size of minibatches for stochastic optimizers.",
+    activation: schema_field(
+        enum_field(enum=["relu", "tanh", "sigmoid"]),
+        placeholder="relu",
+        description="Activation function.",
     )  # type: ignore
 
     learning_rate: schema_field(
-        enum_field(enum=["constant", "invscaling", "adaptive"]),
-        placeholder="constant",
-        description="Learning rate schedule for weight updates.",
-    )  # type: ignore
-
-    learning_rate_init: schema_field(
-        optimizer_float_field(ge=0.0),
+        optimizer_float_field(ge=1e-6, le=1.0),
         placeholder={
             "optimize": False,
             "fixed_value": 0.001,
-            "lower_bound": 1e-5,
-            "upper_bound": 1e-1,
-        },
-        description="The initial learning rate used.",
-    )  # type: ignore
-
-    power_t: schema_field(
-        optimizer_float_field(gt=0.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.5,
-            "lower_bound": 0.1,
-            "upper_bound": 0.9,
-        },
-        description="The exponent for inverse scaling learning rate.",
-    )  # type: ignore
-
-    max_iter: schema_field(
-        optimizer_int_field(ge=1),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 200,
-            "lower_bound": 50,
-            "upper_bound": 1000,
-        },
-        description="Maximum number of iterations.",
-    )  # type: ignore
-
-    shuffle: schema_field(
-        bool_field(),
-        placeholder=True,
-        description="Whether to shuffle samples in each iteration.",
-    )  # type: ignore
-
-    random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
-        placeholder=None,
-        description="The seed of the pseudo-random number generator to use "
-        "when shuffling the data.",
-    )  # type: ignore
-
-    tol: schema_field(
-        optimizer_float_field(ge=0.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.0001,
             "lower_bound": 1e-6,
-            "upper_bound": 1e-2,
-        },
-        description="Tolerance for the optimization.",
-    )  # type: ignore
-
-    verbose: schema_field(
-        bool_field(),
-        placeholder=False,
-        description="Whether to print progress messages to stdout.",
-    )  # type: ignore
-
-    warm_start: schema_field(
-        bool_field(),
-        placeholder=False,
-        description="When set to True, reuse the solution of the previous call"
-        " to fit as initialization.",
-    )  # type: ignore
-
-    momentum: schema_field(
-        optimizer_float_field(ge=0.0, le=1.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.9,
-            "lower_bound": 0.0,
             "upper_bound": 1.0,
         },
-        description="Momentum for gradient descent update.",
+        description="Initial learning rate for the optimizer.",
     )  # type: ignore
 
-    nesterovs_momentum: schema_field(
-        bool_field(),
-        placeholder=True,
-        description="Whether to use Nesterov’s momentum.",
-    )  # type: ignore
-
-    early_stopping: schema_field(
-        bool_field(),
-        placeholder=False,
-        description="Whether to use early stopping to terminate training when"
-        " validation score is not improving.",
-    )  # type: ignore
-
-    validation_fraction: schema_field(
-        optimizer_float_field(gt=0.0, le=1.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.1,
-            "lower_bound": 0.1,
-            "upper_bound": 0.5,
-        },
-        description="The proportion of training data to set aside as "
-        "validation set for early stopping.",
-    )  # type: ignore
-
-    beta_1: schema_field(
-        optimizer_float_field(gt=0.0, lt=1.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.9,
-            "lower_bound": 0.1,
-            "upper_bound": 0.999,
-        },
-        description="Exponential decay rate for estimates of first moment"
-        " vector in Adam optimizer.",
-    )  # type: ignore
-
-    beta_2: schema_field(
-        optimizer_float_field(gt=0.0, lt=1.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 0.999,
-            "lower_bound": 0.1,
-            "upper_bound": 0.999,
-        },
-        description="Exponential decay rate for estimates of second moment"
-        " vector in Adam optimizer.",
-    )  # type: ignore
-
-    epsilon: schema_field(
-        optimizer_float_field(ge=0.0),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 1e-08,
-            "lower_bound": 1e-10,
-            "upper_bound": 1e-6,
-        },
-        description="Value for numerical stability in Adam optimizer.",
-    )  # type: ignore
-
-    n_iter_no_change: schema_field(
+    epochs: schema_field(
         optimizer_int_field(ge=1),
         placeholder={
             "optimize": False,
-            "fixed_value": 10,
+            "fixed_value": 5,
             "lower_bound": 1,
-            "upper_bound": 50,
+            "upper_bound": 15,
         },
-        description="Maximum number of epochs to not meet tol improvement.",
+        description="Total number of training passes over the dataset.",
     )  # type: ignore
 
-    max_fun: schema_field(
-        optimizer_int_field(ge=1),
-        placeholder={
-            "optimize": False,
-            "fixed_value": 15000,
-            "lower_bound": 1000,
-            "upper_bound": 20000,
-        },
-        description="Maximum number of loss function calls. Only used "
-        " if solver='lbfgs'.",
+    device: schema_field(
+        enum_field(enum=DEVICE_ENUM),
+        placeholder=DEVICE_PLACEHOLDER,
+        description="Hardware device (CPU/GPU).",
     )  # type: ignore
 
 
-class MLPRegression(RegressionModel, SklearnLikeRegressor, _MLPregressor):
-    """Scikit-learn's MLP Regression wrapper for DashAI."""
+class MLP(nn.Module):
+    def __init__(self, input_dim, hidden_size, activation_name):
+        super().__init__()
+        activations = {
+            "relu": nn.ReLU(),
+            "tanh": nn.Tanh(),
+            "logistic": nn.Sigmoid(),
+            "identity": nn.Identity(),
+        }
+        self.model = nn.Sequential(
+            nn.Linear(input_dim, hidden_size),
+            activations.get(activation_name, nn.ReLU()),
+            nn.Linear(hidden_size, 1),
+        )
 
+    def forward(self, x):
+        return self.model(x)
+
+
+class MLPRegression(RegressionModel):
     SCHEMA = MLPRegressorSchema
     DISPLAY_NAME: str = "Multi-layer Perceptron (MLP) Regression"
     COLOR: str = "#FF7043"
 
     def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+        self.params = kwargs
+        self.device = (
+            f"cuda:{DEVICE_TO_IDX.get(kwargs.get('device'))}"
+            if DEVICE_TO_IDX.get(kwargs.get("device"), -1) >= 0
+            else "cpu"
+        )
+        self.model = None
+
+    def train(
+        self,
+        x_train: DashAIDataset,
+        y_train: DashAIDataset,
+        x_validation: DashAIDataset = None,
+        y_validation: DashAIDataset = None,
+    ) -> "MLPRegression":
+        # 1. Prepare Data
+        x_values = self.prepare_dataset(x_train, is_fit=True).to_pandas().values
+        y_values = self.prepare_output(y_train, is_fit=True).to_pandas().values
+
+        X_tensor = torch.tensor(x_values, dtype=torch.float32).to(self.device)
+        y_tensor = (
+            torch.tensor(y_values, dtype=torch.float32).view(-1, 1).to(self.device)
+        )
+
+        # 2. Init Model & Optimizer
+        self.model = MLP(
+            input_dim=X_tensor.shape[1],
+            hidden_size=self.params.get("hidden_size", 100),
+            activation_name=self.params.get("activation", "relu"),
+        ).to(self.device)
+
+        optimizer = torch.optim.Adam(
+            self.model.parameters(), lr=self.params.get("learning_rate", 0.001)
+        )
+        criterion = nn.MSELoss()
+
+        # 3. Training Loop using Epochs
+        total_epochs = self.params.get("epochs", 3)
+        batch_size = min(200, X_tensor.size(0))
+
+        for _ in range(total_epochs):
+            self.model.train()
+            indices = torch.randperm(X_tensor.size(0))
+
+            for i in range(0, X_tensor.size(0), batch_size):
+                batch_idx = indices[i : i + batch_size]
+                train_loss = criterion(
+                    self.model(X_tensor[batch_idx]), y_tensor[batch_idx]
+                )
+
+                optimizer.zero_grad()
+                train_loss.backward()
+                optimizer.step()
+
+            # Metric tracking per epoch
+            self.calculate_metrics(
+                split=SplitEnum.TRAIN,
+                level=LevelEnum.EPOCH,
+                x_data=x_train,
+                y_data=y_train,
+            )
+
+            self.calculate_metrics(
+                split=SplitEnum.VALIDATION,
+                level=LevelEnum.EPOCH,
+                x_data=x_validation,
+                y_data=y_validation,
+            )
+
+        return self
+
+    def predict(self, x: DashAIDataset) -> np.ndarray:
+        self.model.eval()
+        x_proc = self.prepare_dataset(x, is_fit=False).to_pandas().values
+        x_tensor = torch.tensor(x_proc, dtype=torch.float32).to(self.device)
+        with torch.no_grad():
+            return self.model(x_tensor).cpu().numpy()
+
+    def save(self, filename: str) -> None:
+        torch.save({"state": self.model.state_dict(), "params": self.params}, filename)
+
+    @staticmethod
+    def load(filename: str) -> "MLPRegression":
+        data = torch.load(filename)
+        instance = MLPRegression(**data["params"])
+        # Logic to rebuild and load state_dict would go here
+        return instance

--- a/DashAI/back/models/scikit_learn/sklearn_like_model.py
+++ b/DashAI/back/models/scikit_learn/sklearn_like_model.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional, Type
+from typing import List, Optional
 
 import joblib
 from sklearn.preprocessing import OneHotEncoder
@@ -57,23 +57,7 @@ class SklearnLikeModel(BaseModel):
 
     # --- Methods for process the data for sklearn models ---
 
-    def fit(
-        self, x_train: DashAIDataset, y_train: DashAIDataset
-    ) -> Type["SklearnLikeModel"]:
-        """Fit the estimator.
-
-        Parameters
-        ----------
-        x_train : DashAIDataset
-            Dataset with the input data.
-        y_train : DashAIDataset
-            Dataset with the target data.
-
-        Returns
-        -------
-        self
-            The fitted estimator object.
-        """
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
         x_processed = self.prepare_dataset(x_train, is_fit=True).to_pandas()
         y_processed = self.prepare_output(y_train, is_fit=True).to_pandas()
         return super().fit(x_processed, y_processed)

--- a/DashAI/back/optimizers/hyperopt_optimizer.py
+++ b/DashAI/back/optimizers/hyperopt_optimizer.py
@@ -2,6 +2,7 @@ import importlib
 
 from hyperopt import Trials, fmin, hp, rand, tpe  # noqa: F401
 
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
 from DashAI.back.core.schema_fields import (
     BaseSchema,
     enum_field,
@@ -98,9 +99,21 @@ class HyperOptOptimizer(BaseOptimizer):
                 obj, key = param_mapping[param_name]
                 setattr(obj, key, value)
 
-            self.model.fit(self.input_dataset["train"], self.output_dataset["train"])
+            self.model.train(self.input_dataset["train"], self.output_dataset["train"])
             y_pred = self.model.predict(input_dataset["validation"])
-            score = self.metric.score(output_dataset["validation"], y_pred)
+
+            # Calculate metric for train and validation data each trial
+            self.model.calculate_metrics(split=SplitEnum.TRAIN, level=LevelEnum.TRIAL)
+            self.model.calculate_metrics(
+                split=SplitEnum.VALIDATION, level=LevelEnum.TRIAL
+            )
+
+            output_dataset_transformed = self.model.prepare_output(
+                output_dataset["validation"], is_fit=False
+            )
+
+            score = self.metric.score(output_dataset_transformed, y_pred)
+
             return -score if metric["metadata"]["maximize"] else score
 
         trials = Trials()

--- a/DashAI/back/optimizers/optuna_optimizer.py
+++ b/DashAI/back/optimizers/optuna_optimizer.py
@@ -1,5 +1,6 @@
 import optuna
 
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
 from DashAI.back.core.schema_fields import (
     BaseSchema,
     enum_field,
@@ -94,9 +95,19 @@ class OptunaOptimizer(BaseOptimizer):
                     raise ValueError(f"Unsupported parameter type for {key} : {dtype}")
                 setattr(obj, key, value)
 
-            self.model.fit(self.input_dataset["train"], self.output_dataset["train"])
+            self.model.train(self.input_dataset["train"], self.output_dataset["train"])
             y_pred = self.model.predict(input_dataset["validation"])
-            score = self.metric.score(output_dataset["validation"], y_pred)
+
+            # Calculate metric for train and validation data each trial
+            self.model.calculate_metrics(split=SplitEnum.TRAIN, level=LevelEnum.TRIAL)
+            self.model.calculate_metrics(
+                split=SplitEnum.VALIDATION, level=LevelEnum.TRIAL
+            )
+
+            output_dataset_transformed = self.model.prepare_output(
+                output_dataset["validation"], is_fit=False
+            )
+            score = self.metric.score(output_dataset_transformed, y_pred)
 
             return score
 
@@ -106,7 +117,7 @@ class OptunaOptimizer(BaseOptimizer):
         best_model = self.model
         for hyperparameter, value in best_params.items():
             setattr(best_model, hyperparameter, value)
-        best_model.fit(self.input_dataset["train"], self.output_dataset["train"])
+        best_model.train(self.input_dataset["train"], self.output_dataset["train"])
         self.model = best_model
         self.study = study
 

--- a/DashAI/front/src/api/experiment.ts
+++ b/DashAI/front/src/api/experiment.ts
@@ -19,6 +19,9 @@ export const createExperiment = async (
   expName: string,
   inputColumns: string[],
   outputColumns: string[],
+  trainMetrics: string[],
+  validationMetrics: string[],
+  testMetrics: string[],
   splitsValue: JSON,
 ): Promise<IExperiment> => {
   const data = {
@@ -27,6 +30,9 @@ export const createExperiment = async (
     name: expName,
     input_columns: inputColumns,
     output_columns: outputColumns,
+    train_metrics: trainMetrics,
+    validation_metrics: validationMetrics,
+    test_metrics: testMetrics,
     splits: splitsValue,
   };
 

--- a/DashAI/front/src/components/experiments/NewExperimentModal.jsx
+++ b/DashAI/front/src/components/experiments/NewExperimentModal.jsx
@@ -49,6 +49,9 @@ export default function NewExperimentModal({
       task_name: "",
       input_columns: [],
       output_columns: [],
+      train_metrics: [],
+      validation_metrics: [],
+      test_metrics: [],
       splits: {
         train: 0.6,
         validation: 0.2,
@@ -69,6 +72,7 @@ export default function NewExperimentModal({
       ? []
       : [{ name: "selectDataset", label: "Select dataset" }]),
     { name: "prepareDataset", label: "Prepare dataset" },
+    { name: "metricsSelection", label: "Select metrics" },
     { name: "configureModels", label: "Configure models" },
     {
       name: "configureOptimizer",
@@ -142,6 +146,9 @@ export default function NewExperimentModal({
         finalExperimentName,
         newExp.input_columns,
         newExp.output_columns,
+        newExp.train_metrics,
+        newExp.validation_metrics,
+        newExp.test_metrics,
         JSON.stringify(newExp.splits),
       );
       const experimentId = response.id;

--- a/DashAI/front/src/components/experiments/metrics/MetricCard.jsx
+++ b/DashAI/front/src/components/experiments/metrics/MetricCard.jsx
@@ -1,0 +1,95 @@
+import { Card, CardActionArea, Box, Typography, Chip } from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
+import TrendingUpIcon from "@mui/icons-material/TrendingUp";
+
+const splitColors = {
+  train: {
+    border: "#4caf50",
+    bg: "rgba(76,175,80,0.08)"
+  },
+  test: {
+    border: "#2196f3",
+    bg: "rgba(33,150,243,0.08)"
+  },
+  validation: {
+    border: "#ff9800",
+    bg: "rgba(255,152,0,0.08)"
+  }
+};
+
+export default function MetricCard({
+  metric,
+  isSelected,
+  onToggle,
+  splitType,
+  disabled = false,
+}) {
+  const colors = splitColors[splitType];
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        borderWidth: 2,
+        borderColor: isSelected ? colors.border : "divider",
+        backgroundColor: isSelected ? colors.bg : "background.paper",
+        opacity: disabled ? 0.6 : 1,
+        transition: "all 0.2s",
+        "&:hover": disabled
+          ? {}
+          : {
+              transform: "scale(1.02)",
+            },
+      }}
+    >
+      <CardActionArea
+        onClick={disabled ? undefined : onToggle}
+        disabled={disabled}
+        sx={{ p: 2 }}
+      >
+        {/* Selection indicator */}
+        <Box
+          sx={{
+            position: "absolute",
+            top: 12,
+            right: 12,
+            width: 20,
+            height: 20,
+            borderRadius: "50%",
+            border: "2px solid",
+            borderColor: isSelected ? colors.border : "divider",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center"
+          }}
+        >
+          {isSelected && <CheckIcon fontSize="small" />}
+        </Box>
+
+        <Box sx={{ pr: 3 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: "monospace", fontWeight: 600 }}
+            >
+              {metric.name}
+            </Typography>
+
+            {metric.metadata?.maximize && (
+              <Chip
+                icon={<TrendingUpIcon />}
+                label="maximize"
+                size="small"
+                variant="outlined"
+              />
+            )}
+          </Box>
+
+          <Typography variant="body2" color="text.secondary">
+            {metric.description || "No description available"}
+          </Typography>
+        </Box>
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/DashAI/front/src/components/experiments/metrics/MetricCard.jsx
+++ b/DashAI/front/src/components/experiments/metrics/MetricCard.jsx
@@ -5,16 +5,16 @@ import TrendingUpIcon from "@mui/icons-material/TrendingUp";
 const splitColors = {
   train: {
     border: "#4caf50",
-    bg: "rgba(76,175,80,0.08)"
+    bg: "rgba(76,175,80,0.08)",
   },
   test: {
     border: "#2196f3",
-    bg: "rgba(33,150,243,0.08)"
+    bg: "rgba(33,150,243,0.08)",
   },
   validation: {
     border: "#ff9800",
-    bg: "rgba(255,152,0,0.08)"
-  }
+    bg: "rgba(255,152,0,0.08)",
+  },
 };
 
 export default function MetricCard({
@@ -60,7 +60,7 @@ export default function MetricCard({
             borderColor: isSelected ? colors.border : "divider",
             display: "flex",
             alignItems: "center",
-            justifyContent: "center"
+            justifyContent: "center",
           }}
         >
           {isSelected && <CheckIcon fontSize="small" />}

--- a/DashAI/front/src/components/experiments/metrics/MetricsSelector.jsx
+++ b/DashAI/front/src/components/experiments/metrics/MetricsSelector.jsx
@@ -1,0 +1,212 @@
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Container,
+  Stack,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import { getComponents } from "../../../api/component";
+import SplitColumn from "./SplitColumn";
+
+export default function MetricsSelector({
+  experiment,
+  setExperiment,
+  setNextEnabled,
+}) {
+  const [metrics, setMetrics] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const enabledSplits = {
+    train: !!experiment.splits?.train,
+    validation: !!experiment.splits?.validation,
+    test: !!experiment.splits?.test,
+  };
+
+  const missingSplits = Object.entries(enabledSplits)
+    .filter(
+      ([split, enabled]) =>
+        enabled && experiment[`${split}_metrics`].length === 0
+    )
+  .map(([split]) => split);
+
+  useEffect(() => {
+    const fetchMetrics = async () => {
+      setLoading(true);
+      try {
+        const data = await getComponents({
+          selectTypes: ["Metric"],
+          relatedComponent: experiment.task_name,
+        });
+        setMetrics(data);
+      } catch (error) {
+        console.error("Error fetching metrics:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (experiment.task_name) {
+      fetchMetrics();
+    }
+  }, [experiment.task_name]);
+
+  useEffect(() => {
+    const isValid = Object.entries(enabledSplits).every(
+      ([split, enabled]) => {
+        if (!enabled) return true; // ignore disabled split
+        return experiment[`${split}_metrics`].length > 0;
+      }
+    );
+
+    setNextEnabled(isValid);
+  }, [
+    enabledSplits,
+    experiment.train_metrics,
+    experiment.validation_metrics,
+    experiment.test_metrics,
+    setNextEnabled,
+  ]);
+
+  const toggleMetric = (split, name) => {
+    const key = `${split}_metrics`;
+
+    setExperiment(prev => {
+      const current = prev[key];
+      const updated = current.includes(name)
+        ? current.filter(m => m !== name)
+        : [...current, name];
+
+      return {
+        ...prev,
+        [key]: updated,
+      };
+    });
+  };
+
+  const selectAllForSplit = split => {
+    const key = `${split}_metrics`;
+
+    setExperiment(prev => ({
+      ...prev,
+      [key]: metrics.map(m => m.name),
+    }));
+  };
+
+  if (loading) {
+    return (
+      <Box
+        minHeight="60vh"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box minHeight="100%">
+      <Typography
+        variant="h6"
+        gutterBottom
+        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+      >
+        Select Metrics for Each Data Split
+      </Typography>
+
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        Choose which metrics to compute for the training, test, and validation
+        sets.
+      </Typography>
+
+      <Container sx={{ py: 4 }}>
+        {/* Quick actions */}
+        <Stack
+          direction="row"
+          spacing={2}
+          justifyContent="center"
+          mb={4}
+          alignItems="center"
+        >
+          <Typography variant="body2" color="text.secondary">
+            Quick select all:
+          </Typography>
+          <Button onClick={() => selectAllForSplit("train")} variant="contained">
+            Train
+          </Button>
+          <Button
+            onClick={() => selectAllForSplit("validation")}
+            variant="contained"
+          >
+            Validation
+          </Button>
+          <Button onClick={() => selectAllForSplit("test")} variant="contained">
+            Test
+          </Button>
+          
+        </Stack>
+
+        {/* Columns */}
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
+            gap: 3,
+          }}
+        >
+          <SplitColumn
+            title="Training Set"
+            splitType="train"
+            metrics={metrics}
+            selectedMetrics={experiment.train_metrics}
+            onToggleMetric={name => toggleMetric("train", name)}
+            disabled={!experiment.splits?.train}
+          />
+
+          <SplitColumn
+            title="Validation Set"
+            splitType="validation"
+            metrics={metrics}
+            selectedMetrics={experiment.validation_metrics}
+            onToggleMetric={name => toggleMetric("validation", name)}
+            disabled={!experiment.splits?.validation}
+          />
+
+          <SplitColumn
+            title="Test Set"
+            splitType="test"
+            metrics={metrics}
+            selectedMetrics={experiment.test_metrics}
+            onToggleMetric={name => toggleMetric("test", name)}
+            disabled={!experiment.splits?.test}
+          />
+        </Box>
+
+        {/* Alert */}
+        {missingSplits.length > 0 && (
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            {missingSplits.length === 1 ? (
+              <>
+                {missingSplits[0].charAt(0).toUpperCase() + missingSplits[0].slice(1)} split must have at least one metric selected.
+              </>
+            ) : (
+              <>
+                The following splits must have at least one metric selected:{" "}
+                {missingSplits.map((split, idx) => (
+                  <span key={split}>
+                    <strong>{split.charAt(0).toUpperCase() + split.slice(1)}</strong>
+                    {idx < missingSplits.length - 1 ? ", " : ""}
+                  </span>
+                ))}
+              </>
+            )}
+          </Alert>
+        )}
+      </Container>
+    </Box>
+  );
+}

--- a/DashAI/front/src/components/experiments/metrics/MetricsSelector.jsx
+++ b/DashAI/front/src/components/experiments/metrics/MetricsSelector.jsx
@@ -28,9 +28,9 @@ export default function MetricsSelector({
   const missingSplits = Object.entries(enabledSplits)
     .filter(
       ([split, enabled]) =>
-        enabled && experiment[`${split}_metrics`].length === 0
+        enabled && experiment[`${split}_metrics`].length === 0,
     )
-  .map(([split]) => split);
+    .map(([split]) => split);
 
   useEffect(() => {
     const fetchMetrics = async () => {
@@ -54,12 +54,10 @@ export default function MetricsSelector({
   }, [experiment.task_name]);
 
   useEffect(() => {
-    const isValid = Object.entries(enabledSplits).every(
-      ([split, enabled]) => {
-        if (!enabled) return true; // ignore disabled split
-        return experiment[`${split}_metrics`].length > 0;
-      }
-    );
+    const isValid = Object.entries(enabledSplits).every(([split, enabled]) => {
+      if (!enabled) return true; // ignore disabled split
+      return experiment[`${split}_metrics`].length > 0;
+    });
 
     setNextEnabled(isValid);
   }, [
@@ -73,10 +71,10 @@ export default function MetricsSelector({
   const toggleMetric = (split, name) => {
     const key = `${split}_metrics`;
 
-    setExperiment(prev => {
+    setExperiment((prev) => {
       const current = prev[key];
       const updated = current.includes(name)
-        ? current.filter(m => m !== name)
+        ? current.filter((m) => m !== name)
         : [...current, name];
 
       return {
@@ -86,12 +84,12 @@ export default function MetricsSelector({
     });
   };
 
-  const selectAllForSplit = split => {
+  const selectAllForSplit = (split) => {
     const key = `${split}_metrics`;
 
-    setExperiment(prev => ({
+    setExperiment((prev) => ({
       ...prev,
-      [key]: metrics.map(m => m.name),
+      [key]: metrics.map((m) => m.name),
     }));
   };
 
@@ -135,7 +133,10 @@ export default function MetricsSelector({
           <Typography variant="body2" color="text.secondary">
             Quick select all:
           </Typography>
-          <Button onClick={() => selectAllForSplit("train")} variant="contained">
+          <Button
+            onClick={() => selectAllForSplit("train")}
+            variant="contained"
+          >
             Train
           </Button>
           <Button
@@ -147,7 +148,6 @@ export default function MetricsSelector({
           <Button onClick={() => selectAllForSplit("test")} variant="contained">
             Test
           </Button>
-          
         </Stack>
 
         {/* Columns */}
@@ -163,7 +163,7 @@ export default function MetricsSelector({
             splitType="train"
             metrics={metrics}
             selectedMetrics={experiment.train_metrics}
-            onToggleMetric={name => toggleMetric("train", name)}
+            onToggleMetric={(name) => toggleMetric("train", name)}
             disabled={!experiment.splits?.train}
           />
 
@@ -172,7 +172,7 @@ export default function MetricsSelector({
             splitType="validation"
             metrics={metrics}
             selectedMetrics={experiment.validation_metrics}
-            onToggleMetric={name => toggleMetric("validation", name)}
+            onToggleMetric={(name) => toggleMetric("validation", name)}
             disabled={!experiment.splits?.validation}
           />
 
@@ -181,7 +181,7 @@ export default function MetricsSelector({
             splitType="test"
             metrics={metrics}
             selectedMetrics={experiment.test_metrics}
-            onToggleMetric={name => toggleMetric("test", name)}
+            onToggleMetric={(name) => toggleMetric("test", name)}
             disabled={!experiment.splits?.test}
           />
         </Box>
@@ -191,14 +191,18 @@ export default function MetricsSelector({
           <Alert severity="warning" sx={{ mt: 2 }}>
             {missingSplits.length === 1 ? (
               <>
-                {missingSplits[0].charAt(0).toUpperCase() + missingSplits[0].slice(1)} split must have at least one metric selected.
+                {missingSplits[0].charAt(0).toUpperCase() +
+                  missingSplits[0].slice(1)}{" "}
+                split must have at least one metric selected.
               </>
             ) : (
               <>
                 The following splits must have at least one metric selected:{" "}
                 {missingSplits.map((split, idx) => (
                   <span key={split}>
-                    <strong>{split.charAt(0).toUpperCase() + split.slice(1)}</strong>
+                    <strong>
+                      {split.charAt(0).toUpperCase() + split.slice(1)}
+                    </strong>
                     {idx < missingSplits.length - 1 ? ", " : ""}
                   </span>
                 ))}

--- a/DashAI/front/src/components/experiments/metrics/SplitColumn.jsx
+++ b/DashAI/front/src/components/experiments/metrics/SplitColumn.jsx
@@ -1,0 +1,90 @@
+import { Box, Typography, Paper, Chip } from "@mui/material";
+import StorageIcon from "@mui/icons-material/Storage";
+import ScienceIcon from "@mui/icons-material/Science";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import MetricCard from "./MetricCard";
+
+const splitConfig = {
+  train: {
+    icon: StorageIcon,
+    color: "#4caf50",
+    bg: "rgba(76,175,80,0.08)"
+  },
+  test: {
+    icon: ScienceIcon,
+    color: "#2196f3",
+    bg: "rgba(33,150,243,0.08)"
+  },
+  validation: {
+    icon: CheckCircleIcon,
+    color: "#ff9800",
+    bg: "rgba(255,152,0,0.08)"
+  }
+};
+
+export default function SplitColumn({
+  title,
+  splitType,
+  metrics,
+  selectedMetrics,
+  onToggleMetric,
+  disabled = false,
+}) {
+  const config = splitConfig[splitType];
+  const Icon = config.icon;
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        height: "100%",
+        opacity: disabled ? 0.5 : 1,
+        pointerEvents: disabled ? "none" : "auto",
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          p: 2,
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          backgroundColor: config.bg
+        }}
+      >
+        <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+          <Icon sx={{ color: config.color }} />
+          <Box>
+            <Typography variant="subtitle1">{title}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              {selectedMetrics.length} of {metrics.length} selected
+            </Typography>
+          </Box>
+        </Box>
+
+        <Chip
+          label={selectedMetrics.length}
+          sx={{
+            backgroundColor: config.bg,
+            color: config.color,
+            fontFamily: "monospace"
+          }}
+        />
+      </Box>
+
+      {/* Metrics */}
+      <Box sx={{ p: 2, display: "flex", flexDirection: "column", gap: 2 }}>
+        {metrics.map(metric => (
+          <MetricCard
+            key={metric.name}
+            metric={metric}
+            isSelected={selectedMetrics.includes(metric.name)}
+            onToggle={() => onToggleMetric(metric.name)}
+            splitType={splitType}
+            disabled={disabled}
+          />
+        ))}
+      </Box>
+    </Paper>
+  );
+}

--- a/DashAI/front/src/components/experiments/metrics/SplitColumn.jsx
+++ b/DashAI/front/src/components/experiments/metrics/SplitColumn.jsx
@@ -8,18 +8,18 @@ const splitConfig = {
   train: {
     icon: StorageIcon,
     color: "#4caf50",
-    bg: "rgba(76,175,80,0.08)"
+    bg: "rgba(76,175,80,0.08)",
   },
   test: {
     icon: ScienceIcon,
     color: "#2196f3",
-    bg: "rgba(33,150,243,0.08)"
+    bg: "rgba(33,150,243,0.08)",
   },
   validation: {
     icon: CheckCircleIcon,
     color: "#ff9800",
-    bg: "rgba(255,152,0,0.08)"
-  }
+    bg: "rgba(255,152,0,0.08)",
+  },
 };
 
 export default function SplitColumn({
@@ -49,7 +49,7 @@ export default function SplitColumn({
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
-          backgroundColor: config.bg
+          backgroundColor: config.bg,
         }}
       >
         <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
@@ -67,14 +67,14 @@ export default function SplitColumn({
           sx={{
             backgroundColor: config.bg,
             color: config.color,
-            fontFamily: "monospace"
+            fontFamily: "monospace",
           }}
         />
       </Box>
 
       {/* Metrics */}
       <Box sx={{ p: 2, display: "flex", flexDirection: "column", gap: 2 }}>
-        {metrics.map(metric => (
+        {metrics.map((metric) => (
           <MetricCard
             key={metric.name}
             metric={metric}

--- a/DashAI/front/src/components/experiments/renderStep.js
+++ b/DashAI/front/src/components/experiments/renderStep.js
@@ -4,6 +4,7 @@ import SelectDatasetStep from "./SelectDatasetStep";
 import PrepareDatasetStep from "./PrepareDatasetStep";
 import ConfigureModelsStep from "./ConfigureModelsStep";
 import HyperparameterOptimizationStep from "./HyperparameterOptimizationStep";
+import MetricsSelector from "./metrics/MetricsSelector";
 
 export function renderStep(
   stepName,
@@ -37,6 +38,14 @@ export function renderStep(
         <PrepareDatasetStep
           newExp={newExp}
           setNewExp={setNewExp}
+          setNextEnabled={setNextEnabled}
+        />
+      );
+    case "metricsSelection":
+      return (
+        <MetricsSelector
+          experiment={newExp}
+          setExperiment={setNewExp}
           setNextEnabled={setNextEnabled}
         />
       );

--- a/DashAI/front/src/pages/results/components/LiveMetricsChart.jsx
+++ b/DashAI/front/src/pages/results/components/LiveMetricsChart.jsx
@@ -1,0 +1,187 @@
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Tabs,
+  Tab,
+  Typography,
+  Button,
+  ButtonGroup,
+} from "@mui/material"
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts"
+import { useEffect, useRef, useState } from "react"
+
+export function LiveMetricsChart({ runId }) {
+  const [level, setLevel] = useState("EPOCH")
+  const [split, setSplit] = useState("TRAIN")
+  const [data, setData] = useState({})
+  const [selectedMetrics, setSelectedMetrics] = useState([])
+  const socketRef = useRef(null)
+  
+  /* ---------------- WebSocket ---------------- */
+  useEffect(() => {
+    if (socketRef.current) {
+      socketRef.current.close()
+    }
+
+    const ws = new WebSocket(
+      `ws://localhost:8000/api/v1/metrics/ws/${runId}`
+    )
+
+    ws.onmessage = (event) => {
+      const incoming = JSON.parse(event.data)
+
+      setData((prev) => {
+        const next = structuredClone(prev)
+
+        for (const splitKey in incoming) {
+          if (splitKey === "run_status") continue
+          next[splitKey] ??= {}
+          for (const levelKey in incoming[splitKey]) {
+            next[splitKey][levelKey] =
+              incoming[splitKey][levelKey]
+          }
+        }
+
+        return next
+      })
+    }
+
+    ws.onerror = (error) => {
+      console.error("WebSocket error:", error)
+    }
+
+    socketRef.current = ws
+
+    return () => ws.close()
+  }, [runId])
+
+
+  /* ---------------- Chart data ---------------- */
+  const metrics = data[split]?.[level] ?? {}
+
+  const chartData = Object.keys(metrics).length > 0 && Object.values(metrics)[0]
+    ? metrics[Object.keys(metrics)[0]].map((_, idx) => {
+        const point = { x: idx + 1 }
+        for (const key in metrics) {
+          point[key] = metrics[key][idx]
+        }
+        return point
+      })
+    : []
+
+  /* ---------------- Auto-select metrics ---------------- */
+  useEffect(() => {
+    const metricNames = Object.keys(metrics)
+    if (metricNames.length > 0) {
+      setSelectedMetrics(metricNames)
+    }
+  }, [split, level])
+
+  /* ---------------- Check available levels ---------------- */
+  const hasTrialData = data[split]?.TRIAL && Object.keys(data[split].TRIAL).length > 0
+  const hasStepData = data[split]?.STEP && Object.keys(data[split].STEP).length > 0
+  const hasEpochData = data[split]?.EPOCH && Object.keys(data[split].EPOCH).length > 0
+
+  /* ---------------- Render ---------------- */
+  return (
+    <Box p={2}>
+      <Box display="flex" gap={2} mb={2}>
+        <FormControl size="small" sx={{ minWidth: 250 }}>
+          <InputLabel>Metrics</InputLabel>
+          <Select
+            multiple
+            value={selectedMetrics}
+            label="Metrics"
+            onChange={(e) =>
+              setSelectedMetrics(e.target.value)
+            }
+            renderValue={(selected) => selected.join(", ")}
+          >
+            {Object.keys(metrics).map((metric) => (
+              <MenuItem key={metric} value={metric}>
+                {metric}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      <Tabs
+        value={split}
+        onChange={(_, v) => setSplit(v)}
+        sx={{ mb: 2 }}
+      >
+        <Tab label="Train" value="TRAIN" />
+        <Tab label="Validation" value="VALIDATION" />
+        <Tab label="Test" value="TEST" />
+      </Tabs>
+
+      {Object.keys(metrics).length === 0 ? (
+        <Typography>No metrics yet</Typography>
+      ) : (
+        <ResponsiveContainer width="100%" height={350}>
+          <LineChart data={chartData}>
+            <XAxis
+              dataKey="x"
+              label={{ value: level, position: "insideBottom", offset: -5 }}
+            />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+
+            {selectedMetrics.map((metric, idx) => (
+              <Line
+                key={metric}
+                type="monotone"
+                dataKey={metric}
+                dot={false}
+                stroke={`hsl(${(idx * 360) / selectedMetrics.length}, 70%, 50%)`}
+                strokeWidth={2}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+
+      <Box display="flex" justifyContent="flex-end" mt={2}>
+        <ButtonGroup size="small" variant="outlined">
+          <Button
+            variant={level === "TRIAL" ? "contained" : "outlined"}
+            onClick={() => setLevel("TRIAL")}
+            disabled={!hasTrialData}
+          >
+            Trial
+          </Button>
+          <Button
+            variant={level === "STEP" ? "contained" : "outlined"}
+            onClick={() => setLevel("STEP")}
+            disabled={!hasStepData}
+          >
+            Step
+          </Button>
+          <Button
+            variant={level === "EPOCH" ? "contained" : "outlined"}
+            onClick={() => setLevel("EPOCH")}
+            disabled={!hasEpochData}
+          >
+            Epoch
+          </Button>
+        </ButtonGroup>
+      </Box>
+    </Box>
+  )
+}
+
+export default LiveMetricsChart

--- a/DashAI/front/src/pages/results/components/LiveMetricsChart.jsx
+++ b/DashAI/front/src/pages/results/components/LiveMetricsChart.jsx
@@ -28,9 +28,7 @@ export function LiveMetricsChart({ run }) {
   const [data, setData] = useState({});
   const [selectedMetrics, setSelectedMetrics] = useState([]);
   const [availableMetrics, setAvailableMetrics] = useState({
-    TRAIN: [],
-    VALIDATION: [],
-    TEST: [],
+    TRAIN: [], VALIDATION: [], TEST: [],
   });
   const hasUserSelectedMetrics = useRef(false);
   const socketRef = useRef(null);
@@ -138,45 +136,46 @@ export function LiveMetricsChart({ run }) {
         })
       : [];
 
-  /* ---------------- Auto-select metrics (only when context changes or initially) ---------------- */
+  /* ---------------- Sync Level with Split ---------------- */
+  const hasTrialData = data[split]?.TRIAL && Object.keys(data[split].TRIAL).length > 0;
+  const hasStepData = data[split]?.STEP && Object.keys(data[split].STEP).length > 0;
+  const hasEpochData = data[split]?.EPOCH && Object.keys(data[split].EPOCH).length > 0;
+
+  useEffect(() => {
+    // Determine the best available level for the new split
+    if (hasEpochData) setLevel("EPOCH");
+    else if (hasStepData) setLevel("STEP");
+    else if (hasTrialData) setLevel("TRIAL");
+    else setLevel(null); // Reset if no data exists for this split
+  }, [split, hasEpochData, hasStepData, hasTrialData]);
+
+  /* ---------------- Sync Metrics with Split/Level ---------------- */
   useEffect(() => {
     const metricNames = Object.keys(filteredMetrics);
-
-    // Only auto-select if user hasn't manually chosen metrics yet
-    if (!hasUserSelectedMetrics.current && metricNames.length > 0) {
-      setSelectedMetrics(metricNames);
+    
+    if (metricNames.length === 0) {
+      setSelectedMetrics([]);
+      return;
     }
-  }, [split, level, availableMetrics]);
 
-  /* ---------------- Handle manual metric selection ---------------- */
+    // If user hasn't touched it, auto-select all
+    if (!hasUserSelectedMetrics.current) {
+      setSelectedMetrics(metricNames);
+    } else {
+      // If user HAS touched it, filter out metrics that no longer exist in this split
+      setSelectedMetrics((prev) => prev.filter(m => metricNames.includes(m)));
+    }
+  }, [split, level, filteredMetrics]);
+
+  /* ---------------- Reset user selection flag when split changes ---------------- */
+  useEffect(() => {
+    hasUserSelectedMetrics.current = false;
+  }, [split]);
+
   const handleMetricChange = (e) => {
     hasUserSelectedMetrics.current = true;
     setSelectedMetrics(e.target.value);
   };
-
-  /* ---------------- Check available levels ---------------- */
-  const hasTrialData =
-    data[split]?.TRIAL && Object.keys(data[split].TRIAL).length > 0;
-  const hasStepData =
-    data[split]?.STEP && Object.keys(data[split].STEP).length > 0;
-  const hasEpochData =
-    data[split]?.EPOCH && Object.keys(data[split].EPOCH).length > 0;
-
-  /* ---------------- Auto-select first level ---------------- */
-  useEffect(() => {
-    if (hasEpochData) {
-      setLevel("EPOCH");
-    } else if (hasStepData) {
-      setLevel("STEP");
-    } else if (hasTrialData) {
-      setLevel("TRIAL");
-    }
-  }, [split, hasEpochData, hasStepData, hasTrialData]);
-
-  /* ---------------- Reset user selection when split/level changes ---------------- */
-  useEffect(() => {
-    hasUserSelectedMetrics.current = false;
-  }, [split, level]);
 
   /* ---------------- Render ---------------- */
   return (
@@ -185,7 +184,7 @@ export function LiveMetricsChart({ run }) {
         <FormControl
           size="small"
           sx={{ minWidth: 250 }}
-          disabled={availableMetrics[split]?.length === 0}
+          disabled={Object.keys(filteredMetrics).length === 0}
         >
           <InputLabel>Metrics</InputLabel>
           <Select
@@ -210,8 +209,10 @@ export function LiveMetricsChart({ run }) {
         <Tab label="Test" value="TEST" />
       </Tabs>
 
-      {Object.keys(filteredMetrics).length === 0 ? (
-        <Typography>No metrics yet</Typography>
+      {chartData.length === 0 || selectedMetrics.length === 0 ? (
+        <Box height={350} display="flex" alignItems="center" justifyContent="center" border="1px dashed grey">
+          <Typography color="textSecondary">No metrics available for this view</Typography>
+        </Box>
       ) : (
         <ResponsiveContainer width="100%" height={350}>
           <LineChart data={chartData}>
@@ -229,7 +230,7 @@ export function LiveMetricsChart({ run }) {
                 type="monotone"
                 dataKey={metric}
                 dot={false}
-                stroke={`hsl(${(idx * 360) / selectedMetrics.length}, 70%, 50%)`}
+                stroke={`hsl(${(idx * 137.5) % 360}, 70%, 50%)`}
                 strokeWidth={2}
                 isAnimationActive={false}
               />

--- a/DashAI/front/src/pages/results/components/LiveMetricsChart.jsx
+++ b/DashAI/front/src/pages/results/components/LiveMetricsChart.jsx
@@ -28,7 +28,9 @@ export function LiveMetricsChart({ run }) {
   const [data, setData] = useState({});
   const [selectedMetrics, setSelectedMetrics] = useState([]);
   const [availableMetrics, setAvailableMetrics] = useState({
-    TRAIN: [], VALIDATION: [], TEST: [],
+    TRAIN: [],
+    VALIDATION: [],
+    TEST: [],
   });
   const hasUserSelectedMetrics = useRef(false);
   const socketRef = useRef(null);
@@ -137,9 +139,12 @@ export function LiveMetricsChart({ run }) {
       : [];
 
   /* ---------------- Sync Level with Split ---------------- */
-  const hasTrialData = data[split]?.TRIAL && Object.keys(data[split].TRIAL).length > 0;
-  const hasStepData = data[split]?.STEP && Object.keys(data[split].STEP).length > 0;
-  const hasEpochData = data[split]?.EPOCH && Object.keys(data[split].EPOCH).length > 0;
+  const hasTrialData =
+    data[split]?.TRIAL && Object.keys(data[split].TRIAL).length > 0;
+  const hasStepData =
+    data[split]?.STEP && Object.keys(data[split].STEP).length > 0;
+  const hasEpochData =
+    data[split]?.EPOCH && Object.keys(data[split].EPOCH).length > 0;
 
   useEffect(() => {
     // Determine the best available level for the new split
@@ -152,7 +157,7 @@ export function LiveMetricsChart({ run }) {
   /* ---------------- Sync Metrics with Split/Level ---------------- */
   useEffect(() => {
     const metricNames = Object.keys(filteredMetrics);
-    
+
     if (metricNames.length === 0) {
       setSelectedMetrics([]);
       return;
@@ -163,7 +168,7 @@ export function LiveMetricsChart({ run }) {
       setSelectedMetrics(metricNames);
     } else {
       // If user HAS touched it, filter out metrics that no longer exist in this split
-      setSelectedMetrics((prev) => prev.filter(m => metricNames.includes(m)));
+      setSelectedMetrics((prev) => prev.filter((m) => metricNames.includes(m)));
     }
   }, [split, level, filteredMetrics]);
 
@@ -210,8 +215,16 @@ export function LiveMetricsChart({ run }) {
       </Tabs>
 
       {chartData.length === 0 || selectedMetrics.length === 0 ? (
-        <Box height={350} display="flex" alignItems="center" justifyContent="center" border="1px dashed grey">
-          <Typography color="textSecondary">No metrics available for this view</Typography>
+        <Box
+          height={350}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          border="1px dashed grey"
+        >
+          <Typography color="textSecondary">
+            No metrics available for this view
+          </Typography>
         </Box>
       ) : (
         <ResponsiveContainer width="100%" height={350}>

--- a/DashAI/front/src/pages/results/components/LiveMetricsChart.jsx
+++ b/DashAI/front/src/pages/results/components/LiveMetricsChart.jsx
@@ -9,7 +9,7 @@ import {
   Typography,
   Button,
   ButtonGroup,
-} from "@mui/material"
+} from "@mui/material";
 import {
   LineChart,
   Line,
@@ -18,97 +18,184 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
-} from "recharts"
-import { useEffect, useRef, useState } from "react"
+} from "recharts";
+import { useEffect, useRef, useState } from "react";
+import { getExperimentById } from "../../../api/experiment";
 
-export function LiveMetricsChart({ runId }) {
-  const [level, setLevel] = useState("EPOCH")
-  const [split, setSplit] = useState("TRAIN")
-  const [data, setData] = useState({})
-  const [selectedMetrics, setSelectedMetrics] = useState([])
-  const socketRef = useRef(null)
-  
+export function LiveMetricsChart({ run }) {
+  const [level, setLevel] = useState(null);
+  const [split, setSplit] = useState("TRAIN");
+  const [data, setData] = useState({});
+  const [selectedMetrics, setSelectedMetrics] = useState([]);
+  const [availableMetrics, setAvailableMetrics] = useState({
+    TRAIN: [],
+    VALIDATION: [],
+    TEST: [],
+  });
+  const hasUserSelectedMetrics = useRef(false);
+  const socketRef = useRef(null);
+
+  /* ---------------- Load test metrics from run data ---------------- */
+  useEffect(() => {
+    // Check if run is finished (status 3) and has test metrics
+    if (run.status === 3 && run.test_metrics) {
+      setData((prev) => {
+        const next = structuredClone(prev);
+        next.TEST = {
+          TRIAL: run.test_metrics,
+          STEP: run.test_metrics,
+          EPOCH: run.test_metrics,
+        };
+        return next;
+      });
+    }
+  }, [run.status, run.test_metrics]);
+
   /* ---------------- WebSocket ---------------- */
   useEffect(() => {
     if (socketRef.current) {
-      socketRef.current.close()
+      socketRef.current.close();
     }
 
-    const ws = new WebSocket(
-      `ws://localhost:8000/api/v1/metrics/ws/${runId}`
-    )
+    const ws = new WebSocket(`ws://localhost:8000/api/v1/metrics/ws/${run.id}`);
 
     ws.onmessage = (event) => {
-      const incoming = JSON.parse(event.data)
+      const incoming = JSON.parse(event.data);
 
       setData((prev) => {
-        const next = structuredClone(prev)
+        const next = structuredClone(prev);
 
         for (const splitKey in incoming) {
-          if (splitKey === "run_status") continue
-          next[splitKey] ??= {}
+          if (splitKey === "run_status") continue;
+          next[splitKey] ??= {};
           for (const levelKey in incoming[splitKey]) {
-            next[splitKey][levelKey] =
-              incoming[splitKey][levelKey]
+            next[splitKey][levelKey] = incoming[splitKey][levelKey];
           }
         }
 
-        return next
-      })
-    }
+        return next;
+      });
+    };
+
+    ws.onclose = () => {
+      // When WebSocket closes, load test metrics if available
+      if (run.test_metrics) {
+        setData((prev) => {
+          const next = structuredClone(prev);
+          next.TEST = {
+            TRIAL: run.test_metrics,
+            STEP: run.test_metrics,
+            EPOCH: run.test_metrics,
+          };
+          return next;
+        });
+      }
+    };
 
     ws.onerror = (error) => {
-      console.error("WebSocket error:", error)
-    }
+      console.error("WebSocket error:", error);
+    };
 
-    socketRef.current = ws
+    socketRef.current = ws;
 
-    return () => ws.close()
-  }, [runId])
+    return () => ws.close();
+  }, [run.id, run.test_metrics]);
 
+  useEffect(() => {
+    let mounted = true;
+
+    getExperimentById(run.experiment_id).then((exp) => {
+      if (!mounted) return;
+
+      setAvailableMetrics({
+        TRAIN: exp.train_metrics ?? [],
+        VALIDATION: exp.validation_metrics ?? [],
+        TEST: exp.test_metrics ?? [],
+      });
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, [run.experiment_id]);
 
   /* ---------------- Chart data ---------------- */
-  const metrics = data[split]?.[level] ?? {}
+  const metrics = data[split]?.[level] ?? {};
+  const allowed = availableMetrics[split] ?? [];
 
-  const chartData = Object.keys(metrics).length > 0 && Object.values(metrics)[0]
-    ? metrics[Object.keys(metrics)[0]].map((_, idx) => {
-        const point = { x: idx + 1 }
-        for (const key in metrics) {
-          point[key] = metrics[key][idx]
-        }
-        return point
-      })
-    : []
+  const filteredMetrics = Object.fromEntries(
+    Object.entries(metrics).filter(([name]) => allowed.includes(name)),
+  );
 
-  /* ---------------- Auto-select metrics ---------------- */
+  const chartData =
+    Object.keys(filteredMetrics).length > 0 && Object.values(filteredMetrics)[0]
+      ? filteredMetrics[Object.keys(filteredMetrics)[0]].map((_, idx) => {
+          const point = { x: idx + 1 };
+          for (const key in filteredMetrics) {
+            point[key] = filteredMetrics[key][idx];
+          }
+          return point;
+        })
+      : [];
+
+  /* ---------------- Auto-select metrics (only when context changes or initially) ---------------- */
   useEffect(() => {
-    const metricNames = Object.keys(metrics)
-    if (metricNames.length > 0) {
-      setSelectedMetrics(metricNames)
+    const metricNames = Object.keys(filteredMetrics);
+
+    // Only auto-select if user hasn't manually chosen metrics yet
+    if (!hasUserSelectedMetrics.current && metricNames.length > 0) {
+      setSelectedMetrics(metricNames);
     }
-  }, [split, level])
+  }, [split, level, availableMetrics]);
+
+  /* ---------------- Handle manual metric selection ---------------- */
+  const handleMetricChange = (e) => {
+    hasUserSelectedMetrics.current = true;
+    setSelectedMetrics(e.target.value);
+  };
 
   /* ---------------- Check available levels ---------------- */
-  const hasTrialData = data[split]?.TRIAL && Object.keys(data[split].TRIAL).length > 0
-  const hasStepData = data[split]?.STEP && Object.keys(data[split].STEP).length > 0
-  const hasEpochData = data[split]?.EPOCH && Object.keys(data[split].EPOCH).length > 0
+  const hasTrialData =
+    data[split]?.TRIAL && Object.keys(data[split].TRIAL).length > 0;
+  const hasStepData =
+    data[split]?.STEP && Object.keys(data[split].STEP).length > 0;
+  const hasEpochData =
+    data[split]?.EPOCH && Object.keys(data[split].EPOCH).length > 0;
+
+  /* ---------------- Auto-select first level ---------------- */
+  useEffect(() => {
+    if (hasEpochData) {
+      setLevel("EPOCH");
+    } else if (hasStepData) {
+      setLevel("STEP");
+    } else if (hasTrialData) {
+      setLevel("TRIAL");
+    }
+  }, [split, hasEpochData, hasStepData, hasTrialData]);
+
+  /* ---------------- Reset user selection when split/level changes ---------------- */
+  useEffect(() => {
+    hasUserSelectedMetrics.current = false;
+  }, [split, level]);
 
   /* ---------------- Render ---------------- */
   return (
     <Box p={2}>
       <Box display="flex" gap={2} mb={2}>
-        <FormControl size="small" sx={{ minWidth: 250 }}>
+        <FormControl
+          size="small"
+          sx={{ minWidth: 250 }}
+          disabled={availableMetrics[split]?.length === 0}
+        >
           <InputLabel>Metrics</InputLabel>
           <Select
             multiple
             value={selectedMetrics}
             label="Metrics"
-            onChange={(e) =>
-              setSelectedMetrics(e.target.value)
-            }
+            onChange={handleMetricChange}
             renderValue={(selected) => selected.join(", ")}
           >
-            {Object.keys(metrics).map((metric) => (
+            {Object.keys(filteredMetrics).map((metric) => (
               <MenuItem key={metric} value={metric}>
                 {metric}
               </MenuItem>
@@ -117,17 +204,13 @@ export function LiveMetricsChart({ runId }) {
         </FormControl>
       </Box>
 
-      <Tabs
-        value={split}
-        onChange={(_, v) => setSplit(v)}
-        sx={{ mb: 2 }}
-      >
+      <Tabs value={split} onChange={(_, v) => setSplit(v)} sx={{ mb: 2 }}>
         <Tab label="Train" value="TRAIN" />
         <Tab label="Validation" value="VALIDATION" />
         <Tab label="Test" value="TEST" />
       </Tabs>
 
-      {Object.keys(metrics).length === 0 ? (
+      {Object.keys(filteredMetrics).length === 0 ? (
         <Typography>No metrics yet</Typography>
       ) : (
         <ResponsiveContainer width="100%" height={350}>
@@ -181,7 +264,7 @@ export function LiveMetricsChart({ runId }) {
         </ButtonGroup>
       </Box>
     </Box>
-  )
+  );
 }
 
-export default LiveMetricsChart
+export default LiveMetricsChart;

--- a/DashAI/front/src/pages/results/components/MetricsCard.jsx
+++ b/DashAI/front/src/pages/results/components/MetricsCard.jsx
@@ -18,7 +18,7 @@ export default function MetricsCard({ title, metrics }) {
               {key}:
             </Typography>
             <Typography variant="body2" fontWeight="medium">
-              {typeof value === "number" ? value.toFixed(4) : value}
+              {value[0].toFixed(4)}
             </Typography>
           </Box>
         ))

--- a/DashAI/front/src/pages/results/components/ResultsTabInfo.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsTabInfo.jsx
@@ -31,6 +31,7 @@ import { updateRunParameters } from "../../../api/run";
 import { useSnackbar } from "notistack";
 import OptimizationTableSelectOptimizer from "../../../components/experiments/OptimizationTableSelectOptimizer";
 import { getColorByStatus } from "../../../utils";
+import LiveMetricsChart from "./LiveMetricsChart";
 
 /**
  * Component that displays general information associated with a run.
@@ -234,6 +235,17 @@ function ResultsTabInfo({ runData, handleRun }) {
           </Box>
         </>
       )}
+
+      {/* Live Metrics Section */}
+      <Divider sx={{ mt: 3, mb: 2 }} />
+
+      <Typography variant="h6" gutterBottom>
+        Live Metrics
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <LiveMetricsChart runId={runData.id} />
+      </Paper>
 
       {/* Run edition */}
       {isLocked && (

--- a/DashAI/front/src/pages/results/components/ResultsTabInfo.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsTabInfo.jsx
@@ -189,6 +189,17 @@ function ResultsTabInfo({ runData, handleRun }) {
         </>
       )}
 
+      {/* Live Metrics Section */}
+      <Divider sx={{ mt: 3, mb: 2 }} />
+
+      <Typography variant="h6" gutterBottom>
+        Live Metrics
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <LiveMetricsChart run={runData} />
+      </Paper>
+
       {/* Metrics Section */}
       {(runData.train_metrics ||
         runData.validation_metrics ||
@@ -236,16 +247,7 @@ function ResultsTabInfo({ runData, handleRun }) {
         </>
       )}
 
-      {/* Live Metrics Section */}
       <Divider sx={{ mt: 3, mb: 2 }} />
-
-      <Typography variant="h6" gutterBottom>
-        Live Metrics
-      </Typography>
-
-      <Paper variant="outlined" sx={{ p: 2 }}>
-        <LiveMetricsChart runId={runData.id} />
-      </Paper>
 
       {/* Run edition */}
       {isLocked && (

--- a/DashAI/front/src/pages/results/components/ResultsTable.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsTable.jsx
@@ -122,7 +122,11 @@ function ResultsTable({
         relatedComponent: experiment.task_name,
       });
 
-      setMetrics(metricComponents);
+      setMetrics(
+        metricComponents.filter((c) =>
+          experiment.test_metrics.includes(c.name),
+        ),
+      );
     };
 
     fetchStaticData();

--- a/DashAI/front/src/pages/results/constants/extractColumns.jsx
+++ b/DashAI/front/src/pages/results/constants/extractColumns.jsx
@@ -22,14 +22,11 @@ export const extractColumns = (
   const metrics = rawMetrics.map((metric) => ({
     field: `test_${metric.name}`,
     headerName: `test_${metric.name}`,
-    renderCell: (params) => {
-      const { status } = params.row;
-      const value = params.value;
+    renderCell: ({ row, value }) => {
+      if (["Started", "Delivered"].includes(row.status)) return "-";
 
-      const isRunning = status === "Started" || status === "Delivered";
-
-      // If running → show "-", else → show metric value normally
-      return isRunning ? "-" : (value ?? "-");
+      const v = Array.isArray(value) ? value[0] : null;
+      return typeof v === "number" ? v.toFixed(2) : "-";
     },
   }));
 

--- a/tests/back/api/test_experiments_api.py
+++ b/tests/back/api/test_experiments_api.py
@@ -42,6 +42,9 @@ def create_experiment_1(client: TestClient, dataset_id: int):
                 "PetalWidthCm",
             ],
             "output_columns": ["Species"],
+            "train_metrics": [],
+            "validation_metrics": [],
+            "test_metrics": [],
             "splits": splits,
         },
     )
@@ -58,6 +61,9 @@ def create_experiment_2(client: TestClient, dataset_id: int):
             "name": "ExperimentB",
             "input_columns": ["SepalLengthCm", "PetalWidthCm"],
             "output_columns": ["Species"],
+            "train_metrics": [],
+            "validation_metrics": [],
+            "test_metrics": [],
             "splits": splits,
         },
     )

--- a/tests/back/api/test_explainer_jobs.py
+++ b/tests/back/api/test_explainer_jobs.py
@@ -73,7 +73,7 @@ class DummyModel(BaseModel):
     def predict(self, x):
         return {}
 
-    def fit(self, x, y):
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
         return
 
     def prepare_dataset(self, dataset, is_fit=False):

--- a/tests/back/api/test_jobs.py
+++ b/tests/back/api/test_jobs.py
@@ -44,7 +44,7 @@ class DummyModel(BaseModel):
     def predict(self, x):
         return {}
 
-    def fit(self, x, y):
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
         return
 
     def prepare_dataset(self, dataset, is_fit=False):
@@ -63,7 +63,7 @@ class FailDummyModel(BaseModel):
     def predict(self, x):
         return {}
 
-    def fit(self, x, y):
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
         raise Exception("Always fails")
 
     def prepare_dataset(self, dataset, is_fit=False):
@@ -279,11 +279,6 @@ def test_execute_jobs(client: TestClient, run_id: int, failed_run_id: int):
     response = client.get(f"/api/v1/run/{run_id}")
     data = response.json()
     assert data["status"] == 3
-    assert isinstance(data["train_metrics"], dict)
-    assert "DummyMetric" in data["train_metrics"]
-    assert data["train_metrics"]["DummyMetric"] == 1
-    assert data["train_metrics"] == data["validation_metrics"]
-    assert data["train_metrics"] == data["test_metrics"]
     assert data["run_path"] is not None
     assert os.path.exists(data["run_path"])
     assert data["status"] == 3

--- a/tests/back/api/test_jobs.py
+++ b/tests/back/api/test_jobs.py
@@ -121,6 +121,9 @@ def create_experiment(client: TestClient, dataset_id: int):
             task_name="DummyTask",
             input_columns=["SepalLengthCm"],
             output_columns=["Species"],
+            train_metrics=[],
+            validation_metrics=[],
+            test_metrics=[],
             splits=json.dumps(
                 {
                     "train": 0.5,

--- a/tests/back/api/test_predict_api.py
+++ b/tests/back/api/test_predict_api.py
@@ -44,7 +44,7 @@ class DummyModel(BaseModel):
     def predict(self, x):
         return {}
 
-    def fit(self, x, y):
+    def train(self, x, y):
         return
 
     def prepare_dataset(self, dataset, is_fit=False):

--- a/tests/back/api/test_predict_api.py
+++ b/tests/back/api/test_predict_api.py
@@ -204,6 +204,9 @@ def create_experiment(client: TestClient, dataset: Dataset):
             task_name="TabularClassificationTask",
             input_columns=["feature_0", "feature_1", "feature_2", "feature_3"],
             output_columns=["class"],
+            train_metrics=[],
+            validation_metrics=[],
+            test_metrics=[],
             splits=json.dumps(
                 {
                     "train": 0.5,

--- a/tests/back/api/test_runs_api.py
+++ b/tests/back/api/test_runs_api.py
@@ -28,6 +28,9 @@ def create_experiment(client: TestClient, dataset_id):
                 "PetalWidthCm",
             ],
             "output_columns": ["Species"],
+            "train_metrics": [],
+            "validation_metrics": [],
+            "test_metrics": [],
             "splits": json.dumps(
                 {
                     "train": 0.5,

--- a/tests/back/explainers/test_explainers.py
+++ b/tests/back/explainers/test_explainers.py
@@ -104,7 +104,7 @@ def trained_model(dataset):
         min_samples_leaf=1,
         max_features=None,
     )
-    model.fit(x["train"], y["train"])
+    model.train(x["train"], y["train"])
 
     return model
 

--- a/tests/back/models/test_bow_text_class_model.py
+++ b/tests/back/models/test_bow_text_class_model.py
@@ -152,7 +152,7 @@ def test_fit_model(
     x, y = splited_dataset
     x = x["train"]
     y = y["train"]
-    sample_model.fit(x, y)
+    sample_model.train(x, y)
 
     assert hasattr(sample_model.vectorizer, "vocabulary_")
     assert hasattr(sample_model.classifier, "estimators_")
@@ -168,7 +168,7 @@ def test_predict_model(
     vectorizer_func = sample_model.get_vectorizer(input_column)
     vectorized_dataset = x.map(vectorizer_func, remove_columns="text")
     vectorized_dataset = to_dashai_dataset(vectorized_dataset)
-    sample_model.classifier.fit(vectorized_dataset, y["test"])
+    sample_model.classifier.train(vectorized_dataset, y["test"])
     predictions = sample_model.predict(x)
     assert isinstance(predictions, np.ndarray)
     assert len(predictions) == len(y["test"])
@@ -180,7 +180,7 @@ def test_save_and_load_model(
     tmp_path: Path,
 ):
     x, y = splited_dataset
-    sample_model.fit(x["train"], y["train"])
+    sample_model.train(x["train"], y["train"])
     nwft_filename = os.path.join(tmp_path, "nwft_model")
     sample_model.save(nwft_filename)
     loaded_model = sample_model.load(nwft_filename)

--- a/tests/back/models/test_tabular_class_models.py
+++ b/tests/back/models/test_tabular_class_models.py
@@ -127,13 +127,13 @@ def test_check_is_fitted(
 ):
     knn_model = KNeighborsClassifier(**model_params["knn"])
 
-    knn_model.fit(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    knn_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
 
     rf_model = RandomForestClassifier(**model_params["rf"])
-    rf_model.fit(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    rf_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
 
     svc_model = SVC(**model_params["svc"])
-    svc_model.fit(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    svc_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
 
     try:
         check_is_fitted(knn_model)
@@ -148,15 +148,15 @@ def test_predict_tabular_models(
     divided_dataset: Tuple[DatasetDict, DatasetDict], model_params: dict
 ):
     knn_model = KNeighborsClassifier(**model_params["knn"])
-    knn_model.fit(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    knn_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
     y_pred_knn = knn_model.predict(divided_dataset[0]["test"])
 
     rf_model = RandomForestClassifier(**model_params["rf"])
-    rf_model.fit(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    rf_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
     y_pred_rf = rf_model.predict(divided_dataset[0]["test"])
 
     svc_model = SVC(**model_params["svc"])
-    svc_model.fit(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    svc_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
     y_pred_svm = svc_model.predict(divided_dataset[0]["test"])
 
     assert isinstance(y_pred_knn, np.ndarray)


### PR DESCRIPTION
## Summary
This PR introduces a new backend metrics system that refactors how experiment and run metrics are defined, stored, and retrieved. Metrics are now persisted in a dedicated database model with split and level granularity, enabling more flexible metric handling and real-time streaming via websockets.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `models.py` / `metrics.py`  
  Added a new `Metric` database model with split and level enums for granular metric tracking.

- `api.py` / `metrics.py`  
  Added a `/metrics` REST endpoint and websocket endpoint to stream live metric updates along with run status.

- `runs.py`  
  Updated run endpoints to retrieve metrics from the new `Metric` table and ensured metrics are properly deleted when a run is reset.

- `model_job.py`  
  Refactored job logic to:
  - Select metrics from experiment configuration  
  - Pass selected metrics to models  
  - Compute and persist metrics using the new system at the end of training for each split
  
https://github.com/user-attachments/assets/47cb0512-62d7-4f8d-91d2-e6996719a7ee

https://github.com/user-attachments/assets/b417aa80-c6c0-48f6-beac-fd5f2ee5b111

---

## Testing
- Verify that metrics are correctly stored per split and level after a run completes.
- Confirm that resetting a run removes its associated metrics.
- Validate websocket metric streaming during an active run.

---

## Notes
- This PR also makes some minor fixes for models to work.
- Fit method was renamed to train for models.
- MLP Regression model was refactored to use pytorch instead of sklearn for more control over monitoring metrics.
