### PR TITLE
Use theme palette for ToolGrid colors

### DIFF
--- a/DashAI/front/src/components/notebooks/converter/ConverterBox.jsx
+++ b/DashAI/front/src/components/notebooks/converter/ConverterBox.jsx
@@ -123,7 +123,7 @@ export default function ConverterBox({
                   "&:hover": { bgcolor: "error.dark" },
                 }}
               >
-                <Delete sx={{ fontSize: 16 }} />
+                <Delete sx={{ fontSize: 16, color: "white" }} />
               </IconButton>
             )}
           </Box>

--- a/DashAI/front/src/components/notebooks/explorer/ExplorerBox.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/ExplorerBox.jsx
@@ -152,7 +152,7 @@ export default function ExplorerBox({
                     "&:hover": { bgcolor: "error.dark" },
                   }}
                 >
-                  <Delete sx={{ fontSize: 16 }} />
+                  <Delete sx={{ fontSize: 16, color: "white" }} />
                 </IconButton>
               )}
             </>

--- a/DashAI/front/src/components/notebooks/explorer/ExplorerBox.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/ExplorerBox.jsx
@@ -131,7 +131,8 @@ export default function ExplorerBox({
                   }
                   onClick={() => handleExplorerDetailsClick(explorer)}
                   size="small"
-                  icon={<Info sx={{ color: "white !important" }} />}
+                  color="primary"
+                  icon={<Info />}
                   sx={{
                     bgcolor: "primary.main",
                     "&:hover": {

--- a/DashAI/front/src/components/notebooks/tool/ToolGrid.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolGrid.jsx
@@ -5,12 +5,14 @@ import ConfigureToolModal from "./ConfigureToolModal";
 import { useTourContext } from "../../tour/TourProvider";
 import { groupByCategory, sortCategories } from "./toolCategories";
 import { useTranslation } from "react-i18next";
+import { useTheme } from "@mui/material/styles";
 
 export default function ToolGrid({ tools, notebook, FormComponent }) {
   const [open, setOpen] = useState(false);
   const [selectedTool, setSelectedTool] = useState(null);
   const tourContext = useTourContext();
   const { t } = useTranslation(["datasets", "common"]);
+  const theme = useTheme();
 
   const grouped = useMemo(() => groupByCategory(tools), [tools]);
   const categories = useMemo(
@@ -62,10 +64,14 @@ export default function ToolGrid({ tools, notebook, FormComponent }) {
                 gap: 1,
                 mb: 1.5,
                 pb: 0.5,
-                borderBottom: "1px solid rgb(39, 39, 42)",
+                borderBottom: "1px solid",
+                borderColor: theme.palette.divider,
               }}
             >
-              <Typography variant="subtitle2" sx={{ flex: 1 }}>
+              <Typography
+                variant="subtitle2"
+                sx={{ flex: 1, color: "text.primary" }}
+              >
                 {cat}
               </Typography>
               <Typography variant="caption" sx={{ color: "text.secondary" }}>


### PR DESCRIPTION
## Summary
This pull request updates the `ToolGrid` component to use the application's theme palette instead of hardcoded color values. Specifically, divider and text colors now reference the theme configuration.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `ToolGrid.jsx`: Replaced hardcoded divider and text colors with values from the theme palette.

---

## Testing (optional)
- Verify that divider and text colors in `ToolGrid` match the current theme.
- Confirm appearance remains correct in both light and dark modes.