### PR TITLE
Replace ConverterList with Converter across backend

### DIFF
--- a/DashAI/alembic/versions/b4f9e70098e7_change_converterlist_to_converter.py
+++ b/DashAI/alembic/versions/b4f9e70098e7_change_converterlist_to_converter.py
@@ -1,0 +1,25 @@
+"""Change ConverterList to Converter
+
+Revision ID: b4f9e70098e7
+Revises: 98791b9df4f0
+Create Date: 2026-03-30 16:50:49.118389
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b4f9e70098e7"
+down_revision: Union[str, None] = "98791b9df4f0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.rename_table("converter_list", "converter")
+
+
+def downgrade() -> None:
+    op.rename_table("converter", "converter_list")

--- a/DashAI/back/api/api_v1/endpoints/converters.py
+++ b/DashAI/back/api/api_v1/endpoints/converters.py
@@ -20,7 +20,7 @@ router = APIRouter()
 @router.post("/", status_code=status.HTTP_201_CREATED)
 @inject
 async def post_notebook_converter_list(
-    params: schemas.ConverterListParams,
+    params: schemas.ConverterParams,
     session_factory: "sessionmaker" = Depends(lambda: di["session_factory"]),
 ):
     """Save a list of converters to apply to the notebook.
@@ -45,7 +45,7 @@ async def post_notebook_converter_list(
     HTTPException
         If the notebook is not found or if there is an internal database error.
     """
-    from DashAI.back.dependencies.database.models import ConverterList, Notebook
+    from DashAI.back.dependencies.database.models import Converter, Notebook
 
     with session_factory() as db:
         try:
@@ -59,7 +59,7 @@ async def post_notebook_converter_list(
             converter_name = params.converter
             converter_parameters = params.parameters.serialize()
 
-            converter_list = ConverterList(
+            converter_list = Converter(
                 notebook_id=params.notebook_id,
                 converter=converter_name,
                 parameters=converter_parameters,
@@ -97,7 +97,7 @@ async def get_converter_list(
 
     Returns
     -------
-    ConverterList
+    Converter
         The converter list.
 
     Raises
@@ -105,11 +105,11 @@ async def get_converter_list(
     HTTPException
         If the converter list is not found or if there is an internal database error.
     """
-    from DashAI.back.dependencies.database.models import ConverterList
+    from DashAI.back.dependencies.database.models import Converter
 
     with session_factory() as db:
         try:
-            converter_list = db.get(ConverterList, converter_list_id)
+            converter_list = db.get(Converter, converter_list_id)
             if not converter_list:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
@@ -144,7 +144,7 @@ async def get_converters_by_notebook(
 
     Returns
     -------
-    List[ConverterList]
+    List[Converter]
         A list of converter lists.
 
     Raises
@@ -152,15 +152,15 @@ async def get_converters_by_notebook(
     HTTPException
         If there is an internal database error.
     """
-    from DashAI.back.core.enums.status import ConverterListStatus
-    from DashAI.back.dependencies.database.models import ConverterList
+    from DashAI.back.core.enums.status import ConverterStatus
+    from DashAI.back.dependencies.database.models import Converter
 
     with session_factory() as db:
         try:
             converter_lists = (
-                db.query(ConverterList)
-                .filter(ConverterList.notebook_id == notebook_id)
-                .filter(ConverterList.status == ConverterListStatus.FINISHED)
+                db.query(Converter)
+                .filter(Converter.notebook_id == notebook_id)
+                .filter(Converter.status == ConverterStatus.FINISHED)
                 .all()
             )
             return converter_lists
@@ -183,12 +183,12 @@ async def delete_converter_list(
     """Delete a converter list from the database."""
     import shutil
 
-    from DashAI.back.dependencies.database.models import ConverterList, Explorer
-    from DashAI.back.job.converter_job import ConverterListJob
+    from DashAI.back.dependencies.database.models import Converter, Explorer
+    from DashAI.back.job.converter_job import ConverterJob
 
     with session_factory() as db:
         try:
-            converter_list = db.get(ConverterList, converter_list_id)
+            converter_list = db.get(Converter, converter_list_id)
             if not converter_list:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
@@ -197,19 +197,19 @@ async def delete_converter_list(
             notebook = converter_list.notebook
 
             previous_converters = (
-                db.query(ConverterList)
+                db.query(Converter)
                 .filter(
-                    ConverterList.notebook_id == converter_list.notebook_id,
-                    ConverterList.created < converter_list.created,
+                    Converter.notebook_id == converter_list.notebook_id,
+                    Converter.created < converter_list.created,
                 )
                 .all()
             )
 
             next_converters = (
-                db.query(ConverterList)
+                db.query(Converter)
                 .filter(
-                    ConverterList.notebook_id == converter_list.notebook_id,
-                    ConverterList.created >= converter_list.created,
+                    Converter.notebook_id == converter_list.notebook_id,
+                    Converter.created >= converter_list.created,
                 )
                 .all()
             )
@@ -233,8 +233,8 @@ async def delete_converter_list(
             # Enqueue all previous converters
             job_ids = []
             for converter in previous_converters:
-                # Crear instancia de ConverterListJob y encolarlo directamente
-                job = ConverterListJob(converter_list_id=converter.id)
+                # Crear instancia de ConverterJob y encolarlo directamente
+                job = ConverterJob(converter_list_id=converter.id)
                 job_queue.put(job)
                 if hasattr(job, "id"):
                     job_ids.append(job.id)

--- a/DashAI/back/api/api_v1/endpoints/converters.py
+++ b/DashAI/back/api/api_v1/endpoints/converters.py
@@ -19,7 +19,7 @@ router = APIRouter()
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
 @inject
-async def post_notebook_converter_list(
+async def post_notebook_converter(
     params: schemas.ConverterParams,
     session_factory: "sessionmaker" = Depends(lambda: di["session_factory"]),
 ):
@@ -59,17 +59,17 @@ async def post_notebook_converter_list(
             converter_name = params.converter
             converter_parameters = params.parameters.serialize()
 
-            converter_list = Converter(
+            converter = Converter(
                 notebook_id=params.notebook_id,
                 converter=converter_name,
                 parameters=converter_parameters,
             )
 
-            db.add(converter_list)
+            db.add(converter)
             db.commit()
-            db.refresh(converter_list)
+            db.refresh(converter)
 
-            return converter_list
+            return converter
 
         except exc.SQLAlchemyError as e:
             logger.exception(e)
@@ -79,17 +79,17 @@ async def post_notebook_converter_list(
             ) from e
 
 
-@router.get("/{converter_list_id}")
+@router.get("/{converter_id}")
 @inject
-async def get_converter_list(
-    converter_list_id: int,
+async def get_converter(
+    converter_id: int,
     session_factory: "sessionmaker" = Depends(lambda: di["session_factory"]),
 ):
     """Get a converter list from the database.
 
     Parameters
     ----------
-    converter_list_id : int
+    converter_id : int
         ID of the converter list.
     session_factory : Callable[..., ContextManager[Session]]
         A factory that creates a context manager that handles a SQLAlchemy session.
@@ -109,14 +109,14 @@ async def get_converter_list(
 
     with session_factory() as db:
         try:
-            converter_list = db.get(Converter, converter_list_id)
-            if not converter_list:
+            converter = db.get(Converter, converter_id)
+            if not converter:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="Converter list not found",
                 )
 
-            return converter_list
+            return converter
 
         except exc.SQLAlchemyError as e:
             logger.exception(e)
@@ -157,13 +157,13 @@ async def get_converters_by_notebook(
 
     with session_factory() as db:
         try:
-            converter_lists = (
+            converters = (
                 db.query(Converter)
                 .filter(Converter.notebook_id == notebook_id)
                 .filter(Converter.status == ConverterStatus.FINISHED)
                 .all()
             )
-            return converter_lists
+            return converters
 
         except exc.SQLAlchemyError as e:
             logger.exception(e)
@@ -173,10 +173,10 @@ async def get_converters_by_notebook(
             ) from e
 
 
-@router.delete("/{converter_list_id}")
+@router.delete("/{converter_id}")
 @inject
-async def delete_converter_list(
-    converter_list_id: int,
+async def delete_converter(
+    converter_id: int,
     session_factory: "sessionmaker" = Depends(lambda: di["session_factory"]),
     job_queue: "BaseJobQueue" = Depends(lambda: di["job_queue"]),
 ):
@@ -188,19 +188,19 @@ async def delete_converter_list(
 
     with session_factory() as db:
         try:
-            converter_list = db.get(Converter, converter_list_id)
-            if not converter_list:
+            converter = db.get(Converter, converter_id)
+            if not converter:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="Converter list not found",
                 )
-            notebook = converter_list.notebook
+            notebook = converter.notebook
 
             previous_converters = (
                 db.query(Converter)
                 .filter(
-                    Converter.notebook_id == converter_list.notebook_id,
-                    Converter.created < converter_list.created,
+                    Converter.notebook_id == converter.notebook_id,
+                    Converter.created < converter.created,
                 )
                 .all()
             )
@@ -208,8 +208,8 @@ async def delete_converter_list(
             next_converters = (
                 db.query(Converter)
                 .filter(
-                    Converter.notebook_id == converter_list.notebook_id,
-                    Converter.created >= converter_list.created,
+                    Converter.notebook_id == converter.notebook_id,
+                    Converter.created >= converter.created,
                 )
                 .all()
             )
@@ -217,8 +217,8 @@ async def delete_converter_list(
             next_explorers = (
                 db.query(Explorer)
                 .filter(
-                    Explorer.notebook_id == converter_list.notebook_id,
-                    Explorer.created >= converter_list.created,
+                    Explorer.notebook_id == converter.notebook_id,
+                    Explorer.created >= converter.created,
                 )
                 .all()
             )
@@ -234,7 +234,7 @@ async def delete_converter_list(
             job_ids = []
             for converter in previous_converters:
                 # Crear instancia de ConverterJob y encolarlo directamente
-                job = ConverterJob(converter_list_id=converter.id)
+                job = ConverterJob(converter_id=converter.id)
                 job_queue.put(job)
                 if hasattr(job, "id"):
                     job_ids.append(job.id)
@@ -248,7 +248,7 @@ async def delete_converter_list(
                 db.delete(explorer)
 
             # Delete the current converter
-            db.delete(converter_list)
+            db.delete(converter)
             db.commit()
 
             last_job_id = job_ids[-1] if job_ids else None

--- a/DashAI/back/api/api_v1/endpoints/notebook.py
+++ b/DashAI/back/api/api_v1/endpoints/notebook.py
@@ -12,7 +12,7 @@ from DashAI.back.api.api_v1.schemas.notebook_params import (
     NotebookUpdateParams,
 )
 from DashAI.back.dependencies.database.models import (
-    ConverterList,
+    Converter,
     Dataset,
     Explorer,
     Notebook,
@@ -229,7 +229,7 @@ async def get_notebook_converter_list(
 
     Returns
     -------
-    ConverterList
+    Converter
         The converter list associated with the notebook.
 
     Raises
@@ -240,9 +240,7 @@ async def get_notebook_converter_list(
     with session_factory() as db:
         try:
             converter_list = (
-                db.query(ConverterList)
-                .filter(ConverterList.notebook_id == notebook_id)
-                .all()
+                db.query(Converter).filter(Converter.notebook_id == notebook_id).all()
             )
 
             return converter_list

--- a/DashAI/back/api/api_v1/endpoints/notebook.py
+++ b/DashAI/back/api/api_v1/endpoints/notebook.py
@@ -214,7 +214,7 @@ def get_notebook_explorer_list(
 
 @router.get("/{notebook_id}/converters")
 @inject
-async def get_notebook_converter_list(
+async def get_notebook_converter(
     notebook_id: int,
     session_factory: "sessionmaker" = Depends(lambda: di["session_factory"]),
 ):
@@ -239,11 +239,11 @@ async def get_notebook_converter_list(
     """
     with session_factory() as db:
         try:
-            converter_list = (
+            converter = (
                 db.query(Converter).filter(Converter.notebook_id == notebook_id).all()
             )
 
-            return converter_list
+            return converter
         except Exception as e:
             log.error(
                 f"Error retrieving converter list for notebook {notebook_id}: {e}"

--- a/DashAI/back/api/api_v1/schemas/converter_params.py
+++ b/DashAI/back/api/api_v1/schemas/converter_params.py
@@ -18,7 +18,7 @@ class ConverterParams(BaseModel):
         }
 
 
-class ConverterListParams(BaseModel):
+class ConverterParams(BaseModel):
     notebook_id: int
     converter: str
     parameters: ConverterParams

--- a/DashAI/back/api/api_v1/schemas/job_params.py
+++ b/DashAI/back/api/api_v1/schemas/job_params.py
@@ -12,7 +12,7 @@ class JobParams(BaseModel):
         "PredictJob",
         "DatasetJob",
         "ExplorerJob",
-        "ConverterListJob",
+        "ConverterJob",
         "GenerativeJob",
         "PipelineJob",
     ]

--- a/DashAI/back/core/enums/status.py
+++ b/DashAI/back/core/enums/status.py
@@ -25,7 +25,7 @@ class ExplorerStatus(Enum):
     ERROR = 4
 
 
-class ConverterListStatus(Enum):
+class ConverterStatus(Enum):
     NOT_STARTED = 0
     DELIVERED = 1
     STARTED = 2

--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -535,7 +535,7 @@ class Pipeline(Base):
 
 
 class Converter(Base):
-    __tablename__ = "converter_list"
+    __tablename__ = "converter"
     """
     Table to store a list of converters applied to a dataset.
     """

--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
 from DashAI.back.core.enums.plugin_tags import PluginTag
 from DashAI.back.core.enums.status import (
-    ConverterListStatus,
+    ConverterStatus,
     DatasetStatus,
     ExplainerStatus,
     ExplorerStatus,
@@ -534,7 +534,7 @@ class Pipeline(Base):
     prediction: Mapped[Dict[str, Any]] = mapped_column(JSON, nullable=True)
 
 
-class ConverterList(Base):
+class Converter(Base):
     __tablename__ = "converter_list"
     """
     Table to store a list of converters applied to a dataset.
@@ -553,9 +553,9 @@ class ConverterList(Base):
         onupdate=datetime.now,
     )
     status: Mapped[Enum] = mapped_column(
-        Enum(ConverterListStatus),
+        Enum(ConverterStatus),
         nullable=False,
-        default=ConverterListStatus.NOT_STARTED,
+        default=ConverterStatus.NOT_STARTED,
     )
     delivery_time: Mapped[DateTime] = mapped_column(DateTime, nullable=True)
     start_time: Mapped[DateTime] = mapped_column(DateTime, nullable=True)
@@ -568,26 +568,26 @@ class ConverterList(Base):
         """Update the status of the list to delivered and set delivery_time
         to now.
         """
-        self.status = ConverterListStatus.DELIVERED
+        self.status = ConverterStatus.DELIVERED
         self.delivery_time = datetime.now()
 
     def set_status_as_started(self) -> None:
         """Update the status of the list to started and set start_time
         to now.
         """
-        self.status = ConverterListStatus.STARTED
+        self.status = ConverterStatus.STARTED
         self.start_time = datetime.now()
 
     def set_status_as_finished(self) -> None:
         """Update the status of the list to finished and set end_time
         to now.
         """
-        self.status = ConverterListStatus.FINISHED
+        self.status = ConverterStatus.FINISHED
         self.end_time = datetime.now()
 
     def set_status_as_error(self) -> None:
         """Update the status of the list to error."""
-        self.status = ConverterListStatus.ERROR
+        self.status = ConverterStatus.ERROR
 
 
 class Notebook(Base):
@@ -612,7 +612,7 @@ class Notebook(Base):
     explorers: Mapped[List["Explorer"]] = relationship(
         back_populates="notebook", cascade="all, delete-orphan"
     )
-    converters: Mapped[List["ConverterList"]] = relationship(
+    converters: Mapped[List["Converter"]] = relationship(
         back_populates="notebook", cascade="all, delete-orphan"
     )
     dataset: Mapped["Dataset"] = relationship(back_populates="notebooks")

--- a/DashAI/back/dependencies/database/utils.py
+++ b/DashAI/back/dependencies/database/utils.py
@@ -265,16 +265,14 @@ def find_entity_by_huey_id(huey_id: str) -> dict:
                 "last_modified": local_explainer.last_modified,
             }
 
-        converter_list = (
-            db.query(Converter).filter(Converter.huey_id == huey_id).first()
-        )
-        if converter_list:
+        converter = db.query(Converter).filter(Converter.huey_id == huey_id).first()
+        if converter:
             return {
                 "entity_type": "converter",
-                "entity_id": converter_list.id,
-                "entity_name": converter_list.name,
-                "created_at": converter_list.created,
-                "last_modified": converter_list.last_modified,
+                "entity_id": converter.id,
+                "entity_name": converter.name,
+                "created_at": converter.created,
+                "last_modified": converter.last_modified,
             }
 
         return None

--- a/DashAI/back/dependencies/database/utils.py
+++ b/DashAI/back/dependencies/database/utils.py
@@ -197,7 +197,7 @@ def find_entity_by_huey_id(huey_id: str) -> dict:
     from kink import di
 
     from DashAI.back.dependencies.database.models import (
-        ConverterList,
+        Converter,
         Dataset,
         Explorer,
         GlobalExplainer,
@@ -266,7 +266,7 @@ def find_entity_by_huey_id(huey_id: str) -> dict:
             }
 
         converter_list = (
-            db.query(ConverterList).filter(ConverterList.huey_id == huey_id).first()
+            db.query(Converter).filter(Converter.huey_id == huey_id).first()
         )
         if converter_list:
             return {

--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -95,7 +95,7 @@ from DashAI.back.exploration.explorers.scatter_plot import ScatterPlotExplorer
 from DashAI.back.exploration.explorers.wordcloud import WordcloudExplorer
 
 # Jobs
-from DashAI.back.job.converter_job import ConverterListJob
+from DashAI.back.job.converter_job import ConverterJob
 from DashAI.back.job.dataset_job import DatasetJob
 from DashAI.back.job.explainer_job import ExplainerJob
 from DashAI.back.job.explorer_job import ExplorerJob
@@ -297,7 +297,7 @@ def get_initial_components():
         ModelJob,
         ExplorerJob,
         PredictJob,
-        ConverterListJob,
+        ConverterJob,
         DatasetJob,
         GenerativeJob,
         PipelineJob,

--- a/DashAI/back/job/converter_job.py
+++ b/DashAI/back/job/converter_job.py
@@ -5,7 +5,7 @@ from kink import inject
 from sqlalchemy import exc
 
 from DashAI.back.api.api_v1.schemas.converter_params import ConverterParams
-from DashAI.back.dependencies.database.models import ConverterList
+from DashAI.back.dependencies.database.models import Converter
 from DashAI.back.dependencies.database.models import Dataset as DatasetModel
 from DashAI.back.job.base_job import BaseJob, JobError
 
@@ -94,8 +94,8 @@ def _rebuild_dataset_with_transformed_columns(
     return modified_dataset
 
 
-class ConverterListJob(BaseJob):
-    """ConverterListJob class to modify a dataset by applying a
+class ConverterJob(BaseJob):
+    """ConverterJob class to modify a dataset by applying a
     sequence of converters."""
 
     @inject
@@ -106,7 +106,7 @@ class ConverterListJob(BaseJob):
         converter_list_id = self.kwargs["converter_list_id"]
 
         with session_factory() as db:
-            converter_list = db.get(ConverterList, converter_list_id)
+            converter_list = db.get(Converter, converter_list_id)
             if converter_list is None:
                 raise JobError(
                     f"Converter list with id {converter_list_id} does not exist in DB."
@@ -131,7 +131,7 @@ class ConverterListJob(BaseJob):
             return
 
         with session_factory() as db:
-            converter_list = db.get(ConverterList, converter_list_id)
+            converter_list = db.get(Converter, converter_list_id)
             if converter_list is None:
                 return
 
@@ -154,7 +154,7 @@ class ConverterListJob(BaseJob):
 
         try:
             with session_factory() as db:
-                converter_list = db.get(ConverterList, converter_list_id)
+                converter_list = db.get(Converter, converter_list_id)
                 if not converter_list:
                     return f"Converter Job #{converter_list_id}"
                 converter_name = converter_list.converter
@@ -210,7 +210,7 @@ class ConverterListJob(BaseJob):
                 if converter_list_id is None:
                     raise JobError("Converter list ID is required")
 
-                converter_list: ConverterList = db.get(ConverterList, converter_list_id)
+                converter_list: Converter = db.get(Converter, converter_list_id)
                 if not converter_list:
                     raise JobError(
                         f"Converter list with id {converter_list_id} not found"

--- a/DashAI/back/job/converter_job.py
+++ b/DashAI/back/job/converter_job.py
@@ -102,41 +102,39 @@ class ConverterJob(BaseJob):
     def set_status_as_delivered(
         self, session_factory: "sessionmaker" = lambda di: di["session_factory"]
     ) -> None:
-        """Set the status of the list as delivered."""
-        converter_list_id = self.kwargs["converter_list_id"]
+        """Set the status of the converter as delivered."""
+        converter_id = self.kwargs["converter_id"]
 
         with session_factory() as db:
-            converter_list = db.get(Converter, converter_list_id)
-            if converter_list is None:
+            converter = db.get(Converter, converter_id)
+            if converter is None:
                 raise JobError(
-                    f"Converter list with id {converter_list_id} does not exist in DB."
+                    f"Converter with id {converter_id} does not exist in DB."
                 )
 
             try:
-                converter_list.set_status_as_delivered()
+                converter.set_status_as_delivered()
                 db.commit()
             except exc.SQLAlchemyError as e:
                 log.exception(e)
-                raise JobError(
-                    "Error setting converter list status as delivered"
-                ) from e
+                raise JobError("Error setting converter status as delivered") from e
 
     @inject
     def set_status_as_error(
         self, session_factory: "sessionmaker" = lambda di: di["session_factory"]
     ) -> None:
-        """Set the status of the converter list as error."""
-        converter_list_id = self.kwargs.get("converter_list_id")
-        if converter_list_id is None:
+        """Set the status of the converter as error."""
+        converter_id = self.kwargs.get("converter_id")
+        if converter_id is None:
             return
 
         with session_factory() as db:
-            converter_list = db.get(Converter, converter_list_id)
-            if converter_list is None:
+            converter = db.get(Converter, converter_id)
+            if converter is None:
                 return
 
             try:
-                converter_list.set_status_as_error()
+                converter.set_status_as_error()
                 db.commit()
             except exc.SQLAlchemyError as e:
                 log.exception(e)
@@ -144,8 +142,8 @@ class ConverterJob(BaseJob):
     @inject
     def get_job_name(self) -> str:
         """Get a descriptive name for the job."""
-        converter_list_id = self.kwargs.get("converter_list_id")
-        if not converter_list_id:
+        converter_id = self.kwargs.get("converter_id")
+        if not converter_id:
             return "Converter Job"
 
         from kink import di
@@ -154,13 +152,13 @@ class ConverterJob(BaseJob):
 
         try:
             with session_factory() as db:
-                converter_list = db.get(Converter, converter_list_id)
-                if not converter_list:
-                    return f"Converter Job #{converter_list_id}"
-                converter_name = converter_list.converter
+                converter = db.get(Converter, converter_id)
+                if not converter:
+                    return f"Converter Job #{converter_id}"
+                converter_name = converter.converter
 
-                if hasattr(converter_list, "notebook") and converter_list.notebook:
-                    dataset = db.get(DatasetModel, converter_list.notebook.dataset_id)
+                if hasattr(converter, "notebook") and converter.notebook:
+                    dataset = db.get(DatasetModel, converter.notebook.dataset_id)
                     if dataset and dataset.name:
                         return f"{converter_name}: {dataset.name}"
 
@@ -168,7 +166,7 @@ class ConverterJob(BaseJob):
         except Exception as e:
             log.exception(f"Error getting job name: {e}")
 
-        return f"Converter Job #{converter_list_id}"
+        return f"Converter Job #{converter_id}"
 
     @inject
     def run(
@@ -203,34 +201,32 @@ class ConverterJob(BaseJob):
             return converter_constructor(**converter_parameters)
 
         # Extract job parameters
-        converter_list_id = self.kwargs["converter_list_id"]
+        converter_id = self.kwargs["converter_id"]
         with session_factory() as db:
             # Validate input parameters
             try:
-                if converter_list_id is None:
-                    raise JobError("Converter list ID is required")
+                if converter_id is None:
+                    raise JobError("Converter ID is required")
 
-                converter_list: Converter = db.get(Converter, converter_list_id)
-                if not converter_list:
-                    raise JobError(
-                        f"Converter list with id {converter_list_id} not found"
-                    )
+                converter: Converter = db.get(Converter, converter_id)
+                if not converter:
+                    raise JobError(f"Converter with id {converter_id} not found")
 
-                converter_list.set_status_as_started()
+                converter.set_status_as_started()
                 db.commit()
             except exc.SQLAlchemyError as e:
                 log.exception(e)
-                raise JobError("Error loading converter list info") from e
+                raise JobError("Error loading converter info") from e
 
             # Get dataset
             try:
-                dataset_id = converter_list.notebook.dataset_id
+                dataset_id = converter.notebook.dataset_id
                 dataset = db.get(DatasetModel, dataset_id)
 
                 # dataset to edit
-                dataset_path = f"{converter_list.notebook.file_path}/dataset"
+                dataset_path = f"{converter.notebook.file_path}/dataset"
                 loaded_dataset = load_dataset(dataset_path)
-                params = converter_list.parameters or {}
+                params = converter.parameters or {}
                 target_column_index = (
                     params["target"].get("idx")
                     if params.get("target") is not None
@@ -242,7 +238,7 @@ class ConverterJob(BaseJob):
 
             except exc.SQLAlchemyError as e:
                 log.exception(e)
-                converter_list.set_status_as_error()
+                converter.set_status_as_error()
                 db.commit()
                 raise JobError("Error loading dataset info") from e
 
@@ -258,15 +254,13 @@ class ConverterJob(BaseJob):
                     )
             except Exception as e:
                 log.exception(e)
-                converter_list.set_status_as_error()
+                converter.set_status_as_error()
                 db.commit()
                 raise JobError(f"Cannot load dataset from {dataset_path}") from e
 
             try:
                 # Get stored converter configurations
-                converters_stored_info = {
-                    converter_list.converter: converter_list.parameters
-                }
+                converters_stored_info = {converter.converter: converter.parameters}
                 dataset_original_columns = loaded_dataset.column_names
 
                 # Sort converters by order
@@ -301,7 +295,7 @@ class ConverterJob(BaseJob):
 
                 # Apply each converter in sequence
                 for converter_info in converter_instances:
-                    converter = converter_info["instance"]
+                    converter_instance = converter_info["instance"]
                     converter_name = converter_info["name"]
                     converter_scope = converter_info["scope"]
 
@@ -347,7 +341,9 @@ class ConverterJob(BaseJob):
                         X_dataset_fit = X_dataset_fit.select(scope_rows_indexes)
 
                     try:
-                        converter = converter.fit(X_dataset_fit, y_dataset_fit)
+                        converter_instance = converter_instance.fit(
+                            X_dataset_fit, y_dataset_fit
+                        )
                     except ValueError as e:
                         log.error(f"Validation error in {converter_name}: {e}")
                         raise JobError(
@@ -362,7 +358,7 @@ class ConverterJob(BaseJob):
                     X_full_transform = loaded_dataset.select_columns(scope_column_names)
 
                     try:
-                        transformed_dataset = converter.transform(
+                        transformed_dataset = converter_instance.transform(
                             X_full_transform, y_full_transform
                         )
                     except Exception as e:
@@ -371,7 +367,7 @@ class ConverterJob(BaseJob):
                             f"Error transforming data with {converter_name}: {e}"
                         ) from e
 
-                    if converter.changes_row_count():
+                    if converter_instance.changes_row_count():
                         loaded_dataset = transformed_dataset
                     else:
                         loaded_dataset = _rebuild_dataset_with_transformed_columns(
@@ -384,13 +380,13 @@ class ConverterJob(BaseJob):
                     dataset_original_columns = loaded_dataset.column_names
 
                 save_dataset(loaded_dataset, f"{dataset_path}")
-                converter_list.set_status_as_finished()
+                converter.set_status_as_finished()
                 db.commit()
                 db.refresh(dataset)
 
             except Exception as e:
                 log.exception(e)
-                converter_list.set_status_as_error()
+                converter.set_status_as_error()
                 db.commit()
                 raise JobError(
                     f"Error applying converters to dataset {dataset_id}: {e}"

--- a/DashAI/front/src/api/converter.ts
+++ b/DashAI/front/src/api/converter.ts
@@ -3,7 +3,7 @@ import { IConverter } from "../types/converter";
 
 const converterEndpoint = "/v1/converter";
 
-export const saveConverterList = async (
+export const saveConverter = async (
   converters: object,
 ): Promise<IConverter> => {
   const data = converters;
@@ -12,7 +12,7 @@ export const saveConverterList = async (
   return response.data;
 };
 
-export const getDatasetConverterList = async (
+export const getDatasetConverter = async (
   datasetId: number,
 ): Promise<IConverter> => {
   const response = await api.get<IConverter>(

--- a/DashAI/front/src/api/job.ts
+++ b/DashAI/front/src/api/job.ts
@@ -180,7 +180,7 @@ export const enqueueConverterJob = async (
   const data = {
     job_type: "ConverterJob",
     kwargs: {
-      converter_list_id: converterId,
+      converter_id: converterId,
     },
     stop_when_queue_empties: true,
   };

--- a/DashAI/front/src/api/job.ts
+++ b/DashAI/front/src/api/job.ts
@@ -175,12 +175,12 @@ export const enqueueGenerativeProcessJob = async (
 };
 
 export const enqueueConverterJob = async (
-  converterListId: number,
+  converterId: number,
 ): Promise<object> => {
   const data = {
-    job_type: "ConverterListJob",
+    job_type: "ConverterJob",
     kwargs: {
-      converter_list_id: converterListId,
+      converter_list_id: converterId,
     },
     stop_when_queue_empties: true,
   };

--- a/DashAI/front/src/components/datasets/ConvertDatasetModal.jsx
+++ b/DashAI/front/src/components/datasets/ConvertDatasetModal.jsx
@@ -21,11 +21,8 @@ import ConverterSelectorModal from "./converterModals/ConverterSelectorModal";
 import ConverterTable from "./ConverterTable";
 import { useSnackbar } from "notistack";
 import { enqueueConverterJob as enqueueConverterJobRequest } from "../../api/job";
-import {
-  saveConverterList,
-  getDatasetConverterList,
-} from "../../api/converter";
-import { ConverterListStatus } from "../../types/converter";
+import { saveConverter, getDatasetConverter } from "../../api/converter";
+import { ConverterStatus } from "../../types/converter";
 import { getModelSessionsExist } from "../../api/datasets";
 import CopyDatasetModal from "./converterModals/CopyDatasetModal";
 import ConverterClassColumnModal from "./converterModals/ConverterClassColumnModal";
@@ -43,17 +40,17 @@ function ConvertDatasetModal({ datasetId }) {
   const [convertersToApply, setConvertersToApply] = useState([]);
   const [openCopyModal, setOpenCopyModal] = useState(false);
   const [datasetIdToModify, setDatasetIdToModify] = useState(datasetId);
-  const [converterListId, setConverterListId] = useState(null);
-  const [converterListStatus, setConverterListStatus] = useState(null);
+  const [converterId, setConverterId] = useState(null);
+  const [converterStatus, setConverterStatus] = useState(null);
   const [running, setRunning] = useState(false);
 
   const handleCloseContent = () => {
     setOpen(false);
   };
 
-  const enqueueConverterJob = async (converterListId) => {
+  const enqueueConverterJob = async (converterId) => {
     try {
-      await enqueueConverterJobRequest(converterListId, targetColumnIndex);
+      await enqueueConverterJobRequest(converterId, targetColumnIndex);
       enqueueSnackbar("Converter job successfully created.", {
         variant: "success",
       });
@@ -69,10 +66,10 @@ function ConvertDatasetModal({ datasetId }) {
     }
   };
 
-  const saveAndEnqueueConverterList = async (id) => {
+  const saveAndEnqueueConverter = async (id) => {
     try {
       // Save the list of converters to apply
-      const flattenConverterList = convertersToApply.reduce(
+      const flattenConverter = convertersToApply.reduce(
         (acc, { name, params, scope }, index) => {
           acc[name] = {
             params: params,
@@ -85,13 +82,13 @@ function ConvertDatasetModal({ datasetId }) {
         {},
       );
 
-      const response = await saveConverterList(id, flattenConverterList);
+      const response = await saveConverter(id, flattenConverter);
 
-      const converterListId = response.id;
-      setConverterListId(converterListId);
+      const converterId = response.id;
+      setConverterId(converterId);
 
       // Enqueue the converter job using the id of the saved list
-      await enqueueConverterJob(converterListId);
+      await enqueueConverterJob(converterId);
 
       setRunning(true);
       enqueueSnackbar("Running converter jobs.", {
@@ -118,7 +115,7 @@ function ConvertDatasetModal({ datasetId }) {
       if (hasExperiments) {
         setOpenCopyModal(true);
       } else {
-        await saveAndEnqueueConverterList(datasetIdToModify);
+        await saveAndEnqueueConverter(datasetIdToModify);
       }
     } catch (error) {
       enqueueSnackbar(
@@ -130,18 +127,18 @@ function ConvertDatasetModal({ datasetId }) {
     }
   };
 
-  const getConverterListStatus = async () => {
+  const getConverterStatus = async () => {
     try {
-      const convertersFromDB = await getDatasetConverterList(converterListId);
-      setConverterListStatus(convertersFromDB.status);
+      const convertersFromDB = await getDatasetConverter(converterId);
+      setConverterStatus(convertersFromDB.status);
 
       // Set running to false if status is ERROR or FINISHED
-      if (convertersFromDB.status === ConverterListStatus.ERROR) {
+      if (convertersFromDB.status === ConverterStatus.ERROR) {
         setRunning(false);
         enqueueSnackbar("Converter job failed", {
           variant: "error",
         });
-      } else if (convertersFromDB.status === ConverterListStatus.FINISHED) {
+      } else if (convertersFromDB.status === ConverterStatus.FINISHED) {
         setRunning(false);
         enqueueSnackbar("Dataset successfully modified.", {
           variant: "success",
@@ -164,7 +161,7 @@ function ConvertDatasetModal({ datasetId }) {
       enqueueSnackbar(errorMessage, {
         variant: "error",
       });
-      console.error("Error in getConverterListStatus:", error);
+      console.error("Error in getConverterStatus:", error);
     }
   };
 
@@ -172,7 +169,7 @@ function ConvertDatasetModal({ datasetId }) {
   useEffect(() => {
     if (running) {
       const interval = setInterval(() => {
-        getConverterListStatus();
+        getConverterStatus();
       }, 5000);
       return () => clearInterval(interval);
     }
@@ -292,7 +289,7 @@ function ConvertDatasetModal({ datasetId }) {
         updateDatasetId={setDatasetIdToModify}
         open={openCopyModal}
         setOpen={setOpenCopyModal}
-        modifyDataset={saveAndEnqueueConverterList}
+        modifyDataset={saveAndEnqueueConverter}
       />
     </React.Fragment>
   );

--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Box } from "@mui/material";
-import { saveConverterList } from "../../../api/converter";
+import { saveConverter } from "../../../api/converter";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
 import { useSnackbar } from "notistack";
 import ParameterStepConverter from "./ParameterStepConverter";
@@ -39,7 +39,7 @@ export default function FormConverterSection({
       },
     };
 
-    saveConverterList(data)
+    saveConverter(data)
       .then((response) => {
         const data = { ...response, type: "converter" };
         setExplorersAndConverters((prev) => [...prev, data]);

--- a/DashAI/front/src/types/converter.ts
+++ b/DashAI/front/src/types/converter.ts
@@ -6,7 +6,7 @@ export interface IConverter {
   converters: Object;
 }
 
-export enum ConverterListStatus {
+export enum ConverterStatus {
   NOT_STARTED,
   DELIVERED,
   STARTED,

--- a/docs/source/api/back.rst
+++ b/docs/source/api/back.rst
@@ -100,7 +100,7 @@ Jobs
    DashAI.back.job.ModelJob
    DashAI.back.job.PredictJob
    DashAI.back.job.ExplorerJob
-   DashAI.back.job.ConverterListJob
+   DashAI.back.job.ConverterJob
 
 Explainers
 ==========


### PR DESCRIPTION
## Summary
Refactored the codebase to replace the `ConverterList` model with a simplified and clearer `Converter` model. This change updates the database schema, API, schemas, enums, and job handling to improve naming consistency and maintainability.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `models/converter.py`: Renamed `ConverterList` to `Converter` and updated fields/relationships.
- `migrations/*`: Updated Alembic migration to rename `converter_list` table to `converter`.
- `api/converter.py`: Refactored endpoints, request/response types, and paths to use `Converter`.
- `schemas/converter.py`: Updated Pydantic schemas, including `ConverterParams`.
- `enums/converter.py`: Renamed `ConverterListStatus` to `ConverterStatus`.
- `jobs/converter_job.py`: Replaced `ConverterListJob` with `ConverterJob` and updated job handling logic.
- `utils/converter.py`: Updated queries and helper functions to use the new model.
- `*`: General refactor of imports and references across the backend.

---

## Testing (optional)
- Verify existing converters are correctly migrated and accessible.
- Test all CRUD endpoints for `Converter`.
- Ensure job queueing and execution works with `ConverterJob`.