### PR TITLE
Fix/polling efficiency

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/jobs.py
+++ b/DashAI/back/api/api_v1/endpoints/jobs.py
@@ -58,7 +58,6 @@ async def get_job_changes(
         since_decoded = unquote_plus(since)
 
         jobs = job_queue.changes_since(since_decoded)
-        all_jobs = job_queue.to_list()
 
         current_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
 
@@ -71,7 +70,6 @@ async def get_job_changes(
             "server_now": current_time,
             "queue_empty": is_queue_empty,
             "recently_completed": recently_completed,
-            "all_jobs": all_jobs,
         }
     except Exception as e:
         logger.exception(f"Error retrieving job changes: {e}")
@@ -82,7 +80,6 @@ async def get_job_changes(
             "server_now": current_time,
             "queue_empty": True,
             "recently_completed": False,
-            "all_jobs": [],
             "error": str(e),
         }
 

--- a/DashAI/front/src/api/datasets.ts
+++ b/DashAI/front/src/api/datasets.ts
@@ -9,7 +9,7 @@ export const copyDataset = async (formData: object): Promise<object> => {
 };
 
 export const getDatasets = async (): Promise<IDataset[]> => {
-  const response = await api.get<IDataset[]>(datasetEndpoint);
+  const response = await api.get<IDataset[]>(`${datasetEndpoint}/`);
   return response.data;
 };
 

--- a/DashAI/front/src/api/job.ts
+++ b/DashAI/front/src/api/job.ts
@@ -18,7 +18,6 @@ export const getJobChanges = async (
   server_now: string;
   queue_empty: boolean;
   recently_completed: boolean;
-  all_jobs: any[];
 }> => {
   const response = await api.get<any>("/v1/job/changes", {
     params: { since },

--- a/DashAI/front/src/hooks/datasets/useDatasets.js
+++ b/DashAI/front/src/hooks/datasets/useDatasets.js
@@ -61,8 +61,10 @@ export function useDatasets({ t }) {
 
   useEffect(() => {
     const unsubscribe = subscribeJobs((jobs) => {
-      const hasActiveJobs = Array.isArray(jobs) && jobs.length > 0;
-      if (hasActiveJobs) {
+      const datasetJobs = Array.isArray(jobs)
+        ? jobs.filter((job) => job.task_type === "DatasetJob")
+        : [];
+      if (datasetJobs.length > 0) {
         fetchDatasets();
       }
     });

--- a/DashAI/front/src/utils/jobPoller.js
+++ b/DashAI/front/src/utils/jobPoller.js
@@ -69,7 +69,7 @@ async function pollJobs() {
     state.lastCursor = changeData.cursor;
     state.lastFetchTime = new Date();
 
-    const jobsToProcess = changeData.all_jobs || [];
+    const jobsToProcess = changeData.jobs || [];
 
     const activeJobsExist = hasActiveJobs(jobsToProcess);
     for (const subscriber of state.subscribers) {


### PR DESCRIPTION
## Summary

Improve polling efficiency and fix dataset upload behavior:
1. **Fix dataset upload tab switching**: Optimize `useDatasets` to filter jobs by type (`DatasetJob`), preventing the UI from getting stuck when switching tabs while uploading a dataset. This also prevents unnecessary dataset polling triggered by unrelated job types.
2. **Optimize polling**: Remove unused `all_jobs` property from the job changes response and update job processing logic, reducing unnecessary data transmission and improving performance.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

**Task 1 - Dataset Upload Fix:**
- `DashAI/front/src/hooks/datasets/useDatasets.js`: Filter jobs by `task_type === "DatasetJob"` to only trigger dataset refreshes for dataset-related jobs. This prevents UI from getting stuck when switching tabs during upload and prevents polling on jobs that aren't dataset-related (e.g., experiment jobs, model training jobs).

**Task 2 - Polling Efficiency:**
- `DashAI/back/api/api_v1/endpoints/jobs.py`: Removed unused `all_jobs` calculation and removed it from responses in both success and error cases.
- `DashAI/front/src/api/job.ts`: Removed `all_jobs` property from the `getJobChanges` response type definition.
- `DashAI/front/src/api/datasets.ts`: Added trailing slash to dataset endpoint for consistency.
- `DashAI/front/src/utils/jobPoller.js`: Updated to use `changeData.jobs` instead of the removed `changeData.all_jobs` property.

---

## Testing (optional)

- Verify dataset upload doesn't get stuck when switching tabs mid-upload.
- Confirm other job types (experiments, models, etc.) don't trigger unnecessary dataset refetches.
- Ensure job polling continues to work correctly with the updated response structure.
- Confirm only dataset jobs trigger dataset refresh correctly.




