### PR TITLE
Added check for pypi archived proyects

### DIFF
--- a/DashAI/back/plugins/utils.py
+++ b/DashAI/back/plugins/utils.py
@@ -13,6 +13,35 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import entry_points
 
+_PYPI_SIMPLE_JSON_ACCEPT = "application/vnd.pypi.simple.v1+json"
+_PYPI_SIMPLE_URL = "https://pypi.org/simple/"
+_REQUEST_TIMEOUT_SECONDS = 15
+
+
+def _get_pypi_project_status(plugin_name: str) -> str:
+    """
+    Retrieve PyPI project status marker using the Simple API project endpoint.
+
+    Returns
+    -------
+    str
+        One of: "active", "archived", "quarantined" (or other future values).
+        Defaults to "active" on missing marker.
+        Returns "unknown" on request/parse errors.
+    """
+    try:
+        response = requests.get(
+            f"{_PYPI_SIMPLE_URL}{plugin_name}/",
+            headers={"Accept": _PYPI_SIMPLE_JSON_ACCEPT},
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        data = response.json()
+        project_status = data.get("project-status") or {}
+        return (project_status.get("status") or "active").lower()
+    except Exception:
+        return "unknown"
+
 
 def _get_all_plugins() -> List[str]:
     """
@@ -41,6 +70,7 @@ def _get_all_plugins() -> List[str]:
 
     else:
         print(f"Failed to retrieve packages. Status code: {response.status_code}")
+        packages = []
 
     return packages
 
@@ -118,6 +148,10 @@ def get_plugins_from_pypi() -> List[dict]:
 
     for plugin_name in plugins_names:
         try:
+            status = _get_pypi_project_status(plugin_name)
+            if status == "archived":
+                continue
+
             plugin_info = get_plugin_by_name_from_pypi(plugin_name)
             plugins.append(plugin_info)
         except ValueError as e:

--- a/tests/back/api/test_plugins.py
+++ b/tests/back/api/test_plugins.py
@@ -25,7 +25,7 @@ def test_post_plugin(client: TestClient):
 
 
 def test_refresh_plugins(client: TestClient):
-    # Mock para requests.get
+    # Mock para requests.get (lista global /simple/)
     mock_client = Mock()
     mock_client.json.return_value = {
         "meta": {"_last-serial": 0, "api-version": "1.0"},
@@ -37,7 +37,13 @@ def test_refresh_plugins(client: TestClient):
     }
     mock_client.status_code = 200
 
-    # Mock para el segundo request.get
+    # Mock para requests.get (status /simple/<project>/)
+    status_mock = Mock()
+    status_mock.status_code = 200
+    status_mock.raise_for_status.return_value = None
+    status_mock.json.return_value = {"project-status": {"status": "active"}}
+
+    # Mock para requests.get (metadata /pypi/<project>/json)
     request_mock = Mock()
     json_return = {
         "info": {
@@ -52,7 +58,7 @@ def test_refresh_plugins(client: TestClient):
     }
     request_mock.json.return_value = json_return
 
-    with patch("requests.get", side_effect=[mock_client, request_mock]):
+    with patch("requests.get", side_effect=[mock_client, status_mock, request_mock]):
         response = client.post("/api/v1/plugin/index")
         assert response.status_code == 201, response.text
         assert len(response.json()) == 1
@@ -82,7 +88,6 @@ def test_post_existing_plugin(client: TestClient):
 
 
 def test_refresh_existing_plugin_with_new_version(client: TestClient):
-    # Mock para requests.get
     mock_client = Mock()
     mock_client.json.return_value = {
         "meta": {"_last-serial": 0, "api-version": "1.0"},
@@ -94,7 +99,11 @@ def test_refresh_existing_plugin_with_new_version(client: TestClient):
     }
     mock_client.status_code = 200
 
-    # Mock para el segundo request.get
+    status_mock = Mock()
+    status_mock.status_code = 200
+    status_mock.raise_for_status.return_value = None
+    status_mock.json.return_value = {"project-status": {"status": "active"}}
+
     request_mock = Mock()
     json_return = {
         "info": {
@@ -109,7 +118,7 @@ def test_refresh_existing_plugin_with_new_version(client: TestClient):
     }
     request_mock.json.return_value = json_return
 
-    with patch("requests.get", side_effect=[mock_client, request_mock]):
+    with patch("requests.get", side_effect=[mock_client, status_mock, request_mock]):
         response = client.post("/api/v1/plugin/index")
         assert response.status_code == 201, response.text
         assert len(response.json()) == 1
@@ -118,6 +127,30 @@ def test_refresh_existing_plugin_with_new_version(client: TestClient):
         assert plugin["summary"] == "Tabular Classification Package"
         assert plugin["installed_version"] == "0.0.2"
         assert plugin["lastest_version"] == "0.0.5"
+
+
+def test_refresh_plugins_skips_archived(client: TestClient):
+    mock_client = Mock()
+    mock_client.json.return_value = {
+        "meta": {"_last-serial": 0, "api-version": "1.0"},
+        "projects": [
+            {"_last-serial": 1, "name": "dashai-tabular-classification-package"}
+        ],
+    }
+    mock_client.status_code = 200
+
+    status_mock = Mock()
+    status_mock.status_code = 200
+    status_mock.raise_for_status.return_value = None
+    status_mock.json.return_value = {"project-status": {"status": "archived"}}
+
+    # No debería llamarse, pero igual lo dejamos por seguridad
+    request_mock = Mock()
+
+    with patch("requests.get", side_effect=[mock_client, status_mock, request_mock]):
+        response = client.post("/api/v1/plugin/index")
+        assert response.status_code == 201, response.text
+        assert len(response.json()) == 0
 
 
 def test_get_all_plugins(client: TestClient):

--- a/tests/back/plugins/test_plugin_utils.py
+++ b/tests/back/plugins/test_plugin_utils.py
@@ -124,7 +124,7 @@ def test_get_plugin_by_name_from_pypi_with_other_tags():
 
 
 def test_get_plugins_from_pypi():
-    # Mock to server_proxy
+    # Mock GET /simple/
     server_proxy_mock = Mock()
     server_proxy_mock.json.return_value = {
         "meta": {"_last-serial": 0, "api-version": "1.0"},
@@ -135,9 +135,16 @@ def test_get_plugins_from_pypi():
         ],
     }
     server_proxy_mock.status_code = 200
-    # Mock to request.get
+
+    # Mock GET /simple/<project>/ (status)
+    status_mock = Mock()
+    status_mock.status_code = 200
+    status_mock.raise_for_status.return_value = None
+    status_mock.json.return_value = {"project-status": {"status": "active"}}
+
+    # Mock GET /pypi/<project>/json
     request_mock = Mock()
-    json_return = {
+    request_mock.json.return_value = {
         "info": {
             "author": "DashAI Team",
             "version": "0.1.0",
@@ -148,9 +155,11 @@ def test_get_plugins_from_pypi():
             "summary": "Tabular Classification Package",
         },
     }
-    request_mock.json.return_value = json_return
 
-    with patch("requests.get", side_effect=[server_proxy_mock, request_mock]):
+    with patch(
+        "requests.get",
+        side_effect=[server_proxy_mock, status_mock, request_mock],
+    ):
         plugins = get_plugins_from_pypi()
 
     assert plugins == [


### PR DESCRIPTION
## Summary
Added checks for Pypi archived proyects

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

Example:
- `DashAI\back\plugins\utils.py`: Added _get_pypi_project_status`to verify proyect status

---

## Testing (optional)
Need to delete database and then go to plugins page, shouldnt no longer see image-classification-package
