### PR TITLE
Add missing parameters in OpusMtEnESTransformer's load method

### DIFF
--- a/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
@@ -407,6 +407,10 @@ class OpusMtEnESTransformer(TranslationModel):
             learning_rate=custom_params.get("learning_rate"),
             device=custom_params.get("device"),
             weight_decay=custom_params.get("weight_decay"),
+            log_train_every_n_epochs=None,
+            log_train_every_n_steps=None,
+            log_validation_every_n_epochs=None,
+            log_validation_every_n_steps=None,
         )
         loaded_model.fitted = custom_params.get("fitted", False)
 


### PR DESCRIPTION
## Summary
This pull request fixes an issue where loading the model for prediction failed due to schema validation errors. The fix ensures that logging-related parameters defined in the schema are properly handled during model loading, preventing errors when the model is loaded outside of a training context.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Bug fix
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Documentation

---

## Changes (by file)
- `opus_mt_en_es_transformer.py`: Updated the `load` method to accept and correctly validate logging configuration parameters (`log_train_every_n_epochs`, `log_train_every_n_steps`, `log_validation_every_n_epochs`, `log_validation_every_n_steps`) defined in the schema, avoiding validation errors when loading the model for prediction.

---

## Testing (optional)
- Verify that training behavior remains unchanged.
- Confirm that schema validation no longer raises errors for logging-related parameters.
- Verify tha the prediction is working properly with the trained model.
