### PR TITLE
Add lazy imports to remaining backend files

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset_utils.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset_utils.py
@@ -1,14 +1,13 @@
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
-import numpy as np
-import pandas as pd
-import pyarrow as pa
-from sklearn.preprocessing import OneHotEncoder
-
-from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset, modify_table
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.utils import to_arrow_types
 from DashAI.back.types.value_types import Float, Text
+
+if TYPE_CHECKING:
+    from sklearn.preprocessing import OneHotEncoder
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
 # Data Transformations
 
@@ -16,8 +15,8 @@ from DashAI.back.types.value_types import Float, Text
 
 
 def categorical_label_encoder(
-    dataset: DashAIDataset,
-) -> Tuple[DashAIDataset, Dict[str, Dict[str, int]]]:
+    dataset: "DashAIDataset",
+) -> Tuple["DashAIDataset", Dict[str, Dict[str, int]]]:
     """Convert categorical columns from the DashAIDataset to label encoded integers.
 
     Parameters
@@ -35,6 +34,10 @@ def categorical_label_encoder(
         A dictionary containing the encodings for each categorical column,
         where keys are column names and values.
     """
+    import pyarrow as pa
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import modify_table
+
     new_columns = {}
     table = dataset.arrow_table
     encodings = {}
@@ -60,8 +63,8 @@ def categorical_label_encoder(
 # This function is used to apply the encodings stored in the model
 # to the categorical columns in the dataset.
 def apply_categorical_label_encoder(
-    dataset: DashAIDataset, encodings: Dict[str, Dict[str, int]]
-) -> DashAIDataset:
+    dataset: "DashAIDataset", encodings: Dict[str, Dict[str, int]]
+) -> "DashAIDataset":
     """Apply Model stored encodings to the categorical columns in the dataset.
 
     Parameters
@@ -81,6 +84,9 @@ def apply_categorical_label_encoder(
         label encoded integers using the provided encodings.
 
     """
+    import pyarrow as pa
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import modify_table
 
     table = dataset.arrow_table
     new_columns = {}
@@ -113,9 +119,13 @@ def apply_categorical_label_encoder(
 
 
 def vectorize_text(
-    dataset: DashAIDataset,
-) -> DashAIDataset:
+    dataset: "DashAIDataset",
+) -> "DashAIDataset":
     """Convert text columns from the DashAIDataset to vectorized columns."""
+    import pyarrow as pa
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import modify_table
+
     new_columns = {}
     table = dataset.arrow_table
     for col, _type in dataset.types.items():
@@ -138,9 +148,9 @@ def vectorize_text(
 
 
 def categorical_one_hot_encoder(
-    dataset: DashAIDataset,
-    encoder: Optional[OneHotEncoder] = None,
-) -> Tuple[DashAIDataset, OneHotEncoder, List[str]]:
+    dataset: "DashAIDataset",
+    encoder: Optional["OneHotEncoder"] = None,
+) -> Tuple["DashAIDataset", "OneHotEncoder", List[str]]:
     """Convert categorical columns from the DashAIDataset to one-hot encoded columns.
 
     Parameters
@@ -159,6 +169,10 @@ def categorical_one_hot_encoder(
     List[str]
         List of original categorical column names that were encoded.
     """
+    import numpy as np
+    import pandas as pd
+    import pyarrow as pa
+
     types = dataset.types
 
     categorical_cols = [
@@ -204,10 +218,10 @@ def categorical_one_hot_encoder(
 
 
 def apply_categorical_one_hot_encoder(
-    dataset: DashAIDataset,
-    encoder: OneHotEncoder,
+    dataset: "DashAIDataset",
+    encoder: "OneHotEncoder",
     categorical_cols: List[str],
-) -> DashAIDataset:
+) -> "DashAIDataset":
     """Apply a pre-fitted OneHotEncoder to categorical columns in the dataset.
 
     Parameters
@@ -224,6 +238,9 @@ def apply_categorical_one_hot_encoder(
     DashAIDataset
         A new DashAIDataset with categorical columns replaced by one-hot columns.
     """
+    import pandas as pd
+    import pyarrow as pa
+
     if encoder is None or not categorical_cols:
         return dataset
 

--- a/DashAI/back/models/dummy_text_classification_model.py
+++ b/DashAI/back/models/dummy_text_classification_model.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from datasets import Dataset
-
 from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 from DashAI.back.models.text_classification_model import TextClassificationModel
 
@@ -40,6 +38,8 @@ class DummyTextClassifier(TextClassificationModel):
 
     def predict(self, x_pred: DashAIDataset) -> DashAIDataset:
         """Predict labels for the input dataset."""
+        from datasets import Dataset
+
         if not self.is_trained:
             raise RuntimeError("The model must be trained before making predictions.")
 

--- a/DashAI/back/models/hugging_face/distilbert_transformer.py
+++ b/DashAI/back/models/hugging_face/distilbert_transformer.py
@@ -1,7 +1,5 @@
 """DashAI implementation of DistilBERT model for english classification."""
 
-import shutil
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
 from sklearn.exceptions import NotFittedError
@@ -15,7 +13,6 @@ from DashAI.back.core.schema_fields import (
     schema_field,
 )
 from DashAI.back.core.utils import MultilingualString
-from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
 from DashAI.back.models.text_classification_model import TextClassificationModel
 from DashAI.back.models.utils import GPU_OR_CPU, GPU_OR_CPU_PLACEHOLDER
 from DashAI.back.types.categorical import Categorical
@@ -252,6 +249,8 @@ class DistilBertTransformer(TextClassificationModel):
         self.encodings = {}  # Store encodings for categorical columns
 
     def train(self, x_train, y_train, x_validation, y_validation):
+        import shutil
+
         import torch
         from transformers import (
             AutoConfig,
@@ -260,6 +259,8 @@ class DistilBertTransformer(TextClassificationModel):
             Trainer,
             TrainingArguments,
         )
+
+        from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
 
         output_column_name = y_train.column_names[0]
 

--- a/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
@@ -15,7 +15,6 @@ from DashAI.back.core.schema_fields import (
     schema_field,
 )
 from DashAI.back.core.utils import MultilingualString
-from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
 from DashAI.back.models.translation_model import TranslationModel
 from DashAI.back.models.utils import GPU_OR_CPU, GPU_OR_CPU_PLACEHOLDER
 
@@ -278,6 +277,8 @@ class OpusMtEnESTransformer(TranslationModel):
         x_validation: "DashAIDataset" = None,
         y_validation: "DashAIDataset" = None,
     ) -> "OpusMtEnESTransformer":
+        from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
+
         dataset = self.tokenize_data(x_train, y_train)
         dataset.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
 

--- a/DashAI/back/models/hugging_face/stable_diffusion_xl_model.py
+++ b/DashAI/back/models/hugging_face/stable_diffusion_xl_model.py
@@ -1,8 +1,5 @@
 from typing import Any, List, Optional
 
-import torch
-from diffusers import StableDiffusionXLPipeline
-
 from DashAI.back.core.schema_fields import (
     enum_field,
     float_field,
@@ -241,6 +238,9 @@ class StableDiffusionXLModel(TextToImageGenerationTaskModel):
 
     def __init__(self, **kwargs):
         """Initialize the model."""
+        import torch
+        from diffusers import StableDiffusionXLPipeline
+
         kwargs = self.validate_and_transform(kwargs)
         use_gpu = DEVICE_TO_IDX.get(kwargs.get("device")) >= 0
         self.device = (
@@ -278,6 +278,8 @@ class StableDiffusionXLModel(TextToImageGenerationTaskModel):
         List[Any]
             Generated output images in a list.
         """
+        import torch
+
         generator = None
         if self.seed is not None and self.seed > 0:
             generator = torch.Generator(device=self.device).manual_seed(self.seed)


### PR DESCRIPTION
## Summary
Adds lazy imports to remaining backend files to reduce unnecessary top-level dependencies.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- Multiple backend files: Moved remaining heavy/optional imports into function scope and added `TYPE_CHECKING` where needed for type-only imports.

---

## Testing (optional)
- Ensure modules import correctly without optional dependencies installed.
- Verify affected models/functions still run as expected.