### PR TITLE
Restrict pandas version to <3.0.0 to prevent LabelEncoder dtype incompatibility

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -14,7 +14,7 @@ kink
 
 # NumPy & Pandas stack
 numpy
-pandas
+pandas<3.0.0
 joblib
 
 # Config & validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ streaming_form_data
 alembic
 kink
 numpy
-pandas
+pandas<3.0.0
 joblib
 pydantic
 pydantic-settings


### PR DESCRIPTION
## Summary
Restricts the `pandas` version to `<3.0.0` in `requirements-cpu.txt` to prevent incompatibilities introduced in Pandas 3.0. Specifically, Pandas 3.0 enforces a `string` dtype for columns with strings/nulls, which breaks the current `LabelEncoder` transformation logic that assigns integer arrays back into the DataFrame. Earlier versions use `object` dtype, allowing this behavior.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `requirements-cpu.txt`: Restricted `pandas` version to `<3.0.0` to avoid breaking changes in dtype handling.
- `requirements.txt`: Restricted `pandas` version to `<3.0.0` to avoid breaking changes in dtype handling.

---

## Testing (optional)
- Verify that training pipelines using `LabelEncoder` run without errors.
- Confirm that prediction workflows still function correctly with encoded categorical features.

---

## Notes (optional)
The issue arises because Pandas 3.0 uses `string` dtype instead of `object` for string columns, which prevents assigning integer arrays during encoding. A future fix could involve explicitly casting column dtypes before transformation to support newer Pandas versions.