### PR TITLE
Add DashAIDataset documentation and update architecture references

### DIFF
--- a/docs/docs/deep-dive/architecture.md
+++ b/docs/docs/deep-dive/architecture.md
@@ -46,12 +46,13 @@ so that API endpoints can receive them automatically.
 
 ## Further Reading
 
-| Topic | Page |
-| ----- | ---- |
-| REST API structure, router map, dependency injection | [API](./api) |
-| Component types, registry, and configurable objects | [Components](./components) |
-| SQLite schema, ORM tables, and data storage | [Database](./database) |
-| Huey job queue and job types | [Job System](./job-system) |
-| Notebook sessions, explorers, and converters | [Notebook](./notebook) |
-| End-to-end training and exploration walkthroughs | [Workflow Examples](./workflow-examples) |
-| Column semantic types and inference | [Semantic Types](./semantic-types) |
+| Topic                                                | Page                                     |
+| ---------------------------------------------------- | ---------------------------------------- |
+| REST API structure, router map, dependency injection | [API](./api)                             |
+| Component types, registry, and configurable objects  | [Components](./components)               |
+| SQLite schema, ORM tables, and data storage          | [Database](./database)                   |
+| Huey job queue and job types                         | [Job System](./job-system)               |
+| Notebook sessions, explorers, and converters         | [Notebook](./notebook)                   |
+| End-to-end training and exploration walkthroughs     | [Workflow Examples](./workflow-examples) |
+| Column semantic types and inference                  | [Semantic Types](./semantic-types)       |
+| Core dataset primitive, splits, and data lifecycle   | [DashAIDataset](./dashai-dataset)        |

--- a/docs/docs/deep-dive/dashai-dataset.md
+++ b/docs/docs/deep-dive/dashai-dataset.md
@@ -1,0 +1,254 @@
+---
+title: DashAIDataset
+sidebar_label: DashAIDataset
+sidebar_position: 9
+---
+
+# DashAIDataset
+
+## What Is DashAIDataset?
+
+`DashAIDataset` is DashAI's core dataset primitive. It extends the HuggingFace `Dataset` class with two additional responsibilities:
+
+- **Semantic type metadata** — a `_types` dictionary (`Dict[str, DashAIDataType]`) that maps every column name to its DashAI semantic type (see [Semantic Types](./semantic-types)). This metadata is persisted inside the Apache Arrow schema so it survives save/load round-trips.
+- **Split metadata** — a `splits` dictionary that records which row indices belong to which split (`train`, `test`, `validation`), plus aggregate statistics computed during upload.
+
+Every piece of data that flows through DashAI — upload, notebook transformations, model training, predictions — is represented as a `DashAIDataset`.
+
+---
+
+## Internal Structure
+
+### Instance Attributes
+
+| Attribute | Type                        | Description                                                      |
+| --------- | --------------------------- | ---------------------------------------------------------------- |
+| `_table`  | `pyarrow.Table`             | The underlying Arrow table. All column data lives here.          |
+| `_types`  | `Dict[str, DashAIDataType]` | Semantic type for each column. Kept in sync with Arrow metadata. |
+| `splits`  | `dict`                      | Split indices and computed statistics (see below).               |
+
+### The `splits` Dictionary
+
+`splits` is a plain Python dict. Its keys are populated progressively:
+
+| Key                 | Set by                                    | Content                                                                  |
+| ------------------- | ----------------------------------------- | ------------------------------------------------------------------------ |
+| `split_indices`     | `split_dataset` / `update_dataset_splits` | `{"train": [...], "test": [...], "validation": [...]}` — row index lists |
+| `column_names`      | `compute_base_metadata` / `save_dataset`  | List of column names                                                     |
+| `total_rows`        | `compute_base_metadata` / `save_dataset`  | Total row count                                                          |
+| `nan`               | `compute_base_metadata`                   | Per-column NaN counts                                                    |
+| `general_info`      | `compute_metadata`                        | Row/column counts, memory, duplicates, dtype map                         |
+| `numeric_stats`     | `compute_metadata`                        | Per-column descriptive statistics for numeric columns                    |
+| `categorical_stats` | `compute_metadata`                        | Per-column value counts and top-5 for categorical columns                |
+| `text_stats`        | `compute_metadata`                        | Length and word-count statistics for text columns                        |
+| `quality_info`      | `compute_metadata`                        | Completeness, constant columns, high-cardinality columns, quality score  |
+| `correlations`      | `compute_metadata`                        | Pearson correlation matrix for numeric columns                           |
+
+### Arrow Metadata
+
+Semantic types are serialised to the Arrow table's schema metadata under the key `dashai_types`. This means:
+
+```python
+table.schema.metadata[b"dashai_types"]  # JSON-serialised type map
+```
+
+The utilities `save_types_in_arrow_metadata()` and `get_types_from_arrow_metadata()` in `DashAI/back/types/utils.py` handle this serialisation. When `DashAIDataset` is constructed with `types=None`, it reads the type map directly from the Arrow metadata.
+
+---
+
+## On-disk Format
+
+`save_dataset` writes two files to a directory:
+
+```
+<dataset_path>/
+├── data.arrow    # PyArrow IPC file — table + type metadata in schema
+└── splits.json   # JSON — split indices, row counts, NaN map, computed stats
+```
+
+`load_dataset` reads both files and reconstructs the `DashAIDataset`. Types are recovered from the Arrow schema metadata, so no separate type file is needed.
+
+---
+
+## Key Instance Methods
+
+### `get_split(split_name)`
+
+Returns a new `DashAIDataset` containing only the rows of the requested split.
+
+```python
+train_ds = dataset.get_split("train")  # uses split_indices["train"]
+```
+
+`split_name` must exist in `splits["split_indices"]`. The returned dataset's `splits` metadata contains only that split's index list.
+
+### `select_columns(column_names)`
+
+Returns a new `DashAIDataset` with only the specified columns, copying the corresponding types.
+
+```python
+features_ds = dataset.select_columns(["age", "income", "city"])
+```
+
+### `sample(n, method, seed)`
+
+Returns `n` rows as a plain Python `dict`. `method` controls selection:
+
+| Method     | Behaviour                                  |
+| ---------- | ------------------------------------------ |
+| `"head"`   | First `n` rows                             |
+| `"tail"`   | Last `n` rows                              |
+| `"random"` | `n` random rows (reproducible with `seed`) |
+
+### `compute_metadata()`
+
+Runs all EDA computations and stores results in `self.splits`. Called once after upload. Requires `_types` to be set. Returns `self`.
+
+### `compute_base_metadata()`
+
+Lightweight subset of `compute_metadata()` — only sets `column_names`, `total_rows`, and `nan`. Used when full stats are not needed.
+
+### `keys()`
+
+Returns the list of available split names from `splits["split_indices"]`. Mirrors the `DatasetDict.keys()` interface so `DashAIDataset` can be used interchangeably in some contexts.
+
+---
+
+## Data Lifecycle Functions
+
+These module-level functions cover the full journey from raw input to training-ready splits.
+
+### Loading and Conversion
+
+**`to_dashai_dataset(dataset, types=None)`**
+
+Universal converter. Accepts `DashAIDataset` (pass-through), HuggingFace `Dataset`, HuggingFace `DatasetDict`, or `pandas.DataFrame`. Multi-split `DatasetDict` inputs are merged via `merge_splits_with_metadata`.
+
+```python
+from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+
+ds = to_dashai_dataset(my_hf_dataset, types=my_type_map)
+```
+
+**`merge_splits_with_metadata(dataset_dict)`**
+
+Concatenates all splits of a `DatasetDict` into a single `DashAIDataset` and records the row-index ranges in `splits["split_indices"]`. The splits are merged in sorted key order.
+
+### Persistence
+
+**`save_dataset(dataset, path, schema=None)`**
+
+Writes `data.arrow` and `splits.json` to `path`. If `schema` is provided, `transform_dataset_with_schema` is applied first.
+
+**`load_dataset(dataset_path)`**
+
+Reads `data.arrow` and `splits.json` from `dataset_path` and returns a `DashAIDataset`. Types are recovered from Arrow metadata.
+
+**`get_columns_spec(dataset_path)`**
+
+Reads only the Arrow schema (no row data) and returns a `Dict[str, Dict]` describing each column's type, dtype, and — for `Categorical` columns — the category list. Used by the API to return column metadata without loading the full dataset.
+
+### Type Transformation
+
+**`transform_dataset_with_schema(dataset, schema)`**
+
+Applies a type schema to the dataset, casting columns to their target Arrow types and updating `_types`. The `schema` format is:
+
+```python
+schema = {
+    "age":    {"type": "Integer", "dtype": "int64"},
+    "income": {"type": "Float",   "dtype": "float64"},
+    "city":   {"type": "Categorical", "dtype": "string", "converted": False},
+}
+```
+
+`Categorical` columns have their category list inferred from the actual data at this point, ensuring no values are silently excluded.
+
+### Splitting
+
+**`split_indexes(total_rows, train_size, test_size, val_size, seed, shuffle, stratify, labels)`**
+
+Returns `(train_indexes, test_indexes, val_indexes)` as lists of integer row indices. Uses a two-phase strategy:
+
+1. Split all rows into `train` vs `test+validation`.
+2. Split `test+validation` into `test` and `validation` proportionally.
+
+Supports stratified splitting: pass the label array in `labels`.
+
+**`split_dataset(dataset, train_indexes, test_indexes, val_indexes)`**
+
+Partitions `dataset` into a `DatasetDict` with `"train"`, `"test"`, and `"validation"` keys, each being a `DashAIDataset`. Column types from the original dataset are preserved.
+
+If all three index arguments are `None`, the function reads existing `split_indices` from `dataset.splits` instead.
+
+**`update_dataset_splits(dataset, new_splits, is_random)`**
+
+Updates `dataset.splits["split_indices"]` in place.
+
+- `is_random=True` — `new_splits` values are float proportions; `split_indexes` is called to generate row lists.
+- `is_random=False` — `new_splits` values are already row-index lists; used directly.
+
+### Training Preparation
+
+**`prepare_for_model_session(dataset, splits, output_columns)`**
+
+High-level entry point used by the job system before training. Handles the full split pipeline:
+
+1. Determines split type from `splits["splitType"]` (`"manual"`, `"predefined"`, or `"random"`).
+2. Calls `split_dataset` with the appropriate index lists.
+3. Returns `(prepared_dataset, index_map)` where `index_map` has keys `train_indexes`, `test_indexes`, `val_indexes`.
+
+For random splits with `stratify=True`, it reads the output column values and passes them as labels to `split_indexes`.
+
+---
+
+## Modifying Data — `modify_table`
+
+**`modify_table(dataset, columns, types=None)`**
+
+Used inside converters and models to replace or add columns while preserving all other columns and metadata.
+
+```python
+import pyarrow as pa
+from DashAI.back.dataloaders.classes.dashai_dataset import modify_table
+
+new_col = pa.array([1.0, 2.0, 3.0], type=pa.float64())
+result = modify_table(dataset, {"scaled_age": new_col}, types={"scaled_age": Float("float64")})
+```
+
+- Columns in `columns` that already exist in the dataset are replaced.
+- New columns require a matching entry in `types`.
+- Original Arrow metadata (including `dashai_types`) is preserved and extended.
+
+---
+
+## Relationship to Other Subsystems
+
+```
+DataLoader
+  └─ loads raw file → DashAIDataset (types inferred by DashAIPtype)
+        │
+        ├─ Notebook workspace
+        │     └─ Converter.fit_transform(DashAIDataset) → DashAIDataset
+        │          (modify_table used internally)
+        │
+        └─ Model training
+              └─ prepare_for_model_session → DatasetDict of DashAIDatasets
+                    └─ select_columns → (X_train, y_train) pair
+```
+
+- **DataLoaders** produce `DashAIDataset` via `to_dashai_dataset`.
+- **Converters** consume and return `DashAIDataset`, using `modify_table` to update columns.
+- **Models** receive a `DatasetDict` from `prepare_for_model_session` and call `get_split` / `select_columns` to extract their inputs.
+- **Explorers** receive a `DashAIDataset` and read `_types` to dispatch column-appropriate visualisations.
+
+---
+
+## Source Files
+
+| File                                                | Role                                                                                                |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `DashAI/back/dataloaders/classes/dashai_dataset.py` | `DashAIDataset` class and all module-level functions                                                |
+| `DashAI/back/types/utils.py`                        | Arrow ↔ DashAI type serialisation (`save_types_in_arrow_metadata`, `get_types_from_arrow_metadata`) |
+| `DashAI/back/types/value_types.py`                  | Concrete value type classes used in `_types`                                                        |
+| `DashAI/back/types/categorical.py`                  | `Categorical` type with `str2int` / `int2str` encoding                                              |

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/architecture.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/architecture.md
@@ -31,12 +31,13 @@ La inyección de dependencias es gestionada por **Kink**. El contenedor DI (`bac
 
 ## Lecturas Adicionales
 
-| Tema | Página |
-| ----- | ---- |
-| Estructura de la API REST, mapa de rutas, inyección de dependencias | [API](./api) |
-| Tipos de componentes, registro y objetos configurables | [Componentes](./components) |
-| Esquema SQLite, tablas ORM y almacenamiento de datos | [Base de Datos](./database) |
-| Cola de trabajos Huey y tipos de trabajos | [Sistema de Trabajos](./job-system) |
-| Sesiones de Notebook, exploradores y converters | [Notebook](./notebook) |
-| Recorridos completos de entrenamiento y exploración | [Ejemplos de Flujo de Trabajo](./workflow-examples) |
-| Tipos semánticos de columnas e inferencia | [Tipos Semánticos](./semantic-types) |
+| Tema                                                                | Página                                              |
+| ------------------------------------------------------------------- | --------------------------------------------------- |
+| Estructura de la API REST, mapa de rutas, inyección de dependencias | [API](./api)                                        |
+| Tipos de componentes, registro y objetos configurables              | [Componentes](./components)                         |
+| Esquema SQLite, tablas ORM y almacenamiento de datos                | [Base de Datos](./database)                         |
+| Cola de trabajos Huey y tipos de trabajos                           | [Sistema de Trabajos](./job-system)                 |
+| Sesiones de Notebook, exploradores y converters                     | [Notebook](./notebook)                              |
+| Recorridos completos de entrenamiento y exploración                 | [Ejemplos de Flujo de Trabajo](./workflow-examples) |
+| Tipos semánticos de columnas e inferencia                           | [Tipos Semánticos](./semantic-types)                |
+| Primitivo central de datos, splits y ciclo de vida del dato         | [DashAIDataset](./dashai-dataset)                   |

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/dashai-dataset.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/dashai-dataset.md
@@ -1,0 +1,254 @@
+---
+title: DashAIDataset
+sidebar_label: DashAIDataset
+sidebar_position: 9
+---
+
+# DashAIDataset
+
+## ¿Qué Es DashAIDataset?
+
+`DashAIDataset` es el primitivo central de datos de DashAI. Extiende la clase `Dataset` de HuggingFace con dos responsabilidades adicionales:
+
+- **Metadatos de tipo semántico** — un diccionario `_types` (`Dict[str, DashAIDataType]`) que mapea cada nombre de columna a su tipo semántico DashAI (ver [Tipos Semánticos](./semantic-types)). Estos metadatos se persisten dentro del esquema Apache Arrow para sobrevivir ciclos de guardado/carga.
+- **Metadatos de splits** — un diccionario `splits` que registra qué índices de fila pertenecen a qué split (`train`, `test`, `validation`), junto con estadísticas agregadas calculadas durante la carga del dataset.
+
+Cada pieza de datos que fluye por DashAI — carga, transformaciones en el notebook, entrenamiento de modelos, predicciones — se representa como un `DashAIDataset`.
+
+---
+
+## Estructura Interna
+
+### Atributos de Instancia
+
+| Atributo | Tipo                        | Descripción                                                              |
+| -------- | --------------------------- | ------------------------------------------------------------------------ |
+| `_table` | `pyarrow.Table`             | La tabla Arrow subyacente. Todos los datos de columnas residen aquí.     |
+| `_types` | `Dict[str, DashAIDataType]` | Tipo semántico de cada columna. Sincronizado con los metadatos de Arrow. |
+| `splits` | `dict`                      | Índices de splits y estadísticas calculadas (ver abajo).                 |
+
+### El Diccionario `splits`
+
+`splits` es un dict Python plano. Sus claves se van poblando de forma progresiva:
+
+| Clave               | Establecido por                           | Contenido                                                                           |
+| ------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------- |
+| `split_indices`     | `split_dataset` / `update_dataset_splits` | `{"train": [...], "test": [...], "validation": [...]}` — listas de índices de fila  |
+| `column_names`      | `compute_base_metadata` / `save_dataset`  | Lista de nombres de columnas                                                        |
+| `total_rows`        | `compute_base_metadata` / `save_dataset`  | Número total de filas                                                               |
+| `nan`               | `compute_base_metadata`                   | Conteo de NaN por columna                                                           |
+| `general_info`      | `compute_metadata`                        | Conteo de filas/columnas, memoria, duplicados, mapa de dtypes                       |
+| `numeric_stats`     | `compute_metadata`                        | Estadísticas descriptivas por columna numérica                                      |
+| `categorical_stats` | `compute_metadata`                        | Conteos de valores y top-5 por columna categórica                                   |
+| `text_stats`        | `compute_metadata`                        | Estadísticas de longitud y conteo de palabras para columnas de texto                |
+| `quality_info`      | `compute_metadata`                        | Completitud, columnas constantes, columnas de alta cardinalidad, puntaje de calidad |
+| `correlations`      | `compute_metadata`                        | Matriz de correlación de Pearson para columnas numéricas                            |
+
+### Metadatos de Arrow
+
+Los tipos semánticos se serializan en los metadatos del esquema de la tabla Arrow bajo la clave `dashai_types`:
+
+```python
+table.schema.metadata[b"dashai_types"]  # mapa de tipos serializado en JSON
+```
+
+Las utilidades `save_types_in_arrow_metadata()` y `get_types_from_arrow_metadata()` en `DashAI/back/types/utils.py` gestionan esta serialización. Cuando `DashAIDataset` se construye con `types=None`, lee el mapa de tipos directamente de los metadatos de Arrow.
+
+---
+
+## Formato en Disco
+
+`save_dataset` escribe dos archivos en un directorio:
+
+```
+<dataset_path>/
+├── data.arrow    # Archivo IPC de PyArrow — tabla + metadatos de tipos en el esquema
+└── splits.json   # JSON — índices de splits, conteos de filas, mapa de NaN, estadísticas calculadas
+```
+
+`load_dataset` lee ambos archivos y reconstruye el `DashAIDataset`. Los tipos se recuperan de los metadatos del esquema Arrow, por lo que no se necesita un archivo de tipos separado.
+
+---
+
+## Métodos de Instancia Clave
+
+### `get_split(split_name)`
+
+Devuelve un nuevo `DashAIDataset` que contiene solo las filas del split solicitado.
+
+```python
+train_ds = dataset.get_split("train")  # usa split_indices["train"]
+```
+
+`split_name` debe existir en `splits["split_indices"]`. Los metadatos `splits` del dataset devuelto contienen únicamente la lista de índices de ese split.
+
+### `select_columns(column_names)`
+
+Devuelve un nuevo `DashAIDataset` con solo las columnas especificadas, copiando los tipos correspondientes.
+
+```python
+features_ds = dataset.select_columns(["age", "income", "city"])
+```
+
+### `sample(n, method, seed)`
+
+Devuelve `n` filas como un `dict` Python plano. `method` controla la selección:
+
+| Método     | Comportamiento                                 |
+| ---------- | ---------------------------------------------- |
+| `"head"`   | Primeras `n` filas                             |
+| `"tail"`   | Últimas `n` filas                              |
+| `"random"` | `n` filas aleatorias (reproducible con `seed`) |
+
+### `compute_metadata()`
+
+Ejecuta todos los cálculos de EDA y almacena los resultados en `self.splits`. Se llama una vez tras la carga. Requiere que `_types` esté definido. Devuelve `self`.
+
+### `compute_base_metadata()`
+
+Subconjunto ligero de `compute_metadata()` — solo establece `column_names`, `total_rows` y `nan`. Se usa cuando no se necesitan estadísticas completas.
+
+### `keys()`
+
+Devuelve la lista de nombres de splits disponibles en `splits["split_indices"]`. Refleja la interfaz `DatasetDict.keys()` para que `DashAIDataset` pueda usarse de forma intercambiable en algunos contextos.
+
+---
+
+## Funciones del Ciclo de Vida del Dato
+
+Estas funciones a nivel de módulo cubren el recorrido completo desde la entrada en bruto hasta los splits listos para entrenamiento.
+
+### Carga y Conversión
+
+**`to_dashai_dataset(dataset, types=None)`**
+
+Conversor universal. Acepta `DashAIDataset` (pass-through), `Dataset` de HuggingFace, `DatasetDict` de HuggingFace, o `pandas.DataFrame`. Los `DatasetDict` con múltiples splits se fusionan mediante `merge_splits_with_metadata`.
+
+```python
+from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+
+ds = to_dashai_dataset(my_hf_dataset, types=my_type_map)
+```
+
+**`merge_splits_with_metadata(dataset_dict)`**
+
+Concatena todos los splits de un `DatasetDict` en un único `DashAIDataset` y registra los rangos de índices de fila en `splits["split_indices"]`. Los splits se fusionan en orden de clave alfabético.
+
+### Persistencia
+
+**`save_dataset(dataset, path, schema=None)`**
+
+Escribe `data.arrow` y `splits.json` en `path`. Si se proporciona `schema`, se aplica `transform_dataset_with_schema` primero.
+
+**`load_dataset(dataset_path)`**
+
+Lee `data.arrow` y `splits.json` desde `dataset_path` y devuelve un `DashAIDataset`. Los tipos se recuperan de los metadatos de Arrow.
+
+**`get_columns_spec(dataset_path)`**
+
+Lee solo el esquema Arrow (sin datos de filas) y devuelve un `Dict[str, Dict]` que describe el tipo, dtype y — para columnas `Categorical` — la lista de categorías de cada columna. Es usado por la API para retornar metadatos de columnas sin cargar el dataset completo.
+
+### Transformación de Tipos
+
+**`transform_dataset_with_schema(dataset, schema)`**
+
+Aplica un esquema de tipos al dataset, convirtiendo las columnas a sus tipos Arrow destino y actualizando `_types`. El formato del `schema` es:
+
+```python
+schema = {
+    "age":    {"type": "Integer", "dtype": "int64"},
+    "income": {"type": "Float",   "dtype": "float64"},
+    "city":   {"type": "Categorical", "dtype": "string", "converted": False},
+}
+```
+
+Las columnas `Categorical` tienen su lista de categorías inferida a partir de los datos reales en este punto, garantizando que ningún valor sea excluido silenciosamente.
+
+### Splitting
+
+**`split_indexes(total_rows, train_size, test_size, val_size, seed, shuffle, stratify, labels)`**
+
+Devuelve `(train_indexes, test_indexes, val_indexes)` como listas de índices de fila enteros. Usa una estrategia en dos fases:
+
+1. Divide todas las filas en `train` vs `test+validation`.
+2. Divide `test+validation` en `test` y `validation` proporcionalmente.
+
+Soporta splitting estratificado: pasar el array de etiquetas en `labels`.
+
+**`split_dataset(dataset, train_indexes, test_indexes, val_indexes)`**
+
+Particiona `dataset` en un `DatasetDict` con claves `"train"`, `"test"` y `"validation"`, siendo cada uno un `DashAIDataset`. Los tipos de columnas del dataset original se preservan.
+
+Si los tres argumentos de índice son `None`, la función lee los `split_indices` existentes en `dataset.splits`.
+
+**`update_dataset_splits(dataset, new_splits, is_random)`**
+
+Actualiza `dataset.splits["split_indices"]` en lugar.
+
+- `is_random=True` — los valores de `new_splits` son proporciones flotantes; se llama a `split_indexes` para generar las listas de filas.
+- `is_random=False` — los valores de `new_splits` ya son listas de índices de fila; se usan directamente.
+
+### Preparación para Entrenamiento
+
+**`prepare_for_model_session(dataset, splits, output_columns)`**
+
+Punto de entrada de alto nivel usado por el sistema de jobs antes del entrenamiento. Gestiona el pipeline completo de splits:
+
+1. Determina el tipo de split desde `splits["splitType"]` (`"manual"`, `"predefined"` o `"random"`).
+2. Llama a `split_dataset` con las listas de índices apropiadas.
+3. Devuelve `(prepared_dataset, index_map)` donde `index_map` tiene las claves `train_indexes`, `test_indexes`, `val_indexes`.
+
+Para splits aleatorios con `stratify=True`, lee los valores de la columna de salida y los pasa como etiquetas a `split_indexes`.
+
+---
+
+## Modificar Datos — `modify_table`
+
+**`modify_table(dataset, columns, types=None)`**
+
+Usado dentro de converters y modelos para reemplazar o agregar columnas preservando todas las demás columnas y metadatos.
+
+```python
+import pyarrow as pa
+from DashAI.back.dataloaders.classes.dashai_dataset import modify_table
+
+new_col = pa.array([1.0, 2.0, 3.0], type=pa.float64())
+result = modify_table(dataset, {"scaled_age": new_col}, types={"scaled_age": Float("float64")})
+```
+
+- Las columnas en `columns` que ya existen en el dataset son reemplazadas.
+- Las columnas nuevas requieren una entrada correspondiente en `types`.
+- Los metadatos Arrow originales (incluyendo `dashai_types`) se preservan y extienden.
+
+---
+
+## Relación con Otros Subsistemas
+
+```
+DataLoader
+  └─ carga archivo en bruto → DashAIDataset (tipos inferidos por DashAIPtype)
+        │
+        ├─ Espacio de trabajo Notebook
+        │     └─ Converter.fit_transform(DashAIDataset) → DashAIDataset
+        │          (modify_table usado internamente)
+        │
+        └─ Entrenamiento de modelos
+              └─ prepare_for_model_session → DatasetDict de DashAIDatasets
+                    └─ select_columns → par (X_train, y_train)
+```
+
+- **DataLoaders** producen `DashAIDataset` mediante `to_dashai_dataset`.
+- **Converters** consumen y devuelven `DashAIDataset`, usando `modify_table` para actualizar columnas.
+- **Modelos** reciben un `DatasetDict` de `prepare_for_model_session` y llaman a `get_split` / `select_columns` para extraer sus entradas.
+- **Explorers** reciben un `DashAIDataset` y leen `_types` para despachar visualizaciones apropiadas por tipo de columna.
+
+---
+
+## Archivos Fuente
+
+| Archivo                                             | Rol                                                                                                     |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `DashAI/back/dataloaders/classes/dashai_dataset.py` | Clase `DashAIDataset` y todas las funciones a nivel de módulo                                           |
+| `DashAI/back/types/utils.py`                        | Serialización de tipos Arrow ↔ DashAI (`save_types_in_arrow_metadata`, `get_types_from_arrow_metadata`) |
+| `DashAI/back/types/value_types.py`                  | Clases de tipos de valor concretos usados en `_types`                                                   |
+| `DashAI/back/types/categorical.py`                  | Tipo `Categorical` con codificación `str2int` / `int2str`                                               |

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -59,6 +59,7 @@ const sidebars = {
         "deep-dive/notebook",
         "deep-dive/workflow-examples",
         "deep-dive/semantic-types",
+        "deep-dive/dashai-dataset",
       ],
     },
     "deep-dive/papers",


### PR DESCRIPTION
## Summary  
Adds comprehensive documentation for the `DashAIDataset` core dataset primitive, detailing its structure, lifecycle, and integration within the system. Also updates architecture deep-dive documentation (in both English and Spanish) to reference this new resource.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [ ] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [ ] Bug fix  
- [x] Documentation  

---

## Changes (by file)  
- `docs/dashai-dataset.md`: New documentation file with an in-depth explanation of the `DashAIDataset` class, including metadata, lifecycle, and integration points.  
- `docs/architecture.md` (EN): Added link to `DashAIDataset` documentation in the "Further Reading" section.  
- `docs/architecture.md` (ES): Added link to `DashAIDataset` documentation in the "Lecturas Adicionales" section.  
