### PR TITLE
Add nvidia-ml-py to requirements and improve WebSocket management

### DIFF
--- a/DashAI/front/src/hooks/useHardwareMonitor.js
+++ b/DashAI/front/src/hooks/useHardwareMonitor.js
@@ -5,11 +5,43 @@ export function useHardwareMonitor(enabled) {
   const [connected, setConnected] = useState(false);
   const wsRef = useRef(null);
   const reconnectTimeout = useRef(null);
+  const enabledRef = useRef(enabled);
+
+  const clearReconnectTimeout = useCallback(() => {
+    if (reconnectTimeout.current) {
+      clearTimeout(reconnectTimeout.current);
+      reconnectTimeout.current = null;
+    }
+  }, []);
+
+  const closeSocket = useCallback(() => {
+    if (!wsRef.current) {
+      return;
+    }
+
+    // Remove handlers to avoid reconnect scheduling from intentional closes.
+    wsRef.current.onopen = null;
+    wsRef.current.onmessage = null;
+    wsRef.current.onclose = null;
+    wsRef.current.onerror = null;
+    wsRef.current.close();
+    wsRef.current = null;
+  }, []);
 
   const connect = useCallback(() => {
-    if (wsRef.current) {
-      wsRef.current.close();
+    if (!enabledRef.current) {
+      return;
     }
+
+    if (
+      wsRef.current &&
+      (wsRef.current.readyState === WebSocket.OPEN ||
+        wsRef.current.readyState === WebSocket.CONNECTING)
+    ) {
+      return;
+    }
+
+    clearReconnectTimeout();
 
     const apiUrl = process.env.REACT_APP_API_URL || `${window.location.origin}`;
     let wsUrl;
@@ -27,6 +59,7 @@ export function useHardwareMonitor(enabled) {
     }
 
     const ws = new WebSocket(wsUrl.toString());
+    wsRef.current = ws;
 
     ws.onopen = () => {
       setConnected(true);
@@ -43,8 +76,11 @@ export function useHardwareMonitor(enabled) {
 
     ws.onclose = () => {
       setConnected(false);
-      wsRef.current = null;
-      if (enabled) {
+      if (wsRef.current === ws) {
+        wsRef.current = null;
+      }
+      if (enabledRef.current) {
+        clearReconnectTimeout();
         reconnectTimeout.current = setTimeout(connect, 3000);
       }
     };
@@ -52,25 +88,27 @@ export function useHardwareMonitor(enabled) {
     ws.onerror = (error) => {
       console.error("Hardware WebSocket error:", error);
     };
-
-    wsRef.current = ws;
-  }, [enabled]);
+  }, [clearReconnectTimeout]);
 
   useEffect(() => {
+    enabledRef.current = enabled;
+
     if (enabled) {
       connect();
+    } else {
+      setConnected(false);
+      clearReconnectTimeout();
+      closeSocket();
     }
+  }, [enabled, connect, clearReconnectTimeout, closeSocket]);
 
+  useEffect(() => {
     return () => {
-      if (reconnectTimeout.current) {
-        clearTimeout(reconnectTimeout.current);
-      }
-      if (wsRef.current) {
-        wsRef.current.close();
-        wsRef.current = null;
-      }
+      enabledRef.current = false;
+      clearReconnectTimeout();
+      closeSocket();
     };
-  }, [enabled, connect]);
+  }, [clearReconnectTimeout, closeSocket]);
 
   return { stats, connected };
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ sacrebleu
 sentencepiece
 optuna
 hyperopt
+nvidia-ml-py
 openpyxl
 httpx
 wordcloud


### PR DESCRIPTION
## Summary
Refactors the `useHardwareMonitor` hook to improve WebSocket lifecycle management, making connections more reliable and preventing unnecessary reconnections or resource leaks when monitoring is disabled or the component unmounts.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `useHardwareMonitor.ts`: 
  - Introduced `enabledRef` to keep track of the latest enabled state inside callbacks.
  - Added `clearReconnectTimeout` and `closeSocket` helpers to centralize cleanup logic.
  - Improved `connect` logic to avoid duplicate connections and respect the enabled state.
  - Ensured proper cleanup of WebSocket, timeouts, and event handlers on disable/unmount.
  - Prevented stale event listeners and unintended reconnections.

---

## Testing (optional)
- Verify that enabling/disabling monitoring does not create multiple WebSocket connections.
- Confirm that no reconnection attempts occur after disabling the hook.
- Check for absence of memory leaks when mounting/unmounting components repeatedly.