### PR TITLE
add collapsible table feature in SessionVisualization component

### DIFF
--- a/DashAI/front/src/components/models/SessionVisualization.jsx
+++ b/DashAI/front/src/components/models/SessionVisualization.jsx
@@ -9,8 +9,17 @@ import {
   ButtonGroup,
   ToggleButtonGroup,
   ToggleButton,
+  Collapse,
+  IconButton,
+  Tooltip,
 } from "@mui/material";
-import { PlayArrow, TableChart, BarChart } from "@mui/icons-material";
+import {
+  PlayArrow,
+  TableChart,
+  BarChart,
+  ExpandMore,
+  ExpandLess,
+} from "@mui/icons-material";
 import ModelComparisonTable from "./ModelComparisonTable";
 import RunCard from "./RunCard";
 import { getComponents } from "../../api/component";
@@ -28,6 +37,7 @@ export default function SessionVisualization() {
   const [showTable, setShowTable] = useState(true);
   const [previousTableHeight, setPreviousTableHeight] = useState(280);
   const [metricSplit, setMetricSplit] = useState("test");
+  const [tableCollapsed, setTableCollapsed] = useState(false);
   const [explainerRefreshTrigger, setExplainerRefreshTrigger] = useState(0);
   const isResizing = React.useRef(false);
   const { t } = useTranslation(["models", "common"]);
@@ -216,12 +226,14 @@ export default function SessionVisualization() {
         <Paper
           data-tour="model-comparison-panel"
           sx={{
-            height: `${tableHeight}px`,
+            height: tableCollapsed ? "auto" : `${tableHeight}px`,
             flexShrink: 0,
             borderBottom: "1px solid",
             borderColor: "divider",
             p: 2,
             position: "relative",
+            display: "flex",
+            flexDirection: "column",
           }}
         >
           <Box
@@ -230,11 +242,26 @@ export default function SessionVisualization() {
               justifyContent: "space-between",
               alignItems: "center",
               mb: 2,
+              flexShrink: 0,
             }}
           >
-            <Typography variant="h6" color="text.primary">
-              {t("models:label.modelComparison")}
-            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Tooltip
+                title={
+                  tableCollapsed ? t("common:expand") : t("common:collapse")
+                }
+              >
+                <IconButton
+                  size="small"
+                  onClick={() => setTableCollapsed((v) => !v)}
+                >
+                  {tableCollapsed ? <ExpandMore /> : <ExpandLess />}
+                </IconButton>
+              </Tooltip>
+              <Typography variant="h6" color="text.primary">
+                {t("models:label.modelComparison")}
+              </Typography>
+            </Box>
             <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
               {/* Metric Split Selector — controls both table and graph views */}
               {(hasTrainMetrics || hasValidationMetrics || hasTestMetrics) && (
@@ -298,63 +325,86 @@ export default function SessionVisualization() {
                 )}
             </Box>
           </Box>
-          {runs.length === 0 ? (
-            <Box
+          <Box
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              overflow: "hidden",
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            <Collapse
+              in={!tableCollapsed}
+              unmountOnExit
               sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                height: "calc(100% - 40px)",
+                flex: 1,
+                minHeight: 0,
+                "& .MuiCollapse-wrapper": { height: "100%" },
+                "& .MuiCollapse-wrapperInner": { height: "100%" },
               }}
             >
-              <Typography variant="body2" color="text.secondary">
-                {t("models:label.noRunsYet")}
-              </Typography>
-            </Box>
-          ) : (
-            <Box sx={{ height: "calc(100% - 40px)", overflow: "auto" }}>
-              {showTable ? (
-                <ModelComparisonTable
-                  runs={runs}
-                  session={session}
-                  onTrain={onTrain}
-                  onViewDetails={handleViewDetails}
-                  onDelete={onDeleteRun}
-                  onRowClick={handleRowClick}
-                  metricSplit={metricSplit}
-                />
+              {runs.length === 0 ? (
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    height: "100%",
+                  }}
+                >
+                  <Typography variant="body2" color="text.secondary">
+                    {t("models:label.noRunsYet")}
+                  </Typography>
+                </Box>
               ) : (
-                <ResultsGraphs
-                  runs={runs}
-                  selectedSplit={metricSplit}
-                  onSplitChange={setMetricSplit}
-                />
+                <Box sx={{ height: "100%", overflow: "auto" }}>
+                  {showTable ? (
+                    <ModelComparisonTable
+                      runs={runs}
+                      session={session}
+                      onTrain={onTrain}
+                      onViewDetails={handleViewDetails}
+                      onDelete={onDeleteRun}
+                      onRowClick={handleRowClick}
+                      metricSplit={metricSplit}
+                    />
+                  ) : (
+                    <ResultsGraphs
+                      runs={runs}
+                      selectedSplit={metricSplit}
+                      onSplitChange={setMetricSplit}
+                    />
+                  )}
+                </Box>
               )}
-            </Box>
-          )}
+            </Collapse>
+          </Box>
 
           {/* Resize Handle */}
-          <Box
-            onMouseDown={() => {
-              isResizing.current = true;
-              document.body.style.cursor = "row-resize";
-              document.body.style.userSelect = "none";
-            }}
-            sx={{
-              position: "absolute",
-              bottom: -2,
-              left: 0,
-              right: 0,
-              height: "5px",
-              cursor: "row-resize",
-              bgcolor: "transparent",
-              transition: "background-color 0.2s ease",
-              "&:hover": {
-                bgcolor: "primary.main",
-              },
-              zIndex: 10,
-            }}
-          />
+          {!tableCollapsed && (
+            <Box
+              onMouseDown={() => {
+                isResizing.current = true;
+                document.body.style.cursor = "row-resize";
+                document.body.style.userSelect = "none";
+              }}
+              sx={{
+                position: "absolute",
+                bottom: -2,
+                left: 0,
+                right: 0,
+                height: "5px",
+                cursor: "row-resize",
+                bgcolor: "transparent",
+                transition: "background-color 0.2s ease",
+                "&:hover": {
+                  bgcolor: "primary.main",
+                },
+                zIndex: 10,
+              }}
+            />
+          )}
         </Paper>
 
         <Divider sx={{ my: 1, mt: 1 }} />


### PR DESCRIPTION
This pull request enhances the usability of the `SessionVisualization` component by adding a collapsible feature to the model comparison table panel. Users can now collapse or expand the table section for a cleaner interface, especially when working with limited screen space. The implementation leverages Material UI's `Collapse`, `IconButton`, and `Tooltip` components, and includes UI/UX improvements to ensure smooth interaction.

**Collapsible Table Panel Feature:**

- Added a `tableCollapsed` state and implemented a collapsible model comparison table panel using Material UI's `Collapse` component, allowing users to hide or show the table as needed. [[1]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061R40) [[2]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061R328-R361)
- Integrated `ExpandMore` and `ExpandLess` icons, along with an `IconButton` and `Tooltip`, to provide an intuitive toggle control for collapsing and expanding the table panel. [[1]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061R12-R22) [[2]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061R245-R264)
- Adjusted the layout and styling of the `Paper` container and its children to support the new collapsible behavior and maintain a responsive, flexible design. [[1]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061L219-R236) [[2]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061R328-R361)
- Ensured that the resize handle and related UI elements are only visible when the table is expanded, preventing unnecessary UI clutter when collapsed. [[1]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061R381-R385) [[2]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061R407)