### PR TITLE
Improve dataset selection UI for local explainers

### DIFF
--- a/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
@@ -176,15 +176,28 @@ export default function SelectDatasetStep({
     enableRowSelection: false,
     muiTableBodyRowProps: ({ row }) => ({
       onClick: () => handleRowClick(row),
-      sx: { cursor: "pointer" },
+      sx: {
+        cursor: "pointer",
+        ...(row.original.id === selectedDatasetId && {
+          backgroundColor: theme.palette.accent.amberDim,
+          borderLeft: `3px solid ${theme.palette.primary.main}`,
+          "&:hover td": {
+            backgroundColor: "transparent",
+          },
+        }),
+      },
     }),
     state: { isLoading: loading },
     enableGlobalFilter: false,
     enableColumnFilters: false,
     enableSorting: true,
     enablePagination: true,
-    muiPaginationProps: { rowsPerPageOptions: [10, 25] },
-    initialState: { pagination: { pageSize: 10, pageIndex: 0 } },
+    enableTopToolbar: false,
+    muiPaginationProps: { showRowsPerPage: false },
+    initialState: {
+      pagination: { pageSize: 10, pageIndex: 0 },
+      density: "compact",
+    },
     localization,
   });
 


### PR DESCRIPTION
## Summary
Improves the dataset selection for local explainers by adding clear visual feedback for the selected row and simplifying the table UI. These changes make it easier to identify the active dataset and reduce unnecessary interface elements.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/explainers/SelectDatasetStep.jsx`:  
  - Highlight selected dataset row with background color and left border, and disable hover effect for that row.  
  - Hide top toolbar and "rows per page" selector.  
  - Set table density to compact by default.

---

## Testing (optional)
- Verify that selecting a dataset clearly highlights the row.
- Confirm that unnecessary table UI elements are hidden.
- Ensure compact density is applied consistently.

---

## Notes (optional)
This is a UI/UX improvement and does not modify dataset selection logic.