### PR TITLE
feat: add running indicator and progress message for explainers

### DIFF
--- a/DashAI/front/src/components/explainers/ExplainersCard.jsx
+++ b/DashAI/front/src/components/explainers/ExplainersCard.jsx
@@ -12,6 +12,7 @@ import {
   Button,
   Collapse,
   Box,
+  CircularProgress,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ZoomInIcon from "@mui/icons-material/ZoomIn";
@@ -23,6 +24,8 @@ import { useNavigate } from "react-router-dom";
 import { deleteExplainer } from "../../api/explainer";
 import { useTranslation } from "react-i18next";
 import { getComponentById } from "../../api/component";
+
+const RUNNING_STATUSES = [1, 2]; // Delivered or Started
 
 /**
  * GlobalExplainersCard
@@ -47,6 +50,7 @@ export default function ExplainersCard({
   }, [expanded, expandedStorageKey]);
   const [componentData, setComponentData] = useState(null);
   const { t } = useTranslation(["explainers"]);
+  const isRunning = RUNNING_STATUSES.includes(explainer.status);
 
   function plotName(name) {
     return name.match(/[A-Z][a-z]+|[0-9]+/g).join(" ");
@@ -118,37 +122,46 @@ export default function ExplainersCard({
                   </Typography>
                 </Typography>
               </Grid>
-              <Grid>
+              <Grid sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                {isRunning && <CircularProgress size={18} />}
                 <IconButton
                   size="small"
                   aria-label="delete"
                   color="error"
                   onClick={handleDeleteExplainer}
+                  disabled={isRunning}
                 >
                   <DeleteIcon fontSize="small" />
                 </IconButton>
               </Grid>
             </Grid>
 
-            {/* Expandable plot section */}
-            <Grid sx={{ width: "100%" }}>
-              <Button
-                size="small"
-                onClick={() => setExpanded(!expanded)}
-                endIcon={expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                sx={{ textTransform: "none" }}
-              >
-                {expanded
-                  ? t("explainers:button.hidePlot")
-                  : t("explainers:button.showPlot")}
-              </Button>
+            {isRunning ? (
+              <Box sx={{ py: 1, textAlign: "center" }}>
+                <Typography variant="body2" color="text.secondary">
+                  {t("explainers:label.explainerInProgress")}
+                </Typography>
+              </Box>
+            ) : (
+              <Grid sx={{ width: "100%" }}>
+                <Button
+                  size="small"
+                  onClick={() => setExpanded(!expanded)}
+                  endIcon={expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                  sx={{ textTransform: "none" }}
+                >
+                  {expanded
+                    ? t("explainers:button.hidePlot")
+                    : t("explainers:button.showPlot")}
+                </Button>
 
-              <Collapse in={expanded} timeout="auto" unmountOnExit>
-                <Box sx={{ mt: 2 }}>
-                  <ExplainersPlot explainer={explainer} scope={scope} />
-                </Box>
-              </Collapse>
-            </Grid>
+                <Collapse in={expanded} timeout="auto" unmountOnExit>
+                  <Box sx={{ mt: 2 }}>
+                    <ExplainersPlot explainer={explainer} scope={scope} />
+                  </Box>
+                </Collapse>
+              </Grid>
+            )}
           </Grid>
         </Paper>
 
@@ -196,9 +209,11 @@ export default function ExplainersCard({
               {t("explainers:label.forExplainer", { name: explainer.name })}
             </Typography>
           </Grid>
-          <Grid>
+          <Grid sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            {isRunning && <CircularProgress size={22} />}
             <IconButton
               aria-label="zoomin"
+              disabled={isRunning}
               onClick={() => {
                 navigate(
                   `/app/explainers/explainer/${scope}/${explainer.run_id}/${explainer.id}`,
@@ -211,6 +226,7 @@ export default function ExplainersCard({
               aria-label="delete"
               color="error"
               onClick={handleDeleteExplainer}
+              disabled={isRunning}
             >
               <DeleteIcon />
             </IconButton>

--- a/DashAI/front/src/components/explainers/InlineExplainerCreator.jsx
+++ b/DashAI/front/src/components/explainers/InlineExplainerCreator.jsx
@@ -251,6 +251,7 @@ export default function InlineExplainerCreator({
 
       await enqueueExplainerJob(response.id);
       await loadExistingExplainers();
+      if (onCreated) onCreated();
       return true;
     } catch (error) {
       enqueueSnackbar(

--- a/DashAI/front/src/components/models/RunResults.jsx
+++ b/DashAI/front/src/components/models/RunResults.jsx
@@ -82,6 +82,16 @@ export default function RunResults({
     fetchOperations();
   }, [fetchOperations, explainerRefreshTrigger]);
 
+  const hasRunningExplainers =
+    globalExplainers.some((e) => e.status === 1 || e.status === 2) ||
+    localExplainers.some((e) => e.status === 1 || e.status === 2);
+
+  useEffect(() => {
+    if (!hasRunningExplainers) return;
+    const interval = setInterval(fetchOperations, 3000);
+    return () => clearInterval(interval);
+  }, [hasRunningExplainers, fetchOperations]);
+
   useEffect(() => {
     const handleOpenDialog = (event) => {
       if (event.detail.runId === run.id) {

--- a/DashAI/front/src/utils/i18n/locales/en/explainers.json
+++ b/DashAI/front/src/utils/i18n/locales/en/explainers.json
@@ -52,6 +52,7 @@
     "selectDatasetToExplain": "Select a dataset with instances to explain",
     "selectExplainer": "Set name and explainer",
     "selectExplainerAndName": "Select a explainer and enter a name",
+    "explainerInProgress": "Explainer in progress...",
     "splitSelectionSummary": "Percentage: {{percentage}}% | Rows selected: {{rowsSelected}} / {{totalRows}}"
   },
   "message": {

--- a/DashAI/front/src/utils/i18n/locales/es/explainers.json
+++ b/DashAI/front/src/utils/i18n/locales/es/explainers.json
@@ -52,6 +52,7 @@
     "selectDatasetToExplain": "Seleccione un dataset con instancias para explicar",
     "selectExplainer": "Establecer nombre y explicador",
     "selectExplainerAndName": "Seleccione un explicador e ingrese un nombre",
+    "explainerInProgress": "Explicador en progreso...",
     "splitSelectionSummary": "Porcentaje: {{percentage}}% | Filas seleccionadas: {{rowsSelected}} / {{totalRows}}"
   },
   "message": {


### PR DESCRIPTION
 ## Summary                                                                                                                        
  Explainer cards had no visual feedback when a job was running. This adds a `CircularProgress` spinner, a progress message, and disables destructive actions while the job is in progress — matching the pattern already used by `PredictionCard`.                
   
  ---                                                                                                                               
                                                                                                                                  
  ## Type of Change
  - [ ] Backend change
  - [x] Frontend change                                                                                                             
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change                                                                                                    
  - [ ] Bug fix                                                                                                                   
  - [ ] Documentation

  ---

  ## Changes (by file)
  - `DashAI/front/src/components/explainers/ExplainersCard.jsx`: Added `CircularProgress` spinner next to the title, "Explainer in progress..." message replacing the plot section, and disabled delete/zoom buttons while the explainer job is running (status 1 or 2). Applied to both compact and full modes.
  - `DashAI/front/src/components/explainers/InlineExplainerCreator.jsx`: Added immediate `onCreated()` call after enqueuing the job  so the explainer card appears right away with the running indicator.                                                              
  - `DashAI/front/src/components/models/RunResults.jsx`: Added 3-second polling interval when any explainer has a running status, so the card automatically updates when the job finishes.                                                                            
  - `DashAI/front/src/utils/i18n/locales/en/explainers.json`: Added `explainerInProgress` translation key.                        
  - `DashAI/front/src/utils/i18n/locales/es/explainers.json`: Added `explainerInProgress` translation key (Spanish).                
                                                                                                                                  
  ---                                                                                                                               
                                                                                                                                  
  ## Testing
  1. Create a global or local explainer and verify the card appears immediately with a spinner and progress message.
  2. Confirm delete and zoom buttons are disabled while the job runs.                                                               
  3. Verify the card automatically transitions to showing the plot once the job finishes (polling).
  4. Check both compact mode (inside RunResults) and full mode (standalone page).                                                   
                                                                                                                                    
  ---
                                                                                                                                    
  ## Notes                                                  
  Follows the same `RUNNING_STATUSES = [1, 2]` pattern used by `PredictionCard` and `RunCard`.