### PR TITLE
Add Windows installer build to CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
           echo SITEPKG=%SITEPKG%
           if exist "%SITEPKG%\llama_cpp\lib" (
               echo Found llama_cpp/lib — adding binaries
-              pyinstaller -F -n DashAI-launcher-cpu --clean ^
+              pyinstaller -D -n DashAI-launcher-cpu --clean --noconfirm ^
                 --add-data "DashAI/front/build;DashAI/front/build" ^
                 --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
                 --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
@@ -122,7 +122,7 @@ jobs:
                 --additional-hooks-dir=hooks DashAI/__main__.py
           ) else (
               echo No llama_cpp/lib — building without binaries
-              pyinstaller -F -n DashAI-launcher-cpu --clean ^
+              pyinstaller -D -n DashAI-launcher-cpu --clean --noconfirm  ^
                 --add-data "DashAI/front/build;DashAI/front/build" ^
                 --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
                 --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
@@ -131,11 +131,19 @@ jobs:
                 --add-data "DashAI/alembic;DashAI/alembic" ^
                 --additional-hooks-dir=hooks DashAI/__main__.py
           )
-      - name: Upload Windows executable
+
+      - name: Install Inno Setup
+        run: choco install innosetup -y
+
+      - name: Build Windows Installer
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer/installer.iss
+      - name: Upload Windows Installer
         uses: actions/upload-artifact@v4
         with:
-          name: DashAI-windows-cpu
-          path: dist/DashAI-launcher-cpu.exe
+          name: DashAI-windows-installer
+          path: installer/DashAI-Installer.exe
           retention-days: 1
 
   # ============================================================


### PR DESCRIPTION
## Summary  
This pull request updates the Windows release pipeline in `.github/workflows/publish.yml`.

The build process was changed from a single file PyInstaller executable to a directory based build. Additionally, automated installer generation was introduced using Inno Setup, allowing the workflow to produce a proper Windows installer instead of distributing a raw executable.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [ ] Frontend change  
- [x] CI / Workflow change  
- [x] Build / Packaging change  
- [ ] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  

- `.github/workflows/publish.yml`:  
  - Switched PyInstaller from single-file mode (`-F`) to directory mode (`-D`).  
  - Added step to install Inno Setup via Chocolatey.  
  - Added step to build Windows installer using `installer/installer.iss`.  
  - Updated uploaded artifact to `installer/DashAI-Installer.exe` instead of the raw executable.

---

## Testing (optional)  

- Verify the GitHub Actions workflow completes successfully on Windows.  
- Download the generated installer artifact and confirm:
  - The installer runs correctly.  
  - The application installs and launches without missing dependencies.  
  - No runtime issues occur due to the switch from `-F` to `-D`.