### PR TITLE
Remove unused code for converters directory path validation

### DIFF
--- a/DashAI/back/job/converter_job.py
+++ b/DashAI/back/job/converter_job.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 from typing import List
 
 from kink import inject
@@ -258,18 +257,6 @@ class ConverterListJob(BaseJob):
                 raise JobError(f"Cannot load dataset from {dataset_path}") from e
 
             try:
-                # Get the absolute path to the converters directory
-                current_file = Path(__file__)
-                project_root = (
-                    current_file.parent.parent.parent
-                )  # Go up three levels to reach project root
-                converters_base_path = project_root / "back" / "converters"
-
-                if not converters_base_path.exists():
-                    raise JobError(
-                        f"Converters directory not found at {converters_base_path}"
-                    )
-
                 # Get stored converter configurations
                 converters_stored_info = {
                     converter_list.converter: converter_list.parameters


### PR DESCRIPTION
## Summary
Removes redundant absolute path calculations and existence checks, the setup process is more streamlined and less prone to path-related failures (executable).

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `DashAI/back/job/converter_job.py`: Removed the logic for calculating and validating the converters directory path in instantiate_converters, reducing complexity and potential points of failure.

---

## Testing (optional)
- Verify that the converters are still correctly instantiated and that the removal of the explicit path check does not interfere with the job execution environment.
- Verify that converters are working properly in the executable version of the app.
