### PR TITLE
Add metric tooltips to comparison table 

### DIFF
--- a/DashAI/front/src/components/models/ModelComparisonTable.jsx
+++ b/DashAI/front/src/components/models/ModelComparisonTable.jsx
@@ -21,6 +21,7 @@ function ModelComparisonTable({
   metricSplit = "test",
 }) {
   const [models, setModels] = useState([]);
+  const [metrics, setMetrics] = useState([]);
   const { t } = useTranslation(["models", "common"]);
 
   useEffect(() => {
@@ -33,6 +34,18 @@ function ModelComparisonTable({
       }
     };
     fetchModels();
+  }, []);
+
+  useEffect(() => {
+    const fetchMetrics = async () => {
+      try {
+        const response = await getComponents({ selectTypes: ["Metric"] });
+        setMetrics(response);
+      } catch (error) {
+        console.error("Error fetching metrics:", error);
+      }
+    };
+    fetchMetrics();
   }, []);
 
   const getRows = () => {
@@ -84,11 +97,27 @@ function ModelComparisonTable({
 
     return Array.from(metricsSet).map((metricField) => {
       const metricName = metricField.replace(/^(test|train|val)_/, "");
+      const metricInfo = metrics.find((m) => m.name === metricName);
+      const metricDescription = metricInfo?.description || metricName;
 
       return {
         field: metricField,
         headerName: metricName,
         width: 120,
+        renderHeader: (params) => (
+          <Tooltip title={metricDescription} arrow placement="top">
+            <Box
+              sx={{
+                cursor: "help",
+                width: "100%",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {metricName}
+            </Box>
+          </Tooltip>
+        ),
         renderCell: (params) => {
           const { statusCode } = params.row;
           const isRunning = statusCode === 1 || statusCode === 2;


### PR DESCRIPTION
## Summary
Added tooltips to metric column headers in the model comparison table to display metric descriptions. When users hover over metric names (e.g., Accuracy, Precision, F1), they now see a tooltip with the metric's full description from the backend, making it easier to understand what each metric represents without cluttering the table layout.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/models/ModelComparisonTable.jsx`: 
  - Added `metrics` state to fetch metric definitions from backend
  - Implemented `renderHeader` in metric columns to display tooltips with descriptions
  - Added visual cursor hint (`cursor: help`) to indicate interactive headers

---

## Testing (optional)
- Navigate to a model session with trained runs
- Hover over metric column headers in the comparison table
- Verify tooltips display the correct metric descriptions
- Test with different metric types 