### PR TITLE
Pin transformers version to 4.50.0 in requirements files

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -41,7 +41,7 @@ torch --index-url https://download.pytorch.org/whl/cpu
 torchvision --index-url https://download.pytorch.org/whl/cpu
 
 # Transformers ecosystem
-transformers<5.0.0
+transformers==4.50.0
 sacrebleu
 sentencepiece
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ typer
 rich
 torch
 torchvision
-transformers<5.0.0
+transformers==4.50.0
 sacrebleu
 sentencepiece
 optuna


### PR DESCRIPTION
## Summary
This pull request updates the requirements to pin the `transformers` library to version `4.50.0`.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `requirements-cpu.txt`, `requirements.txt`:  
  - Pinned `transformers` to version `4.50.0` to avoid incompatibilities.  

---

## Testing (optional)
- Verified that the `opus_mt` transformer works correctly.

---

## Notes (optional)
See upstream discussion for details: 
https://github.com/huggingface/transformers/issues/38464
