### PR TITLE
refactor: Update explainers plots

### DIFF
--- a/DashAI/front/src/components/explainers/ExplainersGrid.jsx
+++ b/DashAI/front/src/components/explainers/ExplainersGrid.jsx
@@ -63,7 +63,7 @@ export default function ExplainersGrid(explainerConfig) {
       overflow={"auto"}
       rowGap={5}
       justifyContent="center"
-      alignItems="center"
+      alignItems="stretch"
     >
       {getFilteredExplainers(explainers).map((explainer, i) => (
         <ExplainersCard explainer={explainer} key={i} scope={scope} />

--- a/DashAI/front/src/components/explainers/ExplainersPlot.jsx
+++ b/DashAI/front/src/components/explainers/ExplainersPlot.jsx
@@ -1,4 +1,4 @@
-import { React, useEffect, useState } from "react";
+import { React, useEffect, useMemo, useState } from "react";
 import {
   FormControl,
   InputLabel,
@@ -7,6 +7,7 @@ import {
   CircularProgress,
   Box,
 } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import Plot from "react-plotly.js";
 import PropTypes from "prop-types";
 import { useSnackbar } from "notistack";
@@ -14,13 +15,95 @@ import { useSnackbar } from "notistack";
 import { getExplainerPlot as getExplainerPlotRequest } from "../../api/explainer";
 import { useTranslation } from "react-i18next";
 
+function applyThemeToLayout(baseLayout, theme) {
+  const bg = theme.palette.background.paper;
+  const textColor = theme.palette.text.primary;
+  const gridColor = theme.palette.divider;
+
+  // Strip backend-provided fixed dimensions so our responsive sizing takes over
+  // eslint-disable-next-line no-unused-vars
+  const { width: _w, height: _h, ...rest } = baseLayout ?? {};
+
+  const axisOverride = {
+    gridcolor: gridColor,
+    zerolinecolor: gridColor,
+  };
+
+  return {
+    ...rest,
+    paper_bgcolor: bg,
+    plot_bgcolor: bg,
+    font: {
+      ...baseLayout?.font,
+      color: textColor,
+      family: "Quicksand-Bold, sans-serif",
+    },
+    xaxis: {
+      ...baseLayout?.xaxis,
+      ...axisOverride,
+      tickfont: { ...baseLayout?.xaxis?.tickfont, color: textColor },
+    },
+    yaxis: {
+      ...baseLayout?.yaxis,
+      ...axisOverride,
+      tickfont: { ...baseLayout?.yaxis?.tickfont, color: textColor },
+    },
+    legend: {
+      ...baseLayout?.legend,
+      bgcolor: bg,
+      bordercolor: gridColor,
+    },
+    title: {
+      ...baseLayout?.title,
+      font: { ...baseLayout?.title?.font, color: textColor },
+    },
+    ...(baseLayout?.updatemenus && {
+      updatemenus: baseLayout.updatemenus.map((menu) => ({
+        ...menu,
+        bgcolor:
+          theme.palette.ui?.borderLight ?? theme.palette.background.paper,
+        bordercolor: gridColor,
+        font: { color: "#000000" },
+        activecolor: theme.palette.primary.main,
+      })),
+    }),
+    ...(baseLayout?.polar && {
+      polar: {
+        ...baseLayout.polar,
+        bgcolor: bg,
+        radialaxis: {
+          ...baseLayout.polar.radialaxis,
+          gridcolor: gridColor,
+          linecolor: gridColor,
+          tickfont: {
+            ...baseLayout.polar.radialaxis?.tickfont,
+            color: textColor,
+          },
+        },
+        angularaxis: {
+          ...baseLayout.polar.angularaxis,
+          color: textColor,
+          gridcolor: gridColor,
+          linecolor: gridColor,
+        },
+      },
+    }),
+  };
+}
+
 export default function ExplainersPlot({ explainer, scope }) {
   const { enqueueSnackbar } = useSnackbar();
+  const theme = useTheme();
   const [explainersPlots, setExplainersPlots] = useState([]);
   const [currentPlot, setCurrentPlot] = useState(0);
   const [loading, setLoading] = useState(true);
   const isLocal = scope === "local";
   const { t } = useTranslation(["explainers"]);
+
+  const themedLayout = useMemo(() => {
+    if (!explainersPlots[currentPlot]) return {};
+    return applyThemeToLayout(explainersPlots[currentPlot].layout, theme);
+  }, [explainersPlots, currentPlot, theme]);
   function parseExplanationPlot(explanation) {
     const formattedPlot = JSON.parse(JSON.stringify(explanation));
     return formattedPlot.map(JSON.parse);
@@ -62,7 +145,7 @@ export default function ExplainersPlot({ explainer, scope }) {
       sx={{
         display: "flex",
         flexDirection: "column",
-        alignItems: "flex-start",
+        width: "100%",
       }}
     >
       {!loading && isLocal && (
@@ -87,11 +170,11 @@ export default function ExplainersPlot({ explainer, scope }) {
         <Plot
           data={explainersPlots[currentPlot].data}
           layout={{
-            ...explainersPlots[currentPlot].layout,
-            width: 730,
+            ...themedLayout,
+            width: 700,
             height: 380,
           }}
-          config={{ staticPlot: false }}
+          config={{ responsive: false, displayModeBar: false }}
         />
       ) : explainer.status === 4 ? (
         <Box sx={{ p: 2 }}>{t("explainers:error.explainerFailed")}</Box>

--- a/DashAI/front/src/components/explainers/ExplanainersCard.jsx
+++ b/DashAI/front/src/components/explainers/ExplanainersCard.jsx
@@ -133,7 +133,7 @@ export default function ExplainersCard({
             </Grid>
 
             {/* Expandable plot section */}
-            <Grid item>
+            <Grid item sx={{ width: "100%" }}>
               <Button
                 size="small"
                 onClick={() => setExpanded(!expanded)}
@@ -181,8 +181,8 @@ export default function ExplainersCard({
 
   // Full mode for standalone page
   return (
-    <Paper elevation={3}>
-      <Grid container item sx={{ width: 800 }} p={4} gap={2}>
+    <Paper elevation={3} sx={{ width: "100%" }}>
+      <Grid container item p={4} gap={2}>
         <Grid
           item
           container


### PR DESCRIPTION

This pull request introduces several improvements to the DashAI explainers UI, focusing on better theming support for plots, improved layout responsiveness, and enhanced visual consistency. The most significant changes are the addition of theme-aware styling for Plotly plots, updates to grid alignment and sizing, and minor UI tweaks to ensure components stretch and fill available space.

**Theming and Plot Improvements:**
- Added a new `applyThemeToLayout` function in `ExplainersPlot.jsx` to dynamically apply MUI theme colors and fonts to Plotly plot layouts, ensuring visual consistency with the rest of the app. This includes background, text, grid, axis, and legend theming, as well as handling polar plots and update menus. (`DashAI/front/src/components/explainers/ExplainersPlot.jsx`)
- Integrated the new theming logic using `useTheme` and `useMemo`, and updated the plot rendering to use the themed layout. Also adjusted Plotly config for a cleaner look by disabling mode bar and responsiveness. (`DashAI/front/src/components/explainers/ExplainersPlot.jsx`) [[1]](diffhunk://#diff-421a9f3ec3674aa6d0e542e1677c9c7acaef1131c5d3ac1bdcbd9c5128b83b23R10-R106) [[2]](diffhunk://#diff-421a9f3ec3674aa6d0e542e1677c9c7acaef1131c5d3ac1bdcbd9c5128b83b23L90-R177)

**Layout and Responsiveness:**
- Changed the alignment of the explainers grid from `center` to `stretch` to allow cards to expand and fill the available vertical space. (`DashAI/front/src/components/explainers/ExplainersGrid.jsx`)
- Updated the `ExplainersCard` and its plot section to use `width: "100%"`, making cards and plots more responsive and better fitting their containers. (`DashAI/front/src/components/explainers/ExplanainersCard.jsx`) [[1]](diffhunk://#diff-0bb088a3135f6f90519143bbb02d6945586d1c71f307ef7f5e0d5d0ce0c523d6L136-R136) [[2]](diffhunk://#diff-0bb088a3135f6f90519143bbb02d6945586d1c71f307ef7f5e0d5d0ce0c523d6L184-R185)
- Adjusted the plot container in `ExplainersPlot` to use `width: "100%"` instead of `alignItems: "flex-start"`, further improving layout flexibility. (`DashAI/front/src/components/explainers/ExplainersPlot.jsx`)






<img width="1286" height="828" alt="image" src="https://github.com/user-attachments/assets/ffdee6c2-7ccc-42b8-988d-56342e3b191a" />

There is a problem with dropdown of plotly: https://github.com/plotly/plotly.py/issues/3120
So now it have a ugly color. 
<img width="1194" height="780" alt="image" src="https://github.com/user-attachments/assets/19c67f6a-7a5e-468f-b925-0e9ce9f424b1" />
