### PR TITLE
Fix/converters runtime errors

### DIFF
--- a/DashAI/back/converters/hugging_face/embedding.py
+++ b/DashAI/back/converters/hugging_face/embedding.py
@@ -177,7 +177,7 @@ class Embedding(AdvancedPreprocessingConverter, HuggingFaceWrapper):
 
         for column in batch.column_names:
             # Get text data from dataset
-            texts = [row[column] for row in batch]
+            texts = [row[column] if row[column] is not None else "" for row in batch]
 
             # Tokenize
             encoded = self.tokenizer(

--- a/DashAI/back/converters/hugging_face/embedding.py
+++ b/DashAI/back/converters/hugging_face/embedding.py
@@ -93,6 +93,11 @@ class Embedding(AdvancedPreprocessingConverter, HuggingFaceWrapper):
     DISPLAY_NAME = MultilingualString(en="Embedding", es="Embedding")
     IMAGE_PREVIEW = "embedding.png"
 
+    metadata = {
+        "allowed_dtypes": ["string"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialise the embedding converter and extract schema parameters.
 

--- a/DashAI/back/converters/hugging_face/tokenizer.py
+++ b/DashAI/back/converters/hugging_face/tokenizer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from DashAI.back.converters.category.advanced_preprocessing import (
     AdvancedPreprocessingConverter,
@@ -7,6 +7,8 @@ from DashAI.back.converters.hugging_face_wrapper import HuggingFaceWrapper
 from DashAI.back.core.schema_fields import enum_field, int_field, schema_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.types.dashai_data_type import DashAIDataType
+from DashAI.back.types.value_types import Integer
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -160,3 +162,26 @@ class TokenizerConverter(AdvancedPreprocessingConverter, HuggingFaceWrapper):
         # Concatenate all tokenized columns
         concatenated_dataset = concatenate_datasets(all_column_tokens)
         return DashAIDataset(concatenated_dataset.data.table)
+
+    def get_output_type(self, column_name: Optional[str] = None) -> DashAIDataType:
+        """Return the DashAI data type produced by this converter for a column.
+
+        The output of this converter is a set of integer columns, one per
+        token position. The number of output columns depends on the maximum
+        sequence length specified in the configuration.
+
+        Parameters
+        ----------
+        column_name : str, optional
+            The column name to look up in the fitted encoders. When provided
+            and the encoder has been fitted, the returned type reflects the
+            actual fitted classes. Defaults to None.
+
+        Returns
+        -------
+        DashAIDataType
+            An Integer type for each token position column.
+        """
+        import pyarrow as pa
+
+        return Integer(arrow_type=pa.int64())

--- a/DashAI/back/converters/hugging_face/tokenizer.py
+++ b/DashAI/back/converters/hugging_face/tokenizer.py
@@ -82,6 +82,11 @@ class TokenizerConverter(AdvancedPreprocessingConverter, HuggingFaceWrapper):
     DISPLAY_NAME = MultilingualString(en="Tokenizer", es="Tokenizador")
     IMAGE_PREVIEW = "tokenizer.png"
 
+    metadata = {
+        "allowed_dtypes": ["string"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialise the tokenizer converter and extract schema parameters.
 

--- a/DashAI/back/converters/imbalanced_learn/random_under_sampler_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/random_under_sampler_converter.py
@@ -81,6 +81,11 @@ class RandomUnderSamplerConverter(
     )
     IMAGE_PREVIEW = "random_under_sampler.png"
 
+    metadata = {
+        "allowed_dtypes": ["*"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialise by forwarding kwargs to the imbalanced-learn wrapper.
 

--- a/DashAI/back/converters/imbalanced_learn/smote_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smote_converter.py
@@ -85,6 +85,11 @@ class SMOTEConverter(SamplingConverter, ImbalancedLearnWrapper, SMOTE):
     )
     IMAGE_PREVIEW = "smote.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialise by forwarding kwargs to the imbalanced-learn wrapper.
 

--- a/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
@@ -92,6 +92,11 @@ class SMOTEENNConverter(SamplingConverter, ImbalancedLearnWrapper, SMOTEENN):
     )
     IMAGE_PREVIEW = "smoteenn.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialise SMOTE-ENN with a SMOTE sub-instance and combined kwargs.
 

--- a/DashAI/back/converters/scikit_learn/additive_chi_2_sampler.py
+++ b/DashAI/back/converters/scikit_learn/additive_chi_2_sampler.py
@@ -61,6 +61,11 @@ class AdditiveChi2Sampler(
     DISPLAY_NAME = MultilingualString(en="Additive Chi² Sampler", es="Muestreador Chi²")
     IMAGE_PREVIEW = "additive_chi2_sampler.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.
 

--- a/DashAI/back/converters/scikit_learn/bag_of_words.py
+++ b/DashAI/back/converters/scikit_learn/bag_of_words.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from DashAI.back.converters.base_converter import BaseConverter
 from DashAI.back.converters.category.advanced_preprocessing import (
@@ -13,6 +13,8 @@ from DashAI.back.core.schema_fields import (
     schema_field,
 )
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.types.dashai_data_type import DashAIDataType
+from DashAI.back.types.value_types import Integer
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -200,3 +202,26 @@ class BagOfWordsConverter(AdvancedPreprocessingConverter, BaseConverter):
         df_bow = pd.DataFrame(bow_matrix.toarray(), columns=feature_names)
 
         return to_dashai_dataset(df_bow)
+
+    def get_output_type(self, column_name: Optional[str] = None) -> DashAIDataType:
+        """Return the DashAI data type produced by this converter for a column.
+
+        The output of this converter is a set of integer columns, one per
+        vocabulary term, containing the raw token-frequency counts produced
+        by ``CountVectorizer``.
+
+        Parameters
+        ----------
+        column_name : str, optional
+            The column name to look up in the fitted vectoriser. When provided
+            and the vectoriser has been fitted, the returned type reflects the
+            actual fitted vocabulary. Defaults to None.
+
+        Returns
+        -------
+        DashAIDataType
+            An Integer type for each token-frequency column.
+        """
+        import pyarrow as pa
+
+        return Integer(arrow_type=pa.int64())

--- a/DashAI/back/converters/scikit_learn/bag_of_words.py
+++ b/DashAI/back/converters/scikit_learn/bag_of_words.py
@@ -141,7 +141,7 @@ class BagOfWordsConverter(AdvancedPreprocessingConverter, BaseConverter):
         self.vectorizer = CountVectorizer(
             max_features=kwargs.get("max_features", 1000),
             lowercase=kwargs.get("lowercase", True),
-            stop_words=kwargs.get("stop_words", "english"),
+            stop_words=kwargs.get("stop_words"),
             ngram_range=(
                 kwargs.get("lower_bound_ngrams", 1),
                 kwargs.get("upper_bound_ngrams", 1),
@@ -206,7 +206,11 @@ class BagOfWordsConverter(AdvancedPreprocessingConverter, BaseConverter):
         # One column per token (frequency)
         df_bow = pd.DataFrame(bow_matrix.toarray(), columns=feature_names)
 
-        return to_dashai_dataset(df_bow)
+        converted_dataset = to_dashai_dataset(df_bow)
+        output_type = self.get_output_type()
+        for col in converted_dataset.column_names:
+            converted_dataset.types[col] = output_type
+        return converted_dataset
 
     def get_output_type(self, column_name: Optional[str] = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.

--- a/DashAI/back/converters/scikit_learn/bag_of_words.py
+++ b/DashAI/back/converters/scikit_learn/bag_of_words.py
@@ -102,6 +102,11 @@ class BagOfWordsConverter(AdvancedPreprocessingConverter, BaseConverter):
     SCHEMA = BagOfWordsConverterSchema
     DISPLAY_NAME = MultilingualString(en="Bag of Words", es="Bolsa de Palabras")
     IMAGE_PREVIEW = "bag_of_words.png"
+
+    metadata = {
+        "allowed_dtypes": ["string"],
+        "restricted_dtypes": [],
+    }
     DESCRIPTION = MultilingualString(
         en=(
             "Converts text into a Bag-of-Words representation with one column "

--- a/DashAI/back/converters/scikit_learn/binarizer.py
+++ b/DashAI/back/converters/scikit_learn/binarizer.py
@@ -45,6 +45,11 @@ class Binarizer(EncodingConverter, SklearnWrapper, BinarizerOperation):
     DISPLAY_NAME = MultilingualString(en="Binarizer", es="Binarizador")
     IMAGE_PREVIEW = "binarizer.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.
 

--- a/DashAI/back/converters/scikit_learn/binarizer.py
+++ b/DashAI/back/converters/scikit_learn/binarizer.py
@@ -2,7 +2,7 @@ from sklearn.preprocessing import Binarizer as BinarizerOperation
 
 from DashAI.back.converters.category.encoding import EncodingConverter
 from DashAI.back.converters.sklearn_wrapper import SklearnWrapper
-from DashAI.back.core.schema_fields import bool_field, float_field, schema_field
+from DashAI.back.core.schema_fields import float_field, schema_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.types.dashai_data_type import DashAIDataType
@@ -25,15 +25,6 @@ class BinarizerSchema(BaseSchema):
                 "los superiores por 1."
             ),
         ),
-    )  # type: ignore
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en="Set to False to perform inplace binarization.",
-            es="Ponlo en False para binarizar in situ.",
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
     )  # type: ignore
 
 

--- a/DashAI/back/converters/scikit_learn/cca.py
+++ b/DashAI/back/converters/scikit_learn/cca.py
@@ -106,6 +106,11 @@ class CCA(AdvancedPreprocessingConverter, SklearnWrapper, CCAOPERATION):
     )
     DISPLAY_NAME = MultilingualString(en="CCA", es="CCA")
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.
 

--- a/DashAI/back/converters/scikit_learn/fast_ica.py
+++ b/DashAI/back/converters/scikit_learn/fast_ica.py
@@ -177,6 +177,11 @@ class FastICA(DimensionalityReductionConverter, SklearnWrapper, FastICAOperation
     DISPLAY_NAME = MultilingualString(en="Fast ICA", es="Fast ICA")
     IMAGE_PREVIEW = "fast_ica.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialize the FastICA converter.
 

--- a/DashAI/back/converters/scikit_learn/generic_univariate_select.py
+++ b/DashAI/back/converters/scikit_learn/generic_univariate_select.py
@@ -66,7 +66,10 @@ class GenericUnivariateSelect(
         en="Generic Univariate Select", es="Selección Univariante Genérica"
     )
     IMAGE_PREVIEW = "generic_univariate_select.png"
-    metadata = {}
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
 
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.

--- a/DashAI/back/converters/scikit_learn/incremental_pca.py
+++ b/DashAI/back/converters/scikit_learn/incremental_pca.py
@@ -101,3 +101,8 @@ class IncrementalPCA(
     )
     DISPLAY_NAME = MultilingualString(en="Incremental PCA", es="PCA Incremental")
     IMAGE_PREVIEW = "incremental_pca.png"
+
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }

--- a/DashAI/back/converters/scikit_learn/incremental_pca.py
+++ b/DashAI/back/converters/scikit_learn/incremental_pca.py
@@ -12,6 +12,8 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.types.dashai_data_type import DashAIDataType
+from DashAI.back.types.value_types import Float
 
 
 class IncrementalPCASchema(BaseSchema):
@@ -106,3 +108,21 @@ class IncrementalPCA(
         "allowed_dtypes": ["int64", "float64", "float32"],
         "restricted_dtypes": [],
     }
+
+    def get_output_type(self, column_name: str = None) -> DashAIDataType:
+        """Return the DashAI data type produced by this converter for a column.
+
+        Parameters
+        ----------
+        column_name : str, optional
+            Not used; all output columns share the
+            same type. Defaults to None.
+
+        Returns
+        -------
+        DashAIDataType
+            A Float type backed by ``pyarrow.float64()``.
+        """
+        import pyarrow as pa
+
+        return Float(arrow_type=pa.float64())

--- a/DashAI/back/converters/scikit_learn/incremental_pca.py
+++ b/DashAI/back/converters/scikit_learn/incremental_pca.py
@@ -43,21 +43,6 @@ class IncrementalPCASchema(BaseSchema):
             ),
         ),
     )  # type: ignore
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en=(
-                "If False, data passed to fit are overwritten. Use "
-                "fit_transform(X) instead."
-            ),
-            es=(
-                "Si es False, los datos pasados a fit se sobrescriben. Usa "
-                "fit_transform(X) en su lugar."
-            ),
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
-    )  # type: ignore
     batch_size: schema_field(
         none_type(int_field(ge=1)),
         None,

--- a/DashAI/back/converters/scikit_learn/knn_imputer.py
+++ b/DashAI/back/converters/scikit_learn/knn_imputer.py
@@ -49,15 +49,6 @@ class KNNImputerSchema(BaseSchema):
             es="La métrica a usar para la imputación.",
         ),
     )  # type: ignore
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en="If True, a copy of X will be created.",
-            es="Si es True, se creará una copia de X.",
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
-    )  # type: ignore
     add_indicator: schema_field(
         bool_field(),
         False,

--- a/DashAI/back/converters/scikit_learn/knn_imputer.py
+++ b/DashAI/back/converters/scikit_learn/knn_imputer.py
@@ -101,6 +101,11 @@ class KNNImputer(BasicPreprocessingConverter, SklearnWrapper, KNNImputerOperatio
     DISPLAY_NAME = MultilingualString(en="KNN Imputer", es="Imputador KNN")
     IMAGE_PREVIEW = "knn_imputer.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialize the KNNImputer converter.
 

--- a/DashAI/back/converters/scikit_learn/label_binarizer.py
+++ b/DashAI/back/converters/scikit_learn/label_binarizer.py
@@ -69,6 +69,11 @@ class LabelBinarizer(EncodingConverter, SklearnWrapper, LabelBinarizerOperation)
     )
     IMAGE_PREVIEW = "label_binarizer.png"
 
+    metadata = {
+        "allowed_dtypes": ["string"],
+        "restricted_dtypes": [],
+    }
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.
 

--- a/DashAI/back/converters/scikit_learn/label_binarizer.py
+++ b/DashAI/back/converters/scikit_learn/label_binarizer.py
@@ -74,6 +74,42 @@ class LabelBinarizer(EncodingConverter, SklearnWrapper, LabelBinarizerOperation)
         "restricted_dtypes": [],
     }
 
+    def fit(self, x, y=None):
+        """Fit LabelBinarizer with validation for exactly 2 unique labels.
+
+        LabelBinarizer is designed for binary classification problems and expects
+        exactly 2 unique class labels. For multiclass problems, use OneHotEncoder
+        or OrdinalEncoder instead.
+        """
+        import pandas as pd
+
+        # Convert to pandas if needed
+        x_pandas = x.to_pandas() if hasattr(x, "to_pandas") else x
+
+        # Validate that we have exactly 1 column
+        if isinstance(x_pandas, pd.DataFrame):
+            if x_pandas.shape[1] != 1:
+                raise ValueError(
+                    f"LabelBinarizer only supports a single column, "
+                    f"but got {x_pandas.shape[1]} columns. "
+                    f"Please select exactly one column in the scope."
+                )
+            column_data = x_pandas.iloc[:, 0]
+        else:
+            column_data = x_pandas
+
+        # Validate that we have exactly 2 unique labels
+        unique_labels = column_data.dropna().unique()
+        if len(unique_labels) != 2:
+            raise ValueError(
+                f"LabelBinarizer requires exactly 2 unique labels for binary "
+                f"classification, but got {len(unique_labels)}. "
+                f"For multiclass problems, use OneHotEncoder instead."
+            )
+
+        # Call parent fit
+        return super().fit(x, y)
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.
 

--- a/DashAI/back/converters/scikit_learn/max_abs_scaler.py
+++ b/DashAI/back/converters/scikit_learn/max_abs_scaler.py
@@ -4,7 +4,6 @@ from DashAI.back.converters.category.scaling_and_normalization import (
     ScalingAndNormalizationConverter,
 )
 from DashAI.back.converters.sklearn_wrapper import SklearnWrapper
-from DashAI.back.core.schema_fields import bool_field, schema_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.types.dashai_data_type import DashAIDataType
@@ -14,21 +13,10 @@ from DashAI.back.types.value_types import Float
 class MaxAbsScalerSchema(BaseSchema):
     """Schema for MaxAbsScaler hyperparameters.
 
-    Configures the copy semantics for sklearn's ``MaxAbsScaler``. Because
-    ``MaxAbsScaler`` has no configurable scaling range (it always maps to
-    [-1, 1] by dividing by the per-feature maximum absolute value), the only
-    tuneable option is whether to copy the data before transforming.
+    ``MaxAbsScaler`` has no configurable hyperparameters in DashAI: it always
+    maps each feature to [-1, 1] by dividing by the per-feature maximum
+    absolute value.
     """
-
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en="Set to False to perform inplace scaling.",
-            es="Ponlo en False para realizar el escalado in situ.",
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
-    )  # type: ignore
 
 
 class MaxAbsScaler(

--- a/DashAI/back/converters/scikit_learn/max_abs_scaler.py
+++ b/DashAI/back/converters/scikit_learn/max_abs_scaler.py
@@ -50,6 +50,11 @@ class MaxAbsScaler(
     DISPLAY_NAME = MultilingualString(en="Max Abs Scaler", es="Escalador Max Abs")
     IMAGE_PREVIEW = "max_abs_scaler.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.
 

--- a/DashAI/back/converters/scikit_learn/min_max_scaler.py
+++ b/DashAI/back/converters/scikit_learn/min_max_scaler.py
@@ -36,15 +36,6 @@ class MinMaxScalerSchema(BaseSchema):
             es="El valor máximo del rango al que escalar los datos.",
         ),
     )  # type: ignore
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en="Set to False to perform inplace row normalization.",
-            es="Ponlo en False para normalizar filas in situ.",
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
-    )  # type: ignore
     clip: schema_field(
         bool_field(),
         False,

--- a/DashAI/back/converters/scikit_learn/missing_indicator.py
+++ b/DashAI/back/converters/scikit_learn/missing_indicator.py
@@ -54,6 +54,11 @@ class MissingIndicator(
     )
     IMAGE_PREVIEW = "missing_indicator.png"
 
+    metadata = {
+        "allowed_dtypes": ["*"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialize the MissingIndicator converter.
 

--- a/DashAI/back/converters/scikit_learn/normalizer.py
+++ b/DashAI/back/converters/scikit_learn/normalizer.py
@@ -4,7 +4,7 @@ from DashAI.back.converters.category.scaling_and_normalization import (
     ScalingAndNormalizationConverter,
 )
 from DashAI.back.converters.sklearn_wrapper import SklearnWrapper
-from DashAI.back.core.schema_fields import bool_field, enum_field, schema_field
+from DashAI.back.core.schema_fields import enum_field, schema_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.types.dashai_data_type import DashAIDataType
@@ -26,15 +26,6 @@ class NormalizerSchema(BaseSchema):
             en="The norm to use to normalize each non-zero sample.",
             es="La norma a usar para normalizar cada muestra no nula.",
         ),
-    )  # type: ignore
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en="Set to False to perform inplace row normalization.",
-            es="Ponlo en False para normalizar filas in situ.",
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
     )  # type: ignore
 
 

--- a/DashAI/back/converters/scikit_learn/normalizer.py
+++ b/DashAI/back/converters/scikit_learn/normalizer.py
@@ -65,6 +65,11 @@ class Normalizer(ScalingAndNormalizationConverter, SklearnWrapper, NormalizerOpe
     DISPLAY_NAME = MultilingualString(en="Normalizer", es="Normalizador")
     IMAGE_PREVIEW = "normalizer.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.
 

--- a/DashAI/back/converters/scikit_learn/nystroem.py
+++ b/DashAI/back/converters/scikit_learn/nystroem.py
@@ -157,6 +157,11 @@ class Nystroem(DimensionalityReductionConverter, SklearnWrapper, NystroemOperati
     )
     IMAGE_PREVIEW = "nystroem.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialize the Nystroem converter.
 

--- a/DashAI/back/converters/scikit_learn/one_hot_encoder.py
+++ b/DashAI/back/converters/scikit_learn/one_hot_encoder.py
@@ -126,6 +126,11 @@ class OneHotEncoder(EncodingConverter, SklearnWrapper, OneHotEncoderOperation):
     DISPLAY_NAME = MultilingualString(en="One-Hot Encoder", es="Codificador One-Hot")
     IMAGE_PREVIEW = "one_hot_encoder.png"
 
+    metadata = {
+        "allowed_dtypes": ["string"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialize the OneHotEncoder converter.
 

--- a/DashAI/back/converters/scikit_learn/pca.py
+++ b/DashAI/back/converters/scikit_learn/pca.py
@@ -192,7 +192,11 @@ class PCA(DimensionalityReductionConverter, SklearnWrapper, PCAOPERATION):
         es="Análisis de Componentes Principales (PCA)",
     )
     IMAGE_PREVIEW = "pca.png"
-    metadata = {}
+
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
 
     def __init__(self, **kwargs):
         """Initialize the PCA converter.

--- a/DashAI/back/converters/scikit_learn/pca.py
+++ b/DashAI/back/converters/scikit_learn/pca.py
@@ -43,21 +43,6 @@ class PCASchema(BaseSchema):
             ),
         ),
     )  # type: ignore
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en=(
-                "If False, data passed to fit are overwritten. Use "
-                "fit_transform(X) instead of fit(X).transform(X)."
-            ),
-            es=(
-                "Si es False, los datos pasados a fit se sobrescriben. Usa "
-                "fit_transform(X) en lugar de fit(X).transform(X)."
-            ),
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
-    )  # type: ignore
     whiten: schema_field(
         bool_field(),
         False,

--- a/DashAI/back/converters/scikit_learn/polynomial_features.py
+++ b/DashAI/back/converters/scikit_learn/polynomial_features.py
@@ -124,6 +124,11 @@ class PolynomialFeatures(
     )
     IMAGE_PREVIEW = "polynomial_features.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return ``Float64`` as the output type for all polynomial feature columns.
 

--- a/DashAI/back/converters/scikit_learn/rbf_sampler.py
+++ b/DashAI/back/converters/scikit_learn/rbf_sampler.py
@@ -103,6 +103,11 @@ class RBFSampler(PolynomialKernelConverter, SklearnWrapper, RBFSamplerOperation)
     DISPLAY_NAME = MultilingualString(en="RBF Sampler", es="Muestreador RBF")
     IMAGE_PREVIEW = "rbf_sampler.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialise the RBF sampler, resolving the ``"RandomState"`` sentinel.
 

--- a/DashAI/back/converters/scikit_learn/select_fdr.py
+++ b/DashAI/back/converters/scikit_learn/select_fdr.py
@@ -71,7 +71,10 @@ class SelectFdr(FeatureSelectionConverter, SklearnWrapper, SelectFdrOperation):
     SUPERVISED = True
     DISPLAY_NAME = MultilingualString(en="Select FDR", es="Seleccionar FDR")
     IMAGE_PREVIEW = "select_fdr.png"
-    metadata = {}
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
 
     def __init__(self, **kwargs):
         """Initialize the SelectFdr converter.

--- a/DashAI/back/converters/scikit_learn/select_fpr.py
+++ b/DashAI/back/converters/scikit_learn/select_fpr.py
@@ -68,7 +68,10 @@ class SelectFpr(FeatureSelectionConverter, SklearnWrapper, SelectFprOperation):
     SUPERVISED = True
     DISPLAY_NAME = MultilingualString(en="Select FPR", es="Seleccionar FPR")
     IMAGE_PREVIEW = "select_fpr.png"
-    metadata = {}
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
 
     def __init__(self, **kwargs):
         """Initialize the SelectFpr converter.

--- a/DashAI/back/converters/scikit_learn/select_fwe.py
+++ b/DashAI/back/converters/scikit_learn/select_fwe.py
@@ -73,7 +73,10 @@ class SelectFwe(FeatureSelectionConverter, SklearnWrapper, SelectFweOperation):
     SUPERVISED = True
     DISPLAY_NAME = MultilingualString(en="Select FWE", es="Seleccionar FWE")
     IMAGE_PREVIEW = "select_fwe.png"
-    metadata = {}
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
 
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.

--- a/DashAI/back/converters/scikit_learn/select_k_best.py
+++ b/DashAI/back/converters/scikit_learn/select_k_best.py
@@ -69,7 +69,10 @@ class SelectKBest(FeatureSelectionConverter, SklearnWrapper, SelectKBestOperatio
     SUPERVISED = True
     DISPLAY_NAME = MultilingualString(en="Select K Best", es="Seleccionar K Mejores")
     IMAGE_PREVIEW = "select_k_best.png"
-    metadata = {}
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
 
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.

--- a/DashAI/back/converters/scikit_learn/select_k_best.py
+++ b/DashAI/back/converters/scikit_learn/select_k_best.py
@@ -95,22 +95,10 @@ class SelectKBest(FeatureSelectionConverter, SklearnWrapper, SelectKBestOperatio
     def __init__(self, **kwargs):
         """Initialize the SelectKBest converter.
 
-        Patches ``_get_tags`` to advertise ``requires_y=True`` so that the
-        pipeline passes the target array at fit time, then delegates to the
-        parent initializer.
-
         Parameters
         ----------
         **kwargs
             Configuration keyword arguments matching the converter's
             schema fields. Forwarded to the underlying scikit-learn class.
         """
-        if callable(self._get_tags):
-            original_get_tags = self._get_tags
-            self._get_tags = lambda *a, **k: {
-                **original_get_tags(*a, **k),
-                "requires_y": True,
-            }
-        else:
-            self._get_tags = {**self._get_tags, "requires_y": True}
         super().__init__(**kwargs)

--- a/DashAI/back/converters/scikit_learn/select_percentile.py
+++ b/DashAI/back/converters/scikit_learn/select_percentile.py
@@ -98,22 +98,10 @@ class SelectPercentile(
     def __init__(self, **kwargs):
         """Initialize the SelectPercentile converter.
 
-        Patches ``_get_tags`` to advertise ``requires_y=True`` so that the
-        pipeline passes the target array at fit time, then delegates to the
-        parent initializer.
-
         Parameters
         ----------
         **kwargs
             Configuration keyword arguments matching the converter's
             schema fields. Forwarded to the underlying scikit-learn class.
         """
-        if callable(self._get_tags):
-            original_get_tags = self._get_tags
-            self._get_tags = lambda *a, **k: {
-                **original_get_tags(*a, **k),
-                "requires_y": True,
-            }
-        else:
-            self._get_tags = {**self._get_tags, "requires_y": True}
         super().__init__(**kwargs)

--- a/DashAI/back/converters/scikit_learn/select_percentile.py
+++ b/DashAI/back/converters/scikit_learn/select_percentile.py
@@ -72,7 +72,10 @@ class SelectPercentile(
         en="Select Percentile", es="Seleccionar Percentil"
     )
     IMAGE_PREVIEW = "select_percentile.png"
-    metadata = {}
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
 
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.

--- a/DashAI/back/converters/scikit_learn/simple_imputer.py
+++ b/DashAI/back/converters/scikit_learn/simple_imputer.py
@@ -53,15 +53,6 @@ class SimpleImputerSchema(BaseSchema):
             es="El valor para reemplazar los valores faltantes.",
         ),
     )  # type: ignore
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en="If True, a copy of X will be created.",
-            es="Si es True, se creará una copia de X.",
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
-    )  # type: ignore
     add_indicator: schema_field(
         bool_field(),
         False,

--- a/DashAI/back/converters/scikit_learn/simple_imputer.py
+++ b/DashAI/back/converters/scikit_learn/simple_imputer.py
@@ -116,6 +116,11 @@ class SimpleImputer(
     DISPLAY_NAME = MultilingualString(en="Simple Imputer", es="Imputador Simple")
     IMAGE_PREVIEW = "simple_imputer.png"
 
+    metadata = {
+        "allowed_dtypes": ["string", "int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialize the SimpleImputer converter.
 

--- a/DashAI/back/converters/scikit_learn/simple_imputer.py
+++ b/DashAI/back/converters/scikit_learn/simple_imputer.py
@@ -117,7 +117,7 @@ class SimpleImputer(
     IMAGE_PREVIEW = "simple_imputer.png"
 
     metadata = {
-        "allowed_dtypes": ["string", "int64", "float64", "float32"],
+        "allowed_dtypes": ["int64", "float64", "float32"],
         "restricted_dtypes": [],
     }
 

--- a/DashAI/back/converters/scikit_learn/skewed_chi_2_sampler.py
+++ b/DashAI/back/converters/scikit_learn/skewed_chi_2_sampler.py
@@ -114,6 +114,11 @@ class SkewedChi2Sampler(
     DISPLAY_NAME = MultilingualString(en="Skewed Chi² Sampler", es="Muestreador Chi²")
     IMAGE_PREVIEW = "skewed_chi_2_sampler.png"
 
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self, **kwargs):
         """Initialise the skewed chi-squared sampler,
         resolving the ``"RandomState"`` sentinel.

--- a/DashAI/back/converters/scikit_learn/standard_scaler.py
+++ b/DashAI/back/converters/scikit_learn/standard_scaler.py
@@ -20,15 +20,6 @@ class StandardScalerSchema(BaseSchema):
     the result is divided by the standard deviation.
     """
 
-    use_copy: schema_field(
-        bool_field(),
-        True,
-        description=MultilingualString(
-            en=("If False, try to avoid a copy and do inplace scaling instead."),
-            es=("Si es False, intenta evitar copias y realiza la escalación in situ."),
-        ),
-        alias=MultilingualString(en="copy", es="copiar"),
-    )  # type: ignore
     with_mean: schema_field(
         bool_field(),
         True,

--- a/DashAI/back/converters/scikit_learn/tf_idf.py
+++ b/DashAI/back/converters/scikit_learn/tf_idf.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from DashAI.back.converters.base_converter import BaseConverter
 from DashAI.back.converters.category.advanced_preprocessing import (
@@ -13,6 +13,8 @@ from DashAI.back.core.schema_fields import (
     schema_field,
 )
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.types.dashai_data_type import DashAIDataType
+from DashAI.back.types.value_types import Float
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -211,3 +213,26 @@ class TFIDFConverter(AdvancedPreprocessingConverter, BaseConverter):
         df_tfidf = pd.DataFrame(tfidf_matrix.toarray(), columns=feature_names)
 
         return to_dashai_dataset(df_tfidf)
+
+    def get_output_type(self, column_name: Optional[str] = None) -> DashAIDataType:
+        """Return the DashAI data type produced by this converter for a column.
+
+        The output of this converter is a set of float columns, one per
+        vocabulary term, containing the TF-IDF weights produced by
+        ``TfidfVectorizer``.
+
+        Parameters
+        ----------
+        column_name : str, optional
+            The column name to look up in the fitted vectoriser. When provided
+            and the vectoriser has been fitted, the returned type reflects the
+            actual fitted vocabulary. Defaults to None.
+
+        Returns
+        -------
+        DashAIDataType
+            A Float type for each TF-IDF weight column.
+        """
+        import pyarrow as pa
+
+        return Float(arrow_type=pa.float64())

--- a/DashAI/back/converters/scikit_learn/tf_idf.py
+++ b/DashAI/back/converters/scikit_learn/tf_idf.py
@@ -113,6 +113,11 @@ class TFIDFConverter(AdvancedPreprocessingConverter, BaseConverter):
     SCHEMA = TFIDFConverterSchema
     DISPLAY_NAME = MultilingualString(en="TF-IDF", es="TF-IDF")
     IMAGE_PREVIEW = "tf_idf.png"
+
+    metadata = {
+        "allowed_dtypes": ["string"],
+        "restricted_dtypes": [],
+    }
     DESCRIPTION = MultilingualString(
         en=(
             "Converts text into a TF-IDF representation with one column per "

--- a/DashAI/back/converters/scikit_learn/tf_idf.py
+++ b/DashAI/back/converters/scikit_learn/tf_idf.py
@@ -152,7 +152,7 @@ class TFIDFConverter(AdvancedPreprocessingConverter, BaseConverter):
         self.vectorizer = TfidfVectorizer(
             max_features=kwargs.get("max_features", 1000),
             lowercase=kwargs.get("lowercase", True),
-            stop_words=kwargs.get("stop_words", "english"),
+            stop_words=kwargs.get("stop_words"),
             ngram_range=(
                 kwargs.get("lower_bound_ngrams", 1),
                 kwargs.get("upper_bound_ngrams", 1),
@@ -217,7 +217,11 @@ class TFIDFConverter(AdvancedPreprocessingConverter, BaseConverter):
         # One column per token/ngram (TF-IDF weight)
         df_tfidf = pd.DataFrame(tfidf_matrix.toarray(), columns=feature_names)
 
-        return to_dashai_dataset(df_tfidf)
+        converted_dataset = to_dashai_dataset(df_tfidf)
+        output_type = self.get_output_type()
+        for col in converted_dataset.column_names:
+            converted_dataset.types[col] = output_type
+        return converted_dataset
 
     def get_output_type(self, column_name: Optional[str] = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.

--- a/DashAI/back/converters/scikit_learn/truncated_svd.py
+++ b/DashAI/back/converters/scikit_learn/truncated_svd.py
@@ -147,7 +147,10 @@ class TruncatedSVD(
     )
     DISPLAY_NAME = MultilingualString(en="Truncated SVD", es="SVD Truncado")
     IMAGE_PREVIEW = "truncated_svd.png"
-    metadata = {}
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }
 
     def __init__(self, **kwargs):
         """Initialize the TruncatedSVD converter.

--- a/DashAI/back/converters/scikit_learn/variance_threshold.py
+++ b/DashAI/back/converters/scikit_learn/variance_threshold.py
@@ -90,3 +90,8 @@ class VarianceThreshold(
         return Float(arrow_type=pa.float64())
 
     IMAGE_PREVIEW = "variance_threshold.png"
+
+    metadata = {
+        "allowed_dtypes": ["int64", "float64", "float32"],
+        "restricted_dtypes": [],
+    }

--- a/DashAI/back/converters/simple_converters/character_replacer.py
+++ b/DashAI/back/converters/simple_converters/character_replacer.py
@@ -7,6 +7,7 @@ from DashAI.back.converters.category.basic_preprocessing import (
 from DashAI.back.core.schema_fields import none_type, schema_field, string_field
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.dashai_data_type import DashAIDataType
 from DashAI.back.types.value_types import Integer, Text
 
@@ -119,16 +120,20 @@ class CharacterReplacer(BasicPreprocessingConverter, BaseConverter):
             return self
 
         for col_name in x.column_names:
-            if col_name in x.types and isinstance(x.types[col_name], Text):
+            if col_name in x.types and isinstance(
+                x.types[col_name], (Text, Categorical)
+            ):
                 self._target_columns.append(col_name)
             else:
                 print(
-                    f"Warning: Column '{col_name}' in scope is not of Text type "
+                    f"Warning: Column '{col_name}' in scope is not of "
+                    "Text or Categorical type "
                     "and will be ignored by CharacterReplacer."
                 )
         if not self._target_columns:
             print(
-                "Warning: CharacterReplacer did not find any valid Text columns "
+                "Warning: CharacterReplacer did not find any valid "
+                "Text or Categorical columns "
                 "in the provided scope."
             )
         return self
@@ -223,7 +228,15 @@ class CharacterReplacer(BasicPreprocessingConverter, BaseConverter):
                             processed_batch[column_name] = replaced_values
                             new_types[column_name] = Text(arrow_type=pa.string())
                     else:
-                        processed_batch[column_name] = values
+                        # Categorical column: apply replacement to string values
+                        processed_batch[column_name] = [
+                            (
+                                val.replace(self.char_to_replace, self.replacement_char)
+                                if isinstance(val, str)
+                                else val
+                            )
+                            for val in values
+                        ]
                 else:
                     processed_batch[column_name] = values
             return processed_batch

--- a/DashAI/back/converters/simple_converters/column_remover.py
+++ b/DashAI/back/converters/simple_converters/column_remover.py
@@ -37,6 +37,11 @@ class ColumnRemover(BasicPreprocessingConverter, BaseConverter):
     DISPLAY_NAME = MultilingualString(en="Column Remover", es="Removedor de Columnas")
     IMAGE_PREVIEW = "column_remover.png"
 
+    metadata = {
+        "allowed_dtypes": ["*"],
+        "restricted_dtypes": [],
+    }
+
     def __init__(self):
         """Initialise the column remover and set up state.
 

--- a/DashAI/back/converters/sklearn_wrapper.py
+++ b/DashAI/back/converters/sklearn_wrapper.py
@@ -1,3 +1,4 @@
+import contextlib
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Union
 
@@ -87,9 +88,21 @@ class SklearnWrapper(BaseConverter, metaclass=ABCMeta):
         x_pandas = x.to_pandas() if hasattr(x, "to_pandas") else x
         y_pandas = y.to_pandas() if y is not None and hasattr(y, "to_pandas") else y
 
-        requires_y = hasattr(self, "_get_tags") and self._get_tags().get(
-            "requires_y", False
-        )
+        # Detect whether the underlying sklearn estimator needs a target.
+        # sklearn >= 1.6 moved tags from ``_get_tags`` to ``__sklearn_tags__``,
+        # so we consult both for backward/forward compatibility.
+        requires_y = False
+        if hasattr(self, "__sklearn_tags__"):
+            try:
+                tags = self.__sklearn_tags__()
+                target_tags = getattr(tags, "target_tags", None)
+                if target_tags is not None:
+                    requires_y = bool(getattr(target_tags, "required", False))
+            except Exception:
+                requires_y = False
+        if not requires_y and hasattr(self, "_get_tags"):
+            with contextlib.suppress(Exception):
+                requires_y = bool(self._get_tags().get("requires_y", False))
 
         if requires_y and y is None:
             raise ValueError("This transformer requires y for fitting")
@@ -111,7 +124,7 @@ class SklearnWrapper(BaseConverter, metaclass=ABCMeta):
                 "Ensure that your transformer inherits from a valid sklearn class."
             )
         fit_method = sklearn_cls.__dict__["fit"]
-        if requires_y:
+        if requires_y or y_pandas is not None:
             fit_method(self, x_pandas, y_pandas)
         else:
             fit_method(self, x_pandas)

--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -79,7 +79,7 @@ export default function FormConverterSection({
                   console.error("Converter job failed:", result);
                   enqueueSnackbar(
                     t("datasets:error.converterFailedWithInfo", {
-                      error: result.error || t("common:unknownError"),
+                      error: result.error_msg || t("common:unknownError"),
                     }),
                     { variant: "error" },
                   );


### PR DESCRIPTION
## Summary                                                                                 
  Multiple fixes and improvements across DashAI converters: corrected output type handling,  
  dtype metadata, schema cleanups, and related backend/frontend bugs surfaced while testing  
  the converter pipeline.                                                                    
                                                                                             
  ---             
                                                                                             
  ## Type of Change                                                                          

  - [x] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change                                                             
  - [x] Bug fix
  - [ ] Documentation                                                                        
                  
  ---

  ## Changes (by file)

  - `SimpleImputer`: removed `string` from `allowed_dtypes` since it is not actually         
  supported.
  - `FormConverterSection.tsx`: updated error handling to use the `error_msg` property.      
  - `BagOfWordsConverter` / `TFIDFConverter`: fixed `stop_words` parameter handling and set  
  explicit output types.
  - `IncrementalPCA`: added `get_output_type` method for output type resolution.             
  - `SelectKBest` / `SelectPercentile`: removed unnecessary `_get_tags` patching now handled 
  by the wrapper.                                                                            
  - `SklearnWrapper`: added backward/forward compatibility for sklearn target tags.          
  - `LabelBinarizer`: added validation for unique labels in `fit`.                           
  - Multiple converters: added metadata for allowed and restricted data types.               
  - `Embedding` converter: handle `None` values when extracting text data.
  - `CharacterReplacer`: support `Categorical` columns for character replacement.            
  - `Tokenizer` / `BagOfWords` / `TFIDF`: added output type methods.                         
  - Multiple converters: removed the unused `use_copy` schema field.
                                                                                             
  ---             
                                                                                             
  ## Testing      
  - Run the converter pipeline end-to-end with text and tabular datasets.
  - Verify `SimpleImputer`, `LabelBinarizer`, and `CharacterReplacer` against
  categorical/edge-case inputs.                                                              
  - Confirm `FormConverterSection` displays errors correctly in the UI.
                                                                                             
  ---                                                                                        
   
  ## Notes                                                                                   
  Most fixes were uncovered while testing the converters together; several are small
  compatibility/metadata patches rather than behavioral changes.