### PR TITLE
Update flag emoji for Spanish language

### DIFF
--- a/DashAI/front/src/components/LanguageSelector.jsx
+++ b/DashAI/front/src/components/LanguageSelector.jsx
@@ -31,7 +31,7 @@ export default function LanguageSelector() {
         >
           <MenuItem value="es">
             <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <span>🇪🇸</span>
+              <span>🇨🇱</span>
               <span>Español</span>
             </Box>
           </MenuItem>


### PR DESCRIPTION
## Summary
Updates the `LanguageSelector` component to display the Chilean flag (🇨🇱) instead of the Spanish flag (🇪🇸) for the Spanish language option.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `LanguageSelector.tsx`: Replaced the Spanish flag (🇪🇸) with the Chilean flag (🇨🇱) for the Spanish language option.

---

## Testing (optional)
Verify that the `LanguageSelector` correctly displays the Chilean flag for the Spanish language option in the UI.