### PR TITLE
Fix type inference scope for uploaded datasets

### DIFF
--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -170,13 +170,15 @@ class DatasetJob(BaseJob):
                         n_sample=n_sample,
                     )
 
-                if "inferred_types" in params:
-                    schema = params["inferred_types"]
-                else:
-                    schema = infer_types(new_dataset.to_pandas(), method="DashAIPtype")
+                    if "inferred_types" in params:
+                        schema = params["inferred_types"]
+                    else:
+                        schema = infer_types(
+                            new_dataset.to_pandas(), method="DashAIPtype"
+                        )
 
-                # Cast dataset to inferred types
-                new_dataset = transform_dataset_with_schema(new_dataset, schema)
+                    # Cast dataset to inferred types
+                    new_dataset = transform_dataset_with_schema(new_dataset, schema)
 
                 # Calculate metadata
                 new_dataset.compute_metadata()


### PR DESCRIPTION
## Summary
Fixes a minor indentation issue in the `run` method to ensure the dataset type inference logic is applied only to datasets uploaded via the Datasets tab and not to those created from notebooks.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change  
- [ ] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)
- `DashAI/back/job/dataset_job.py`:  
  Corrected the indentation in the `run` method so type inference is executed only for datasets uploaded from the Datasets tab.

---

## Testing
- Uploaded a dataset via the Datasets tab and verified type inference still runs.
- Created a dataset from a notebook and confirmed type inference is not triggered.
