### PR TITLE
Include back images in executable builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,6 +113,7 @@ jobs:
               echo Found llama_cpp/lib — adding binaries
               pyinstaller -F -n DashAI-launcher-cpu --clean ^
                 --add-data "DashAI/front/build;DashAI/front/build" ^
+                --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
                 --add-data "%SITEPKG%\transformers;transformers" ^
                 --add-binary "%SITEPKG%\llama_cpp\lib\*;llama_cpp/lib" ^
                 --additional-hooks-dir=hooks DashAI/__main__.py
@@ -120,6 +121,7 @@ jobs:
               echo No llama_cpp/lib — building without binaries
               pyinstaller -F -n DashAI-launcher-cpu --clean ^
                 --add-data "DashAI/front/build;DashAI/front/build" ^
+                --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
                 --add-data "%SITEPKG%\transformers;transformers" ^
                 --additional-hooks-dir=hooks DashAI/__main__.py
           )
@@ -160,6 +162,7 @@ jobs:
             echo "Found llama_cpp/lib — adding binaries"
             pyinstaller -F -n DashAI-launcher-cpu-arm64 --clean \
               --add-data "DashAI/front/build:DashAI/front/build" \
+              --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
               --add-data "$SITEPKG/transformers:transformers" \
               --add-binary "$SITEPKG/llama_cpp/lib/*:llama_cpp/lib" \
               --additional-hooks-dir=hooks DashAI/__main__.py
@@ -167,6 +170,7 @@ jobs:
             echo "No llama_cpp/lib — building without binaries"
             pyinstaller -F -n DashAI-launcher-cpu-arm64 --clean \
               --add-data "DashAI/front/build:DashAI/front/build" \
+              --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
               --add-data "$SITEPKG/transformers:transformers" \
               --additional-hooks-dir=hooks DashAI/__main__.py
           fi
@@ -211,6 +215,7 @@ jobs:
             echo "Found llama_cpp/lib — adding binaries"
             pyinstaller -F -n DashAI-launcher-cpu-x86_64 --clean \
               --add-data "DashAI/front/build:DashAI/front/build" \
+              --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
               --add-data "$SITEPKG/transformers:transformers" \
               --add-binary "$SITEPKG/llama_cpp/lib/*:llama_cpp/lib" \
               --additional-hooks-dir=hooks DashAI/__main__.py
@@ -218,6 +223,7 @@ jobs:
             echo "No llama_cpp/lib — building without binaries"
             pyinstaller -F -n DashAI-launcher-cpu-x86_64 --clean \
               --add-data "DashAI/front/build:DashAI/front/build" \
+              --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
               --add-data "$SITEPKG/transformers:transformers" \
               --additional-hooks-dir=hooks DashAI/__main__.py
           fi


### PR DESCRIPTION
## Summary
Fixes missing static image assets in the packaged application by updating the PyInstaller build configuration to include required image directories across all supported platforms.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [x] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `.github/workflows/publish.yml`: Added `DashAI/back/static/images` to the PyInstaller data files for Windows, ARM64, and x86_64 builds to ensure static images are bundled with the executable.

---

## Testing (optional)
- Verify that the built application can access and render static images at runtime on supported platforms.
