### PR TITLE
Fix/search functionality refactor

### DIFF
--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -255,18 +255,23 @@ export default function RightBar({ notebook, onToggle }) {
   };
 
   useEffect(() => {
+    const query = searchQuery.toLowerCase();
+    const matchesQuery = (item) => {
+      const displayName = (
+        item.metadata?.display_name ||
+        item.name ||
+        ""
+      ).toLowerCase();
+      const description = (
+        item.metadata?.short_description ||
+        item.description ||
+        ""
+      ).toLowerCase();
+      return displayName.includes(query) || description.includes(query);
+    };
+
     const filteredAndValidatedExplorers = explorers
-      .filter(
-        (item) =>
-          item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          (item.metadata.short_description
-            ? item.metadata.short_description
-                .toLowerCase()
-                .includes(searchQuery.toLowerCase())
-            : item.description
-                .toLowerCase()
-                .includes(searchQuery.toLowerCase())),
-      )
+      .filter(matchesQuery)
       .map((explorer) => {
         const validation = validateExplorer(explorer);
         return {
@@ -281,17 +286,7 @@ export default function RightBar({ notebook, onToggle }) {
     setFilteredExplorers(filteredAndValidatedExplorers);
 
     const filteredAndValidatedConverters = converters
-      .filter(
-        (item) =>
-          item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          (item.metadata.short_description
-            ? item.metadata.short_description
-                .toLowerCase()
-                .includes(searchQuery.toLowerCase())
-            : item.description
-                .toLowerCase()
-                .includes(searchQuery.toLowerCase())),
-      )
+      .filter(matchesQuery)
       .map((converter) => {
         const validation = validateConverter(converter);
         return {

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import SideBar from "../threeSectionLayout/panelContainers/SideBar";
 import {
   Box,
@@ -28,6 +28,34 @@ import { ChevronRight } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import { useDatasetsAndNotebooks } from "../custom/contexts/DatasetsAndNotebooksContext";
 import ColumnInsights from "./dataset/ColumnInsights";
+
+function SectionHeader({ icon: Icon, label, count, mt, theme, t }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        mb: 1.5,
+        mt: mt ?? 0,
+        pb: 0.5,
+        borderBottom: "1px solid",
+        borderColor: theme.palette.divider,
+      }}
+    >
+      <Icon sx={{ fontSize: 18, color: theme.palette.accent.main }} />
+      <Typography
+        variant="subtitle2"
+        sx={{ flex: 1, color: "text.primary", fontWeight: 600 }}
+      >
+        {label}
+      </Typography>
+      <Typography variant="caption" sx={{ color: "text.secondary" }}>
+        {t("datasets:label.toolsCount", { count })}
+      </Typography>
+    </Box>
+  );
+}
 
 function RightBarDatasetView() {
   const { t } = useTranslation(["datasets"]);
@@ -70,8 +98,6 @@ export default function RightBar({ notebook, onToggle }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [converters, setConverters] = useState([]);
   const [explorers, setExplorers] = useState([]);
-  const [filteredConverters, setFilteredConverters] = useState([]);
-  const [filteredExplorers, setFilteredExplorers] = useState([]);
   const [datasetColumns, setDatasetColumns] = useState([]);
   const tourContext = useTourContext();
   const [viewMode, setViewMode] = useState("list");
@@ -80,24 +106,27 @@ export default function RightBar({ notebook, onToggle }) {
   const { t } = useTranslation(["datasets", "common"]);
 
   useEffect(() => {
-    const fetchData = async () => {
+    let cancelled = false;
+    (async () => {
       try {
         const data = await getComponents({
           selectTypes: ["Converter", "Explorer"],
         });
+        if (cancelled) return;
         setConverters(data.filter((item) => item.type === "Converter"));
         setExplorers(data.filter((item) => item.type === "Explorer"));
-        setFilteredConverters(data.filter((item) => item.type === "Converter"));
-        setFilteredExplorers(data.filter((item) => item.type === "Explorer"));
       } catch (error) {
         enqueueSnackbar(t("datasets:error.fetchingExplorersConverters"), {
           variant: "error",
         });
         console.error("Failed to fetch explorers/converters:", error);
       }
+    })();
+    return () => {
+      cancelled = true;
     };
-    fetchData();
-  }, [t]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [explorersAndConverters]);
 
   // Clear search when the selected notebook changes
   useEffect(() => {
@@ -150,7 +179,8 @@ export default function RightBar({ notebook, onToggle }) {
 
     let validColumns = datasetColumns;
     let disabled = false;
-    let tooltip = explorer.description || "";
+    let tooltip =
+      explorer.description || explorer.metadata?.short_description || "";
 
     // Filter by allowed dtypes
     if (!allowedDtypes.includes("*")) {
@@ -259,8 +289,40 @@ export default function RightBar({ notebook, onToggle }) {
     return { disabled, tooltip, validColumns };
   };
 
-  useEffect(() => {
-    const query = searchQuery.toLowerCase();
+  const validatedExplorers = useMemo(
+    () =>
+      explorers.map((explorer) => {
+        const validation = validateExplorer(explorer);
+        return {
+          ...explorer,
+          disabled: validation.disabled,
+          tooltip: validation.tooltip,
+          validColumns: validation.validColumns,
+          notebook,
+        };
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [explorers, datasetColumns, notebook?.id],
+  );
+
+  const validatedConverters = useMemo(
+    () =>
+      converters.map((converter) => {
+        const validation = validateConverter(converter);
+        return {
+          ...converter,
+          disabled: validation.disabled,
+          tooltip: validation.tooltip,
+          validColumns: validation.validColumns,
+          notebook,
+        };
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [converters, datasetColumns, notebook?.id],
+  );
+
+  const { filteredExplorers, filteredConverters } = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
 
     const rankMatch = (item) => {
       const displayName = (
@@ -278,43 +340,20 @@ export default function RightBar({ notebook, onToggle }) {
       return 0;
     };
 
-    const filterAndRank = (items) =>
-      items
+    const filterAndRank = (items) => {
+      if (!query) return items;
+      return items
         .map((item) => ({ item, rank: rankMatch(item) }))
         .filter(({ rank }) => rank > 0)
         .sort((a, b) => a.rank - b.rank)
         .map(({ item }) => item);
+    };
 
-    const filteredAndValidatedExplorers = filterAndRank(explorers).map(
-      (explorer) => {
-        const validation = validateExplorer(explorer);
-        return {
-          ...explorer,
-          disabled: validation.disabled,
-          tooltip: validation.tooltip,
-          validColumns: validation.validColumns,
-          notebook,
-        };
-      },
-    );
-
-    setFilteredExplorers(filteredAndValidatedExplorers);
-
-    const filteredAndValidatedConverters = filterAndRank(converters).map(
-      (converter) => {
-        const validation = validateConverter(converter);
-        return {
-          ...converter,
-          disabled: validation.disabled,
-          tooltip: validation.tooltip,
-          validColumns: validation.validColumns,
-          notebook,
-        };
-      },
-    );
-
-    setFilteredConverters(filteredAndValidatedConverters);
-  }, [searchQuery, explorers, converters, datasetColumns, notebook]);
+    return {
+      filteredExplorers: filterAndRank(validatedExplorers),
+      filteredConverters: filterAndRank(validatedConverters),
+    };
+  }, [searchQuery, validatedExplorers, validatedConverters]);
 
   const handleChangeTab = (_event, newValue) => {
     setActiveTab(newValue);
@@ -481,62 +520,58 @@ export default function RightBar({ notebook, onToggle }) {
                         }
                       : { flex: 1, overflow: "auto", p: 2 };
 
-                  const SectionHeader = ({ icon: Icon, label, count, mt }) => (
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 1,
-                        mb: 1.5,
-                        mt: mt ?? 0,
-                        pb: 0.5,
-                        borderBottom: "1px solid",
-                        borderColor: theme.palette.divider,
-                      }}
-                    >
-                      <Icon
-                        sx={{ fontSize: 18, color: theme.palette.accent.main }}
-                      />
-                      <Typography
-                        variant="subtitle2"
-                        sx={{ flex: 1, color: "text.primary", fontWeight: 600 }}
-                      >
-                        {label}
-                      </Typography>
-                      <Typography
-                        variant="caption"
-                        sx={{ color: "text.secondary" }}
-                      >
-                        {t("datasets:label.toolsCount", { count })}
-                      </Typography>
-                    </Box>
-                  );
+                  const hasExplorers = filteredExplorers.length > 0;
+                  const hasConverters = filteredConverters.length > 0;
 
                   return (
                     <Box sx={containerSx}>
                       {isSearching ? (
                         <>
-                          <SectionHeader
-                            icon={AnalyticsIcon}
-                            label={t("datasets:label.explore")}
-                            count={filteredExplorers.length}
-                          />
-                          <ListComponent
-                            tools={filteredExplorers}
-                            notebook={notebook}
-                            FormComponent={FormExplorerSection}
-                          />
-                          <SectionHeader
-                            icon={TransformIcon}
-                            label={t("datasets:label.convert")}
-                            count={filteredConverters.length}
-                            mt={3}
-                          />
-                          <ListComponent
-                            tools={filteredConverters}
-                            notebook={notebook}
-                            FormComponent={FormConverterSection}
-                          />
+                          {hasExplorers && (
+                            <>
+                              <SectionHeader
+                                icon={AnalyticsIcon}
+                                label={t("datasets:label.explore")}
+                                count={filteredExplorers.length}
+                                theme={theme}
+                                t={t}
+                              />
+                              <ListComponent
+                                tools={filteredExplorers}
+                                notebook={notebook}
+                                FormComponent={FormExplorerSection}
+                              />
+                            </>
+                          )}
+                          {hasConverters && (
+                            <>
+                              <SectionHeader
+                                icon={TransformIcon}
+                                label={t("datasets:label.convert")}
+                                count={filteredConverters.length}
+                                mt={hasExplorers ? 3 : 0}
+                                theme={theme}
+                                t={t}
+                              />
+                              <ListComponent
+                                tools={filteredConverters}
+                                notebook={notebook}
+                                FormComponent={FormConverterSection}
+                              />
+                            </>
+                          )}
+                          {!hasExplorers && !hasConverters && (
+                            <Typography
+                              variant="body2"
+                              sx={{
+                                color: "text.secondary",
+                                textAlign: "center",
+                                py: 2,
+                              }}
+                            >
+                              {t("datasets:label.noToolsMatched")}
+                            </Typography>
+                          )}
                         </>
                       ) : activeTab === 0 ? (
                         <ListComponent

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -256,7 +256,8 @@ export default function RightBar({ notebook, onToggle }) {
 
   useEffect(() => {
     const query = searchQuery.toLowerCase();
-    const matchesQuery = (item) => {
+
+    const rankMatch = (item) => {
       const displayName = (
         item.metadata?.display_name ||
         item.name ||
@@ -267,12 +268,20 @@ export default function RightBar({ notebook, onToggle }) {
         item.description ||
         ""
       ).toLowerCase();
-      return displayName.includes(query) || description.includes(query);
+      if (displayName.includes(query)) return 1;
+      if (description.includes(query)) return 2;
+      return 0;
     };
 
-    const filteredAndValidatedExplorers = explorers
-      .filter(matchesQuery)
-      .map((explorer) => {
+    const filterAndRank = (items) =>
+      items
+        .map((item) => ({ item, rank: rankMatch(item) }))
+        .filter(({ rank }) => rank > 0)
+        .sort((a, b) => a.rank - b.rank)
+        .map(({ item }) => item);
+
+    const filteredAndValidatedExplorers = filterAndRank(explorers).map(
+      (explorer) => {
         const validation = validateExplorer(explorer);
         return {
           ...explorer,
@@ -281,13 +290,13 @@ export default function RightBar({ notebook, onToggle }) {
           validColumns: validation.validColumns,
           notebook,
         };
-      });
+      },
+    );
 
     setFilteredExplorers(filteredAndValidatedExplorers);
 
-    const filteredAndValidatedConverters = converters
-      .filter(matchesQuery)
-      .map((converter) => {
+    const filteredAndValidatedConverters = filterAndRank(converters).map(
+      (converter) => {
         const validation = validateConverter(converter);
         return {
           ...converter,
@@ -296,12 +305,13 @@ export default function RightBar({ notebook, onToggle }) {
           validColumns: validation.validColumns,
           notebook,
         };
-      });
+      },
+    );
 
     setFilteredConverters(filteredAndValidatedConverters);
   }, [searchQuery, explorers, converters, datasetColumns, notebook]);
 
-  const handleChangeTab = (event, newValue) => {
+  const handleChangeTab = (_event, newValue) => {
     setActiveTab(newValue);
 
     if (tourContext && tourContext.run) {

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -303,7 +303,6 @@ export default function RightBar({ notebook, onToggle }) {
 
   const handleChangeTab = (event, newValue) => {
     setActiveTab(newValue);
-    setSearchQuery("");
 
     if (tourContext && tourContext.run) {
       setTimeout(() => {
@@ -452,49 +451,69 @@ export default function RightBar({ notebook, onToggle }) {
                 }}
               >
                 {/* Tool list - grid */}
-                {viewMode === "list" ? (
-                  <Box
-                    sx={{
-                      flex: 1,
-                      overflowY: "auto",
-                      overflowX: "hidden",
-                      p: 2,
-                      minWidth: 0,
-                    }}
-                  >
-                    {activeTab === 0 && (
-                      <ToolList
-                        tools={filteredExplorers}
-                        notebook={notebook}
-                        FormComponent={FormExplorerSection}
-                      />
-                    )}
-                    {activeTab === 1 && (
-                      <ToolList
-                        tools={filteredConverters}
-                        notebook={notebook}
-                        FormComponent={FormConverterSection}
-                      />
-                    )}
-                  </Box>
-                ) : (
-                  <Box sx={{ flex: 1, overflow: "auto", p: 2 }}>
-                    {activeTab === 0 && (
-                      <ToolGrid
-                        tools={filteredExplorers}
-                        notebook={notebook}
-                        FormComponent={FormExplorerSection}
-                      />
-                    )}
-                    {activeTab === 1 && (
-                      <ToolGrid
-                        tools={filteredConverters}
-                        notebook={notebook}
-                        FormComponent={FormConverterSection}
-                      />
-                    )}
-                  </Box>
-                )}
+                {(() => {
+                  const isSearching = searchQuery.trim().length > 0;
+                  const ListComponent =
+                    viewMode === "list" ? ToolList : ToolGrid;
+                  const containerSx =
+                    viewMode === "list"
+                      ? {
+                          flex: 1,
+                          overflowY: "auto",
+                          overflowX: "hidden",
+                          p: 2,
+                          minWidth: 0,
+                        }
+                      : { flex: 1, overflow: "auto", p: 2 };
+
+                  const sectionTitleSx = {
+                    color: "text.secondary",
+                    fontWeight: 600,
+                    mb: 1,
+                    mt: 0,
+                    display: "block",
+                  };
+
+                  return (
+                    <Box sx={containerSx}>
+                      {isSearching ? (
+                        <>
+                          <Typography variant="caption" sx={sectionTitleSx}>
+                            {t("datasets:label.explore")}
+                          </Typography>
+                          <ListComponent
+                            tools={filteredExplorers}
+                            notebook={notebook}
+                            FormComponent={FormExplorerSection}
+                          />
+                          <Typography
+                            variant="caption"
+                            sx={{ ...sectionTitleSx, mt: 2 }}
+                          >
+                            {t("datasets:label.convert")}
+                          </Typography>
+                          <ListComponent
+                            tools={filteredConverters}
+                            notebook={notebook}
+                            FormComponent={FormConverterSection}
+                          />
+                        </>
+                      ) : activeTab === 0 ? (
+                        <ListComponent
+                          tools={filteredExplorers}
+                          notebook={notebook}
+                          FormComponent={FormExplorerSection}
+                        />
+                      ) : (
+                        <ListComponent
+                          tools={filteredConverters}
+                          notebook={notebook}
+                          FormComponent={FormConverterSection}
+                        />
+                      )}
+                    </Box>
+                  );
+                })()}
 
                 {/* Description panel - Fixed height */}
                 <DescriptionPanel />

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -476,32 +476,57 @@ export default function RightBar({ notebook, onToggle }) {
                         }
                       : { flex: 1, overflow: "auto", p: 2 };
 
-                  const sectionTitleSx = {
-                    color: "text.secondary",
-                    fontWeight: 600,
-                    mb: 1,
-                    mt: 0,
-                    display: "block",
-                  };
+                  const SectionHeader = ({ icon: Icon, label, count, mt }) => (
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        mb: 1.5,
+                        mt: mt ?? 0,
+                        pb: 0.5,
+                        borderBottom: "1px solid",
+                        borderColor: theme.palette.divider,
+                      }}
+                    >
+                      <Icon
+                        sx={{ fontSize: 18, color: theme.palette.accent.main }}
+                      />
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ flex: 1, color: "text.primary", fontWeight: 600 }}
+                      >
+                        {label}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        sx={{ color: "text.secondary" }}
+                      >
+                        {t("datasets:label.toolsCount", { count })}
+                      </Typography>
+                    </Box>
+                  );
 
                   return (
                     <Box sx={containerSx}>
                       {isSearching ? (
                         <>
-                          <Typography variant="caption" sx={sectionTitleSx}>
-                            {t("datasets:label.explore")}
-                          </Typography>
+                          <SectionHeader
+                            icon={AnalyticsIcon}
+                            label={t("datasets:label.explore")}
+                            count={filteredExplorers.length}
+                          />
                           <ListComponent
                             tools={filteredExplorers}
                             notebook={notebook}
                             FormComponent={FormExplorerSection}
                           />
-                          <Typography
-                            variant="caption"
-                            sx={{ ...sectionTitleSx, mt: 2 }}
-                          >
-                            {t("datasets:label.convert")}
-                          </Typography>
+                          <SectionHeader
+                            icon={TransformIcon}
+                            label={t("datasets:label.convert")}
+                            count={filteredConverters.length}
+                            mt={3}
+                          />
                           <ListComponent
                             tools={filteredConverters}
                             notebook={notebook}

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -99,6 +99,11 @@ export default function RightBar({ notebook, onToggle }) {
     fetchData();
   }, [t]);
 
+  // Clear search when the selected notebook changes
+  useEffect(() => {
+    setSearchQuery("");
+  }, [notebook?.id]);
+
   // Fetch dataset columns from notebook file
   useEffect(() => {
     let isMounted = true;


### PR DESCRIPTION
## Summary  
  Several improvements to the Explorers/Converters tool panel in the Datasets module:
  - Search now matches by `display_name` (what users actually see) instead of the internal
   `name`, with a fallback to the description.                                            
  - The search filter is now global across tabs: typing a query shows matching Explorers  
  **and** Converters at the same time, grouped under clear section headers with icons and 
  result counts.                                            
  - The search input resets when switching notebooks so stale queries don't leak between  
  contexts.                                                                               
  - Refactored filtering/validation into memoized derivations, moved `SectionHeader` out
  of the render function, and tightened effect dependencies for better performance and    
  cleanliness.                                              
                                                                                          
  ---                                                       

  ## Type of Change

  - [ ] Backend change                                                                    
  - [x] Frontend change
  - [ ] CI / Workflow change                                                              
  - [ ] Build / Packaging change                            
  - [x] Bug fix
  - [ ] Documentation
                                                                                          
  ---
                                                                                          
  ## Changes (by file)                                      

  - `DashAI/front/src/components/notebooks/RightBar.jsx`:
    - Match search against `display_name` (fallback to `name`) and `short_description`
  (fallback to `description`); safely handle null/undefined fields.                       
    - Rank matches so name hits appear before description-only hits.
    - Show both Explorers and Converters simultaneously when a search query is active,    
  each under a styled `SectionHeader` (icon + title + result count + divider). Hide a     
  section when it has zero matches; show a single "no tools matched" message when both are
   empty.                                                                                 
    - Clear `searchQuery` when the selected notebook changes (`notebook?.id` effect).
    - Keep the query persistent when switching tabs (removed `setSearchQuery("")` from    
  `handleChangeTab`).                                                                     
    - Split validation and filtering into separate `useMemo`s so typing in the search box 
  no longer re-validates dataset columns.                                                 
    - Replace `filteredExplorers` / `filteredConverters` state with derived values.
    - Extract `SectionHeader` to a top-level component to avoid recreating it on every    
  render.                                                   
    - Depend on `notebook?.id` instead of the whole `notebook` object; refetch tools on   
  `explorersAndConverters` changes instead of on every `t` change.                        
    - Align `validateExplorer` tooltip fallback with `validateConverter` (`description ||
  short_description`).                                                                    
    - Trim `searchQuery` before matching; add cancellation flag to the initial fetch.
    - Fix lint warning: rename unused `event` parameter in `handleChangeTab` to `_event`. 
                                                                                          
  ---                                                                                     
                                                                                          
  ## Testing                                                

  - Go to the Datasets module and open a notebook.                                        
  - In the right bar, type a query in the search box and verify that matching Explorers
  and Converters are shown together, each under its own section header with a result      
  count.                                                    
  - Verify that searching by a visible tool name (e.g., what appears in the grid/list)    
  matches, not just the internal technical name.                                          
  - Switch between the Explore and Convert tabs with a query typed — the query should
  persist.                                                                                
  - Switch to a different notebook — the search input should be cleared automatically.
  - Type a query that matches only Explorers (or only Converters) — only that section     
  should render; if nothing matches, a single centered "no tools matched" message should  
  appear.                                                                                 
  - Clear the search — the view should return to showing only the active tab's tools.     
                                                                                          
  ---
                                                                                          
  ## Notes                                                  

  - The extracted `SectionHeader` reuses the existing `datasets:label.explore`,           
  `datasets:label.convert` and `datasets:label.toolsCount` translation keys, so no new
  strings were added.                                                                     
  - The filter now prioritizes name matches over description-only matches so results feel
  more predictable (e.g., searching "character" lists "Character Replacer" before tools   
  that only mention the word in their description).