### PR TITLE
Expand docstrings for translation models (NLLB & OpusMT)

### DIFF
--- a/DashAI/back/models/hugging_face/nllb_transformer.py
+++ b/DashAI/back/models/hugging_face/nllb_transformer.py
@@ -20,7 +20,11 @@ if TYPE_CHECKING:
 
 
 class NllbTransformerSchema(OpusMtEnESTransformerSchema):
-    """Schema for NLLB multilingual translation model."""
+    """Schema for the NLLB multilingual translation model. Extends the standard
+    translation schema with ``source_language`` and ``target_language`` fields,
+    which accept NLLB language codes in the form ``<iso639>_<script>``
+    (e.g. ``spa_Latn`` for Spanish, ``eng_Latn`` for English).
+    """
 
     source_language: schema_field(
         string_field(),
@@ -55,7 +59,26 @@ class NllbTransformerSchema(OpusMtEnESTransformerSchema):
 
 
 class NllbTransformer(TranslationModel):
-    """NLLB model for configurable multilingual translation."""
+    """Pre-trained transformer for configurable multilingual translation.
+
+    This model fine-tunes the ``facebook/nllb-200-distilled-600M`` checkpoint from
+    Meta AI's No Language Left Behind (NLLB) project. The base model supports
+    translation across 200 languages using a single unified model, identified by
+    NLLB language codes of the form ``<iso639>_<script>`` (e.g. ``spa_Latn``,
+    ``eng_Latn``). The 600M-parameter distilled variant provides a balance between
+    translation quality and computational cost.
+
+    Target language generation is guided by ``forced_bos_token_id``, which forces
+    the decoder to start with the target language token. Fine-tuning is performed
+    with the HuggingFace ``Seq2SeqTrainer`` using the AdamW optimizer. Training and
+    validation metrics are logged at configurable epoch and step intervals via a
+    custom ``MetricsCallback``.
+
+    References
+    ----------
+    - [1] https://huggingface.co/facebook/nllb-200-distilled-600M
+    - [2] https://arxiv.org/abs/2207.04672
+    """
 
     SCHEMA = NllbTransformerSchema
     DISPLAY_NAME: str = MultilingualString(
@@ -70,7 +93,32 @@ class NllbTransformer(TranslationModel):
     ICON: str = "Translate"
 
     def _resolve_language_token_id(self, language_code: str, field_name: str) -> int:
-        """Resolve NLLB language code to token id across tokenizer variants."""
+        """Resolve an NLLB language code to its vocabulary token ID.
+
+        Tries ``tokenizer.lang_code_to_id`` first (available on
+        ``NllbTokenizer``), then falls back to ``convert_tokens_to_ids``.
+        Raises ``ValueError`` when the code is not found in either lookup.
+
+        Parameters
+        ----------
+        language_code : str
+            NLLB language code in ``<iso639>_<script>`` format
+            (e.g. ``spa_Latn``, ``eng_Latn``).
+        field_name : str
+            Name of the field being resolved, used in the error message
+            (e.g. ``"source_language"``).
+
+        Returns
+        -------
+        int
+            Token ID corresponding to ``language_code`` in the tokenizer
+            vocabulary.
+
+        Raises
+        ------
+        ValueError
+            If ``language_code`` cannot be resolved by either lookup method.
+        """
         lang_code_to_id = getattr(self.tokenizer, "lang_code_to_id", None)
         if isinstance(lang_code_to_id, dict) and language_code in lang_code_to_id:
             return lang_code_to_id[language_code]
@@ -85,7 +133,31 @@ class NllbTransformer(TranslationModel):
         raise ValueError(f"Unsupported {field_name} '{language_code}'.")
 
     def __init__(self, model=None, **kwargs):
-        """Initialize the NLLB tokenizer and model."""
+        """Initialize the NLLB tokenizer and model.
+
+        Downloads the ``facebook/nllb-200-distilled-600M`` tokenizer and,
+        when ``model`` is ``None``, the seq2seq model weights from HuggingFace.
+        Resolves the source and target language codes to vocabulary token IDs
+        and sets ``tokenizer.src_lang`` when the attribute is available.
+
+        Parameters
+        ----------
+        model : transformers.PreTrainedModel or None, optional
+            An already-loaded HuggingFace seq2seq model to reuse. If ``None``,
+            the ``facebook/nllb-200-distilled-600M`` checkpoint is downloaded
+            and initialised. Default ``None``.
+        **kwargs : dict
+            Hyperparameters forwarded to ``validate_and_transform`` and used to
+            configure training (e.g. ``num_train_epochs``, ``batch_size``,
+            ``learning_rate``, ``weight_decay``, ``device``,
+            ``source_language``, ``target_language``).
+
+        Raises
+        ------
+        ValueError
+            If ``source_language`` or ``target_language`` cannot be resolved to
+            a token ID in the tokenizer vocabulary.
+        """
         kwargs = self.validate_and_transform(kwargs)
 
         from transformers import AutoTokenizer
@@ -137,7 +209,29 @@ class NllbTransformer(TranslationModel):
     def tokenize_data(
         self, x: "DashAIDataset", y: Optional["DashAIDataset"] = None
     ) -> "DashAIDataset":
-        """Tokenize input and optional output datasets for NLLB."""
+        """Tokenize input and optional target datasets for seq2seq training.
+
+        Sets ``tokenizer.src_lang`` to ``source_language`` before tokenizing
+        so the NLLB tokenizer inserts the correct language prefix token. Each
+        sample is tokenized with truncation and max-length padding to 512
+        tokens. When ``y`` is provided, target tokens are stored under the
+        ``labels`` key.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            Source-language dataset. Only the first column is used.
+        y : DashAIDataset, optional
+            Target-language dataset. When provided, tokenized targets are added
+            as ``labels``. When ``None``, only ``input_ids`` and
+            ``attention_mask`` are returned (inference mode).
+
+        Returns
+        -------
+        DashAIDataset
+            Tokenized dataset with keys ``input_ids``, ``attention_mask``, and
+            optionally ``labels``.
+        """
         from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
         if hasattr(self.tokenizer, "src_lang"):
@@ -185,7 +279,25 @@ class NllbTransformer(TranslationModel):
         x_validation: "DashAIDataset" = None,
         y_validation: "DashAIDataset" = None,
     ) -> "NllbTransformer":
-        """Train NLLB for the configured language pair."""
+        """Fine-tune the NLLB model on the configured language pair.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            Input source-language text features for training.
+        y_train : DashAIDataset
+            Target-language translation labels for training.
+        x_validation : DashAIDataset, optional
+            Input source-language text features for validation. Default
+            ``None``.
+        y_validation : DashAIDataset, optional
+            Target-language translation labels for validation. Default ``None``.
+
+        Returns
+        -------
+        NllbTransformer
+            The fine-tuned model instance.
+        """
         from transformers import Seq2SeqTrainer, Seq2SeqTrainingArguments
 
         from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
@@ -242,7 +354,28 @@ class NllbTransformer(TranslationModel):
         return self
 
     def predict(self, x_pred: "DashAIDataset") -> List:
-        """Generate translations using NLLB target language forcing."""
+        """Translate source texts to the configured target language.
+
+        Uses ``forced_bos_token_id`` to force the decoder to start with the
+        target language token, ensuring NLLB generates output in the correct
+        language.
+
+        Parameters
+        ----------
+        x_pred : DashAIDataset
+            Source-language dataset. Only the first column is used.
+
+        Returns
+        -------
+        list of str
+            One translated string per input sample, in the same order as
+            ``x_pred``.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If the model has not been fine-tuned yet (``fitted`` is ``False``).
+        """
         if not self.fitted:
             raise NotFittedError(
                 f"This {self.__class__.__name__} instance is not fitted yet. Call 'fit'"
@@ -273,11 +406,40 @@ class NllbTransformer(TranslationModel):
     def prepare_dataset(
         self, dataset: "DashAIDataset", is_fit: bool = False
     ) -> "DashAIDataset":
-        """Keep compatibility with model preprocessing hook."""
+        """Return the dataset unchanged.
+
+        No pre-processing transformations are required for this model. The
+        method exists for compatibility with the DashAI model interface.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The dataset to be prepared.
+        is_fit : bool, optional
+            Whether the call is made during fitting. Unused here. Default
+            ``False``.
+
+        Returns
+        -------
+        DashAIDataset
+            The original dataset, unmodified.
+        """
         return dataset
 
     def save(self, filename: Union[str, "Path"]) -> None:
-        """Save model and custom configuration."""
+        """Store the fine-tuned model and its configuration to disk.
+
+        Saves the model weights via ``save_pretrained`` and embeds the
+        hyperparameters (epochs, batch size, learning rate, language codes,
+        etc.) into the HuggingFace config so they can be restored by
+        :meth:`load`.
+
+        Parameters
+        ----------
+        filename : str or Path
+            Directory path where the model files will be written. If a file
+            exists at that path it is removed and replaced by a directory.
+        """
         from transformers import AutoConfig
 
         save_dir = Path(filename)
@@ -301,7 +463,23 @@ class NllbTransformer(TranslationModel):
 
     @classmethod
     def load(cls, filename: Union[str, "Path"]):
-        """Load model from disk."""
+        """Restore an NllbTransformer instance from disk.
+
+        Reads the HuggingFace config to recover the custom hyperparameters
+        saved by :meth:`save`, then reconstructs the seq2seq model and wraps
+        it in a new :class:`NllbTransformer` instance.
+
+        Parameters
+        ----------
+        filename : str or Path
+            Directory path from which the model files will be read.
+
+        Returns
+        -------
+        NllbTransformer
+            The restored model instance with ``fitted`` set to the persisted
+            value.
+        """
         from transformers import AutoConfig, AutoModelForSeq2SeqLM
 
         model = AutoModelForSeq2SeqLM.from_pretrained(filename)

--- a/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
@@ -26,7 +26,9 @@ if TYPE_CHECKING:
 
 class OpusMtEnESTransformerSchema(BaseSchema):
     """opus-mt-en-es is a transformer pre-trained model that allows translation of
-    texts from English to Spanish.
+    texts from English to Spanish. The implementation is based on the Helsinki-NLP
+    opus-mt-en-es checkpoint, which uses the MarianMT architecture and was trained
+    on parallel corpora from the OPUS collection.
     """
 
     num_train_epochs: schema_field(
@@ -169,9 +171,21 @@ class OpusMtEnESTransformerSchema(BaseSchema):
 
 
 class OpusMtEnESTransformer(TranslationModel):
-    """Pre-trained transformer for english-spanish translation.
+    """Pre-trained transformer for English-to-Spanish translation.
 
-    This model fine-tunes the pre-trained model opus-mt-en-es.
+    This model fine-tunes the Helsinki-NLP ``opus-mt-en-es`` checkpoint, which is
+    based on the MarianMT sequence-to-sequence architecture. The base model was
+    trained on parallel English-Spanish corpora from the OPUS collection and supports
+    direct translation without intermediate pivot languages.
+
+    Fine-tuning is performed with the HuggingFace ``Seq2SeqTrainer`` using the AdamW
+    optimizer. Training and validation metrics are logged at configurable epoch and
+    step intervals via a custom ``MetricsCallback``.
+
+    References
+    ----------
+    - [1] https://huggingface.co/Helsinki-NLP/opus-mt-en-es
+    - [2] https://opus.nlpl.eu/
     """
 
     SCHEMA = OpusMtEnESTransformerSchema
@@ -234,19 +248,26 @@ class OpusMtEnESTransformer(TranslationModel):
     def tokenize_data(
         self, x: "DashAIDataset", y: Optional["DashAIDataset"] = None
     ) -> "DashAIDataset":
-        """Tokenize input and output.
+        """Tokenize input and optional target datasets for seq2seq training.
+
+        Each sample is tokenized with truncation and max-length padding to 512
+        tokens. When ``y`` is provided, the target tokens are stored under the
+        ``labels`` key so the ``Seq2SeqTrainer`` can compute the loss directly.
 
         Parameters
         ----------
-        x: DashAIDataset
-            Dataset with the input data to preprocess.
-        y: Optional DashAIDataset
-            Dataset with the output data to preprocess.
+        x : DashAIDataset
+            Source-language dataset. Only the first column is used.
+        y : DashAIDataset, optional
+            Target-language dataset. When provided, tokenized targets are added
+            as ``labels``. When ``None``, only ``input_ids`` and
+            ``attention_mask`` are returned (inference mode).
 
         Returns
         -------
-        Dataset
-            Dataset with the processed data.
+        DashAIDataset
+            Tokenized dataset with keys ``input_ids``, ``attention_mask``, and
+            optionally ``labels``.
         """
         from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
@@ -354,17 +375,23 @@ class OpusMtEnESTransformer(TranslationModel):
         return self
 
     def predict(self, x_pred: "DashAIDataset") -> List:
-        """Predict with the fine-tuned model.
+        """Translate English source texts to Spanish.
 
         Parameters
         ----------
-        x_pred : Dataset
-            Dataset with text data.
+        x_pred : DashAIDataset
+            Source-language dataset. Only the first column is used.
 
         Returns
         -------
-        List
-            list of translations made by the model.
+        list of str
+            One translated string per input sample, in the same order as
+            ``x_pred``.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If the model has not been fine-tuned yet (``fitted`` is ``False``).
         """
         if not self.fitted:
             raise NotFittedError(
@@ -393,18 +420,23 @@ class OpusMtEnESTransformer(TranslationModel):
     def prepare_dataset(
         self, dataset: "DashAIDataset", is_fit: bool = False
     ) -> "DashAIDataset":
-        """Apply the model transformations to the dataset.
+        """Return the dataset unchanged.
+
+        No pre-processing transformations are required for this model. The
+        method exists for compatibility with the DashAI model interface.
 
         Parameters
         ----------
         dataset : DashAIDataset
-            The dataset to be transformed.
+            The dataset to be prepared.
+        is_fit : bool, optional
+            Whether the call is made during fitting. Unused here. Default
+            ``False``.
 
         Returns
         -------
         DashAIDataset
-            The prepared dataset ready to be converted to
-            an accepted format in the model.
+            The original dataset, unmodified.
         """
         try:
             # Useless in this case, but we keep it for consistency with other models.

--- a/DashAI/back/models/hugging_face/opus_mt_es_en_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_es_en_transformer.py
@@ -19,11 +19,30 @@ if TYPE_CHECKING:
 
 
 class OpusMtEsENTransformerSchema(OpusMtEnESTransformerSchema):
-    """opus-mt-es-en is a pre-trained model for Spanish-to-English translation."""
+    """opus-mt-es-en is a transformer pre-trained model that allows translation of
+    texts from Spanish to English. The implementation is based on the Helsinki-NLP
+    opus-mt-es-en checkpoint, which uses the MarianMT architecture and was trained
+    on parallel corpora from the OPUS collection.
+    """
 
 
 class OpusMtEsENTransformer(TranslationModel):
-    """Pre-trained transformer for spanish-english translation."""
+    """Pre-trained transformer for Spanish-to-English translation.
+
+    This model fine-tunes the Helsinki-NLP ``opus-mt-es-en`` checkpoint, which is
+    based on the MarianMT sequence-to-sequence architecture. The base model was
+    trained on parallel Spanish-English corpora from the OPUS collection and supports
+    direct translation without intermediate pivot languages.
+
+    Fine-tuning is performed with the HuggingFace ``Seq2SeqTrainer`` using the AdamW
+    optimizer. Training and validation metrics are logged at configurable epoch and
+    step intervals via a custom ``MetricsCallback``.
+
+    References
+    ----------
+    - [1] https://huggingface.co/Helsinki-NLP/opus-mt-es-en
+    - [2] https://opus.nlpl.eu/
+    """
 
     SCHEMA = OpusMtEsENTransformerSchema
     DISPLAY_NAME: str = MultilingualString(
@@ -38,7 +57,24 @@ class OpusMtEsENTransformer(TranslationModel):
     ICON: str = "Translate"
 
     def __init__(self, model=None, **kwargs):
-        """Initialize the transformer and tokenizer."""
+        """Initialize the transformer.
+
+        Downloads the ``Helsinki-NLP/opus-mt-es-en`` tokenizer and, when
+        ``model`` is ``None``, the seq2seq model weights from HuggingFace.
+        When a pre-loaded model is supplied, the weights are reused directly
+        and ``fitted`` is set to ``True``.
+
+        Parameters
+        ----------
+        model : transformers.PreTrainedModel or None, optional
+            An already-loaded HuggingFace seq2seq model to reuse. If ``None``,
+            the ``Helsinki-NLP/opus-mt-es-en`` checkpoint is downloaded and
+            initialised. Default ``None``.
+        **kwargs : dict
+            Hyperparameters forwarded to ``validate_and_transform`` and used to
+            configure training (e.g. ``num_train_epochs``, ``batch_size``,
+            ``learning_rate``, ``weight_decay``, ``device``).
+        """
         kwargs = self.validate_and_transform(kwargs)
 
         from transformers import AutoTokenizer
@@ -75,7 +111,27 @@ class OpusMtEsENTransformer(TranslationModel):
     def tokenize_data(
         self, x: "DashAIDataset", y: Optional["DashAIDataset"] = None
     ) -> "DashAIDataset":
-        """Tokenize input and optional output datasets."""
+        """Tokenize input and optional target datasets for seq2seq training.
+
+        Each sample is tokenized with truncation and max-length padding to 512
+        tokens. When ``y`` is provided, the target tokens are stored under the
+        ``labels`` key so the ``Seq2SeqTrainer`` can compute the loss directly.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            Source-language dataset. Only the first column is used.
+        y : DashAIDataset, optional
+            Target-language dataset. When provided, tokenized targets are added
+            as ``labels``. When ``None``, only ``input_ids`` and
+            ``attention_mask`` are returned (inference mode).
+
+        Returns
+        -------
+        DashAIDataset
+            Tokenized dataset with keys ``input_ids``, ``attention_mask``, and
+            optionally ``labels``.
+        """
         from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
         is_y = bool(y)
@@ -120,7 +176,24 @@ class OpusMtEsENTransformer(TranslationModel):
         x_validation: "DashAIDataset" = None,
         y_validation: "DashAIDataset" = None,
     ) -> "OpusMtEsENTransformer":
-        """Train the translation model."""
+        """Fine-tune the opus-mt-es-en model on Spanish-English translation data.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            Input Spanish text features for training.
+        y_train : DashAIDataset
+            Target English translation labels for training.
+        x_validation : DashAIDataset, optional
+            Input Spanish text features for validation. Default ``None``.
+        y_validation : DashAIDataset, optional
+            Target English translation labels for validation. Default ``None``.
+
+        Returns
+        -------
+        OpusMtEsENTransformer
+            The fine-tuned model instance.
+        """
         from transformers import Seq2SeqTrainer, Seq2SeqTrainingArguments
 
         from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
@@ -177,7 +250,24 @@ class OpusMtEsENTransformer(TranslationModel):
         return self
 
     def predict(self, x_pred: "DashAIDataset") -> List:
-        """Generate translations for input text."""
+        """Translate Spanish source texts to English.
+
+        Parameters
+        ----------
+        x_pred : DashAIDataset
+            Source-language dataset. Only the first column is used.
+
+        Returns
+        -------
+        list of str
+            One translated string per input sample, in the same order as
+            ``x_pred``.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If the model has not been fine-tuned yet (``fitted`` is ``False``).
+        """
         if not self.fitted:
             raise NotFittedError(
                 f"This {self.__class__.__name__} instance is not fitted yet. Call 'fit'"
@@ -204,11 +294,39 @@ class OpusMtEsENTransformer(TranslationModel):
     def prepare_dataset(
         self, dataset: "DashAIDataset", is_fit: bool = False
     ) -> "DashAIDataset":
-        """Keep compatibility with model preprocessing hook."""
+        """Return the dataset unchanged.
+
+        No pre-processing transformations are required for this model. The
+        method exists for compatibility with the DashAI model interface.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The dataset to be prepared.
+        is_fit : bool, optional
+            Whether the call is made during fitting. Unused here. Default
+            ``False``.
+
+        Returns
+        -------
+        DashAIDataset
+            The original dataset, unmodified.
+        """
         return dataset
 
     def save(self, filename: Union[str, "Path"]) -> None:
-        """Save model and custom configuration."""
+        """Store the fine-tuned model and its configuration to disk.
+
+        Saves the model weights via ``save_pretrained`` and embeds the
+        hyperparameters (epochs, batch size, learning rate, etc.) into the
+        HuggingFace config so they can be restored by :meth:`load`.
+
+        Parameters
+        ----------
+        filename : str or Path
+            Directory path where the model files will be written. If a file
+            exists at that path it is removed and replaced by a directory.
+        """
         from transformers import AutoConfig
 
         save_dir = Path(filename)
@@ -230,7 +348,23 @@ class OpusMtEsENTransformer(TranslationModel):
 
     @classmethod
     def load(cls, filename: Union[str, "Path"]):
-        """Load model from disk."""
+        """Restore an OpusMtEsENTransformer instance from disk.
+
+        Reads the HuggingFace config to recover the custom hyperparameters
+        saved by :meth:`save`, then reconstructs the seq2seq model and wraps
+        it in a new :class:`OpusMtEsENTransformer` instance.
+
+        Parameters
+        ----------
+        filename : str or Path
+            Directory path from which the model files will be read.
+
+        Returns
+        -------
+        OpusMtEsENTransformer
+            The restored model instance with ``fitted`` set to the persisted
+            value.
+        """
         from transformers import AutoConfig, AutoModelForSeq2SeqLM
 
         model = AutoModelForSeq2SeqLM.from_pretrained(filename)


### PR DESCRIPTION
## Summary  
Adds comprehensive, standardized docstrings to all translation model classes (NLLB, OpusMT En→Es, OpusMT Es→En) and their core methods.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [ ] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [ ] Bug fix  
- [x] Documentation  

---

## Changes (by file)  

- `nllb_transformer.py`:  
  Added detailed class and schema docstrings describing supported languages, checkpoints, and training context. Expanded docstrings for all core methods (`__init__`, `tokenize_data`, `train`, `predict`, `prepare_dataset`, `save`, `load`) with parameter, return, and exception details.

- `opus_mt_en_es_transformer.py`:  
  Improved model-level documentation with checkpoint, architecture, and dataset references. Rewrote method docstrings (`tokenize_data`, `predict`, `prepare_dataset`) for clarity and consistency.

- `opus_mt_es_en_transformer.py`:  
  Added comprehensive model and schema docstrings. Standardized method documentation to clearly describe inputs, outputs, and error handling.