### PR TITLE
Restrict transformers version to <5.0.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ typer
 rich
 torch
 torchvision
-transformers
+transformers<5.0.0
 sacrebleu
 sentencepiece
 optuna


### PR DESCRIPTION
## Summary
Pins the `transformers` dependency to a version below 5.0.0 to fix failing tests related to the `StableDiffusionXLV1ControlNet` model.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change 
- [ ] Frontend change 
- [ ] CI / Workflow change 
- [ ] Build / Packaging change 
- [x] Bug fix 
- [ ] Documentation ---

---
