### PR TITLE
Fix: Update DatasetVisualization props for new session flow

### DIFF
--- a/DashAI/front/src/pages/models/ModelsContent.jsx
+++ b/DashAI/front/src/pages/models/ModelsContent.jsx
@@ -923,10 +923,10 @@ export default function ModelsContent() {
                 ) : step === 2 && selectedDatasetId ? (
                   <DatasetVisualization
                     dataset={datasets.find((d) => d.id === selectedDatasetId)}
-                    onSessionCreated={handleSessionCreated}
-                    onNewSession={handleNewSessionFromDataset}
-                    existingSessions={sessions}
-                    tasks={tasks}
+                    onItemCreated={handleSessionCreated}
+                    onNewItem={handleNewSessionFromDataset}
+                    existingItems={sessions}
+                    newItemButtonText="New Session"
                   />
                 ) : step === 0 ? (
                   <SelectOptionMenu


### PR DESCRIPTION
## Summary

This PR updates the props passed to the `DatasetVisualization` component in `ModelsContent.jsx` to match the expected prop names. The previous implementation used outdated prop names (`onSessionCreated`, `onNewSession`, `existingSessions`, `tasks`), which caused the "New Session" button and related features to not work. Now, the correct props (`onItemCreated`, `onNewItem`, `existingItems`, `newItemButtonText`) are used, restoring the intended functionality.

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

## Changes (by file)

- `DashAI/front/src/pages/models/ModelsContent.jsx`
  - Updated the props passed to the `DatasetVisualization` component to use the correct names (`onItemCreated`, `onNewItem`, `existingItems`, `newItemButtonText`) instead of the outdated ones. This fixes the "New Session" button and related functionality.

## Testing
- Manually verified that clicking "New Session" in the dataset view now triggers the session creation flow as expected.

