### PR TITLE
Fix DatasetTable sorting and renaming conflicts + synchronous cache clearing for correct ascending sort

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -39,6 +39,7 @@ export default function DatasetTable({
   const CLIENT_SIDE_THRESHOLD = 2000;
   const initialized = useRef(false);
   const isLoadingFullDataRef = useRef(false);
+  const allFilteredDataRef = useRef(null);
 
   const [data, setData] = useState([]);
   const [rowCount, setRowCount] = useState(0);
@@ -93,6 +94,7 @@ export default function DatasetTable({
     setData([]);
     setRowCount(0);
     setTotalRowCount(0);
+    allFilteredDataRef.current = null;
     setAllFilteredData(null);
     setIsLoading(true);
     setShowColumnFilters(false);
@@ -182,7 +184,8 @@ export default function DatasetTable({
   // Clear cached data when filters/sorting change
   // Reset lazy-load flag to allow re-fetching full data if needed
   useEffect(() => {
-    if (allFilteredData) {
+    if (allFilteredDataRef.current) {
+      allFilteredDataRef.current = null;
       setAllFilteredData(null);
       isLoadingFullDataRef.current = false;
     }
@@ -195,9 +198,11 @@ export default function DatasetTable({
     if (!initialized.current) return;
 
     // If we have cached filtered data, use it for pagination
-    if (allFilteredData) {
+    if (allFilteredDataRef.current) {
       const start = pagination.pageIndex * pagination.pageSize;
-      setData(allFilteredData.slice(start, start + pagination.pageSize));
+      setData(
+        allFilteredDataRef.current.slice(start, start + pagination.pageSize),
+      );
       setIsLoading(false);
       return;
     }
@@ -256,6 +261,7 @@ export default function DatasetTable({
           if (cancelled) return;
 
           const allRows = fullResponse?.rows ?? rows;
+          allFilteredDataRef.current = allRows;
           setAllFilteredData(allRows);
           setRowCount(total);
           const start = pagination.pageIndex * pagination.pageSize;
@@ -362,7 +368,11 @@ export default function DatasetTable({
             ],
         Header: () =>
           editableColumns && datasetId ? (
-            <div onDoubleClick={(e) => e.stopPropagation()}>
+            <div
+              onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+              style={{ cursor: "default" }}
+            >
               <EditableColumnHeader
                 columnName={key}
                 columnType={getColType(key)}


### PR DESCRIPTION
## Summary  
Fixes two bugs in `DatasetTable` when editable columns are enabled: renaming a column header no longer triggers sorting, and ascending sort now works correctly by ensuring cached filtered data is cleared synchronously before reloading.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  
- `DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx`:  
  - Prevented sorting when interacting with editable column headers by stopping propagation on click and double-click events.  
  - Set `cursor: default` on editable headers to remove misleading sort cursor.  
  - Introduced `allFilteredDataRef` to mirror cached state and ensure synchronous cache clearing.  
  - Updated cache-clear and data-loading logic to use the ref, fixing stale data issues affecting ascending sort.

---

## Testing (optional)  
- Open a dataset with editable columns enabled.  
- Double-click a column name to rename it — verify sorting is not triggered.  
- Sort a column descending, then ascending — verify correct updates in both directions.

---

## Notes (optional)  
- The ascending sort issue was caused by React state timing: clearing cached data via state was asynchronous, allowing stale data to be read. Using a ref ensures the cache is cleared synchronously before the loading logic executes.