### PR TITLE
fix numeric formatting and handle null values in NumericTab

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
@@ -14,6 +14,14 @@ export const NumericTab = ({ numericStats }) => {
   const theme = useTheme();
 
   const toNumberOrNull = (value) => {
+    if (
+      value === null ||
+      value === undefined ||
+      (typeof value === "string" && value.trim() === "")
+    ) {
+      return null;
+    }
+
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : null;
   };
@@ -141,15 +149,14 @@ export const NumericTab = ({ numericStats }) => {
                   />
                   <MetricRow
                     label={t("datasets:label.range")}
-                    value={
-                      toNumberOrNull(stats?.upper_bound) !== null &&
-                      toNumberOrNull(stats?.lower_bound) !== null
-                        ? (
-                            toNumberOrNull(stats?.upper_bound) -
-                            toNumberOrNull(stats?.lower_bound)
-                          ).toFixed(2)
-                        : "N/A"
-                    }
+                    value={(() => {
+                      const upperBound = toNumberOrNull(stats?.upper_bound);
+                      const lowerBound = toNumberOrNull(stats?.lower_bound);
+
+                      return upperBound !== null && lowerBound !== null
+                        ? (upperBound - lowerBound).toFixed(2)
+                        : "N/A";
+                    })()}
                   />
                 </Box>
               </Box>
@@ -313,21 +320,27 @@ export const NumericTab = ({ numericStats }) => {
             )}
 
             {/* Skewness Warning */}
-            {toNumberOrNull(stats?.skew) !== null &&
-              toNumberOrNull(stats?.skew) > 1 && (
-                <Alert
-                  severity="warning"
-                  icon={<InfoIcon fontSize="inherit" />}
-                  sx={{ mt: 3 }}
-                >
-                  <Typography variant="body2">
-                    <Trans i18nKey="datasets:label.rightSkewedWarning">
-                      <strong>Right-skewed distribution:</strong> Consider
-                      applying a log transformation.
-                    </Trans>
-                  </Typography>
-                </Alert>
-              )}
+            {(() => {
+              const skew = toNumberOrNull(stats?.skew);
+
+              return (
+                skew !== null &&
+                skew > 1 && (
+                  <Alert
+                    severity="warning"
+                    icon={<InfoIcon fontSize="inherit" />}
+                    sx={{ mt: 3 }}
+                  >
+                    <Typography variant="body2">
+                      <Trans i18nKey="datasets:label.rightSkewedWarning">
+                        <strong>Right-skewed distribution:</strong> Consider
+                        applying a log transformation.
+                      </Trans>
+                    </Typography>
+                  </Alert>
+                )
+              );
+            })()}
           </CardContent>
         </ExportableCard>
       ))}

--- a/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
@@ -13,9 +13,19 @@ export const NumericTab = ({ numericStats }) => {
   const { t } = useTranslation(["datasets"]);
   const theme = useTheme();
 
+  const toNumberOrNull = (value) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  const formatNumber = (value, decimals = 2) => {
+    const parsed = toNumberOrNull(value);
+    return parsed === null ? "N/A" : parsed.toFixed(decimals);
+  };
+
   return (
     <Box display="flex" flexDirection="column" gap={4}>
-      {Object.entries(numericStats).map(([column, stats]) => (
+      {Object.entries(numericStats ?? {}).map(([column, stats]) => (
         <ExportableCard
           key={column}
           filename={`numeric_${column}`}
@@ -37,25 +47,25 @@ export const NumericTab = ({ numericStats }) => {
               <Box flex="1 1 200px" minWidth="150px">
                 <StatBox
                   label={t("datasets:label.mean")}
-                  value={stats.mean.toFixed(2)}
+                  value={formatNumber(stats?.mean)}
                 />
               </Box>
               <Box flex="1 1 200px" minWidth="150px">
                 <StatBox
                   label={t("datasets:label.median")}
-                  value={stats.median.toFixed(2)}
+                  value={formatNumber(stats?.median)}
                 />
               </Box>
               <Box flex="1 1 200px" minWidth="150px">
                 <StatBox
                   label={t("datasets:label.stdDev")}
-                  value={stats.std.toFixed(2)}
+                  value={formatNumber(stats?.std)}
                 />
               </Box>
               <Box flex="1 1 200px" minWidth="150px">
                 <StatBox
                   label={t("datasets:label.unique")}
-                  value={stats.n_unique}
+                  value={stats?.n_unique ?? "N/A"}
                 />
               </Box>
             </Box>
@@ -76,31 +86,31 @@ export const NumericTab = ({ numericStats }) => {
                 <Box display="flex" flexDirection="column" gap={1}>
                   <MetricRow
                     label={t("datasets:label.lowerBound")}
-                    value={stats.lower_bound.toFixed(2)}
+                    value={formatNumber(stats?.lower_bound)}
                   />
                   <MetricRow
                     label={t("datasets:label.q1")}
-                    value={stats.q1.toFixed(2)}
+                    value={formatNumber(stats?.q1)}
                   />
                   <MetricRow
                     label={t("datasets:label.median")}
-                    value={stats.median.toFixed(2)}
+                    value={formatNumber(stats?.median)}
                   />
                   <MetricRow
                     label={t("datasets:label.q3")}
-                    value={stats.q3.toFixed(2)}
+                    value={formatNumber(stats?.q3)}
                   />
                   <MetricRow
                     label={t("datasets:label.upperBound")}
-                    value={stats.upper_bound.toFixed(2)}
+                    value={formatNumber(stats?.upper_bound)}
                   />
                   <MetricRow
                     label={t("datasets:label.min")}
-                    value={stats.min.toFixed(2)}
+                    value={formatNumber(stats?.min)}
                   />
                   <MetricRow
                     label={t("datasets:label.max")}
-                    value={stats.max.toFixed(2)}
+                    value={formatNumber(stats?.max)}
                   />
                 </Box>
               </Box>
@@ -119,19 +129,27 @@ export const NumericTab = ({ numericStats }) => {
                 <Box display="flex" flexDirection="column" gap={1}>
                   <MetricRow
                     label={t("datasets:label.skewness")}
-                    value={stats.skew.toFixed(3)}
+                    value={formatNumber(stats?.skew, 3)}
                   />
                   <MetricRow
                     label={t("datasets:label.kurtosis")}
-                    value={stats.kurtosis.toFixed(3)}
+                    value={formatNumber(stats?.kurtosis, 3)}
                   />
                   <MetricRow
                     label={t("datasets:label.outliers")}
-                    value={stats.outliers_count}
+                    value={stats?.outliers_count ?? "N/A"}
                   />
                   <MetricRow
                     label={t("datasets:label.range")}
-                    value={(stats.upper_bound - stats.lower_bound).toFixed(2)}
+                    value={
+                      toNumberOrNull(stats?.upper_bound) !== null &&
+                      toNumberOrNull(stats?.lower_bound) !== null
+                        ? (
+                            toNumberOrNull(stats?.upper_bound) -
+                            toNumberOrNull(stats?.lower_bound)
+                          ).toFixed(2)
+                        : "N/A"
+                    }
                   />
                 </Box>
               </Box>
@@ -147,15 +165,34 @@ export const NumericTab = ({ numericStats }) => {
                 {t("datasets:label.boxplot")}
               </Typography>
               {(() => {
-                const hasLowerOutlier = stats.min < stats.lower_bound;
-                const hasUpperOutlier = stats.max > stats.upper_bound;
+                const q1 = toNumberOrNull(stats?.q1);
+                const median = toNumberOrNull(stats?.median);
+                const q3 = toNumberOrNull(stats?.q3);
+                const lowerBound = toNumberOrNull(stats?.lower_bound);
+                const upperBound = toNumberOrNull(stats?.upper_bound);
+                const min = toNumberOrNull(stats?.min);
+                const max = toNumberOrNull(stats?.max);
+
+                const hasBoxplotData =
+                  q1 !== null &&
+                  median !== null &&
+                  q3 !== null &&
+                  lowerBound !== null &&
+                  upperBound !== null;
+
+                if (!hasBoxplotData) {
+                  return null;
+                }
+
+                const hasLowerOutlier = min !== null && min < lowerBound;
+                const hasUpperOutlier = max !== null && max > upperBound;
 
                 const boxTrace = {
-                  q1: [stats.q1],
-                  median: [stats.median],
-                  q3: [stats.q3],
-                  lowerfence: [stats.lower_bound],
-                  upperfence: [stats.upper_bound],
+                  q1: [q1],
+                  median: [median],
+                  q3: [q3],
+                  lowerfence: [lowerBound],
+                  upperfence: [upperBound],
                   y: [column],
                   type: "box",
                   name: column,
@@ -171,14 +208,14 @@ export const NumericTab = ({ numericStats }) => {
 
                 const boxHoverTraces = [
                   {
-                    x: stats.upper_bound,
+                    x: upperBound,
                     label: t("datasets:label.upperBound"),
                   },
-                  { x: stats.q3, label: t("datasets:label.q3") },
-                  { x: stats.median, label: t("datasets:label.median") },
-                  { x: stats.q1, label: t("datasets:label.q1") },
+                  { x: q3, label: t("datasets:label.q3") },
+                  { x: median, label: t("datasets:label.median") },
+                  { x: q1, label: t("datasets:label.q1") },
                   {
-                    x: stats.lower_bound,
+                    x: lowerBound,
                     label: t("datasets:label.lowerBound"),
                   },
                 ].map(({ x, label }) => ({
@@ -187,13 +224,13 @@ export const NumericTab = ({ numericStats }) => {
                   type: "scatter",
                   mode: "markers",
                   marker: { opacity: 0, size: 10 },
-                  hovertemplate: `${label}: ${x.toFixed(2)}<extra></extra>`,
+                  hovertemplate: `${label}: ${formatNumber(x)}<extra></extra>`,
                   showlegend: false,
                 }));
 
                 const lowerOutlierTrace = hasLowerOutlier
                   ? {
-                      x: [stats.min],
+                      x: [min],
                       y: [column],
                       type: "scatter",
                       mode: "markers",
@@ -202,16 +239,14 @@ export const NumericTab = ({ numericStats }) => {
                         size: 8,
                         symbol: "circle-open",
                       },
-                      hovertemplate: `Min: ${stats.min.toFixed(
-                        2,
-                      )}<extra></extra>`,
+                      hovertemplate: `Min: ${formatNumber(min)}<extra></extra>`,
                       showlegend: false,
                     }
                   : null;
 
                 const upperOutlierTrace = hasUpperOutlier
                   ? {
-                      x: [stats.max],
+                      x: [max],
                       y: [column],
                       type: "scatter",
                       mode: "markers",
@@ -220,9 +255,7 @@ export const NumericTab = ({ numericStats }) => {
                         size: 8,
                         symbol: "circle-open",
                       },
-                      hovertemplate: `Max: ${stats.max.toFixed(
-                        2,
-                      )}<extra></extra>`,
+                      hovertemplate: `Max: ${formatNumber(max)}<extra></extra>`,
                       showlegend: false,
                     }
                   : null;
@@ -265,7 +298,7 @@ export const NumericTab = ({ numericStats }) => {
               })()}
             </Box>
 
-            {stats.outliers_count > 0 && (
+            {(stats?.outliers_count ?? 0) > 0 && (
               <Alert
                 severity="warning"
                 icon={<InfoIcon fontSize="inherit" />}
@@ -280,20 +313,21 @@ export const NumericTab = ({ numericStats }) => {
             )}
 
             {/* Skewness Warning */}
-            {stats.skew > 1 && (
-              <Alert
-                severity="warning"
-                icon={<InfoIcon fontSize="inherit" />}
-                sx={{ mt: 3 }}
-              >
-                <Typography variant="body2">
-                  <Trans i18nKey="datasets:label.rightSkewedWarning">
-                    <strong>Right-skewed distribution:</strong> Consider
-                    applying a log transformation.
-                  </Trans>
-                </Typography>
-              </Alert>
-            )}
+            {toNumberOrNull(stats?.skew) !== null &&
+              toNumberOrNull(stats?.skew) > 1 && (
+                <Alert
+                  severity="warning"
+                  icon={<InfoIcon fontSize="inherit" />}
+                  sx={{ mt: 3 }}
+                >
+                  <Typography variant="body2">
+                    <Trans i18nKey="datasets:label.rightSkewedWarning">
+                      <strong>Right-skewed distribution:</strong> Consider
+                      applying a log transformation.
+                    </Trans>
+                  </Typography>
+                </Alert>
+              )}
           </CardContent>
         </ExportableCard>
       ))}


### PR DESCRIPTION
This pull request improves the robustness and user experience of the `NumericTab` component by adding safer handling and formatting of numerical statistics, ensuring that missing or invalid data is gracefully displayed as "N/A" instead of causing errors. It also enhances the reliability of the boxplot and warning displays by validating data before rendering.

Key improvements:

**Robust number handling and formatting:**
* Introduced utility functions `toNumberOrNull` and `formatNumber` to safely parse and format numeric values, displaying "N/A" when data is missing or invalid. These functions are now used throughout the component for all numeric statistics.
* Updated all displayed statistics (mean, median, std, quartiles, bounds, min, max, skewness, kurtosis, etc.) to use these new formatting functions, preventing runtime errors from undefined or non-numeric values. [[1]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L40-R68) [[2]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L79-R113) [[3]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L122-R152)

**Boxplot and outlier display reliability:**
* Added checks to ensure all required boxplot data is present and valid before rendering the boxplot, preventing crashes when data is missing.
* Updated boxplot and outlier trace construction to use safely parsed numbers and the new formatting functions for display and hover templates. [[1]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L174-R218) [[2]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L190-R233) [[3]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L205-R249) [[4]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L223-R258)

**Conditional warnings and alerts:**
* Modified outlier and skewness warnings to only display when the relevant statistics are present and valid, avoiding false positives or errors when data is missing. [[1]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L268-R301) [[2]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L283-R317)