### PR TITLE
Feat/sidebar toggle usability

### DIFF
--- a/DashAI/front/src/components/generative/ParamsBar.jsx
+++ b/DashAI/front/src/components/generative/ParamsBar.jsx
@@ -14,7 +14,6 @@ import {
 import { preprocessSchema, buildYupSchema } from "./utils";
 import SideBar from "../threeSectionLayout/panelContainers/SideBar";
 import { useTranslation } from "react-i18next";
-import { ChevronRight } from "@mui/icons-material";
 import { useGenerative } from "./GenerativeContext";
 import { useTourContext } from "../tour/TourProvider";
 
@@ -141,13 +140,6 @@ export default function ParamsBar({ onToggle }) {
             height: 70,
           }}
         >
-          <IconButton
-            size="small"
-            onClick={onToggle}
-            sx={{ color: "text.secondary" }}
-          >
-            <ChevronRight />
-          </IconButton>
           <Typography variant="h6">{t("common:modelParameters")}</Typography>
 
           {/* Parameter History Modal */}

--- a/DashAI/front/src/components/generative/SessionBar.jsx
+++ b/DashAI/front/src/components/generative/SessionBar.jsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Divider, IconButton } from "@mui/material";
+import { Box, Typography, Divider } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import FolderIcon from "@mui/icons-material/Folder";
 import SearchBar from "../threeSectionLayout/SearchBar";
@@ -8,8 +8,6 @@ import GroupedCollapsibleList from "../threeSectionLayout/GroupedCollapsibleList
 import Footer from "../threeSectionLayout/Footer";
 import NewItemButton from "../threeSectionLayout/NewItemButton";
 import SideBar from "../threeSectionLayout/panelContainers/SideBar";
-import BarHeader from "../threeSectionLayout/BarHeader";
-import { ChevronLeft } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import { useGenerative } from "./GenerativeContext";
 
@@ -142,26 +140,6 @@ export default function SessionBar({ onToggle }) {
         justifyContent={"flex-start"}
         minHeight={0}
       >
-        {/* Header */}
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            pr: 2,
-          }}
-        >
-          <BarHeader />
-          <IconButton
-            size="small"
-            onClick={onToggle}
-            sx={{ color: "text.secondary" }}
-          >
-            <ChevronLeft />
-          </IconButton>
-        </Box>
-        <Divider sx={{ width: "100%", bgcolor: "divider" }} />
-
         <Box
           p={2}
           sx={{ height: "64px", display: "flex", alignItems: "center" }}

--- a/DashAI/front/src/components/models/ModelsLeftBar.jsx
+++ b/DashAI/front/src/components/models/ModelsLeftBar.jsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { Box, Divider, Typography, IconButton } from "@mui/material";
+import { Box, Divider, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import { ChevronLeft } from "@mui/icons-material";
 import StorageIcon from "@mui/icons-material/Storage";
 import Biotech from "@mui/icons-material/Biotech";
 import Footer from "../threeSectionLayout/Footer";
-import BarHeader from "../threeSectionLayout/BarHeader";
 import SideBar from "../threeSectionLayout/panelContainers/SideBar";
 import CollapsibleList from "../threeSectionLayout/CollapsibleList";
 import GroupedCollapsibleList from "../threeSectionLayout/GroupedCollapsibleList";
@@ -230,26 +228,6 @@ export default function ModelsLeftBar({ onToggle }) {
 
   return (
     <SideBar>
-      {/* Header */}
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          pr: 2,
-        }}
-      >
-        <BarHeader />
-        <IconButton
-          size="small"
-          onClick={onToggle}
-          sx={{ color: "text.secondary" }}
-        >
-          <ChevronLeft />
-        </IconButton>
-      </Box>
-      <Divider sx={{ width: "100%", bgcolor: theme.palette.ui.borderDark }} />
-
       {/* Create new item button */}
       <Box p={2} sx={{ height: "64px", display: "flex", alignItems: "center" }}>
         {selectedDatasetId || selectedSessionId ? (

--- a/DashAI/front/src/components/models/ModelsRightBar.jsx
+++ b/DashAI/front/src/components/models/ModelsRightBar.jsx
@@ -1,14 +1,8 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import {
-  Box,
-  Typography,
-  IconButton,
-  TextField,
-  CircularProgress,
-} from "@mui/material";
+import { Box, Typography, TextField, CircularProgress } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import { ChevronRight, Search as SearchIcon } from "@mui/icons-material";
+import { Search as SearchIcon } from "@mui/icons-material";
 import { useSnackbar } from "notistack";
 import SideBar from "../threeSectionLayout/panelContainers/SideBar";
 import { getComponents } from "../../api/component";
@@ -131,13 +125,6 @@ export default function ModelsRightBar({ onToggle }) {
             justifyContent: "flex-start",
           }}
         >
-          <IconButton
-            size="small"
-            onClick={onToggle}
-            sx={{ color: "text.secondary" }}
-          >
-            <ChevronRight />
-          </IconButton>
           <Typography variant="h6" color="text.primary">
             {t("models:label.availableModels")}
           </Typography>

--- a/DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx
+++ b/DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx
@@ -1,15 +1,13 @@
 import { useState, useEffect } from "react";
-import { Box, Divider, Typography, IconButton } from "@mui/material";
+import { Box, Divider, Typography } from "@mui/material";
 import StorageIcon from "@mui/icons-material/Storage";
 import DescriptionIcon from "@mui/icons-material/Description";
 import Footer from "../threeSectionLayout/Footer";
-import BarHeader from "../threeSectionLayout/BarHeader";
 import CollapsibleList from "../threeSectionLayout/CollapsibleList";
 import SearchBar from "../threeSectionLayout/SearchBar";
 import NewItemButton from "../threeSectionLayout/NewItemButton";
 import SideBar from "../threeSectionLayout/panelContainers/SideBar";
 import InfoNotebookModal from "./notebook/InfoNotebookModal";
-import { ChevronLeft } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 
 import { useDatasetsAndNotebooks } from "../custom/contexts/DatasetsAndNotebooksContext";
@@ -153,26 +151,6 @@ export default function DatasetsNotebooksLeftBar({ onToggle }) {
 
   return (
     <SideBar>
-      {/* Header */}
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          pr: 2,
-        }}
-      >
-        <BarHeader />
-        <IconButton
-          size="small"
-          onClick={onToggle}
-          sx={{ color: "text.secondary" }}
-        >
-          <ChevronLeft />
-        </IconButton>
-      </Box>
-      <Divider sx={{ width: "100%", bgcolor: "divider" }} />
-
       {/* Create new item button */}
       <Box p={2} sx={{ height: "64px", display: "flex", alignItems: "center" }}>
         {selectedDatasetId || selectedNotebookId ? (

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -7,7 +7,6 @@ import {
   Tab,
   ToggleButtonGroup,
   ToggleButton,
-  IconButton,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { ViewList, ViewModule } from "@mui/icons-material";
@@ -24,7 +23,6 @@ import { getDatasetTypesByFilePath } from "../../api/datasets";
 import { useSnackbar } from "notistack";
 import { useTourContext } from "../tour/TourProvider";
 import { useExplorersAndConverters } from "./context/ExplorersAndConvertersContext";
-import { ChevronRight } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import { useDatasetsAndNotebooks } from "../custom/contexts/DatasetsAndNotebooksContext";
 import ColumnInsights from "./dataset/ColumnInsights";
@@ -340,13 +338,6 @@ export default function RightBar({ notebook, onToggle }) {
             justifyContent: "flex-start",
           }}
         >
-          <IconButton
-            size="small"
-            onClick={onToggle}
-            sx={{ color: "text.secondary" }}
-          >
-            <ChevronRight />
-          </IconButton>
           <Typography variant="h6" color="text.primary">
             {t("datasets:label.analysisTools")}
           </Typography>

--- a/DashAI/front/src/components/threeSectionLayout/panels/LeftPanel.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/panels/LeftPanel.jsx
@@ -1,5 +1,5 @@
 import { Box, IconButton } from "@mui/material";
-import { ChevronRight } from "@mui/icons-material";
+import { ChevronLeft, ChevronRight } from "@mui/icons-material";
 import { useThreePanelLayoutContext } from "./ThreePanelLayoutContext";
 
 export default function LeftPanel({ children, "data-tour": dataTour }) {
@@ -12,26 +12,38 @@ export default function LeftPanel({ children, "data-tour": dataTour }) {
   } = useThreePanelLayoutContext();
   return (
     <>
-      {!leftBarVisible && (
-        <IconButton
-          onClick={handleToggleLeft}
-          sx={{
-            position: "absolute",
-            left: 8,
-            top: "50%",
-            transform: "translateY(-50%)",
-            bgcolor: "background.paper",
-            zIndex: 10,
-            transition: "all 0.2s ease",
-            "&:hover": {
-              bgcolor: "action.hover",
-              transform: "translateY(-50%) scale(1.1)",
-            },
-          }}
-        >
-          <ChevronRight />
-        </IconButton>
-      )}
+      <IconButton
+        onClick={handleToggleLeft}
+        size="small"
+        sx={{
+          position: "absolute",
+          left: leftBarVisible ? `calc(${leftBarWidth}% - 9px)` : 8,
+          top: "50%",
+          transform: "translateY(-50%)",
+          bgcolor: "primary.main",
+          color: "primary.contrastText",
+          border: "1px solid",
+          borderColor: "primary.dark",
+          boxShadow: 2,
+          width: 18,
+          height: 32,
+          borderRadius: 1,
+          zIndex: 11,
+          transition: isTogglingLeft
+            ? "left 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s ease, transform 0.2s ease"
+            : "background-color 0.2s ease, transform 0.2s ease",
+          "&:hover": {
+            bgcolor: "primary.light",
+            transform: "translateY(-50%) scale(1.1)",
+          },
+        }}
+      >
+        {leftBarVisible ? (
+          <ChevronLeft fontSize="small" />
+        ) : (
+          <ChevronRight fontSize="small" />
+        )}
+      </IconButton>
       <Box
         width={leftBarVisible ? `${leftBarWidth}%` : "0%"}
         position="relative"

--- a/DashAI/front/src/components/threeSectionLayout/panels/RightPanel.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/panels/RightPanel.jsx
@@ -1,5 +1,5 @@
 import { Box, IconButton } from "@mui/material";
-import { ChevronLeft } from "@mui/icons-material";
+import { ChevronLeft, ChevronRight } from "@mui/icons-material";
 import { useThreePanelLayoutContext } from "./ThreePanelLayoutContext";
 export default function RightPanel({
   toggleButtonTop = "50%",
@@ -15,26 +15,38 @@ export default function RightPanel({
   } = useThreePanelLayoutContext();
   return (
     <>
-      {!rightBarVisible && (
-        <IconButton
-          onClick={handleToggleRight}
-          sx={{
-            position: "absolute",
-            right: 8,
-            top: toggleButtonTop,
-            transform: "translateY(-50%)",
-            bgcolor: "background.paper",
-            zIndex: 10,
-            transition: "all 0.2s ease",
-            "&:hover": {
-              bgcolor: "action.hover",
-              transform: "translateY(-50%) scale(1.1)",
-            },
-          }}
-        >
-          <ChevronLeft />
-        </IconButton>
-      )}
+      <IconButton
+        onClick={handleToggleRight}
+        size="small"
+        sx={{
+          position: "absolute",
+          right: rightBarVisible ? `calc(${rightBarWidth}% - 9px)` : 8,
+          top: toggleButtonTop,
+          transform: "translateY(-50%)",
+          bgcolor: "primary.main",
+          color: "primary.contrastText",
+          border: "1px solid",
+          borderColor: "primary.dark",
+          boxShadow: 2,
+          width: 18,
+          height: 32,
+          borderRadius: 1,
+          zIndex: 11,
+          transition: isTogglingRight
+            ? "right 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s ease, transform 0.2s ease"
+            : "background-color 0.2s ease, transform 0.2s ease",
+          "&:hover": {
+            bgcolor: "primary.light",
+            transform: "translateY(-50%) scale(1.1)",
+          },
+        }}
+      >
+        {rightBarVisible ? (
+          <ChevronRight fontSize="small" />
+        ) : (
+          <ChevronLeft fontSize="small" />
+        )}
+      </IconButton>
       <Box
         width={rightBarVisible ? `${rightBarWidth}%` : "0%"}
         position="relative"

--- a/DashAI/front/src/hooks/useThreePanelsLayout.js
+++ b/DashAI/front/src/hooks/useThreePanelsLayout.js
@@ -1,10 +1,55 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 
-export function useThreePanelLayout() {
-  const [leftBarVisible, setLeftBarVisible] = useState(true);
-  const [rightBarVisible, setRightBarVisible] = useState(true);
-  const [leftBarWidth, setLeftBarWidth] = useState(20);
-  const [rightBarWidth, setRightBarWidth] = useState(20);
+const DEFAULT_LAYOUT = {
+  leftBarVisible: true,
+  rightBarVisible: true,
+  leftBarWidth: 20,
+  rightBarWidth: 20,
+};
+
+const readPersisted = (storageKey) => {
+  if (!storageKey) return DEFAULT_LAYOUT;
+  try {
+    const raw = localStorage.getItem(`layout:${storageKey}`);
+    if (!raw) return DEFAULT_LAYOUT;
+    const parsed = JSON.parse(raw);
+    return { ...DEFAULT_LAYOUT, ...parsed };
+  } catch {
+    return DEFAULT_LAYOUT;
+  }
+};
+
+export function useThreePanelLayout({ storageKey } = {}) {
+  const initial = readPersisted(storageKey);
+  const [leftBarVisible, setLeftBarVisible] = useState(initial.leftBarVisible);
+  const [rightBarVisible, setRightBarVisible] = useState(
+    initial.rightBarVisible,
+  );
+  const [leftBarWidth, setLeftBarWidth] = useState(initial.leftBarWidth);
+  const [rightBarWidth, setRightBarWidth] = useState(initial.rightBarWidth);
+
+  useEffect(() => {
+    if (!storageKey) return;
+    try {
+      localStorage.setItem(
+        `layout:${storageKey}`,
+        JSON.stringify({
+          leftBarVisible,
+          rightBarVisible,
+          leftBarWidth,
+          rightBarWidth,
+        }),
+      );
+    } catch {
+      // ignore quota / disabled storage
+    }
+  }, [
+    storageKey,
+    leftBarVisible,
+    rightBarVisible,
+    leftBarWidth,
+    rightBarWidth,
+  ]);
 
   const [isTogglingLeft, setIsTogglingLeft] = useState(false);
   const [isTogglingRight, setIsTogglingRight] = useState(false);

--- a/DashAI/front/src/pages/datasets/DatasetsContent.jsx
+++ b/DashAI/front/src/pages/datasets/DatasetsContent.jsx
@@ -47,7 +47,7 @@ export default function DatasetsContent() {
                 <CenterPanel>
                   <DatasetsCenterContent />
                 </CenterPanel>
-                <RightPanel toggleButtonTop="calc(50% + 60px)">
+                <RightPanel toggleButtonTop="50%">
                   {rightBarContent ? (
                     rightBarContent
                   ) : (

--- a/DashAI/front/src/pages/datasets/DatasetsContent.jsx
+++ b/DashAI/front/src/pages/datasets/DatasetsContent.jsx
@@ -15,7 +15,7 @@ import { useTranslation } from "react-i18next";
 
 export default function DatasetsContent() {
   const { t } = useTranslation();
-  const threePanelLayout = useThreePanelLayout();
+  const threePanelLayout = useThreePanelLayout({ storageKey: "datasets" });
 
   const {
     notebooks,

--- a/DashAI/front/src/pages/generative/GenerativeContent.jsx
+++ b/DashAI/front/src/pages/generative/GenerativeContent.jsx
@@ -15,7 +15,7 @@ import { useGenerative } from "../../components/generative/GenerativeContext";
 import { useTranslation } from "react-i18next";
 
 export default function GenerativeContent() {
-  const threePanelLayout = useThreePanelLayout();
+  const threePanelLayout = useThreePanelLayout({ storageKey: "generative" });
   const { stepIndex, selectedSessionId } = useGenerative();
   const { setDisabled } = useTourContext() ?? {};
   const { t } = useTranslation(["generative"]);

--- a/DashAI/front/src/pages/models/ModelsContent.jsx
+++ b/DashAI/front/src/pages/models/ModelsContent.jsx
@@ -17,7 +17,7 @@ import { useModels } from "../../components/models/ModelsContext";
 
 export default function ModelsContent() {
   const location = useLocation();
-  const threePanelLayout = useThreePanelLayout();
+  const threePanelLayout = useThreePanelLayout({ storageKey: "models" });
   const { t } = useTranslation(["models"]);
 
   const {


### PR DESCRIPTION
## Summary            
  Reworks the sidebar collapse/expand toggle to improve discoverability and consistency across modules. The toggle  
  now lives on the edge of each panel (always visible, primary-color pill), replacing the hidden-away chevron       
  buttons that were inside each sidebar header. Layout state (visibility + width of both panels) is now persisted
  per module in `localStorage`, so navigating between Datasets, Models, and Generative no longer resets your        
  preferred layout.                                         

  ---                                                                                                               
  
  ## Type of Change                                                                                                 
  - [ ] Backend change                                      
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [ ] Bug fix                                                                                                     
  - [ ] Documentation
                                                                                                                    
  ---                                                       

  ## Changes (by file)
  - `src/components/threeSectionLayout/panels/LeftPanel.jsx`: toggle button is now always rendered; slides along the
   panel's inner edge when open and sits at the screen edge when collapsed. Rectangular pill shape with             
  `primary.main` background for visibility.
  - `src/components/threeSectionLayout/panels/RightPanel.jsx`: symmetric change to the right panel toggle.          
  - `src/hooks/useThreePanelsLayout.js`: accepts an optional `storageKey` option; reads initial state from          
  `localStorage` and writes `{leftBarVisible, rightBarVisible, leftBarWidth, rightBarWidth}` on every change. Each  
  module persists independently under `layout:<key>`.                                                               
  - `src/pages/datasets/DatasetsContent.jsx`: passes `storageKey: "datasets"`; also normalizes `toggleButtonTop` to 
  `"50%"` so left/right toggles align vertically after header removal.                                              
  - `src/pages/models/ModelsContent.jsx`: passes `storageKey: "models"`.
  - `src/pages/generative/GenerativeContent.jsx`: passes `storageKey: "generative"`.                                
  - `src/components/notebooks/DatasetNotebookLeftBar.jsx`: removed the in-header chevron button and the empty       
  `BarHeader` spacer that was only there to pad for it.                                                             
  - `src/components/notebooks/RightBar.jsx`: removed the in-header chevron button and stale imports.                
  - `src/components/models/ModelsLeftBar.jsx`: same cleanup — removed chevron, removed empty `BarHeader`.           
  - `src/components/models/ModelsRightBar.jsx`: removed chevron button from header.                                 
  - `src/components/generative/SessionBar.jsx`: removed chevron + empty header spacer.                              
  - `src/components/generative/ParamsBar.jsx`: removed chevron button from header.                                  
                                                                                                                    
  ---                                                                                                               
                                                                                                                    
  ## Testing                                                
  - Open each module (Datasets, Models, Generative) and confirm the toggle is visible at mid-height on both panel
  edges, regardless of collapsed state.                                                                             
  - Collapse a panel in one module, navigate to another module, then back — state should be preserved.
  - Collapse left in Datasets but leave right open; open Models and confirm its layout is independent.              
  - Resize a panel and reload the page — width should persist per module.                                           
  - Verify no layout shift or misalignment between left/right toggles after removing the old empty `BarHeader`      
  spacers.                                                                                                          
                                                                                                                    
  ---                                                                                                               
                                                            
  ## Notes
<img width="2326" height="1310" alt="image" src="https://github.com/user-attachments/assets/d16d5e26-6f3f-41b0-a7dc-060bb95fc800" />
