### PR TITLE
Improve box plot line color in NumericTab

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
@@ -104,7 +104,7 @@ export const NumericTab = ({ numericStats }) => {
                     orientation: "h", // ← rotated here
                     boxpoints: "suspectedoutliers",
                     marker: { color: theme.palette.info.main },
-                    line: { color: theme.palette.background.paper },
+                    line: { color: theme.palette.text.secondary },
                     fillcolor: theme.palette.info.main,
                     opacity: 0.6,
                     showlegend: false,


### PR DESCRIPTION
## Summary  
This pull request updates the styling of the `NumericTab` component by adjusting the box plot line color to improve visual contrast and better align with the application theme.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [ ] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  
- `NumericTab.jsx`: Updated the box plot `line.color` from `theme.palette.background.paper` to `theme.palette.text.secondary` for improved contrast and visual consistency.

---

## Testing
- Visually verified that box plot lines render with improved contrast and match the overall theme styling.
