### PR TITLE
Fix live metrics change view and splits plots

### DIFF
--- a/DashAI/front/src/components/models/LiveMetricsChart.jsx
+++ b/DashAI/front/src/components/models/LiveMetricsChart.jsx
@@ -19,7 +19,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from "recharts";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { getModelSessionById } from "../../api/modelSession";
 
 export function LiveMetricsChart({ run }) {
@@ -72,11 +72,9 @@ export function LiveMetricsChart({ run }) {
       socketRef.current.close();
     }
 
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const host = window.location.host;
-    const ws = new WebSocket(
-      `${protocol}//${host}/api/v1/metrics/ws/${run.id}`,
-    );
+    const apiUrl = process.env.REACT_APP_API_URL || "";
+    const wsBase = apiUrl.replace(/^http/, "ws");
+    const ws = new WebSocket(`${wsBase}/v1/metrics/ws/${run.id}`);
 
     ws.onmessage = (event) => {
       const incoming = JSON.parse(event.data);
@@ -169,20 +167,20 @@ export function LiveMetricsChart({ run }) {
     };
   }, [run.model_session_id]);
 
-  const metrics = data[split]?.[level] ?? {};
-  const allowed = availableMetrics[split] ?? [];
+  const filteredMetrics = useMemo(() => {
+    const m = data[split]?.[level] ?? {};
+    const a = availableMetrics[split] ?? [];
+    return Object.fromEntries(
+      Object.entries(m).filter(([name]) => a.includes(name)),
+    );
+  }, [data, split, level, availableMetrics]);
 
-  const filteredMetrics = Object.fromEntries(
-    Object.entries(metrics).filter(([name]) => allowed.includes(name)),
-  );
-
-  const chartData = (() => {
+  const chartData = useMemo(() => {
     if (Object.keys(filteredMetrics).length === 0) return [];
 
     const allSteps = new Set();
     for (const metricName in filteredMetrics) {
       const metricData = filteredMetrics[metricName];
-
       if (Array.isArray(metricData)) {
         metricData.forEach((point) => {
           allSteps.add(point.step);
@@ -194,10 +192,8 @@ export function LiveMetricsChart({ run }) {
 
     return sortedSteps.map((step) => {
       const point = { x: step };
-
       for (const metricName in filteredMetrics) {
         const metricData = filteredMetrics[metricName];
-
         if (Array.isArray(metricData)) {
           const dataPoint = metricData.find((p) => p.step === step);
           point[metricName] = dataPoint?.value ?? null;
@@ -205,10 +201,9 @@ export function LiveMetricsChart({ run }) {
           point[metricName] = null;
         }
       }
-
       return point;
     });
-  })();
+  }, [filteredMetrics]);
 
   const hasTrialData =
     data[split]?.TRIAL && Object.keys(data[split].TRIAL).length > 0;

--- a/DashAI/front/src/components/models/LiveMetricsChart.jsx
+++ b/DashAI/front/src/components/models/LiveMetricsChart.jsx
@@ -72,9 +72,21 @@ export function LiveMetricsChart({ run }) {
       socketRef.current.close();
     }
 
-    const apiUrl = process.env.REACT_APP_API_URL || "";
-    const wsBase = apiUrl.replace(/^http/, "ws");
-    const ws = new WebSocket(`${wsBase}/v1/metrics/ws/${run.id}`);
+    const apiUrl =
+      process.env.REACT_APP_API_URL || `${window.location.origin}/api`;
+    let wsUrl;
+    try {
+      wsUrl = new URL(`/v1/metrics/ws/${run.id}`, apiUrl);
+    } catch (e) {
+      console.error("Invalid WebSocket base URL:", apiUrl, e);
+      return;
+    }
+    if (wsUrl.protocol === "http:") {
+      wsUrl.protocol = "ws:";
+    } else if (wsUrl.protocol === "https:") {
+      wsUrl.protocol = "wss:";
+    }
+    const ws = new WebSocket(wsUrl.toString());
 
     ws.onmessage = (event) => {
       const incoming = JSON.parse(event.data);
@@ -168,10 +180,10 @@ export function LiveMetricsChart({ run }) {
   }, [run.model_session_id]);
 
   const filteredMetrics = useMemo(() => {
-    const m = data[split]?.[level] ?? {};
-    const a = availableMetrics[split] ?? [];
+    const metrics = data[split]?.[level] ?? {};
+    const allowedMetrics = availableMetrics[split] ?? [];
     return Object.fromEntries(
-      Object.entries(m).filter(([name]) => a.includes(name)),
+      Object.entries(metrics).filter(([name]) => allowedMetrics.includes(name)),
     );
   }, [data, split, level, availableMetrics]);
 


### PR DESCRIPTION
This pull request optimizes the `LiveMetricsChart` component by improving how metric data is filtered and prepared for charting, and by making the WebSocket connection more configurable. The main changes involve using `useMemo` for performance, and updating the WebSocket URL construction to support custom API endpoints.

**Performance improvements:**
* Refactored the filtering of metrics and the computation of chart data to use `useMemo`, ensuring these operations are only recalculated when their dependencies change, which improves rendering efficiency. [[1]](diffhunk://#diff-55e68aa5e7729f573ed6f230b88b7ce5958d2f21c32455777814b2d69e18efc4L22-R22) [[2]](diffhunk://#diff-55e68aa5e7729f573ed6f230b88b7ce5958d2f21c32455777814b2d69e18efc4L172-L185) [[3]](diffhunk://#diff-55e68aa5e7729f573ed6f230b88b7ce5958d2f21c32455777814b2d69e18efc4L197-R206)

**Configuration and maintainability:**
* Changed the WebSocket URL construction to use the `REACT_APP_API_URL` environment variable, allowing the frontend to connect to a custom backend endpoint instead of always using the current window location.



<img width="1614" height="938" alt="image" src="https://github.com/user-attachments/assets/1ae1a218-d608-4935-8c07-b6565c4081f9" />

