### PR TITLE
Fix/webview downloads

### DIFF
--- a/DashAI/__main__.py
+++ b/DashAI/__main__.py
@@ -101,9 +101,85 @@ def _wait_for_backend_server(host="127.0.0.1", port=8000, timeout=15):
 
 
 def _start_webview(local_path: pathlib.Path, logger: logging.Logger) -> None:
+    import base64
+
     import webview
 
-    window = webview.create_window("DashAI", "http://127.0.0.1:8000", hidden=True)
+    class DownloadApi:
+        """Exposed to JavaScript via window.pywebview.api for native file saving."""
+
+        def save_file(self, filename: str, data_b64: str) -> bool:
+            try:
+                result = window.create_file_dialog(
+                    webview.SAVE_DIALOG,
+                    save_filename=filename,
+                )
+                if result:
+                    filepath = result if isinstance(result, str) else result[0]
+                    with open(filepath, "wb") as f:
+                        f.write(base64.b64decode(data_b64))
+                    logger.info(f"File saved: {filepath}")
+                    return True
+            except Exception:
+                logger.exception("Failed to save file")
+            return False
+
+    api = DownloadApi()
+    window = webview.create_window(
+        "DashAI", "http://127.0.0.1:8000", hidden=True, js_api=api
+    )
+
+    _DOWNLOAD_INTERCEPT_JS = """
+    (function() {
+        if (window.__dashaiDownloadHandler) return;
+        window.__dashaiDownloadHandler = true;
+
+        function handleDownload(url, filename) {
+            fetch(url)
+                .then(function(r) { return r.blob(); })
+                .then(function(blob) {
+                    var reader = new FileReader();
+                    reader.onload = function() {
+                        var b64 = reader.result.split(',')[1];
+                        window.pywebview.api.save_file(filename, b64);
+                    };
+                    reader.readAsDataURL(blob);
+                })
+                .catch(function(err) {
+                    console.error('DashAI download intercept failed:', err);
+                });
+        }
+
+        // Intercept programmatic .click() on <a download>
+        var origClick = HTMLAnchorElement.prototype.click;
+        HTMLAnchorElement.prototype.click = function() {
+            if (this.hasAttribute('download')) {
+                handleDownload(this.href, this.download || 'download');
+                return;
+            }
+            return origClick.call(this);
+        };
+
+        // Intercept user clicks on <a download> (e.g. tour sample dataset link)
+        document.addEventListener('click', function(e) {
+            var link = e.target.closest('a[download]');
+            if (link) {
+                e.preventDefault();
+                e.stopPropagation();
+                handleDownload(link.href, link.download || 'download');
+            }
+        }, true);
+    })();
+    """
+
+    def _inject_download_handler():
+        try:
+            window.evaluate_js(_DOWNLOAD_INTERCEPT_JS)
+            logger.info("Download intercept JS injected.")
+        except Exception:
+            logger.exception("Failed to inject download handler JS")
+
+    window.events.loaded += _inject_download_handler
 
     def load_logic():
         if _wait_for_backend_server(timeout=120):

--- a/DashAI/front/src/components/explorations/Visualizations/PlotlyJsonVisualizer.jsx
+++ b/DashAI/front/src/components/explorations/Visualizations/PlotlyJsonVisualizer.jsx
@@ -37,7 +37,7 @@ function PlotlyJsonVisualizer({ data }) {
       "resetScale2d",
     ],
     toImageButtonOptions: {
-      format: "png",
+      format: "svg",
       filename: "dashai-plot",
       height: 800,
       width: 1200,
@@ -128,6 +128,8 @@ function PlotlyJsonVisualizer({ data }) {
             data={plotData.data}
             layout={{
               ...plotData.layout,
+              paper_bgcolor: plotData.layout?.paper_bgcolor || "white",
+              plot_bgcolor: plotData.layout?.plot_bgcolor || "white",
               height: height,
               margin: {
                 l: 60,
@@ -157,6 +159,8 @@ function PlotlyJsonVisualizer({ data }) {
               data={plotData.data}
               layout={{
                 ...plotData.layout,
+                paper_bgcolor: plotData.layout?.paper_bgcolor || "white",
+                plot_bgcolor: plotData.layout?.plot_bgcolor || "white",
                 autosize: true,
                 margin: {
                   l: 80,

--- a/DashAI/front/src/components/notebooks/explorer/visualizations/PlotlyJsonVisualizer.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/visualizations/PlotlyJsonVisualizer.jsx
@@ -63,7 +63,7 @@ function PlotlyJsonVisualizer({ data, minimalist = false }) {
           "resetScale2d",
         ],
     toImageButtonOptions: {
-      format: "png",
+      format: "svg",
       filename: "dashai-plot",
       height: 800,
       width: 1200,
@@ -94,6 +94,8 @@ function PlotlyJsonVisualizer({ data, minimalist = false }) {
 
   const plotLayout = {
     ...plotData.layout,
+    paper_bgcolor: plotData.layout?.paper_bgcolor || "white",
+    plot_bgcolor: plotData.layout?.plot_bgcolor || "white",
     margin: minimalist
       ? {
           l: 40,
@@ -167,6 +169,8 @@ function PlotlyJsonVisualizer({ data, minimalist = false }) {
               data={plotData.data}
               layout={{
                 ...plotData.layout,
+                paper_bgcolor: plotData.layout?.paper_bgcolor || "white",
+                plot_bgcolor: plotData.layout?.plot_bgcolor || "white",
                 autosize: true,
                 margin: {
                   l: 80,


### PR DESCRIPTION
 ## Summary                                                                                           
  Fix file downloads and chart image exports in the macOS webview (pywebview/WKWebView). Clicking
  download links (e.g., sample CSV in the dataset tour, Plotly chart exports) previously navigated the 
  webview to the file URL, leaving the app stuck with no way to go back. Additionally, Plotly heatmap  
  exports were missing cell colors due to a WKWebView canvas rendering issue.                          
                                                            
  ---

  ## Type of Change
  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [x] Build / Packaging change
  - [x] Bug fix                                                                                        
  - [ ] Documentation
                                                                                                       
  ---                                                       

  ## Changes (by file)
  - `DashAI/__main__.py`: Added `DownloadApi` class exposed via pywebview's JS bridge, and injected
  JavaScript that intercepts all `<a download>` clicks (both user clicks and programmatic ones from    
  Plotly/blob exports). Downloads now trigger a native "Save As" dialog instead of navigating the
  webview.                                                                                             
  - `DashAI/front/src/components/notebooks/explorer/visualizations/PlotlyJsonVisualizer.jsx`: Changed
  export format from `png` to `svg` to avoid WKWebView's broken SVG→Canvas→PNG pipeline. Added explicit
   `paper_bgcolor` and `plot_bgcolor` white fallbacks to all layouts.
  - `DashAI/front/src/components/explorations/Visualizations/PlotlyJsonVisualizer.jsx`: Same changes as
   above (second copy of the visualizer component).                                                    
  