### PR TITLE
Add MacOS arm installer build to CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
       - production
 
 jobs:
-
   # ============================================================
   # 1. Frontend Build
   # ============================================================
@@ -22,8 +21,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
-          cache: 'yarn'
+          node-version: "18.x"
+          cache: "yarn"
           cache-dependency-path: DashAI/front/yarn.lock
       - name: Install and build
         run: |
@@ -58,7 +57,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install build tools
         run: |
@@ -168,41 +167,61 @@ jobs:
           pip install -r requirements-cpu.txt
           pip install pyinstaller
           pip install --force-reinstall llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
-      - name: Build ARM64 executable
+          brew install create-dmg
+
+      - name: Build ARM64 App Bundle
         run: |
           SITEPKG=$(python -c "import site; print(site.getsitepackages()[-1])")
           echo "SITEPKG=$SITEPKG"
           if [ -d "$SITEPKG/llama_cpp/lib" ]; then
             echo "Found llama_cpp/lib — adding binaries"
-            pyinstaller -F -n DashAI-launcher-cpu-arm64 --clean \
+            pyinstaller -D -n DashAI --windowed --clean \
+              --add-binary "$SITEPKG/llama_cpp/lib:llama_cpp/lib" \
+              --collect-submodules py4j \
+              --collect-data imblearn \
+              --add-data "DashAI/__main__.py:DashAI/__main__.py" \
+              --add-data "DashAI/alembic:DashAI/alembic" \
               --add-data "DashAI/front/build:DashAI/front/build" \
-              --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
-              --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
-              --add-data "DashAI/back/types/inf/ptype/scaler.pkl;DashAI/back/types/inf/ptype" ^
-              --add-data "$SITEPKG/transformers:transformers" \
-              --add-data "DashAI/alembic;DashAI/alembic" \
-              --add-binary "$SITEPKG/llama_cpp/lib/*:llama_cpp/lib" \
-              --additional-hooks-dir=hooks DashAI/__main__.py
+              --add-data "DashAI/back/types/inf/ptype/LR.sav:DashAI/back/types/inf/ptype" \
+              --add-data "DashAI/back/types/inf/ptype/scaler.pkl:DashAI/back/types/inf/ptype" \
+              --additional-hooks-dir=hooks \
+              DashAI/webview.py
           else
-            echo "No llama_cpp/lib — building without binaries"
-            pyinstaller -F -n DashAI-launcher-cpu-arm64 --clean \
+            pyinstaller -D -n DashAI --windowed --clean \
+              --collect-submodules py4j \
+              --collect-data imblearn \
+              --add-data "DashAI/__main__.py:DashAI/__main__.py" \
+              --add-data "DashAI/alembic:DashAI/alembic" \
               --add-data "DashAI/front/build:DashAI/front/build" \
-              --add-data "DashAI/back/static/images;DashAI/back/static/images" ^
-              --add-data "DashAI/back/types/inf/ptype/LR.sav;DashAI/back/types/inf/ptype" ^
-              --add-data "DashAI/back/types/inf/ptype/scaler.pkl;DashAI/back/types/inf/ptype" ^
-              --add-data "$SITEPKG/transformers:transformers" \
-              --add-data "DashAI/alembic;DashAI/alembic" \
-              --additional-hooks-dir=hooks DashAI/__main__.py
+              --add-data "DashAI/back/types/inf/ptype/LR.sav:DashAI/back/types/inf/ptype" \
+              --add-data "DashAI/back/types/inf/ptype/scaler.pkl:DashAI/back/types/inf/ptype" \
+              --additional-hooks-dir=hooks \
+              DashAI/webview.py
           fi
-      - name: Sign ARM64 binary (ad-hoc)
+
+      - name: Sign App Bundle (ad-hoc)
         run: |
-          chmod +x dist/DashAI-launcher-cpu-arm64
-          codesign --force --deep --sign - dist/DashAI-launcher-cpu-arm64
-      - name: Upload ARM64 executable
+          codesign --force --deep --sign - dist/DashAI.app
+
+      - name: Create DMG
+        run: |
+          rm -f DashAI-macos-arm64.dmg
+
+          create-dmg \
+            --volname "DashAI Installer" \
+            --window-pos 200 120 \
+            --window-size 800 400 \
+            --app-drop-link 600 185 \
+            --hide-extension "DashAI.app" \
+            --no-internet-enable \
+            "DashAI-macos-arm64.dmg" \
+            "dist/DashAI.app"
+
+      - name: Upload DMG Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: DashAI-macos-arm64
-          path: dist/DashAI-launcher-cpu-arm64
+          name: DashAI-dmg-arm64
+          path: DashAI-macos-arm64.dmg
           retention-days: 1
 
   # ============================================================

--- a/DashAI/__main__.py
+++ b/DashAI/__main__.py
@@ -15,14 +15,13 @@ import webbrowser
 from contextlib import suppress
 
 import typer
-import uvicorn
 from typing_extensions import Annotated
 
-from DashAI.back.app import create_app
 from DashAI.back.core.enums.logging_levels import LoggingLevel
 
 
 def open_browser() -> None:
+    _wait_for_backend_server(timeout=120)
     url = "http://localhost:8000/app/"
     webbrowser.open(url=url, new=0, autoraise=True)
 
@@ -47,6 +46,64 @@ def _start_huey_thread() -> threading.Thread:
     t = threading.Thread(target=consumer_main, daemon=True)
     t.start()
     return t
+
+
+def _start_backend_server(
+    local_path: pathlib.Path, logging_level: LoggingLevel
+) -> None:
+    import uvicorn
+
+    from DashAI.back.app import create_app
+
+    app = create_app(
+        local_path=local_path,
+        logging_level=logging_level.value,
+    )
+    logger = logging.getLogger(__name__)
+    logger.info("Starting Uvicorn server on http://127.0.0.1:8000")
+
+    uvicorn.run(
+        app=app,
+        host="127.0.0.1",
+        port=8000,
+    )
+
+
+def _wait_for_backend_server(host="127.0.0.1", port=8000, timeout=15):
+    """Wait for the backend server to start by attempting to connect to the specified
+    host and port."""
+    import socket
+    import time
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return True
+        except (OSError, ConnectionRefusedError):
+            time.sleep(0.5)
+    return False
+
+
+def _start_webview(local_path: pathlib.Path, logger: logging.Logger) -> None:
+    import webview
+
+    window = webview.create_window("DashAI", "http://127.0.0.1:8000", hidden=True)
+
+    def load_logic():
+        if _wait_for_backend_server(timeout=120):
+            logger.info("Backend server is up. Loading webview.")
+            window.load_url("http://127.0.0.1:8000/app/")
+            window.show()
+        else:
+            logger.error("Failed to connect to backend server. Timeout.")
+            window.destroy()
+
+    # create cache directory for webview (if doesn't exist)
+    cache_dir = local_path / "web_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    webview.start(load_logic, private_mode=False, storage_path=str(cache_dir))
 
 
 def main(
@@ -78,10 +135,20 @@ def main(
             is_flag=True,
         ),
     ] = False,
+    webview: Annotated[
+        bool,
+        typer.Option(
+            "--window-mode",
+            "-wm",
+            help="Run in windowed mode (using webview).",
+            is_flag=True,
+        ),
+    ] = False,
 ) -> None:
+    import threading
+
     logging.getLogger(name=__package__).setLevel(level=logging_level.value)
     logger = logging.getLogger(__name__)
-
     logger.info("Starting DashAI application.")
     huey_process = None
 
@@ -93,11 +160,12 @@ def main(
     logger.info("Starting Huey consumer.")
 
     if getattr(sys, "frozen", False):
-        # Ejecutable PyInstaller: usar hilo embebido (sin -m).
+        logger.info("Running inside PyInstaller bundle.")
         _start_huey_thread()
         logger.info("Started embedded Huey consumer (thread).")
     else:
-        # Desarrollo: proceso externo con python -m.
+        logger.info("Running in development mode.")
+
         huey_cmd = [
             sys.executable,
             "-m",
@@ -111,23 +179,30 @@ def main(
         huey_process = subprocess.Popen(huey_cmd, env=child_env)
         logger.info(f"Started external Huey consumer (PID: {huey_process.pid})")
 
-    if not no_browser:
-        logger.info("Opening browser.")
-        timer = threading.Timer(interval=1, function=open_browser)
-        timer.start()
-    else:
-        logger.info("Browser auto-open disabled (--no-browser/-nb).")
-
     try:
-        logger.info("Starting Uvicorn server application.")
-        uvicorn.run(
-            app=create_app(
-                local_path=resolved_local,
-                logging_level=logging_level.value,
-            ),
-            host="127.0.0.1",
-            port=8000,
-        )
+        if webview:
+            logger.info("Creating FastAPI application...")
+
+            t = threading.Thread(
+                target=_start_backend_server,
+                args=(resolved_local, logging_level),
+                daemon=True,
+            )
+            t.start()
+
+            _start_webview(local_path=resolved_local, logger=logger)
+        else:
+            if not no_browser:
+                logger.info("Opening browser.")
+                timer = threading.Timer(interval=1, function=open_browser)
+                timer.start()
+            else:
+                logger.info("Browser auto-open disabled (--no-browser/-nb).")
+
+            _start_backend_server(
+                local_path=resolved_local, logging_level=logging_level
+            )
+
     finally:
         if huey_process:
             logger.info(f"Terminating Huey consumer (PID: {huey_process.pid})")

--- a/DashAI/webview.py
+++ b/DashAI/webview.py
@@ -1,0 +1,6 @@
+import typer
+
+from DashAI.__main__ import main
+
+if __name__ == "__main__":
+    typer.run(lambda: main(webview=True))

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ greenery==3.2
 xlrd
 filetype
 torchmetrics
+pywebview


### PR DESCRIPTION
## Summary

This pull request updates the MacOS arm release pipeline `.github/workflows/publish.yml`

The build proccess was changed to add automated installer (dmg) generation.
Adds pywebview dependecy and webview run mode to be able to run as an isolated app. This is better than opening the app in the browser, because the backend is killed when closing the webview. In the 'normal' the only way of killing the backend process is searching for it and killing it by its ID.

Some changes were applied on the **main**.py file to add webview mode, but its all optional and retains the old logic.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [x] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/__main__.py`:
  - Adds pywebview to support webview mode.
  - Adds some auxiliary functions to separated logic.
  - Move `uvicorn` and `create_app` import to backend start method. This is because app wasnt launching.

- `DashAI/webview.py`:
  - Aux file to create the executable.

- `.github/workflows/publish.yml`:
  - Switched PyInstaller from single-file mode (-F) to directory mode (-D).
  - Add step to install create-dmg
  - Add step to build MacOS installer using create-dmg
  - Upload dmg file artifact instead of raw executable.

- `requirements.txt`:
  - adds pywebview dependency
--- 

## Testing (optional)

The commands were tested locally in a m4 processor.

- Verify the GitHub Actions workflow completes successfully on MacOS arm.
- Download and verify the dmg file.

