### PR TITLE
Add additional data files for PyInstaller builds (LR and scaler)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,6 +114,8 @@ jobs:
               pyinstaller -F -n DashAI-launcher-cpu --clean ^
                 --add-data "DashAI/front/build;DashAI/front/build" ^
                 --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
+                --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
+                --add-data "DashAI/back/types/inf/ptype/scaler.pkl;DashAI/back/types/inf/ptype" ^
                 --add-data "%SITEPKG%\transformers;transformers" ^
                 --add-binary "%SITEPKG%\llama_cpp\lib\*;llama_cpp/lib" ^
                 --additional-hooks-dir=hooks DashAI/__main__.py
@@ -122,6 +124,8 @@ jobs:
               pyinstaller -F -n DashAI-launcher-cpu --clean ^
                 --add-data "DashAI/front/build;DashAI/front/build" ^
                 --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
+                --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
+                --add-data "DashAI/back/types/inf/ptype/scaler.pkl;DashAI/back/types/inf/ptype" ^
                 --add-data "%SITEPKG%\transformers;transformers" ^
                 --additional-hooks-dir=hooks DashAI/__main__.py
           )
@@ -163,6 +167,8 @@ jobs:
             pyinstaller -F -n DashAI-launcher-cpu-arm64 --clean \
               --add-data "DashAI/front/build:DashAI/front/build" \
               --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
+              --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
+              --add-data "DashAI/back/types/inf/ptype/scaler.pkl;DashAI/back/types/inf/ptype" ^
               --add-data "$SITEPKG/transformers:transformers" \
               --add-binary "$SITEPKG/llama_cpp/lib/*:llama_cpp/lib" \
               --additional-hooks-dir=hooks DashAI/__main__.py
@@ -171,6 +177,8 @@ jobs:
             pyinstaller -F -n DashAI-launcher-cpu-arm64 --clean \
               --add-data "DashAI/front/build:DashAI/front/build" \
               --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
+              --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
+              --add-data "DashAI/back/types/inf/ptype/scaler.pkl;DashAI/back/types/inf/ptype" ^
               --add-data "$SITEPKG/transformers:transformers" \
               --additional-hooks-dir=hooks DashAI/__main__.py
           fi
@@ -216,6 +224,8 @@ jobs:
             pyinstaller -F -n DashAI-launcher-cpu-x86_64 --clean \
               --add-data "DashAI/front/build:DashAI/front/build" \
               --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
+              --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
+              --add-data "DashAI/back/types/inf/ptype/scaler.pkl;DashAI/back/types/inf/ptype" ^
               --add-data "$SITEPKG/transformers:transformers" \
               --add-binary "$SITEPKG/llama_cpp/lib/*:llama_cpp/lib" \
               --additional-hooks-dir=hooks DashAI/__main__.py
@@ -224,6 +234,8 @@ jobs:
             pyinstaller -F -n DashAI-launcher-cpu-x86_64 --clean \
               --add-data "DashAI/front/build:DashAI/front/build" \
               --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
+              --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
+              --add-data "DashAI/back/types/inf/ptype/scaler.pkl;DashAI/back/types/inf/ptype" ^
               --add-data "$SITEPKG/transformers:transformers" \
               --additional-hooks-dir=hooks DashAI/__main__.py
           fi


### PR DESCRIPTION
## Summary
This pull request updates the PyInstaller packaging steps in the GitHub Actions workflow to ensure that required inference artifacts (`LR.sav` and `scaler.pkl`) are included in all packaged builds. This prevents runtime errors caused by missing model or scaler files in distributed executables.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [x] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `.github/workflows/publish.yml`: Updated PyInstaller `--add-data` arguments to include `DashAI/back/types/inf/ptype/LR.sav` and `DashAI/back/types/inf/ptype/scaler.pkl` for Windows, ARM64, and x86_64 build targets.

---

## Testing (optional)
- Verified that packaged executables include the model and scaler files and no longer fail at runtime due to missing inference assets (during dataset upload)
