### PR TITLE
Fix the sequential name from models

### DIFF
--- a/DashAI/front/src/components/models/ModelsRightBar.jsx
+++ b/DashAI/front/src/components/models/ModelsRightBar.jsx
@@ -31,6 +31,10 @@ export default function ModelsRightBar({ onToggle }) {
     selectedSession: session,
     onRunCreated,
     runs: existingRuns,
+    selectModel,
+    configOpen,
+    selectedModel,
+    closeConfig,
   } = useModels();
 
   const fetchModels = React.useCallback(async () => {
@@ -79,7 +83,6 @@ export default function ModelsRightBar({ onToggle }) {
   }, [searchQuery, models]);
 
   const tourContext = useTourContext();
-  const { selectModel, configOpen, selectedModel, closeConfig } = useModels();
 
   const handleModelClick = (model) => {
     if (!session) {

--- a/DashAI/front/src/components/models/ModelsRightBar.jsx
+++ b/DashAI/front/src/components/models/ModelsRightBar.jsx
@@ -18,7 +18,7 @@ import { useTourContext } from "../tour/TourProvider";
 import { useModels } from "./ModelsContext";
 import AddModelDialog from "./AddModelDialog";
 
-export default function ModelsRightBar({ existingRuns, onToggle }) {
+export default function ModelsRightBar({ onToggle }) {
   const theme = useTheme();
   const [models, setModels] = useState([]);
   const [filteredModels, setFilteredModels] = useState([]);
@@ -27,7 +27,11 @@ export default function ModelsRightBar({ existingRuns, onToggle }) {
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation(["models"]);
 
-  const { selectedSession: session, onRunCreated } = useModels();
+  const {
+    selectedSession: session,
+    onRunCreated,
+    runs: existingRuns,
+  } = useModels();
 
   const fetchModels = React.useCallback(async () => {
     try {
@@ -232,10 +236,5 @@ export default function ModelsRightBar({ existingRuns, onToggle }) {
 }
 
 ModelsRightBar.propTypes = {
-  session: PropTypes.shape({
-    id: PropTypes.number,
-    name: PropTypes.string,
-    task_name: PropTypes.string,
-  }),
   onToggle: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
This pull request refactors the `ModelsRightBar` component to simplify its props and improve how it accesses run data. The main change is to source `existingRuns` directly from the `useModels` context instead of passing it as a prop, which streamlines the component's interface.

Component API simplification:

* Removed the `existingRuns` prop from `ModelsRightBar` and now retrieve `runs` (renamed as `existingRuns` locally) from the `useModels` context instead. This reduces prop drilling and makes the component easier to use. [[1]](diffhunk://#diff-51aac6e9712bc93905a12f889a56800ac6fb01bf9878761e7a961a1904644de7L21-R21) [[2]](diffhunk://#diff-51aac6e9712bc93905a12f889a56800ac6fb01bf9878761e7a961a1904644de7L30-R34)
* Updated the `propTypes` for `ModelsRightBar` to remove the unused `session` prop, reflecting the new, simpler API.




svc_1 and svc_2
<img width="280" height="446" alt="image" src="https://github.com/user-attachments/assets/6d92a5d7-85e0-4744-a103-879449aa20d8" />

