### PR TITLE
fix: adjust layout for encoder selection tooltip in dataset preview

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx
@@ -288,25 +288,25 @@ export default function PreviewDatasetTable({
                 columnName={displayName}
                 reason={columnType?.inference_reason}
               />
-
-              {columnType?.type === "Categorical" && columnType?.encoder && (
-                <Tooltip title={t("common:changeEncoder")} arrow>
-                  <span style={{ display: "inline-flex" }}>
-                    <Chip
-                      label={encoderLabel(columnType.encoder)}
-                      size="small"
-                      onClick={(e) => handleEncoderClick(e, field)}
-                      aria-label={t("common:encoder")}
-                      sx={{
-                        fontSize: "0.65rem",
-                        height: "18px",
-                        cursor: "pointer",
-                      }}
-                    />
-                  </span>
-                </Tooltip>
-              )}
             </Box>
+
+            {columnType?.type === "Categorical" && columnType?.encoder && (
+              <Tooltip title={t("common:changeEncoder")} arrow>
+                <span style={{ display: "inline-flex" }}>
+                  <Chip
+                    label={encoderLabel(columnType.encoder)}
+                    size="small"
+                    onClick={(e) => handleEncoderClick(e, field)}
+                    aria-label={t("common:encoder")}
+                    sx={{
+                      fontSize: "0.65rem",
+                      height: "18px",
+                      cursor: "pointer",
+                    }}
+                  />
+                </span>
+              </Tooltip>
+            )}
           </Box>
         ),
       };


### PR DESCRIPTION
## Summary

Improved the dataset preview table column header layout by repositioning the encoder selector (one-hot/label) from a horizontal position next to the type dropdown to its own vertical line below it. This reduces horizontal crowding in column headers and makes the interface cleaner and more readable.

---

## Type of Change

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx`: Restructured the `Header` component to move the encoder chip from a horizontal flex container (alongside the type selector) to its own conditional line below the type selector and inference icon. The layout now displays column name, then type selector in one row, and encoder selector on a separate row for Categorical columns only.

---

## Testing (optional)

1. Verify that Categorical columns display the encoder chip below the type dropdown (not beside it)
2. Confirm that non-Categorical columns do not show the encoder chip
3. Test that the encoder selector remains clickable and functional for switching between one-hot and label encoding

