### PR TITLE
Fix optional onValuesChange prop for explorers and converters

### DIFF
--- a/DashAI/front/src/components/shared/FormSchemaWithSelectedModel.jsx
+++ b/DashAI/front/src/components/shared/FormSchemaWithSelectedModel.jsx
@@ -21,7 +21,7 @@ function FormSchemaWithSelectedModel({
   onCancel,
   saveButtonText,
   hideButtons,
-  onValuesChange,
+  onValuesChange = () => {},
 }) {
   const {
     formValues,


### PR DESCRIPTION
## Summary
Fixes an issue where `FormSchemaWithSelectedModel` required the `onValuesChange` prop, causing failures when creating explorers or converters that do not use this handler. A default no-op function is now provided, ensuring these components work correctly without requiring the prop.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `FormSchemaWithSelectedModel.tsx`: Added a default no-op function for the `onValuesChange` prop to support use cases (e.g., explorers and converters) where the prop is not needed.

---

## Testing (optional)
- Verified that explorers and converters can be created without passing `onValuesChange`.
- Confirmed existing behavior remains unchanged when a custom handler is provided.