### PR TITLE
Update ColumnInsights title color

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/ColumnInsights.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/ColumnInsights.jsx
@@ -108,7 +108,7 @@ export default function ColumnInsights({
           fontSize="small"
           sx={{ color: theme.palette.warning.main }}
         />
-        <Typography variant="subtitle2" fontWeight="bold">
+        <Typography variant="subtitle2" fontWeight="bold" color="text.primary">
           {t("datasets:label.columnInsights")}
         </Typography>
         <Chip


### PR DESCRIPTION
## Summary  
Updated the `ColumnInsights` component to use the theme’s primary text color for the insights label. This fixes a visibility issue in light mode.

<img width="479" height="700" alt="image" src="https://github.com/user-attachments/assets/d6c19895-d5d2-478c-b51a-c045bb71df50" />

---

## Type of Change  
Check all that apply like this [x]:  

- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  
- `ColumnInsights.tsx`: Updated the insights label styling to use the theme’s primary text color instead of a hardcoded value.

---

## Testing (optional)  
- Verified that the insights label is clearly visible in both light and dark modes.  