### PR TITLE
Fix dataloader params loss by merging form values in DataloaderConfigBar

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/DataloaderConfigBar.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/DataloaderConfigBar.jsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import PropTypes from "prop-types";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import FormSchema from "../../shared/FormSchema";
 import FormSchemaContainer from "../../shared/FormSchemaContainer";
 import { generateSequentialName } from "../../../utils/nameGenerator";
@@ -26,6 +26,8 @@ export default function DataloaderConfigBar({
   onValuesChange,
 }) {
   const [inferenceRows, setInferenceRows] = useState(1000);
+  // Track FormSchema values separately so we can merge with inference_rows
+  const schemaValuesRef = useRef({});
   const { t } = useTranslation(["common", "datasets"]);
 
   const { defaultName } = useMemo(
@@ -35,6 +37,27 @@ export default function DataloaderConfigBar({
         items: existingDatasets,
       }),
     [existingDatasets],
+  );
+
+  // Handler for when FormSchema values change - merge with inference_rows
+  const handleFormSchemaValuesChange = useCallback(() => {
+    const values = formSubmitRef?.current?.values || {};
+    schemaValuesRef.current = values;
+    if (onValuesChange) {
+      onValuesChange({ ...values, inference_rows: inferenceRows });
+    }
+  }, [formSubmitRef, inferenceRows, onValuesChange]);
+
+  // Handler for when inference_rows changes - merge with schema values
+  const handleInferenceRowsChange = useCallback(
+    (val) => {
+      const numeric = val ? Number(val) : undefined;
+      setInferenceRows(numeric);
+      if (onValuesChange) {
+        onValuesChange({ ...schemaValuesRef.current, inference_rows: numeric });
+      }
+    },
+    [onValuesChange],
   );
 
   if (!selectedDataloader) {
@@ -100,11 +123,7 @@ export default function DataloaderConfigBar({
               label={t("datasets:label.inferenceRows")}
               name="inference_rows"
               value={inferenceRows}
-              onChange={(val) => {
-                setInferenceRows(val);
-                const numeric = val ? Number(val) : undefined;
-                if (onValuesChange) onValuesChange({ inference_rows: numeric });
-              }}
+              onChange={handleInferenceRowsChange}
               type="number"
               helperText=" "
               margin="dense"
@@ -151,7 +170,7 @@ export default function DataloaderConfigBar({
               formSubmitRef={formSubmitRef}
               setError={setError}
               initialValues={{ name: defaultName }}
-              onValuesChange={onValuesChange}
+              onValuesChange={handleFormSchemaValuesChange}
               showBorder={false}
             />
           </FormSchemaContainer>


### PR DESCRIPTION
## Summary
Fixed an issue where the dataset preview and `validate_type_changes` endpoints were not receiving dataloader parameters (e.g., CSV separator). This occurred because `DataloaderConfigBar` was overwriting the entire form state when `inference_rows` changed, causing loss of dataloader-specific values.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- **DashAI/front/src/components/notebooks/datasetCreation/DataloaderConfigBar.jsx**  
  Implemented proper merging between `FormSchema` values (dataloader parameters) and `inference_rows`.  
  Previously, updates to `inference_rows` triggered `onValuesChange({ inference_rows: X })`, replacing the entire form state.  
  Now, a `useRef` is used to track schema values, ensuring that all updates send a fully merged object to the parent.

---

## Testing (optional)

1. Upload a CSV file and verify the preview loads correctly  
2. Change the separator in the config sidebar and confirm the preview updates  
3. Change a column type and verify the validation dialog works  

---

## Notes (optional)

**Root cause:** `onValuesChange` was being called with partial objects (e.g., `{ inference_rows: X }`), which replaced the parent `formValues` state instead of merging it.  

**Fix:** Track `FormSchema` values using a ref and always emit a complete, merged object.