### PR TITLE
Fix DataCloneError in ExplorerDetailsModal by removing unnecessary structuredClone

### DIFF
--- a/DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx
@@ -38,7 +38,7 @@ export default function ExplorerDetailsModal({
   if (!explorer) return null;
   if (!data) return null;
   const [currentTab, setCurrentTab] = useState(3);
-  const [localData, setLocalData] = useState(structuredClone(data));
+  const [localData, setLocalData] = useState(data);
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation(["datasets", "common"]);
 


### PR DESCRIPTION
## Summary  
Fixes a `DataCloneError` thrown when opening `ExplorerDetailsModal` by removing the use of `structuredClone` during state initialization.  

The modal was attempting to deep-clone the incoming `data` prop, which can contain non-cloneable objects (e.g., Plotly-related structures). Since React state updates are already handled immutably, the deep clone was unnecessary and caused runtime crashes.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  

- `ExplorerDetailsModal.jsx`:  
  - Removed `structuredClone(data)` from `useState` initialization.  
  - Initialized local state directly with `data` to prevent `DataCloneError`.  

---

## Testing (optional)  

- Opened Explorer Details modal with:
  - Correlation matrix data  
  - `plotly_json` data type  
- Confirmed modal renders correctly without runtime errors.  
- Verified layout updates and save functionality still work as expected.