### PR TITLE
Specify version constraints for pip tools and setuptools in requirements

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
 
       - name: Upgrade pip tools
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade "pip<24" "setuptools<82" "wheel<0.45"
       - run: python -m pip install --upgrade --upgrade-strategy eager -r requirements.txt
       - run: python -m pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ torchvision
 transformers<5.0.0
 sacrebleu
 sentencepiece
+setuptools<82
 optuna
 hyperopt
 openpyxl


### PR DESCRIPTION
## Summary  
This pull request updates the CI workflow to improve build stability and reproducibility.

Tests were failing with the following error:

`ERROR tests/back - ModuleNotFoundError: No module named 'pkg_resources'`

The issue is caused by `setuptools` version 82, which removed `pkg_resources` from its dependencies. Since parts of our environment (and pip itself during dependency resolution) still rely on `pkg_resources`, newer versions of `setuptools` break the build.

To prevent this, the workflow now installs constrained versions of packaging tools:
- `pip<24`
- `setuptools<82`
- `wheel<0.45`

This ensures compatibility and avoids unexpected breakages caused by upstream changes.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [ ] Frontend change  
- [x] CI / Workflow change  
- [x] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  

- `.github/workflows/build-test.yaml`: Updated the **Upgrade pip tools** step to install `pip<24`, `setuptools<82`, and `wheel<0.45` to ensure consistent and stable builds.

---

## Testing (optional)  

CI should now pass without the `pkg_resources` ImportError.  