### PR TITLE
Preserve HPO plot title on dropdown selection

### DIFF
--- a/DashAI/front/src/utils/plotlyTheme.js
+++ b/DashAI/front/src/utils/plotlyTheme.js
@@ -55,6 +55,28 @@ function applyThemeToLayout(baseLayout, theme) {
         bordercolor: gridColor,
         font: { color: "#000000" },
         activecolor: theme.palette.primary.main,
+        buttons: menu.buttons?.map((button) => {
+          const layoutArgs = button.args?.[1];
+          if (!layoutArgs) return button;
+          const updatedLayoutArgs = { ...layoutArgs };
+          if (typeof updatedLayoutArgs.title === "string") {
+            updatedLayoutArgs.title = {
+              text: updatedLayoutArgs.title,
+              font: { color: textColor },
+            };
+          } else if (updatedLayoutArgs.title != null) {
+            updatedLayoutArgs.title = {
+              ...updatedLayoutArgs.title,
+              font: { ...updatedLayoutArgs.title.font, color: textColor },
+            };
+          }
+          return {
+            ...button,
+            args: button.args.map((arg, i) =>
+              i === 1 ? updatedLayoutArgs : arg,
+            ),
+          };
+        }),
       })),
     }),
     ...(baseLayout?.polar && {


### PR DESCRIPTION
## Summary

When switching options in the contour/slice plot dropdown, the plot title disappeared. Plotly's `updatemenus` buttons store layout updates in `args[1]`, where `title` was defined as a plain string. When the update was triggered, this string overwrote the existing title object set by `applyThemeToLayout` (which uses the `{ text, font }` format), causing the title to vanish.

This fix normalizes button `args` so that `title` is always passed as an object with the correct font color, ensuring it persists across updates.

---

## Type of Change

- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)

- **DashAI/front/src/utils/plotlyTheme.js**  
  - When mapping over `updatemenus`, also map over each button's `args` and convert any plain-string `title` in `args[1]` into:
    ```js
    { text: "...", font: { color: textColor } }
    ```
  - Ensures the title remains visible after Plotly layout updates triggered by dropdown selection.

---

## Testing

1. Open a run with ≥ 2 optimizable hyperparameters so the contour/slice plot is shown.  
2. Note the initial plot title (e.g., `"Contour plot for C vs coef0"`).  
3. Use the dropdown to switch to a different parameter pair.  
4. Confirm the title updates correctly and does not disappear.  
5. Switch back and confirm the title is still visible.