### PR TITLE
Fix KeyError in categorical encoding by rebuilding categories from actual data

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -714,14 +714,14 @@ def transform_dataset_with_schema(
         pa_type = to_arrow_types(dtype)
         if _type == "Categorical":
             base_col = table.column(column_name)
-            # Use categories from schema
-            categories = info.get("categories", [])
             converted = info.get("converted", False)
 
-            # If no categories in schema, infer from data
-            if not categories:
-                col_list = base_col.to_pylist()
-                categories = sorted({v for v in col_list if v is not None})
+            # Always infer categories from actual data to ensure all values are
+            # included. Type inference (ptype) excludes anomalous values from
+            # its suggested categories, which causes KeyErrors during training
+            # when those "anomalous" values appear in the data.
+            col_list = base_col.to_pylist()
+            categories = sorted({v for v in col_list if v is not None})
 
             dashai_types[column_name] = Categorical(
                 values=categories, converted=converted, dtype=dtype


### PR DESCRIPTION
## Summary  
Fixes a `KeyError` crash during model training caused by incomplete categorical mappings when the type inference engine (`ptype`) marked some values as anomalous. The encoder now always rebuilds categories from the actual column data instead of relying on `ptype`’s filtered output, ensuring all values are properly encoded.

---

## Type of Change  
Check all that apply like this [x]:

- [x] Backend change  
- [ ] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  
- `DashAI/back/dataloaders/classes/dashai_dataset.py`: Updated `transform_dataset_with_schema` to always infer categories from the full column data, removing reliance on `ptype`’s potentially incomplete category list.


---

## Testing (optional)  
Reproduce using a dataset where a categorical column contains values flagged as anomalous by `ptype` (e.g., `[10.0, 10.0, 20.0, 30.0, 30.0]` where `20.0` is rare). Training a model such as `DummyClassifier` should no longer raise a `KeyError`.

[loan_data (2).csv](https://github.com/user-attachments/files/26513178/loan_data.2.csv)

---

## Notes (optional)  
`ptype` converts values to strings and excludes anomalous entries via `get_normal_values()`, which can lead to mismatches with the real dataset. This fix avoids both issues by deriving the category set directly from the raw data.