### PR TITLE
Enable probability predictions by default for SVC

### DIFF
--- a/DashAI/back/models/scikit_learn/svc.py
+++ b/DashAI/back/models/scikit_learn/svc.py
@@ -119,21 +119,6 @@ class SVCSchema(BaseSchema):
         ),
         alias=MultilingualString(en="max iterations", es="max iteraciones"),
     )  # type: ignore
-    probability: schema_field(
-        bool_field(),
-        placeholder=True,
-        description=MultilingualString(
-            en=(
-                "The parameter 'probability' indicates whether or not "
-                "to predict with probabilities."
-            ),
-            es=(
-                "El parámetro 'probabilidad' indica si "
-                "se debe predecir o no con probabilidades."
-            ),
-        ),
-        alias=MultilingualString(en="probability", es="probabilidad"),
-    )  # type: ignore
     shrinking: schema_field(
         bool_field(),
         placeholder=True,
@@ -205,4 +190,5 @@ class SVC(TabularClassificationModel, SklearnLikeClassifier, _SVC):
     CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs):
+        kwargs["probability"] = True
         super().__init__(**kwargs)


### PR DESCRIPTION
## Summary
This pull request updates the Support Vector Classifier (SVC) implementation to always enable probability prediction by default. The configurable `probability` option has been removed to simplify the API, ensure consistent availability of probability outputs, and support metrics that require model-predicted probabilities for their calculation.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `DashAI/back/models/scikit_learn/svc.py`:
  - Removed the `probability` field from `SVCSchema` so it can no longer be user-configured.
  - Updated the `SVC` model initialization to always set `probability=True`, ensuring probability predictions are available for metric computation.

---

## Testing (optional)
- Confirm that metrics requiring probability outputs (e.g., ROC AUC, log loss) compute correctly.
- Ensure that removing the `probability` field from the schema does not break existing configurations.

