### PR TITLE
Reset right bar content on dataset and notebook selection

### DIFF
--- a/DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx
+++ b/DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx
@@ -31,6 +31,7 @@ export default function DatasetsNotebooksLeftBar({ onToggle }) {
     editDataset,
     editNotebook,
     deleteNotebookById,
+    setRightBarContent,
   } = useDatasetsAndNotebooks();
 
   const [filteredDatasets, setFilteredDatasets] = useState(datasets);
@@ -91,6 +92,7 @@ export default function DatasetsNotebooksLeftBar({ onToggle }) {
     clearSelectedNotebook();
     setStep(0);
     setSelectedOption("dataset");
+    setRightBarContent(null);
   };
 
   const onNotebookClick = (id) => {
@@ -98,6 +100,7 @@ export default function DatasetsNotebooksLeftBar({ onToggle }) {
     clearSelectedDataset();
     setStep(0);
     setSelectedOption("notebook");
+    setRightBarContent(null);
   };
 
   const onDatasetDelete = async (id) => {


### PR DESCRIPTION
## Summary
This pull request improves UI state management in the `DatasetNotebookLeftBar` component. When a user selects a different dataset or notebook, the right sidebar content is now cleared to prevent stale or irrelevant information from being displayed.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx`:  
  - Added calls to `setRightBarContent(null)` in dataset and notebook selection handlers to clear the right sidebar when a new item is selected.  
  - Included `setRightBarContent` from the `useDatasetsAndNotebooks` hook to enable updating the sidebar state.

---

## Testing (optional)
- Select different datasets and notebooks and verify that the right sidebar content is cleared when dataloader configuration was being displayed.
- Confirm no unintended side effects in other sidebar interactions.