### PR TITLE
Fix column renaming functionality to dataset upload

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
@@ -25,6 +25,7 @@ export default function ConfigureAndUploadDatasetStep({
   const [previewError, setPreviewError] = useState(false);
   const [datasetFileToUpload, setDatasetFileToUpload] = useState(null);
   const [columnTypes, setColumnTypes] = useState(null);
+  const [columnRenames, setColumnRenames] = useState({});
   const tourContext = useTourContext();
 
   const { enqueueSnackbar } = useSnackbar();
@@ -78,6 +79,10 @@ export default function ConfigureAndUploadDatasetStep({
         params["inferred_types"] = columnTypes;
       }
 
+      if (Object.keys(columnRenames).length > 0) {
+        params["column_renames"] = columnRenames;
+      }
+
       const { file, url } = datasetFileToUpload;
 
       const data = await createDataset(name);
@@ -110,6 +115,7 @@ export default function ConfigureAndUploadDatasetStep({
     selectedDataloader,
     datasetFileToUpload,
     columnTypes,
+    columnRenames,
     formSubmitRef,
     handleDatasetCreated,
     backHome,
@@ -123,6 +129,13 @@ export default function ConfigureAndUploadDatasetStep({
 
   const handleTypesChanged = useCallback((types) => {
     setColumnTypes(types);
+  }, []);
+
+  const handleColumnRename = useCallback((oldName, newName) => {
+    setColumnRenames((prev) => ({
+      ...prev,
+      [oldName]: newName,
+    }));
   }, []);
 
   const isFormValid = () => {
@@ -165,6 +178,7 @@ export default function ConfigureAndUploadDatasetStep({
         <Upload
           onFileUpload={handleFileUpload}
           formSubmitRef={formSubmitRef}
+          onColumnRename={handleColumnRename}
           formValues={formValues}
           selectedDataloader={selectedDataloader}
           onPreviewError={setPreviewError}


### PR DESCRIPTION
## Summary
Column renames made in the dataset upload preview were not being persisted after upload. The `submitNewDataset` callback had a stale closure over `columnRenames` — it was missing from the `useCallback` dependency array, so the submit function always captured the initial empty value `{}` instead of the updated renames. Additionally, the `columnRenames` state and its handler were not wired up through the component chain to the `Upload` component.

---

## Type of Change

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx`:
  - Added `columnRenames` state to track column renames made during preview
  - Added `handleColumnRename` callback to accumulate rename mappings
  - Added `columnRenames` to the `submitNewDataset` dependency array (fixing the stale closure)
  - Passed `column_renames` in the request params to the backend when renames exist
  - Passed `onColumnRename` prop down to the `Upload` component

---

## Testing (optional)
1. Upload a dataset and rename one or more columns in the preview table
2. Complete the upload
3. Verify the renamed columns appear correctly in the Dataset Visualization view