### PR TITLE
Add preview loaded state

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
@@ -23,6 +23,7 @@ export default function ConfigureAndUploadDatasetStep({
   const [uploadEnabled, setUploadEnabled] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [previewError, setPreviewError] = useState(false);
+  const [previewLoaded, setPreviewLoaded] = useState(false);
   const [datasetFileToUpload, setDatasetFileToUpload] = useState(null);
   const [columnTypes, setColumnTypes] = useState(null);
   const [columnRenames, setColumnRenames] = useState({});
@@ -125,6 +126,11 @@ export default function ConfigureAndUploadDatasetStep({
 
   const handleFileUpload = (file, url) => {
     setDatasetFileToUpload({ file, url });
+    setPreviewLoaded(false);
+  };
+
+  const handlePreviewLoaded = () => {
+    setPreviewLoaded(true);
   };
 
   const handleTypesChanged = useCallback((types) => {
@@ -152,13 +158,20 @@ export default function ConfigureAndUploadDatasetStep({
       datasetFileToUpload &&
       datasetFileToUpload.file !== null &&
       !previewError &&
+      previewLoaded &&
       isFormValid()
     ) {
       setUploadEnabled(true);
     } else {
       setUploadEnabled(false);
     }
-  }, [datasetFileToUpload, previewError, formHasErrors, formValues]);
+  }, [
+    datasetFileToUpload,
+    previewError,
+    previewLoaded,
+    formHasErrors,
+    formValues,
+  ]);
 
   return (
     <Grid sx={{ width: "100%", height: "100%" }}>
@@ -183,6 +196,7 @@ export default function ConfigureAndUploadDatasetStep({
           selectedDataloader={selectedDataloader}
           onPreviewError={setPreviewError}
           onTypesChanged={handleTypesChanged}
+          onPreviewLoaded={handlePreviewLoaded}
         />
       </Grid>
 

--- a/DashAI/front/src/components/notebooks/datasetCreation/PreviewDataset.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/PreviewDataset.jsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
  * @param {function} onPreviewError - Callback function to notify parent of preview errors
  * @param {function} onTypesChanged - Callback to notify parent when column types change
  * @param {function} onColumnRename - Callback to notify parent when columns are renamed (oldName, newName)
+ * @param {function} onPreviewLoaded - Callback to notify parent when preview is loaded
  */
 function PreviewDataset({
   datasetData,
@@ -22,6 +23,7 @@ function PreviewDataset({
   onPreviewError,
   onTypesChanged,
   onColumnRename,
+  onPreviewLoaded,
 }) {
   const theme = useTheme();
   const { enqueueSnackbar } = useSnackbar();
@@ -41,6 +43,12 @@ function PreviewDataset({
       onPreviewError(!!error);
     }
   }, [error, onPreviewError]);
+
+  useEffect(() => {
+    if (onPreviewLoaded && !loading && !error) {
+      onPreviewLoaded();
+    }
+  }, [loading, error, onPreviewLoaded]);
 
   useEffect(() => {
     const loadPreview = async () => {

--- a/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
@@ -26,6 +26,7 @@ import { useTranslation } from "react-i18next";
  * @param {function} onPreviewError callback to notify parent of preview errors
  * @param {function} onTypesChanged callback to notify parent when column types change
  * @param {function} onColumnRename callback to notify parent when columns are renamed
+ * @param {function} onPreviewLoaded callback to notify parent when preview is loaded
  */
 function Upload({
   onFileUpload,
@@ -35,6 +36,7 @@ function Upload({
   onPreviewError,
   onTypesChanged,
   onColumnRename,
+  onPreviewLoaded,
 }) {
   const [EMPTY, LOADING, LOADED] = [0, 1, 2];
   const [datasetState, setDatasetState] = useState(
@@ -332,6 +334,7 @@ function Upload({
                 onPreviewError={onPreviewError}
                 onTypesChanged={onTypesChanged}
                 onColumnRename={onColumnRename}
+                onPreviewLoaded={onPreviewLoaded}
               />
             </Box>
           );


### PR DESCRIPTION
## Summary
Added preview loaded state and callback mechanism to dataset upload components. This enhancement enables parent components to track when the dataset preview has finished loading and rendering, allowing for proper synchronization of form state and upload button availability. The `previewLoaded` state now prevents premature upload attempts before the preview is ready.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx`: Added `previewLoaded` state, `handlePreviewLoaded` callback function, updated upload validation logic to include preview loaded check, and updated useEffect dependencies.
- `DashAI/front/src/components/notebooks/datasetCreation/PreviewDataset.jsx`: Added `onPreviewLoaded` callback parameter and JSDoc documentation, implemented useEffect hook that triggers callback when preview finishes loading and has no errors.
- `DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx`: Added `onPreviewLoaded` callback parameter to JSDoc and component props, propagated callback to PreviewDataset child component.

---

## Testing (optional)
- Verify that the upload button is disabled until the preview is fully loaded
- Test dataset upload workflow with various file formats to ensure preview loading state is handled correctly
- Confirm that preview errors still prevent upload even if other conditions are met

---

## Notes (optional)
This change improves UX by preventing users from attempting to upload datasets before the preview has finished processing, reducing potential form validation issues.