### PR TITLE
Models view dont wait for backend data to show the page.

### DIFF
--- a/DashAI/back/dataloaders/classes/audio_dataloader.py
+++ b/DashAI/back/dataloaders/classes/audio_dataloader.py
@@ -47,7 +47,10 @@ class AudioDataLoader(BaseDataLoader):
         prepared_path = self.prepare_files(filepath_or_buffer, temp_path)
         if prepared_path[1] == "dir":
             dataset = load_dataset(
-                "audiofolder", data_dir=prepared_path[0], streaming=bool(n_sample)
+                "audiofolder",
+                data_dir=prepared_path[0],
+                streaming=bool(n_sample),
+                cache_dir=temp_path,
             )
             if n_sample:
                 if type(dataset) is IterableDatasetDict:

--- a/DashAI/back/dataloaders/classes/csv_dataloader.py
+++ b/DashAI/back/dataloaders/classes/csv_dataloader.py
@@ -331,6 +331,7 @@ class CSVDataLoader(BaseDataLoader):
                 data_files=prepared_path[0],
                 **clean_params,
                 streaming=bool(n_sample),
+                cache_dir=temp_path,
             )
         else:
             dataset = load_dataset(
@@ -338,6 +339,7 @@ class CSVDataLoader(BaseDataLoader):
                 data_dir=prepared_path[0],
                 **clean_params,
                 streaming=bool(n_sample),
+                cache_dir=temp_path,
             )
             shutil.rmtree(prepared_path[0])
         if n_sample:

--- a/DashAI/back/dataloaders/classes/json_dataloader.py
+++ b/DashAI/back/dataloaders/classes/json_dataloader.py
@@ -137,10 +137,15 @@ class JSONDataLoader(BaseDataLoader):
                 data_files=prepared_path[0],
                 field=field,
                 streaming=bool(n_sample),
+                cache_dir=temp_path,
             )
         else:
             dataset = load_dataset(
-                "json", data_dir=prepared_path[0], field=field, streaming=bool(n_sample)
+                "json",
+                data_dir=prepared_path[0],
+                field=field,
+                streaming=bool(n_sample),
+                cache_dir=temp_path,
             )
             shutil.rmtree(prepared_path[0])
         if n_sample:

--- a/DashAI/front/src/components/models/ModelCenterContent.jsx
+++ b/DashAI/front/src/components/models/ModelCenterContent.jsx
@@ -15,6 +15,7 @@ export default function ModelsCenterContent() {
     setSessions,
     selectedTask,
     tasks,
+    loadingTasks,
     datasets,
     selectedDatasetId,
     step,
@@ -93,6 +94,7 @@ export default function ModelsCenterContent() {
         />
       ) : step === 0 ? (
         <SelectOptionMenu
+          loading={loadingTasks}
           title={
             selectedDatasetId
               ? t("models:label.selectTaskForSession")

--- a/DashAI/front/src/components/models/ModelsContext.jsx
+++ b/DashAI/front/src/components/models/ModelsContext.jsx
@@ -39,6 +39,7 @@ export function ModelsProvider({ children }) {
 
   const {
     tasks,
+    loadingTasks,
     selectedTask,
     selectedSessionId,
     selectedSession,
@@ -116,6 +117,7 @@ export function ModelsProvider({ children }) {
     replaceDatasets,
     startDatasetPolling,
     tasks,
+    loadingTasks,
     selectedTask,
     selectedSessionId,
     selectedSession,

--- a/DashAI/front/src/components/threeSectionLayout/SelectOptionMenu.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/SelectOptionMenu.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box, Grid, Button, Alert, AlertTitle } from "@mui/material";
+import { Box, Grid, Button, Alert, AlertTitle, Skeleton } from "@mui/material";
 import SearchBar from "./SearchBar";
 import CustomLayout from "../custom/CustomLayout";
 import OptionBox from "./OptionBox";
@@ -10,6 +10,7 @@ export default function SelectOptionMenu({
   title,
   subtitle,
   options,
+  loading = false,
   searchBar = false,
   showNoDatasetAlert = false,
   onGoToDatasets = null,
@@ -68,29 +69,43 @@ export default function SelectOptionMenu({
           spacing={1}
           sx={{ mt: 2, mx: 0, maxWidth: "100%" }}
         >
-          {filteredOptions.map((option, index) => {
-            const { name, display_name, description, Icon, ...otherProps } =
-              option;
+          {loading
+            ? Array.from({ length: 6 }).map((_, index) => (
+                <Grid
+                  size={{ xl: 6, lg: 6, md: 6, sm: 12, xs: 12 }}
+                  key={index}
+                >
+                  <Skeleton variant="rounded" height={100} />
+                </Grid>
+              ))
+            : null}
+          {!loading &&
+            filteredOptions.map((option, index) => {
+              const { name, display_name, description, Icon, ...otherProps } =
+                option;
 
-            return (
-              <Grid size={{ xl: 6, lg: 6, md: 6, sm: 12, xs: 12 }} key={index}>
-                <OptionBox
-                  optionName={display_name}
-                  description={description}
-                  onClick={() => goToNextStep(option.name)}
-                  Icon={Icon}
-                  dataTour={
-                    dataTour && dataTourTarget && name === dataTourTarget
-                      ? dataTour
-                      : dataTour && !dataTourTarget
+              return (
+                <Grid
+                  size={{ xl: 6, lg: 6, md: 6, sm: 12, xs: 12 }}
+                  key={index}
+                >
+                  <OptionBox
+                    optionName={display_name}
+                    description={description}
+                    onClick={() => goToNextStep(option.name)}
+                    Icon={Icon}
+                    dataTour={
+                      dataTour && dataTourTarget && name === dataTourTarget
                         ? dataTour
-                        : undefined
-                  }
-                  {...otherProps}
-                />
-              </Grid>
-            );
-          })}
+                        : dataTour && !dataTourTarget
+                          ? dataTour
+                          : undefined
+                    }
+                    {...otherProps}
+                  />
+                </Grid>
+              );
+            })}
         </Grid>
       </Box>
 

--- a/DashAI/front/src/hooks/models/useSessions.js
+++ b/DashAI/front/src/hooks/models/useSessions.js
@@ -21,6 +21,7 @@ import { startJobPolling } from "../../utils/jobPoller";
 export function useSessions({ t }) {
   const { enqueueSnackbar } = useSnackbar();
   const [tasks, setTasks] = useState([]);
+  const [loadingTasks, setLoadingTasks] = useState(true);
   const [selectedTask, setSelectedTask] = useState(null);
   const [selectedSessionId, setSelectedSessionId] = useState(null);
   const [selectedSession, setSelectedSession] = useState(null);
@@ -45,6 +46,7 @@ export function useSessions({ t }) {
   }, [enqueueSnackbar, t]);
 
   const fetchTasks = useCallback(async () => {
+    setLoadingTasks(true);
     try {
       const data = await getComponents({
         selectTypes: ["Task"],
@@ -56,6 +58,8 @@ export function useSessions({ t }) {
         variant: "error",
       });
       console.error("Failed to fetch tasks:", error);
+    } finally {
+      setLoadingTasks(false);
     }
   }, [enqueueSnackbar, t]);
 
@@ -274,6 +278,7 @@ export function useSessions({ t }) {
 
   return {
     tasks,
+    loadingTasks,
     setTasks,
     selectedTask,
     setSelectedTask,

--- a/DashAI/front/src/pages/models/ModelsContent.jsx
+++ b/DashAI/front/src/pages/models/ModelsContent.jsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { Box, CircularProgress } from "@mui/material";
+import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { TourProvider } from "../../components/tour/TourProvider";
@@ -20,7 +19,6 @@ import { useModels } from "../../components/models/ModelsContext";
 export default function ModelsContent() {
   const location = useLocation();
   const threePanelLayout = useThreePanelLayout();
-  const [isInitialLoading, setIsInitialLoading] = useState(true);
   const { t } = useTranslation(["models"]);
 
   const {
@@ -38,11 +36,9 @@ export default function ModelsContent() {
   } = useModels();
 
   useEffect(() => {
-    const loadInitialData = async () => {
-      await Promise.all([fetchDatasets(), fetchSessions(), fetchTasks()]);
-      setIsInitialLoading(false);
-    };
-    loadInitialData();
+    fetchDatasets();
+    fetchSessions();
+    fetchTasks();
   }, []);
 
   useEffect(() => {
@@ -76,21 +72,6 @@ export default function ModelsContent() {
       setSelectedSession(session || null);
     }
   }, [selectedSessionId, sessions]);
-
-  if (isInitialLoading) {
-    return (
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          height: "100vh",
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
-  }
 
   return (
     <ThreePanelLayoutContext.Provider value={threePanelLayout}>

--- a/DashAI/front/src/pages/models/ModelsContent.jsx
+++ b/DashAI/front/src/pages/models/ModelsContent.jsx
@@ -22,10 +22,7 @@ export default function ModelsContent() {
   const { t } = useTranslation(["models"]);
 
   const {
-    fetchDatasets,
     sessions,
-    fetchSessions,
-    fetchTasks,
     step,
     setStep,
     selectedSessionId,
@@ -34,12 +31,6 @@ export default function ModelsContent() {
     setRuns,
     fetchRuns,
   } = useModels();
-
-  useEffect(() => {
-    fetchDatasets();
-    fetchSessions();
-    fetchTasks();
-  }, []);
 
   useEffect(() => {
     if (location.state?.openSessionId && sessions.length > 0) {


### PR DESCRIPTION
This pull request improves the user experience when loading tasks in the models section by introducing a loading state and skeleton placeholders. Instead of blocking the entire page with a spinner, the UI now displays skeleton cards while tasks are being fetched, making the interface feel more responsive and polished. The loading state is managed via a new `loadingTasks` variable, which is propagated through context and component props.

**Loading state management and UI improvements:**

* Added a `loadingTasks` state to the `useSessions` hook, set to `true` while tasks are being fetched and `false` once loading completes. This state is now included in the context and passed down to relevant components. [[1]](diffhunk://#diff-bf26fa0183363c7888aa31a9c21fd047885871a1c752ebb7ce43bf87c2b16309R24) [[2]](diffhunk://#diff-bf26fa0183363c7888aa31a9c21fd047885871a1c752ebb7ce43bf87c2b16309R49) [[3]](diffhunk://#diff-bf26fa0183363c7888aa31a9c21fd047885871a1c752ebb7ce43bf87c2b16309R61-R62) [[4]](diffhunk://#diff-bf26fa0183363c7888aa31a9c21fd047885871a1c752ebb7ce43bf87c2b16309R281) [[5]](diffhunk://#diff-1228b067f9e9a756185092dcab0220d81cd9ef4790738082c55555c43df4e1a3R42) [[6]](diffhunk://#diff-1228b067f9e9a756185092dcab0220d81cd9ef4790738082c55555c43df4e1a3R120) [[7]](diffhunk://#diff-7b7984efd8d467a3e1c90a29fe61cccaa1014d0c591230ac7d0e2c305310a692R18)
* Updated `SelectOptionMenu` to accept a `loading` prop and render six skeleton cards in place of options when loading is `true`, providing a smoother and more modern loading experience. [[1]](diffhunk://#diff-664ce6b6af795c210ec271d78fa3e05f83f1e25cb5e65d005760d975bc119b8eL2-R2) [[2]](diffhunk://#diff-664ce6b6af795c210ec271d78fa3e05f83f1e25cb5e65d005760d975bc119b8eR13) [[3]](diffhunk://#diff-664ce6b6af795c210ec271d78fa3e05f83f1e25cb5e65d005760d975bc119b8eL71-R91) [[4]](diffhunk://#diff-7b7984efd8d467a3e1c90a29fe61cccaa1014d0c591230ac7d0e2c305310a692R97)

**Simplification of initial loading logic:**

* Removed the global loading spinner and associated state from `ModelsContent.jsx`. The initial data fetching is now handled without blocking the entire page, relying on the new skeleton-based loading indicators for tasks. [[1]](diffhunk://#diff-d683d4a00613dadcef236e59c683d4ac9ac2e364c27a20a82b4c0c8a82d9d049L1-R1) [[2]](diffhunk://#diff-d683d4a00613dadcef236e59c683d4ac9ac2e364c27a20a82b4c0c8a82d9d049L23) [[3]](diffhunk://#diff-d683d4a00613dadcef236e59c683d4ac9ac2e364c27a20a82b4c0c8a82d9d049L41-R41) [[4]](diffhunk://#diff-d683d4a00613dadcef236e59c683d4ac9ac2e364c27a20a82b4c0c8a82d9d049L80-L94)