### PR TITLE
feat: enhance PlotlyJsonVisualizer with toolbar for zoom, reset, and …

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
@@ -99,7 +99,7 @@ const OverviewTab = ({
               sx={{
                 display: "flex",
                 alignItems: "center",
-                justifyContent: "space-between",
+                gap: 1,
                 mb: 1,
               }}
             >

--- a/DashAI/front/src/components/notebooks/explorer/visualizations/PlotlyJsonVisualizer.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/visualizations/PlotlyJsonVisualizer.jsx
@@ -1,19 +1,26 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
 import Plot from "react-plotly.js";
-import { Box } from "@mui/material";
+import { Box, IconButton, Tooltip } from "@mui/material";
 import Dialog from "@mui/material/Dialog";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
+import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
+import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
+
 const MIN_WIDTH = 300;
 const MIN_HEIGHT_MINIMALIST = 200;
 const MIN_HEIGHT_NORMAL = 500;
 
 function PlotlyJsonVisualizer({ data, minimalist = false }) {
   const [expanded, setExpanded] = useState(false);
+  const plotRef = useRef(null);
+  const fullscreenPlotRef = useRef(null);
 
-  // Parse JSON if data is a string
   const parsedData = typeof data === "string" ? JSON.parse(data) : data;
 
-  // Remove the name if minimalist
   const plotData = minimalist
     ? {
         ...parsedData,
@@ -27,69 +34,82 @@ function PlotlyJsonVisualizer({ data, minimalist = false }) {
         layout: { ...parsedData.layout, height: MIN_HEIGHT_NORMAL },
       };
 
-  const toggleFullscreen = () => {
-    setExpanded(!expanded);
+  const getPlotly = (ref) => {
+    const el = ref?.current?.el;
+    if (!el) return null;
+    return (
+      el._fullLayout?._context?._exportedPlotly ||
+      el._fullData?.[0]?._fullLayout?._context?._exportedPlotly ||
+      window.Plotly ||
+      null
+    );
+  };
+
+  const relayout = (ref, update) => {
+    const el = ref?.current?.el;
+    const Plotly = getPlotly(ref);
+    if (el && Plotly) Plotly.relayout(el, update);
+  };
+
+  const handleZoomIn = (ref) => {
+    const el = ref?.current?.el;
+    if (!el) return;
+    const xRange = el._fullLayout?.xaxis?.range;
+    const yRange = el._fullLayout?.yaxis?.range;
+    if (xRange && yRange) {
+      const xCenter = (xRange[0] + xRange[1]) / 2;
+      const yCenter = (yRange[0] + yRange[1]) / 2;
+      const xSpan = (xRange[1] - xRange[0]) * 0.25;
+      const ySpan = (yRange[1] - yRange[0]) * 0.25;
+      relayout(ref, {
+        "xaxis.range": [xCenter - xSpan, xCenter + xSpan],
+        "yaxis.range": [yCenter - ySpan, yCenter + ySpan],
+      });
+    }
+  };
+
+  const handleZoomOut = (ref) => {
+    const el = ref?.current?.el;
+    if (!el) return;
+    const xRange = el._fullLayout?.xaxis?.range;
+    const yRange = el._fullLayout?.yaxis?.range;
+    if (xRange && yRange) {
+      const xCenter = (xRange[0] + xRange[1]) / 2;
+      const yCenter = (yRange[0] + yRange[1]) / 2;
+      const xSpan = (xRange[1] - xRange[0]) * 0.75;
+      const ySpan = (yRange[1] - yRange[0]) * 0.75;
+      relayout(ref, {
+        "xaxis.range": [xCenter - xSpan, xCenter + xSpan],
+        "yaxis.range": [yCenter - ySpan, yCenter + ySpan],
+      });
+    }
+  };
+
+  const handleReset = (ref) => {
+    relayout(ref, {
+      "xaxis.autorange": true,
+      "yaxis.autorange": true,
+    });
+  };
+
+  const handleDownload = (ref) => {
+    const el = ref?.current?.el;
+    const Plotly = getPlotly(ref);
+    if (el && Plotly) {
+      Plotly.downloadImage(el, {
+        format: "svg",
+        filename: "dashai-plot",
+        height: 800,
+        width: 1200,
+        scale: 1,
+      });
+    }
   };
 
   const plotConfig = {
     responsive: true,
     displaylogo: false,
-    displayModeBar: true,
-    modeBarButtonsToRemove: minimalist
-      ? [
-          "sendDataToCloud",
-          "lasso2d",
-          "select2d",
-          "zoom2d",
-          "pan2d",
-          "autoScale2d",
-        ]
-      : ["sendDataToCloud", "lasso2d", "select2d"],
-    modeBarButtonsToAdd: minimalist
-      ? []
-      : [
-          {
-            name: "fullscreen",
-            title: "Fullscreen",
-            icon: {
-              width: 1000,
-              path: "M128 32H32C14.31 32 0 46.31 0 64v96c0 17.69 14.31 32 32 32s32-14.31 32-32V96h64c17.69 0 32-14.31 32-32S145.7 32 128 32zM416 32h-96c-17.69 0-32 14.31-32 32s14.31 32 32 32h64v64c0 17.69 14.31 32 32 32s32-14.31 32-32V64C448 46.31 433.7 32 416 32zM128 416H64v-64c0-17.69-14.31-32-32-32s-32 14.31-32 32v96c0 17.69 14.31 32 32 32h96c17.69 0 32-14.31 32-32S145.7 416 128 416zM416 320c-17.69 0-32 14.31-32 32v64h-64c-17.69 0-32 14.31-32 32s14.31 32 32 32h96c17.69 0 32-14.31 32-32v-96C448 334.3 433.7 320 416 320z",
-              transform: "scale(0.03)",
-            },
-            click: () => {
-              toggleFullscreen();
-            },
-          },
-          "resetScale2d",
-        ],
-    toImageButtonOptions: {
-      format: "svg",
-      filename: "dashai-plot",
-      height: 800,
-      width: 1200,
-      scale: 1,
-    },
-  };
-
-  const fullscreenConfig = {
-    ...plotConfig,
-    scrollZoom: true,
-    modeBarButtonsToAdd: [
-      {
-        name: "exit-fullscreen",
-        title: "Exit fullscreen",
-        icon: {
-          width: 1000,
-          path: "M5.5 0a.5.5 0 0 1 .5.5v4A1.5 1.5 0 0 1 4.5 6h-4a.5.5 0 0 1 0-1h4a.5.5 0 0 0 .5-.5v-4a.5.5 0 0 1 .5-.5m5 0a.5.5 0 0 1 .5.5v4a.5.5 0 0 0 .5.5h4a.5.5 0 0 1 0 1h-4A1.5 1.5 0 0 1 10 4.5v-4a.5.5 0 0 1 .5-.5M0 10.5a.5.5 0 0 1 .5-.5h4A1.5 1.5 0 0 1 6 11.5v4a.5.5 0 0 1-1 0v-4a.5.5 0 0 0-.5-.5h-4a.5.5 0 0 1-.5-.5m10 1a1.5 1.5 0 0 1 1.5-1.5h4a.5.5 0 0 1 0 1h-4a.5.5 0 0 0-.5.5v4a.5.5 0 0 1-1 0z",
-        },
-        click: function () {
-          setExpanded(false);
-        },
-      },
-      "zoom2d",
-      "pan2d",
-      "resetScale2d",
-    ],
+    displayModeBar: false,
   };
 
   const plotLayout = {
@@ -125,6 +145,108 @@ function PlotlyJsonVisualizer({ data, minimalist = false }) {
     },
   };
 
+  const iconBtnSx = {
+    bgcolor: "rgba(255,255,255,0.85)",
+    border: "1px solid rgba(0,0,0,0.08)",
+    color: "#9e9e9e",
+    width: 30,
+    height: 30,
+    "&:hover": {
+      bgcolor: "rgba(255,255,255,1)",
+      color: "#616161",
+    },
+  };
+
+  const downloadBtnSx = {
+    bgcolor: "#ef9f27",
+    color: "white",
+    width: 30,
+    height: 30,
+    "&:hover": {
+      bgcolor: "#f5b94a",
+    },
+  };
+
+  const ToolbarButtons = ({
+    plotRefProp,
+    showFullscreenExit = false,
+    compact = false,
+  }) => (
+    <Box
+      sx={{
+        position: "absolute",
+        top: 8,
+        right: 8,
+        zIndex: 2,
+        display: "flex",
+        alignItems: "center",
+        gap: 0.5,
+      }}
+    >
+      {!compact && (
+        <>
+          <Tooltip title="Zoom in" arrow>
+            <IconButton
+              size="small"
+              onClick={() => handleZoomIn(plotRefProp)}
+              sx={iconBtnSx}
+            >
+              <ZoomInIcon sx={{ fontSize: 18 }} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Zoom out" arrow>
+            <IconButton
+              size="small"
+              onClick={() => handleZoomOut(plotRefProp)}
+              sx={iconBtnSx}
+            >
+              <ZoomOutIcon sx={{ fontSize: 18 }} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Reset axes" arrow>
+            <IconButton
+              size="small"
+              onClick={() => handleReset(plotRefProp)}
+              sx={iconBtnSx}
+            >
+              <RestartAltIcon sx={{ fontSize: 18 }} />
+            </IconButton>
+          </Tooltip>
+        </>
+      )}
+      {showFullscreenExit ? (
+        <Tooltip title="Exit fullscreen" arrow>
+          <IconButton
+            size="small"
+            onClick={() => setExpanded(false)}
+            sx={iconBtnSx}
+          >
+            <FullscreenExitIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Tooltip title="Fullscreen" arrow>
+          <IconButton
+            size="small"
+            onClick={() => setExpanded(true)}
+            sx={iconBtnSx}
+          >
+            <FullscreenIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+        </Tooltip>
+      )}
+      <Tooltip title="Download as SVG" arrow>
+        <IconButton
+          size="small"
+          onClick={() => handleDownload(plotRefProp)}
+          sx={downloadBtnSx}
+        >
+          <FileDownloadOutlinedIcon sx={{ fontSize: 18 }} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+
   return (
     <React.Fragment>
       <Box
@@ -140,14 +262,15 @@ function PlotlyJsonVisualizer({ data, minimalist = false }) {
           alignItems: "center",
         }}
       >
+        <ToolbarButtons plotRefProp={plotRef} compact={minimalist} />
         {!expanded ? (
           <Plot
+            ref={plotRef}
             id="plotly-graph"
             data={plotData.data}
             layout={plotLayout}
             style={{
               width: "100%",
-              // Explicit floor so Plotly never renders at 0 height
               minHeight: minimalist ? MIN_HEIGHT_MINIMALIST : MIN_HEIGHT_NORMAL,
               height: minimalist ? "100%" : MIN_HEIGHT_NORMAL,
             }}
@@ -165,36 +288,43 @@ function PlotlyJsonVisualizer({ data, minimalist = false }) {
               },
             }}
           >
-            <Plot
-              data={plotData.data}
-              layout={{
-                ...plotData.layout,
-                paper_bgcolor: plotData.layout?.paper_bgcolor || "white",
-                plot_bgcolor: plotData.layout?.plot_bgcolor || "white",
-                autosize: true,
-                margin: {
-                  l: 80,
-                  r: 40,
-                  t: 80,
-                  b: 80,
-                  ...plotData.layout?.margin,
-                },
-                font: {
-                  size: 14,
-                  ...plotData.layout?.font,
-                },
-                title: {
-                  ...plotData.layout?.title,
-                  font: {
-                    size: 18,
-                    ...plotData.layout?.title?.font,
+            <Box sx={{ position: "relative", width: "100%", height: "100%" }}>
+              <ToolbarButtons
+                plotRefProp={fullscreenPlotRef}
+                showFullscreenExit
+              />
+              <Plot
+                ref={fullscreenPlotRef}
+                data={plotData.data}
+                layout={{
+                  ...plotData.layout,
+                  paper_bgcolor: plotData.layout?.paper_bgcolor || "white",
+                  plot_bgcolor: plotData.layout?.plot_bgcolor || "white",
+                  autosize: true,
+                  margin: {
+                    l: 80,
+                    r: 40,
+                    t: 80,
+                    b: 80,
+                    ...plotData.layout?.margin,
                   },
-                },
-              }}
-              style={{ width: "100vw", height: "100vh" }}
-              useResizeHandler={true}
-              config={fullscreenConfig}
-            />
+                  font: {
+                    size: 14,
+                    ...plotData.layout?.font,
+                  },
+                  title: {
+                    ...plotData.layout?.title,
+                    font: {
+                      size: 18,
+                      ...plotData.layout?.title?.font,
+                    },
+                  },
+                }}
+                style={{ width: "100vw", height: "100vh" }}
+                useResizeHandler={true}
+                config={{ ...plotConfig, scrollZoom: true }}
+              />
+            </Box>
           </Dialog>
         )}
       </Box>


### PR DESCRIPTION
## Summary                                                                                                        
  Replace Plotly's default modebar with custom MUI floating toolbar buttons to improve plot toolbar usability. Users
   had difficulty finding the download and interaction controls with the default Plotly icons. The new toolbar uses 
  clear MUI icons with an amber-highlighted download button for better discoverability.                             
                                                                                                                    
  ---                                                       

  ## Type of Change
  Check all that apply like this [x]:
                                                                                                                    
  - [ ] Backend change
  - [x] Frontend change                                                                                             
  - [ ] CI / Workflow change                                
  - [ ] Build / Packaging change
  - [ ] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)
  - `front/src/components/notebooks/explorer/visualizations/PlotlyJsonVisualizer.jsx`: Hide Plotly's native modebar
  and replace it with custom MUI floating buttons (zoom in, zoom out, reset, fullscreen, download as SVG). In       
  minimalist mode, only fullscreen and download buttons are shown. Download button uses amber styling (`#ef9f27`)
  with `FileDownloadOutlinedIcon` for consistency with `ExportableCard`. Fullscreen dialog also includes the toolbar
   with an exit fullscreen button.                          

  ---

  ## Testing (optional)
  - Verify toolbar buttons appear on explorer plot cards (top-right corner)
  - Test zoom in/out, reset axes, and fullscreen functionality                                                      
  - Test download button exports the plot as SVG
  - Verify minimalist plots only show fullscreen + download buttons                                                 
  - Verify fullscreen mode shows all toolbar buttons with exit fullscreen option
                                                                                                                    