### PR TITLE
Ensure metadata consistency and UI refresh when renaming dataset columns

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -958,13 +958,55 @@ async def rename_dataset_column(
             if os.path.exists(splits_path):
                 with open(splits_path, "r", encoding="utf-8") as f:
                     splits_data = json.load(f)
-                if "column_names" in splits_data:
-                    splits_data["column_names"] = [
-                        new_name if name == old_name else name
-                        for name in splits_data["column_names"]
-                    ]
-                if "nan" in splits_data and old_name in splits_data["nan"]:
-                    splits_data["nan"][new_name] = splits_data["nan"].pop(old_name)
+                # Update column_names in split file
+                splits_data["column_names"] = [
+                    new_name if name == old_name else name
+                    for name in splits_data["column_names"]
+                ]
+                # Update nan entries
+                splits_data["nan"][new_name] = splits_data["nan"].pop(old_name)
+
+                # Update general info
+                splits_data["general_info"]["dtypes"][new_name] = splits_data[
+                    "general_info"
+                ]["dtypes"].pop(old_name)
+
+                # Update quality info nan per ratio
+                splits_data["quality_info"]["nan_ratio_per_column"][new_name] = (
+                    splits_data["quality_info"]["nan_ratio_per_column"].pop(old_name)
+                )
+
+                # Update numeric_stats if column is numerical
+                if old_name in splits_data["numeric_stats"]:
+                    splits_data["numeric_stats"][new_name] = splits_data[
+                        "numeric_stats"
+                    ].pop(old_name)
+
+                    # Update correlations
+                    if "correlations" in splits_data:
+                        correlations = splits_data["correlations"]
+
+                        # Rename the main key if needed
+                        if old_name in correlations:
+                            correlations[new_name] = correlations.pop(old_name)
+
+                        # Rename inner keys
+                        for _, corr_values in correlations.items():
+                            if old_name in corr_values:
+                                corr_values[new_name] = corr_values.pop(old_name)
+
+                # Update categorical_stats columns if column is categorical
+                elif old_name in splits_data.get("categorical_stats", {}):
+                    splits_data["categorical_stats"][new_name] = splits_data[
+                        "categorical_stats"
+                    ].pop(old_name)
+
+                # Update text_stats columns if column is textual
+                elif old_name in splits_data.get("text_stats", {}):
+                    splits_data["text_stats"][new_name] = splits_data["text_stats"].pop(
+                        old_name
+                    )
+
                 with open(splits_path, "w", encoding="utf-8") as f:
                     json.dump(
                         splits_data,

--- a/DashAI/front/src/components/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/DatasetVisualization.jsx
@@ -64,25 +64,26 @@ export default function DatasetVisualization({
     }
   }, [tourContext]);
 
+  const fetchDatasetInfo = async () => {
+    const isProcessing = !(dataset.status === 3 || dataset.status === 4);
+    if (isProcessing && fetchDatasets) {
+      setTimeout(() => {
+        fetchDatasets();
+      }, 1000);
+      return;
+    }
+    try {
+      const info = await getDatasetInfo(Number(dataset.id));
+      setDatasetInfo(info);
+    } catch (error) {
+      setDatasetInfo(null);
+    }
+  };
+
   useEffect(() => {
     if (!dataset) return;
-
     setTab(0);
-    const fetchDatasetInfo = async () => {
-      const isProcessing = !(dataset.status === 3 || dataset.status === 4);
-      if (isProcessing && fetchDatasets) {
-        setTimeout(() => {
-          fetchDatasets();
-        }, 1000);
-        return;
-      }
-      try {
-        const info = await getDatasetInfo(Number(dataset.id));
-        setDatasetInfo(info);
-      } catch (error) {
-        setDatasetInfo(null);
-      }
-    };
+
     fetchDatasetInfo();
   }, [dataset, fetchDatasets]);
 
@@ -118,6 +119,10 @@ export default function DatasetVisualization({
       dataset && dataset.id,
     ],
   );
+
+  const updateDatasetInfo = () => {
+    fetchDatasetInfo();
+  };
 
   if (!dataset) {
     return (
@@ -379,6 +384,7 @@ export default function DatasetVisualization({
                 dtypes={datasetInfo?.general_info?.dtypes}
                 nan={datasetInfo?.nan}
                 total_rows={datasetInfo?.total_rows}
+                onEditColumnName={updateDatasetInfo}
                 fetchDatasetPage={fetchDatasetPage}
               />
             )}

--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -40,6 +40,7 @@ export default function DatasetTable({
   datasetPath,
   datasetId,
   editableColumns = false,
+  onEditColumn = null,
   density = "compact",
   ...props
 }) {
@@ -118,6 +119,7 @@ export default function DatasetTable({
 
       try {
         const result = await renameDatasetColumn(datasetId, oldName, newName);
+        onEditColumn && (await onEditColumn(result));
 
         const { page, pageSize } = paginationModel;
         const data = await fetchPage(page, pageSize, filterModel);

--- a/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
@@ -27,6 +27,7 @@ const OverviewTab = ({
   nan,
   total_rows,
   fetchDatasetPage,
+  onEditColumnName,
 }) => {
   const { t } = useTranslation(["datasets", "common"]);
 
@@ -60,6 +61,7 @@ const OverviewTab = ({
             initialPageSize={10}
             datasetPath={dataset.file_path}
             datasetId={dataset.id}
+            onEditColumn={onEditColumnName}
             editableColumns={true}
           />
         </CardContent>


### PR DESCRIPTION
## Summary
Improves the dataset column renaming workflow by ensuring all related metadata and statistics are correctly updated on the backend, and by refreshing the frontend dataset information automatically after a column rename. This guarantees metadata consistency and keeps the UI synchronized with the updated dataset state.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `backend/.../dataset_api.py`: Updated `rename_dataset_column` to rename columns across all related metadata fields including `column_names`, `nan`, `general_info.dtypes`, `quality_info.nan_ratio_per_column`, and statistics for numeric, categorical, and text columns. Correlation keys and values are also updated to reflect the new column name.
- `DatasetVisualization.tsx`: Reset active tab and trigger dataset info fetch whenever the dataset changes to ensure the UI reflects the latest state.
- `OverviewTab.tsx`: Added support for the `onEditColumn` callback to propagate column rename events.
- `DatasetTable.tsx`: Added `onEditColumn` callback so the parent component can refresh dataset information after a column rename.

---

## Testing (optional)
Rename a column in the dataset table and verify that:
- The column name is updated across all metadata fields and statistics.
- Correlation matrices reflect the new column name.
- The frontend dataset information refreshes automatically without requiring a manual reload.
