### PR TITLE
Standardize device handling and update imports for categorical function in DistilBert Model

### DIFF
--- a/DashAI/back/models/hugging_face/distilbert_transformer.py
+++ b/DashAI/back/models/hugging_face/distilbert_transformer.py
@@ -17,6 +17,7 @@ from DashAI.back.core.schema_fields import (
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
 from DashAI.back.models.text_classification_model import TextClassificationModel
+from DashAI.back.models.utils import GPU_OR_CPU, GPU_OR_CPU_PLACEHOLDER
 from DashAI.back.types.categorical import Categorical
 
 if TYPE_CHECKING:
@@ -59,8 +60,8 @@ class DistilBertTransformerSchema(BaseSchema):
         alias=MultilingualString(en="Learning rate", es="Tasa de aprendizaje"),
     )  # type: ignore
     device: schema_field(
-        enum_field(enum=["gpu", "cpu"]),
-        placeholder="gpu",
+        enum_field(enum=GPU_OR_CPU),
+        placeholder=GPU_OR_CPU_PLACEHOLDER,
         description=MultilingualString(
             en=(
                 "Hardware on which the training is run. If available, GPU is "
@@ -226,7 +227,7 @@ class DistilBertTransformer(TextClassificationModel):
             "weight_decay": kwargs.get("weight_decay", 0.01),
         }
         self.batch_size = kwargs.get("batch_size", 16)
-        self.device = kwargs.get("device", "gpu")
+        self.device = kwargs.get("device")
 
         if model is not None:
             self.model = model
@@ -290,14 +291,14 @@ class DistilBertTransformer(TextClassificationModel):
         # Get number of epochs from training args
         num_epochs = self.training_args_params.get("num_train_epochs", 2)
 
-        can_use_fp16 = torch.cuda.is_available() and self.device == "gpu"
+        can_use_fp16 = torch.cuda.is_available() and self.device.lower() == "gpu"
         training_args_obj = TrainingArguments(
             output_dir="DashAI/back/user_models/temp_checkpoints_distilbert",
             save_strategy="epoch",
             per_device_train_batch_size=self.batch_size,
             per_device_eval_batch_size=self.batch_size,
             eval_strategy="no",
-            use_cpu=self.device != "gpu",
+            use_cpu=self.device.lower() != "gpu",
             fp16=can_use_fp16,
             **self.training_args_params,
         )
@@ -403,7 +404,7 @@ class DistilBertTransformer(TextClassificationModel):
             The prepared dataset ready to be converted to
             an accepted format in the model.
         """
-        from DashAI.back.dataloaders.classes.dashai_dataset import (
+        from DashAI.back.dataloaders.classes.dashai_dataset_utils import (
             apply_categorical_label_encoder,
             categorical_label_encoder,
         )

--- a/tests/back/models/test_distilbert_transformer.py
+++ b/tests/back/models/test_distilbert_transformer.py
@@ -77,7 +77,7 @@ def sample_model():
         num_train_epochs=2,
         batch_size=16,
         learning_rate=5e-5,
-        device="cpu",
+        device="CPU",
         weight_decay=0.01,
         log_train_every_n_epochs=None,
         log_train_every_n_steps=None,


### PR DESCRIPTION
## Summary
Refactors device selection logic in `DistilBertTransformer` to use centralized constants and consistent handling, improving maintainability and reliability. Also fixes an incorrect dataset utility import.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `distilbert_transformer.py`: Refactored device handling to use `GPU_OR_CPU` enum and normalized input values for consistent behavior.
- `distilbert_transformer_schema.py`: Updated `device` field to use centralized enum and placeholder.
- `prepare_dataset` (module): Fixed import to use `dashai_dataset_utils` instead of incorrect module.

---

## Testing (optional)
Verify that training runs correctly on both CPU and GPU when specifying different device values, and that dataset preparation works without import errors.