### PR TITLE
fix: deselect dataset on session click in ModelsLeftBar component

### DIFF
--- a/DashAI/front/src/components/models/ModelsLeftBar.jsx
+++ b/DashAI/front/src/components/models/ModelsLeftBar.jsx
@@ -219,6 +219,7 @@ export default function ModelsLeftBar({ onToggle }) {
 
   const onSessionClick = (sessionId) => {
     setSelectedSessionId(sessionId);
+    selectDataset(null);
   };
 
   const handleNewSessionButton = () => {


### PR DESCRIPTION
## Summary                                                                    
  When a dataset was selected in the Models module and the user clicked a
  session, the dataset remained visually selected in the left bar. This PR      
  aligns the behavior with the Datasets module, where clicking a notebook clears
   the selected dataset.                                                        
                                                                                
  ---                                                                           

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change                                                
  - [x] Bug fix
  - [ ] Documentation                                                           
                                                            
  ---

  ## Changes (by file)

  - `DashAI/front/src/components/models/ModelsLeftBar.jsx`: `onSessionClick` now
   calls `selectDataset(null)` so the dataset gets deselected when a session is
  clicked, mirroring the `onNotebookClick` behavior in                          
  `DatasetNotebookLeftBar.jsx`.                             

  ---

  ## Testing

  - Go to the Models module, click a dataset, then click a session — only the   
  session should appear as selected.
  - Verify the inverse flow (clicking a dataset after selecting a session) still
   works as before.        