### PR TITLE
Use theme-based styles in ConfigureAndUploadDatasetStep

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
@@ -9,6 +9,7 @@ import { useTourContext } from "../../tour/TourProvider";
 
 import { createDataset } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
+import { useTheme } from "@mui/material/styles";
 
 export default function ConfigureAndUploadDatasetStep({
   selectedDataloader,
@@ -31,6 +32,7 @@ export default function ConfigureAndUploadDatasetStep({
 
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation(["common", "datasets"]);
+  const theme = useTheme();
 
   useEffect(() => {
     if (onPreviewError) {
@@ -183,8 +185,8 @@ export default function ConfigureAndUploadDatasetStep({
         spacing={2}
         sx={{
           width: "100%",
-          backgroundColor: "#212121",
-          padding: 4,
+          backgroundColor: theme.palette.background.box,
+          padding: 2,
           borderRadius: 2,
         }}
       >


### PR DESCRIPTION
## Summary
Refactors the `ConfigureAndUploadDatasetStep` component to use theme-based styles instead of hardcoded values, improving visual consistency and maintainability across the application.

### Before
<img width="2539" height="1347" alt="image" src="https://github.com/user-attachments/assets/0f12860c-0d2c-4574-aa7b-533adc9e8942" />

### After
<img width="2543" height="1347" alt="image" src="https://github.com/user-attachments/assets/efef85ac-5208-42d5-bf8e-ad58ca93e8cd" />

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `ConfigureAndUploadDatasetStep.tsx`:  
  - Replaced hardcoded background color and padding with values from the MUI theme (`theme.palette.background.box` and adjusted spacing).  
  - Added `useTheme` hook to access and apply theme variables.

---

## Testing (optional)
- Verify that the component renders correctly in both light and dark modes.