### PR TITLE
style: update Typography styles in NumericTab and TextTab 

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
@@ -59,8 +59,10 @@ export const NumericTab = ({ numericStats }) => {
               <Box flex="1 1 300px" minWidth="250px">
                 <Typography
                   variant="subtitle2"
-                  color="text.secondary"
+                  fontWeight="bold"
+                  color="text.primary"
                   gutterBottom
+                  sx={{ fontSize: "0.875rem", textTransform: "uppercase" }}
                 >
                   {t("datasets:label.distributionMetrics")}
                 </Typography>
@@ -92,8 +94,10 @@ export const NumericTab = ({ numericStats }) => {
               <Box flex="1 1 300px" minWidth="250px">
                 <Typography
                   variant="subtitle2"
-                  color="text.secondary"
+                  fontWeight="bold"
+                  color="text.primary"
                   gutterBottom
+                  sx={{ fontSize: "0.875rem", textTransform: "uppercase" }}
                 >
                   {t("datasets:label.shapeIndicators")}
                 </Typography>

--- a/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
@@ -134,8 +134,10 @@ export const TextTab = ({ textStats }) => {
                 <Box flex="1 1 300px" minWidth="250px">
                   <Typography
                     variant="subtitle2"
-                    color="text.secondary"
+                    fontWeight="bold"
+                    color="text.primary"
                     gutterBottom
+                    sx={{ fontSize: "0.875rem", textTransform: "uppercase" }}
                   >
                     {t("datasets:label.lengthMetrics")}
                   </Typography>


### PR DESCRIPTION
## Summary

Improved visual hierarchy in the Numeric and Text tabs by enhancing section header styling. Subsection headers like "Distribution Metrics", "Shape Indicators", and "Length Metrics" now have **bold font weight**, **primary text color**, and **uppercase transformation**, making them visually distinct from individual metric names (Min, Q1, Skewness, etc.). This change clarifies the structural organization and improves overall readability.

**Problem Addressed**: Section headers and individual metric names previously shared identical typography, making it difficult to distinguish between grouped subsections and their contained metrics.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx`: Enhanced typography for section headers ("Distribution Metrics", "Shape Indicators"):
  - Changed color from `text.secondary` to `text.primary`
  - Added `fontWeight="bold"`
  - Added uppercase transformation and subtle font size adjustment

- `DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx`: Applied same styling improvements to "Length Metrics" header for consistency across tabs



