### PR TITLE
Fix/datasetsVisualization models module

### DIFF
--- a/DashAI/front/src/components/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/DatasetVisualization.jsx
@@ -321,6 +321,7 @@ export default function DatasetVisualization({
                 qualityInfo={datasetInfo?.quality_info}
                 generalInfo={datasetInfo?.general_info}
                 missingValues={datasetInfo?.nan}
+                onNavigateTab={setTab}
               />
             </Box>
             {/* Tabs */}

--- a/DashAI/front/src/components/notebooks/dataset/QualityAlerts.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/QualityAlerts.jsx
@@ -14,10 +14,16 @@ import { useTheme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
 import { useDatasetsAndNotebooks } from "../../custom/contexts/DatasetsAndNotebooksContext";
 
-export const QualityAlerts = ({ qualityInfo, generalInfo, missingValues }) => {
+export const QualityAlerts = ({
+  qualityInfo,
+  generalInfo,
+  missingValues,
+  onNavigateTab,
+}) => {
   const theme = useTheme();
   const { t } = useTranslation(["datasets"]);
-  const { setDatasetTab } = useDatasetsAndNotebooks();
+  const context = useDatasetsAndNotebooks();
+  const setDatasetTab = onNavigateTab ?? context?.setDatasetTab ?? (() => {});
 
   const handleNavigate = useCallback(
     (section) => {


### PR DESCRIPTION
## Summary                                                                                                       
  Fix crash when selecting a dataset in the Models module. `QualityAlerts` was calling `useDatasetsAndNotebooks()`
  directly and destructuring `setDatasetTab`, but in the Models module that context provider doesn't exist, causing
   a TypeError.
                                                                                                                   
  Applied the same safe pattern already used by `ColumnInsights`: optional chaining on the context + an
  `onNavigateTab` prop passed from the parent.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change                                                                                   
  - [x] Bug fix
  - [ ] Documentation                                                                                              
                                                            
  ---

  ## Changes (by file)

  - `DashAI/front/src/components/notebooks/dataset/QualityAlerts.jsx`: Use optional chaining on context and accept 
  `onNavigateTab` prop as fallback, preventing crash when rendered outside `DatasetsAndNotebooksContext`.
  - `DashAI/front/src/components/DatasetVisualization.jsx`: Pass `setTab` (which already resolves both contexts) as
   `onNavigateTab` to `QualityAlerts`.                                                                             
   
  ---                                                                                                              
                                                            
  ## Testing
  1. Open the Models module and click on a dataset — should render without errors.
  2. Open the Datasets/Notebooks module and verify quality alerts navigation still works as before.
