### PR TITLE
Update tool configuration title in ConfigureToolModal

### DIFF
--- a/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
@@ -119,7 +119,6 @@ export default function ConfigureToolModal({
         }}
       >
         <Typography variant="h6" fontWeight="600" sx={{ whiteSpace: "nowrap" }}>
-          Configure {tool.type}: {tool.display_name}
           {t("datasets:label.configureToolTitle", {
             toolType: tool.type,
             toolName: tool.display_name,


### PR DESCRIPTION
## Summary
This pull request applies a small internationalization fix to the `ConfigureToolModal` component by removing a hardcoded tool configuration title and relying solely on the translation function for the modal title.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `path/to/ConfigureToolModal.tsx`: Removed the hardcoded modal title and used the translation function instead.

### Before
<img width="1076" height="876" alt="image" src="https://github.com/user-attachments/assets/fabbb0c1-4a28-4e64-93f9-06788a4ac573" />

### After
<img width="1092" height="886" alt="image" src="https://github.com/user-attachments/assets/35c03787-5a25-4a5e-b6f2-7ddd6fa62001" />


---

## Testing (optional)
- Confirmed the modal title displays correctly with existing translations.
