### PR TITLE
Add i18n support for MUI DataGrid via theme localization

### DIFF
--- a/DashAI/front/src/contexts/ThemeContext.jsx
+++ b/DashAI/front/src/contexts/ThemeContext.jsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useMemo, useEffect } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import getTheme from "../styles/theme";
+import { useTranslation } from "react-i18next";
 
 export const ColorModeContext = createContext({ toggleColorMode: () => {} });
 
@@ -10,6 +11,7 @@ export function CustomThemeProvider({ children }) {
     const savedMode = localStorage.getItem("themeMode");
     return savedMode || "dark";
   });
+  const { i18n } = useTranslation();
 
   // Save theme preference to localStorage whenever it changes
   useEffect(() => {
@@ -25,7 +27,10 @@ export function CustomThemeProvider({ children }) {
     [],
   );
 
-  const theme = useMemo(() => createTheme(getTheme(mode)), [mode]);
+  const theme = useMemo(
+    () => createTheme(getTheme(mode, i18n.language)),
+    [mode, i18n.language],
+  );
 
   return (
     <ColorModeContext.Provider value={colorMode}>

--- a/DashAI/front/src/styles/theme.js
+++ b/DashAI/front/src/styles/theme.js
@@ -1,6 +1,7 @@
 import QuicksandBoldWoff2 from "./fonts/Quicksand-Bold.woff2";
+import { dataGridLocales } from "../utils/i18n/datagridLocale";
 
-const getTheme = (mode) => ({
+const getTheme = (mode, language) => ({
   palette: {
     mode,
 
@@ -198,11 +199,15 @@ const getTheme = (mode) => ({
         ::-webkit-scrollbar-thumb {
             -webkit-border-radius: 10px;
             border-radius: 10px;
-            background: ${mode === "dark" ? "rgba(0, 0, 0, 0.8)" : "rgba(0, 0, 0, 0.3)"};
+            background: ${
+              mode === "dark" ? "rgba(0, 0, 0, 0.8)" : "rgba(0, 0, 0, 0.3)"
+            };
             -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
         }
         ::-webkit-scrollbar-thumb:window-inactive {
-                background: ${mode === "dark" ? "rgba(0,0,0,0.4)" : "rgba(0,0,0,0.2)"};
+                background: ${
+                  mode === "dark" ? "rgba(0,0,0,0.4)" : "rgba(0,0,0,0.2)"
+                };
         }
       `,
     },
@@ -221,6 +226,9 @@ const getTheme = (mode) => ({
         columnHeader: {
           backgroundColor: "transparent",
         },
+      },
+      defaultProps: {
+        localeText: dataGridLocales[language] ?? dataGridLocales.en,
       },
     },
   },

--- a/DashAI/front/src/utils/i18n/datagridLocale.js
+++ b/DashAI/front/src/utils/i18n/datagridLocale.js
@@ -1,0 +1,6 @@
+import { enUS, esES } from "@mui/x-data-grid/locales";
+
+export const dataGridLocales = {
+  en: enUS.components.MuiDataGrid.defaultProps.localeText,
+  es: esES.components.MuiDataGrid.defaultProps.localeText,
+};


### PR DESCRIPTION
## Summary
Adds internationalization support to the MUI DataGrid by integrating locale-based translations into the theme, so DataGrid text adapts to the user’s selected language.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `src/theme/datagridLocale.js`: Added a utility to provide locale-specific DataGrid translations (English and Spanish) using MUI built-in locales.
- `src/theme/theme.js`: Updated `getTheme` to accept a `language` parameter and set `DataGrid` `localeText` based on the current language (fallback to English). Also refactored dynamic scrollbar CSS for readability.
- `src/context/ThemeContext.jsx`: Integrated `useTranslation` to read the current i18n language and pass it to the theme generator.

---

## Testing (optional)
- Switch application language (e.g., EN ↔ ES) and verify DataGrid labels update accordingly.
