### PR TITLE
Fix optimizer parameter initialization, state reset on switch, and default enablement of model creation

### DIFF
--- a/DashAI/front/src/components/models/AddModelDialog.jsx
+++ b/DashAI/front/src/components/models/AddModelDialog.jsx
@@ -56,7 +56,10 @@ function AddModelDialog({
   const { defaultValues: defaultModelParams } = useSchema({
     modelName: selectedModel,
   });
-  const { defaultValues: defaultOptimizerParams } = useSchema({
+  const {
+    defaultValues: defaultOptimizerParams,
+    loading: optimizerSchemaLoading,
+  } = useSchema({
     modelName: selectedOptimizer,
   });
 
@@ -112,6 +115,16 @@ function AddModelDialog({
       setHasLoadedInitialParams(true);
     }
   }, [selectedModel, defaultModelParams, hasLoadedInitialParams]);
+
+  useEffect(() => {
+    if (
+      !optimizerSchemaLoading &&
+      defaultOptimizerParams &&
+      Object.keys(defaultOptimizerParams).length > 0
+    ) {
+      setOptimizerParameters(defaultOptimizerParams);
+    }
+  }, [selectedOptimizer, optimizerSchemaLoading]);
 
   const handleClose = () => {
     setTimeout(() => {
@@ -241,20 +254,13 @@ function AddModelDialog({
     }
   };
 
-  const handleOptimizerSelected = (optimizerName, defaultValues) => {
+  const handleOptimizerSelected = (optimizerName) => {
+    setOptimizerParameters({});
     setSelectedOptimizer(optimizerName);
-    if (defaultValues && Object.keys(defaultValues).length > 0) {
-      setOptimizerParameters(defaultValues);
-    }
   };
 
   const isStep1Valid = Boolean(selectedModel && name.trim() !== "");
-  const isStep2Valid = Boolean(
-    selectedOptimizer &&
-    optimizerParameters &&
-    Object.keys(optimizerParameters).length > 0 &&
-    goalMetric,
-  );
+  const isStep2Valid = Boolean(selectedOptimizer && goalMetric);
 
   return (
     <Dialog
@@ -358,10 +364,10 @@ function AddModelDialog({
                 <Typography variant="subtitle2" sx={{ mb: 2 }}>
                   {t("models:label.optimizerParameters")}
                 </Typography>
-                <FormSchemaContainer>
+                <FormSchemaContainer key={selectedOptimizer}>
                   <FormSchemaWithSelectedModel
                     modelToConfigure={selectedOptimizer}
-                    initialValues={defaultOptimizerParams}
+                    initialValues={optimizerParameters}
                     onFormSubmit={() => {}}
                     onValuesChange={handleOptimizerParametersChange}
                     onCancel={() => {}}


### PR DESCRIPTION
## Summary
Fixes incorrect initialization and persistence of optimizer parameters in `AddModelDialog`. Previously, switching optimizers could retain incompatible parameters or fail to load defaults due to async schema updates re-initializing the form and stale state not being cleared. Additionally, this fixes an issue where the "Add Model" action was not enabled when using default optimizer parameters. The fix ensures parameters are set only after schema loading completes, resets state immediately on optimizer change, and guarantees default parameters are properly recognized.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/models/AddModelDialog.jsx`:
  - Set `optimizerParameters` only after schema fetch completes using `useSchema` loading state
  - Clear `optimizerParameters` on optimizer change to avoid leaking previous values
  - Add `key={selectedOptimizer}` to force form remount on optimizer switch
  - Use `optimizerParameters` as `initialValues` instead of `defaultOptimizerParams`
  - Simplify step validation logic so default parameters correctly enable model creation

---

## Testing (optional)
- Select a model with optimizable parameters
- Go to step 2 and switch between optimizers (e.g., Optuna ↔ Hyperopt)
- Verify only relevant parameters appear for each optimizer
- Confirm "Add Model" is enabled when default parameters are loaded
- Submit and confirm correct optimizer + parameters are sent