### PR TITLE
fix reset step state when selecting dataset or notebook

### DIFF
--- a/DashAI/front/src/pages/datasets/DatasetsContent.jsx
+++ b/DashAI/front/src/pages/datasets/DatasetsContent.jsx
@@ -146,6 +146,7 @@ export default function DatasetsContent() {
     setSelectedDatasetId(datasetId);
     setSelectedNotebookId(null);
     setSelectedOption("dataset");
+    setStep(0);
     setRightBarContent(null);
   };
 
@@ -153,6 +154,7 @@ export default function DatasetsContent() {
     setSelectedNotebookId(notebookId);
     setSelectedDatasetId(null);
     setSelectedOption("notebook");
+    setStep(0);
   };
 
   const handleDatasetDelete = (id) => {


### PR DESCRIPTION
This pull request makes a small update to the dataset and notebook selection logic in the `DatasetsContent` component. Now, when a user selects a dataset or a notebook, the current step is reset to 0, ensuring the UI starts from the initial step for each new selection.

- User experience improvements:
  * Reset the `step` state to 0 when a dataset or notebook is selected, so the interface always starts from the beginning for each new selection.