### PR TITLE
Fix live metrics rendering, state reset, and results visibility issues

### DIFF
--- a/DashAI/front/src/components/models/LiveMetricsChart.jsx
+++ b/DashAI/front/src/components/models/LiveMetricsChart.jsx
@@ -74,11 +74,22 @@ export function LiveMetricsChart({ run }) {
       socketRef.current.close();
     }
 
-    const apiUrl =
-      process.env.REACT_APP_API_URL || `${window.location.origin}/api`;
+    // When a new training starts, clear all previous metrics
+    const isStarting = run.status === 1 || run.status === 2;
+    if (isStarting) {
+      setData({});
+      setSelectedMetrics([]);
+      selectedMetricsPerSplit.current = {
+        TRAIN: null,
+        VALIDATION: null,
+        TEST: null,
+      };
+    }
+
+    const apiUrl = process.env.REACT_APP_API_URL || `${window.location.origin}`;
     let wsUrl;
     try {
-      wsUrl = new URL(`/v1/metrics/ws/${run.id}`, apiUrl);
+      wsUrl = new URL(`/api/v1/metrics/ws/${run.id}`, apiUrl);
     } catch (e) {
       console.error("Invalid WebSocket base URL:", apiUrl, e);
       return;
@@ -122,6 +133,11 @@ export function LiveMetricsChart({ run }) {
     ws.onclose = () => {
       if (run.test_metrics) {
         setData((prev) => {
+          // Skip if TEST data already exists to avoid duplicate re-render
+          if (prev.TEST && Object.keys(prev.TEST).length > 0) {
+            return prev;
+          }
+
           const next = structuredClone(prev);
 
           const formattedTestMetrics = {};
@@ -159,7 +175,7 @@ export function LiveMetricsChart({ run }) {
         console.log("WebSocket already closed");
       }
     };
-  }, [run.id, run.test_metrics]);
+  }, [run.id, run.status]);
 
   useEffect(() => {
     if (!run.model_session_id) return;
@@ -247,8 +263,13 @@ export function LiveMetricsChart({ run }) {
     else setLevel(null);
   }, [split, hasEpochData, hasStepData, hasTrialData, level]);
 
+  const filteredMetricKeys = useMemo(
+    () => Object.keys(filteredMetrics).sort().join(","),
+    [filteredMetrics],
+  );
+
   useEffect(() => {
-    const metricNames = Object.keys(filteredMetrics);
+    const metricNames = filteredMetricKeys ? filteredMetricKeys.split(",") : [];
 
     if (metricNames.length === 0) {
       setSelectedMetrics([]);
@@ -265,7 +286,7 @@ export function LiveMetricsChart({ run }) {
     } else {
       setSelectedMetrics(metricNames);
     }
-  }, [split, level, filteredMetrics]);
+  }, [split, level, filteredMetricKeys]);
 
   const handleMetricChange = (e) => {
     const newSelection = e.target.value;

--- a/DashAI/front/src/components/models/RunCard.jsx
+++ b/DashAI/front/src/components/models/RunCard.jsx
@@ -106,7 +106,7 @@ function RunCard({
       }
     };
     fetchOperationsCount();
-  }, [run, explainerRefreshTrigger]);
+  }, [run.id, explainerRefreshTrigger]);
 
   const hasOptimizableParams = useMemo(() => {
     return Object.values(editedParameters).some(

--- a/DashAI/front/src/components/models/RunResults.jsx
+++ b/DashAI/front/src/components/models/RunResults.jsx
@@ -6,7 +6,6 @@ import {
   Button,
   Chip,
   Stack,
-  CircularProgress,
   Collapse,
   Tabs,
   Tab,
@@ -39,7 +38,6 @@ export default function RunResults({
   const [globalExplainers, setGlobalExplainers] = useState([]);
   const [localExplainers, setLocalExplainers] = useState([]);
   const [predictions, setPredictions] = useState([]);
-  const [loading, setLoading] = useState(true);
   const [resultsVisible, setResultsVisible] = useState(() => {
     const saved = localStorage.getItem(`run-${run.id}-results-visible`);
     return saved ? JSON.parse(saved) : false;
@@ -61,15 +59,15 @@ export default function RunResults({
   const isRunning = run.status === 1 || run.status === 2;
   const { t } = useTranslation("models");
 
+  const runId = run.id;
   const fetchOperations = useCallback(async () => {
-    if (!run || !run.id) return;
+    if (!runId) return;
 
-    setLoading(true);
     try {
       const [globalExpls, localExpls, preds] = await Promise.all([
-        getExplainers(run.id, "global").catch(() => []),
-        getExplainers(run.id, "local").catch(() => []),
-        getPredictions(run.id).catch(() => []),
+        getExplainers(runId, "global").catch(() => []),
+        getExplainers(runId, "local").catch(() => []),
+        getPredictions(runId).catch(() => []),
       ]);
 
       setGlobalExplainers(globalExpls);
@@ -77,10 +75,8 @@ export default function RunResults({
       setPredictions(preds);
     } catch (error) {
       console.error("Error fetching operations:", error);
-    } finally {
-      setLoading(false);
     }
-  }, [run]);
+  }, [runId]);
 
   useEffect(() => {
     fetchOperations();
@@ -98,11 +94,11 @@ export default function RunResults({
   }, [run.id]);
 
   useEffect(() => {
-    if (isRunning && !resultsVisible) {
+    if (isRunning) {
       setResultsVisible(true);
       setActiveTab(0); // Live Metrics tab
     }
-  }, [isRunning, resultsVisible]);
+  }, [isRunning]);
 
   useEffect(() => {
     localStorage.setItem(
@@ -140,14 +136,6 @@ export default function RunResults({
 
   const totalOperations =
     globalExplainers.length + localExplainers.length + predictions.length;
-
-  if (loading && isFinished) {
-    return (
-      <Box sx={{ display: "flex", justifyContent: "center", p: 2 }}>
-        <CircularProgress size={24} />
-      </Box>
-    );
-  }
 
   return (
     <Box id={`run-results-${run.id}`}>


### PR DESCRIPTION
## Summary  
Fixes multiple issues in the live metrics and run results flow, ensuring correct behavior during and after training runs. This includes proper chart reset on retraining, preventing unnecessary re-renders, and fixing UI interactions between live metrics and results display.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  
- `MetricsChart.tsx`:  
  - Fixed live metrics not updating correctly  
  - Prevented chart re-render when training finishes  
  - Reset chart state when a new run starts (clears previous metrics)  

- `RunResults.tsx`:  
  - Fixed “Show Results” button not working when live metrics are open  
  - Ensured results are displayed correctly alongside live metrics  

- `RunCard.tsx`:  
  - Minor optimization to avoid unnecessary updates affecting UI behavior  

---

## Testing (optional)  
- Start a training run and verify live metrics update correctly  
- Open live metrics and click “Show Results” to confirm it works  
- Finish a run and ensure the chart does not re-render unexpectedly  
- Start a new run and verify previous metrics are cleared  