### PR TITLE
fix: skip rows from csvdataloader now dont skip the header

### DIFF
--- a/DashAI/back/dataloaders/classes/csv_dataloader.py
+++ b/DashAI/back/dataloaders/classes/csv_dataloader.py
@@ -270,14 +270,13 @@ class CSVDataLoader(BaseDataLoader):
             if param in params and params[param] is not None:
                 clean_params[param] = params[param]
 
-        int_params = ["nrows"]
-        for param in int_params:
-            if param in params and params[param] is not None:
-                if not isinstance(params[param], int):
-                    raise TypeError(
-                        f"Param {param} should be an integer, got {type(params[param])}"
-                    )
-                clean_params[param] = params[param]
+        if params.get("nrows") is not None:
+            if not isinstance(params["nrows"], int):
+                raise TypeError(
+                    f"Param nrows should be an integer, got {type(params['nrows'])}"
+                )
+            if params["nrows"] < 0:
+                raise ValueError("Param nrows should be greater than or equal to 0")
 
         if params.get("skiprows") is not None:
             if not isinstance(params["skiprows"], int):
@@ -326,6 +325,7 @@ class CSVDataLoader(BaseDataLoader):
         """
         clean_params = self._check_params(params)
         data_skiprows = params.get("skiprows") or 0
+        data_nrows = params.get("nrows")
         prepared_path = self.prepare_files(filepath_or_buffer, temp_path)
         if prepared_path[1] == "file":
             dataset = load_dataset(
@@ -347,15 +347,26 @@ class CSVDataLoader(BaseDataLoader):
                 dataset = dataset["train"]
             if data_skiprows > 0:
                 dataset = dataset.skip(data_skiprows)
-            dataset = Dataset.from_list(list(dataset.take(n_sample)))
+            rows_iterator = iter(dataset)
+            if data_nrows is not None:
+                rows_iterator = islice(rows_iterator, data_nrows)
+            rows_iterator = islice(rows_iterator, n_sample)
+            dataset = Dataset.from_list(list(rows_iterator))
         elif data_skiprows > 0:
             train_dataset = dataset["train"]
-            if data_skiprows >= train_dataset.num_rows:
-                dataset["train"] = train_dataset.select([])
+            end = (
+                min(train_dataset.num_rows, data_skiprows + data_nrows)
+                if data_nrows is not None
+                else train_dataset.num_rows
+            )
+            if data_skiprows >= end:
+                dataset["train"] = Dataset.from_dict(train_dataset[0:0])
             else:
-                dataset["train"] = train_dataset.select(
-                    range(data_skiprows, train_dataset.num_rows)
-                )
+                dataset["train"] = Dataset.from_dict(train_dataset[data_skiprows:end])
+        elif data_nrows is not None:
+            train_dataset = dataset["train"]
+            end = min(train_dataset.num_rows, data_nrows)
+            dataset["train"] = Dataset.from_dict(train_dataset[0:end])
         return to_dashai_dataset(dataset)
 
     def load_preview(
@@ -383,6 +394,7 @@ class CSVDataLoader(BaseDataLoader):
         """
         clean_params = self._check_params(params)
         data_skiprows = params.get("skiprows") or 0
+        data_nrows = params.get("nrows")
 
         dataset_stream = load_dataset(
             "csv",
@@ -394,7 +406,10 @@ class CSVDataLoader(BaseDataLoader):
         if data_skiprows > 0:
             dataset_stream = dataset_stream.skip(data_skiprows)
 
-        sample_rows = list(islice(dataset_stream, n_rows))
+        preview_limit = data_nrows if data_nrows is not None else n_rows
+        preview_limit = min(preview_limit, n_rows)
+
+        sample_rows = list(islice(dataset_stream, preview_limit))
 
         df_preview = pd.DataFrame(sample_rows)
 

--- a/DashAI/back/dataloaders/classes/csv_dataloader.py
+++ b/DashAI/back/dataloaders/classes/csv_dataloader.py
@@ -186,11 +186,11 @@ class CSVDataloaderSchema(BaseSchema):
         None,
         description=MultilingualString(
             en=(
-                "Number of lines to skip at the beginning of the file. "
+                "Number of data rows to skip after reading the header. "
                 "Leave empty to skip none."
             ),
             es=(
-                "Número de líneas a omitir al inicio del archivo. "
+                "Número de filas de datos a omitir después de leer el encabezado. "
                 "Deje vacío para no omitir ninguna."
             ),
         ),
@@ -237,7 +237,7 @@ class CSVDataLoader(BaseDataLoader):
     def _check_params(
         self,
         params: Dict[str, Any],
-    ) -> None:
+    ) -> Dict[str, Any]:
         if "separator" not in params:
             raise ValueError(
                 "Error trying to load the CSV dataset: "
@@ -270,7 +270,7 @@ class CSVDataLoader(BaseDataLoader):
             if param in params and params[param] is not None:
                 clean_params[param] = params[param]
 
-        int_params = ["skiprows", "nrows"]
+        int_params = ["nrows"]
         for param in int_params:
             if param in params and params[param] is not None:
                 if not isinstance(params[param], int):
@@ -278,6 +278,15 @@ class CSVDataLoader(BaseDataLoader):
                         f"Param {param} should be an integer, got {type(params[param])}"
                     )
                 clean_params[param] = params[param]
+
+        if params.get("skiprows") is not None:
+            if not isinstance(params["skiprows"], int):
+                raise TypeError(
+                    "Param skiprows should be an integer, "
+                    f"got {type(params['skiprows'])}"
+                )
+            if params["skiprows"] < 0:
+                raise ValueError("Param skiprows should be greater than or equal to 0")
 
         if "encoding" in params and params["encoding"]:
             valid_encodings = ["utf-8", "latin1", "cp1252", "iso-8859-1"]
@@ -316,6 +325,7 @@ class CSVDataLoader(BaseDataLoader):
             A HuggingFace's Dataset with the loaded data.
         """
         clean_params = self._check_params(params)
+        data_skiprows = params.get("skiprows") or 0
         prepared_path = self.prepare_files(filepath_or_buffer, temp_path)
         if prepared_path[1] == "file":
             dataset = load_dataset(
@@ -335,7 +345,17 @@ class CSVDataLoader(BaseDataLoader):
         if n_sample:
             if type(dataset) is IterableDatasetDict:
                 dataset = dataset["train"]
+            if data_skiprows > 0:
+                dataset = dataset.skip(data_skiprows)
             dataset = Dataset.from_list(list(dataset.take(n_sample)))
+        elif data_skiprows > 0:
+            train_dataset = dataset["train"]
+            if data_skiprows >= train_dataset.num_rows:
+                dataset["train"] = train_dataset.select([])
+            else:
+                dataset["train"] = train_dataset.select(
+                    range(data_skiprows, train_dataset.num_rows)
+                )
         return to_dashai_dataset(dataset)
 
     def load_preview(
@@ -362,6 +382,7 @@ class CSVDataLoader(BaseDataLoader):
             A DataFrame containing the preview rows.
         """
         clean_params = self._check_params(params)
+        data_skiprows = params.get("skiprows") or 0
 
         dataset_stream = load_dataset(
             "csv",
@@ -370,6 +391,8 @@ class CSVDataLoader(BaseDataLoader):
             split="train",
             **clean_params,
         )
+        if data_skiprows > 0:
+            dataset_stream = dataset_stream.skip(data_skiprows)
 
         sample_rows = list(islice(dataset_stream, n_rows))
 


### PR DESCRIPTION
This pull request updates the CSV dataloader to clarify and correct the behavior of the `skiprows` parameter, ensuring it consistently skips data rows after the header and adding stricter validation. The changes also improve how row skipping is handled during both data loading and previewing, and clarify the user-facing descriptions.

**Parameter validation and behavior improvements:**

* Changed the `_check_params` method to return a cleaned dictionary of parameters instead of `None`, and added stricter type and value checks for the `skiprows` parameter, ensuring it is a non-negative integer. (`DashAI/back/dataloaders/classes/csv_dataloader.py`) [[1]](diffhunk://#diff-f2128e87622d4ff11e22bd9196287211b06c1db8ae5f3de145b0c9180647feebL240-R240) [[2]](diffhunk://#diff-f2128e87622d4ff11e22bd9196287211b06c1db8ae5f3de145b0c9180647feebL273-R273) [[3]](diffhunk://#diff-f2128e87622d4ff11e22bd9196287211b06c1db8ae5f3de145b0c9180647feebR282-R290)

* Updated the logic in `load_data` and `load_preview` to consistently apply the `skiprows` parameter after reading the header, both when sampling and when loading the full dataset or preview. This ensures correct and predictable row skipping behavior. (`DashAI/back/dataloaders/classes/csv_dataloader.py`) [[1]](diffhunk://#diff-f2128e87622d4ff11e22bd9196287211b06c1db8ae5f3de145b0c9180647feebR328) [[2]](diffhunk://#diff-f2128e87622d4ff11e22bd9196287211b06c1db8ae5f3de145b0c9180647feebR348-R358) [[3]](diffhunk://#diff-f2128e87622d4ff11e22bd9196287211b06c1db8ae5f3de145b0c9180647feebR385) [[4]](diffhunk://#diff-f2128e87622d4ff11e22bd9196287211b06c1db8ae5f3de145b0c9180647feebR394-R395)

**Documentation and user interface:**

* Clarified the description of the `skiprows` parameter in the schema to specify that it skips data rows after the header, improving clarity for users in both English and Spanish. (`DashAI/back/dataloaders/classes/csv_dataloader.py`)