### PR TITLE
Fix missing DashAIDataset imports in predict methods

### DIFF
--- a/DashAI/back/models/scikit_learn/sklearn_like_model.py
+++ b/DashAI/back/models/scikit_learn/sklearn_like_model.py
@@ -117,6 +117,8 @@ class SklearnLikeModel(BaseModel):
         np.ndarray
             Predicted values.
         """
+        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
         if isinstance(x, DashAIDataset):
             x = self.prepare_dataset(x, is_fit=False).to_pandas()
         return super().predict(x)

--- a/DashAI/back/models/scikit_learn/sklearn_like_regressor.py
+++ b/DashAI/back/models/scikit_learn/sklearn_like_regressor.py
@@ -33,6 +33,8 @@ class SklearnLikeRegressor(SklearnLikeModel):
         """
         import pandas as pd
 
+        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
         if isinstance(x_pred, DashAIDataset):
             try:
                 x_prepared = self.prepare_dataset(x_pred, is_fit=False)


### PR DESCRIPTION
## Summary  
Fixes missing imports in the `predict` methods of sklearn-like model and regressor classes by adding explicit local imports of `DashAIDataset`.

---

## Type of Change  
Check all that apply like this [x]:

- [x] Backend change  
- [ ] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  
- `sklearn_like_model.py`: Added missing local import of `DashAIDataset` inside the `predict` method.  
- `sklearn_like_regressor.py`: Added missing local import of `DashAIDataset` inside the `predict` method.  

---

## Testing (optional)  
Ensure training and prediction workflows run correctly (e.g., models like Gradient Boosting).