### PR TITLE
Add i18n support and fallback handling to ModelCard UI

### DIFF
--- a/DashAI/front/src/components/generative/ModelCard.jsx
+++ b/DashAI/front/src/components/generative/ModelCard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Box, Paper, Typography } from "@mui/material";
 import { alpha, useTheme } from "@mui/material/styles";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import { useTranslation } from "react-i18next";
 
 const DESCRIPTION_LINE_CLAMP = 3;
 
@@ -15,6 +16,7 @@ export default function ModelCard({
   const theme = useTheme();
   const [expanded, setExpanded] = useState(false);
   const [isClamped, setIsClamped] = useState(false);
+  const { t } = useTranslation(["generative"]);
   const descRef = useRef(null);
 
   useEffect(() => {
@@ -67,7 +69,7 @@ export default function ModelCard({
           fontWeight="bold"
           sx={{ color: isSelected ? color : "text.primary", lineHeight: 1.3 }}
         >
-          {model.display_name}
+          {model.display_name ? model.display_name : model.name}
         </Typography>
         {isSelected && (
           <CheckCircleIcon sx={{ color, ml: 1, flexShrink: 0, fontSize: 20 }} />
@@ -89,7 +91,9 @@ export default function ModelCard({
           }),
         }}
       >
-        {model.description}
+        {model.description
+          ? model.description
+          : t("generative:label.noDescriptionAvailable")}
       </Typography>
 
       {(isClamped || expanded) && (
@@ -105,7 +109,9 @@ export default function ModelCard({
             "&:hover": { textDecoration: "underline" },
           }}
         >
-          {expanded ? "Show less" : "Read more"}
+          {expanded
+            ? t("generative:label.showLess")
+            : t("generative:label.readMore")}
         </Typography>
       )}
     </Paper>

--- a/DashAI/front/src/utils/i18n/locales/en/generative.json
+++ b/DashAI/front/src/utils/i18n/locales/en/generative.json
@@ -20,6 +20,9 @@
   "label": {
     "confirmDeleteSession": "Are you sure you want to delete the session \"{{name}}\"? This action cannot be undone.",
     "deleteSessionConfirmation": "Are you sure you want to delete this session? This action cannot be undone.",
+    "noDescriptionAvailable": "No description available",
+    "showLess": "Show less",
+    "readMore": "Read more",
     "generativeModule": "Generative Module",
     "nameYourSession": "Name your session",
     "noSessionsFound": "No sessions found",

--- a/DashAI/front/src/utils/i18n/locales/es/generative.json
+++ b/DashAI/front/src/utils/i18n/locales/es/generative.json
@@ -20,6 +20,9 @@
   "label": {
     "confirmDeleteSession": "¿Seguro que quieres eliminar la sesión \"{{name}}\"? Esta acción no se puede deshacer.",
     "deleteSessionConfirmation": "¿Está seguro de que desea eliminar esta sesión? Esta acción no se puede deshacer.",
+    "noDescriptionAvailable": "No hay descripción disponible",
+    "showLess": "Mostrar menos",
+    "readMore": "Leer más",
     "generativeModule": "Módulo Generativo",
     "nameYourSession": "Nombre su sesión",
     "noSessionsFound": "No se encontraron sesiones",


### PR DESCRIPTION
## Summary
Adds internationalization (i18n) support to the `ModelCard` component and improves its robustness when handling missing model data. User-facing strings are now localized, and fallback values ensure the UI remains clear and informative even when certain fields are unavailable.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `ModelCard.jsx`: Integrated `react-i18next`, replaced hardcoded strings with translation keys, and added fallback logic for missing model name/description.
- `locales/en/models.json`: Added new translation keys for "Read more", "Show less", and "No description available".
- `locales/es/models.json`: Added Spanish equivalents for the new translation keys.

<img width="2551" height="1345" alt="image" src="https://github.com/user-attachments/assets/3b0ce123-89fa-4182-94bc-343416512fbc" />

---

## Testing (optional)
- Verify that UI labels change correctly when switching languages.
- Confirm fallback messages appear when model description or name is missing.
- Check expand/collapse behavior ("Read more" / "Show less") in both supported languages.

---

## Notes (optional)
- Ensures consistency with existing i18n patterns across the application.
- Improves user experience by avoiding empty or unclear UI states when model data is incomplete.