### PR TITLE
Update search functionality to use display_name instead of name

### DIFF
--- a/DashAI/front/src/components/custom/ItemSelector.jsx
+++ b/DashAI/front/src/components/custom/ItemSelector.jsx
@@ -47,7 +47,7 @@ function ItemSelector({ itemsList, selectedItem, setSelectedItem, disabled }) {
     setSearchField(event.target.value.toLowerCase());
     setItemsToShow(
       itemsList.map((val) =>
-        val.name.toLowerCase().includes(event.target.value),
+        val.display_name.toLowerCase().includes(event.target.value),
       ),
     );
   };


### PR DESCRIPTION
## Summary
This pull request updates the filtering logic in the `ItemSelector` component to use the `display_name` property instead of `name` when searching through items. This ensures that the search results align with what is actually shown to the user.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `ItemSelector.jsx`: Updated search/filter logic to use `display_name` instead of `name`.

---

## Testing (optional)
- Verify that searching in `ItemSelector` returns results based on the displayed item names.