### PR TITLE
Feat/improve modal resize ux

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -7,7 +7,7 @@ import {
   GridToolbarDensitySelector,
   useGridApiContext,
 } from "@mui/x-data-grid";
-import { Button, Menu, MenuItem, Typography } from "@mui/material";
+import { Box, Button, Menu, MenuItem, Typography } from "@mui/material";
 import { Download } from "@mui/icons-material";
 import { LinearProgress } from "@mui/material";
 import {
@@ -323,32 +323,34 @@ export default function DatasetTable({
   }, [filterModel]);
 
   return (
-    <DataGrid
-      ref={gridRef}
-      rows={rows}
-      columns={columns}
-      rowCount={rowCount}
-      loading={loading}
-      autoHeight={autoHeight}
-      disableRowSelectionOnClick
-      paginationMode="server"
-      filterMode="server"
-      paginationModel={paginationModel}
-      onPaginationModelChange={setPaginationModel}
-      pageSizeOptions={pageSizeOptions}
-      density={density}
-      filterModel={filterModel}
-      onFilterModelChange={handleFilterModelChange}
-      initialState={{
-        density: "compact",
-        pagination: { paginationModel: { pageSize: initialPageSize } },
-      }}
-      slots={{
-        toolbar: CustomToolbar,
-        loadingOverlay: LinearProgress,
-      }}
-      columnHeaderHeight={editableColumns ? 95 : 85}
-      {...props}
-    />
+    <Box>
+      <DataGrid
+        ref={gridRef}
+        rows={rows}
+        columns={columns}
+        rowCount={rowCount}
+        loading={loading}
+        autoHeight={autoHeight}
+        disableRowSelectionOnClick
+        paginationMode="server"
+        filterMode="server"
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
+        pageSizeOptions={pageSizeOptions}
+        density={density}
+        filterModel={filterModel}
+        onFilterModelChange={handleFilterModelChange}
+        initialState={{
+          density: "compact",
+          pagination: { paginationModel: { pageSize: initialPageSize } },
+        }}
+        slots={{
+          toolbar: CustomToolbar,
+          loadingOverlay: LinearProgress,
+        }}
+        columnHeaderHeight={editableColumns ? 95 : 85}
+        {...props}
+      />
+    </Box>
   );
 }

--- a/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
@@ -35,7 +35,7 @@ export default function ConfigureToolModal({
   const [activeTab, setActiveTab] = useState(0);
   const [step, setStep] = useState(0);
   const containerRef = useRef(null);
-  const [topHeight, setTopHeight] = useState(150);
+  const [topHeight, setTopHeight] = useState(100);
   const isResizingRef = useRef(false);
   const { t } = useTranslation(["datasets", "common"]);
 

--- a/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
@@ -9,9 +9,10 @@ import {
   Stepper,
   Step,
   StepLabel,
+  Tooltip,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import { Close } from "@mui/icons-material";
+import { Close, UnfoldMore } from "@mui/icons-material";
 import DatasetIcon from "@mui/icons-material/Dataset";
 
 import DatasetTable from "../dataset/DatasetTable";
@@ -34,7 +35,7 @@ export default function ConfigureToolModal({
   const [activeTab, setActiveTab] = useState(0);
   const [step, setStep] = useState(0);
   const containerRef = useRef(null);
-  const [topHeight, setTopHeight] = useState(100);
+  const [topHeight, setTopHeight] = useState(150);
   const isResizingRef = useRef(false);
   const { t } = useTranslation(["datasets", "common"]);
 
@@ -248,16 +249,37 @@ export default function ConfigureToolModal({
         </Box>
 
         {/* Divider for resizing */}
-        <Box
-          onMouseDown={handleMouseDown}
-          sx={{
-            height: "6px",
-            cursor: "row-resize",
-            backgroundColor: "divider",
-            "&:hover": { backgroundColor: theme.palette.ui.hover },
-            zIndex: 2,
-          }}
-        />
+        <Tooltip title={t("datasets:label.dragToResize")} placement="top" arrow>
+          <Box
+            onMouseDown={handleMouseDown}
+            sx={{
+              height: "16px",
+              cursor: "row-resize",
+              backgroundColor: "divider",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              position: "relative",
+              transition: "all 0.2s",
+              "&:hover": {
+                backgroundColor: theme.palette.primary.main,
+                "& .drag-icon": {
+                  color: "white",
+                },
+              },
+              zIndex: 2,
+            }}
+          >
+            <UnfoldMore
+              className="drag-icon"
+              sx={{
+                fontSize: 22,
+                color: "text.secondary",
+                transition: "color 0.2s",
+              }}
+            />
+          </Box>
+        </Tooltip>
 
         {/* Bottom section (form) */}
         <Box

--- a/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
@@ -52,7 +52,7 @@ export default function ConfigureToolModal({
     const offsetY = e.clientY - rect.top;
 
     // Limit min/max
-    const minHeight = 100;
+    const minHeight = 0;
     const maxHeight = rect.height - 150;
     const newHeight = Math.max(minHeight, Math.min(maxHeight, offsetY));
 
@@ -253,7 +253,7 @@ export default function ConfigureToolModal({
           <Box
             onMouseDown={handleMouseDown}
             sx={{
-              height: "16px",
+              height: "24px",
               cursor: "row-resize",
               backgroundColor: "divider",
               display: "flex",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -129,6 +129,7 @@
     "dimensionTitle": "Dimension Title",
     "distributionMetrics": "Distribution Metrics",
     "dragAndDropFileHere": "Drag and drop file here",
+    "dragToResize": "Drag to resize and view more content",
     "duplicatedRows": "Duplicated Rows",
     "editPlotLayout": "Edit Plot Layout",
     "endIndex": "End Index",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -131,6 +131,7 @@
     "dimensionTitle": "Título de Dimensión",
     "distributionMetrics": "Métricas de Distribución",
     "dragAndDropFileHere": "Arrastre y suelte el archivo aquí",
+    "dragToResize": "Arrastre para redimensionar y ver más contenido",
     "duplicatedRows": "Filas Duplicadas",
     "editPlotLayout": "Editar Diseño del Gráfico",
     "endIndex": "Índice Final",


### PR DESCRIPTION
## Summary
Improved the resize indicator in the ConfigureToolModal to make it more discoverable and intuitive for users. The top section (description + reference image) was previously visually hidden with no clear signal that it contained additional information. Added visual indicators including a tooltip, hover effects, and a clear drag icon to help users understand they can resize the content area.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx`: 
  - Added `UnfoldMore` icon to the resize divider for better visual indication
  - Implemented tooltip showing "Drag to resize and view more content"
  - Enhanced hover state with color transition (changes to primary color on hover)
  - Increased divider height from 6px to 24px for easier interaction
  - Adjusted initial `minHeight` to 0 for proper layout behavior

- `DashAI/front/src/utils/i18n/locales/en/datasets.json`: 
  - Added translation key `dragToResize`: "Drag to resize and view more content"

- `DashAI/front/src/utils/i18n/locales/es/datasets.json`: 
  - Added translation key `dragToResize`: "Arrastre para redimensionar y ver más contenido"

---

## Testing (optional)

1. Open any notebook and click on an Explorer or Converter tool
2. Verify the ConfigureToolModal opens with the resize divider visible
3. Hover over the divider and confirm:
   - Tooltip appears with resize instructions
   - Background changes to primary color 
   - Icon changes to white
4. Test dragging the divider to resize the top/bottom sections
5. Verify the interaction works smoothly in both tabs (Description and Dataset)

---

## Notes (optional)

This change addresses a UX issue where users were not aware that the description/dataset preview section could be expanded. The resize functionality existed but lacked proper affordance. The new visual indicators make the feature discoverable without taking up additional space when not in use.