### PR TITLE
Fix GPU detection in PyInstaller builds and correct LLAMA device indexing

### DIFF
--- a/DashAI/back/models/hugging_face/llama_utils.py
+++ b/DashAI/back/models/hugging_face/llama_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import ctypes
 import logging
 import os
@@ -16,7 +17,8 @@ except ImportError:
     llama_cpp = None
 
 
-# llama_log_callback signature: void (*)(ggml_log_level level, const char * text, void * user_data)
+# llama_log_callback signature: void (*)(ggml_log_level level,
+# const char * text, void * user_data)
 _LOG_CB_T = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_void_p)
 
 _log_capture: list[str] = []
@@ -185,10 +187,8 @@ def get_llama_gpu_devices_formatted() -> list[str]:
         cuda_lib = _find_symbol(libs, "ggml_backend_cuda_get_device_count")
         if cuda_lib is not None:
             cuda_lib.ggml_backend_cuda_get_device_count.restype = ctypes.c_int
-            try:
+            with contextlib.suppress(Exception):
                 cuda_lib.ggml_backend_cuda_get_device_count()
-            except Exception:
-                pass
 
         caps = _parse_compute_caps("".join(_log_capture))
         devices = _enum_via_cuda_api(libs, caps)
@@ -201,6 +201,17 @@ def get_llama_gpu_devices_formatted() -> list[str]:
 
 
 def is_gpu_available_for_llama_cpp() -> bool:
+    """Check whether the installed llama-cpp-python was compiled with GPU support.
+
+    Dispatches to a version-specific helper based on the ``llama_cpp`` package
+    version, because the internal API changed between 0.2.x and 0.3.x.
+
+    Returns
+    -------
+    bool
+        ``True`` if GPU offloading is available; ``False`` if ``llama-cpp-python``
+        is not installed or if the check raises an unexpected exception.
+    """
     if llama_cpp is None:
         return False
     try:
@@ -217,10 +228,34 @@ def is_gpu_available_for_llama_cpp() -> bool:
 
 
 def __is_gpu_available_for_llama_cpp_v03() -> bool:
+    """Check GPU availability using the llama.cpp v0.3 shared-library API.
+
+    Loads the ``llama`` shared library from the llama_cpp package directory and
+    calls ``llama_supports_gpu_offload`` to determine whether the build was
+    compiled with GPU support.
+
+    Returns
+    -------
+    bool
+        ``True`` if ``llama_supports_gpu_offload()`` returns a truthy value,
+        ``False`` otherwise.
+    """
     lib = _load_llama_lib()
     return bool(lib.llama_supports_gpu_offload())
 
 
 def __is_gpu_available_for_llama_cpp_v02() -> bool:
+    """Check GPU availability using the llama.cpp v0.2 shared-library API.
+
+    Loads the ``llama`` shared library via the legacy ``_load_shared_library``
+    helper and inspects it for the ``ggml_init_cublas`` symbol, which is only
+    present in CUDA-enabled builds.
+
+    Returns
+    -------
+    bool
+        ``True`` if the ``ggml_init_cublas`` attribute is found in the loaded
+        library, ``False`` otherwise.
+    """
     lib = llama_cpp.llama_cpp._load_shared_library("llama")
     return hasattr(lib, "ggml_init_cublas")

--- a/DashAI/back/models/hugging_face/llama_utils.py
+++ b/DashAI/back/models/hugging_face/llama_utils.py
@@ -1,9 +1,8 @@
+import ctypes
 import logging
 import os
 import re
-import subprocess
 import sys
-import textwrap
 from functools import lru_cache
 from pathlib import Path
 
@@ -17,75 +16,198 @@ except ImportError:
     llama_cpp = None
 
 
+# llama_log_callback signature: void (*)(ggml_log_level level, const char * text, void * user_data)
+_LOG_CB_T = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_void_p)
+
+_log_capture: list[str] = []
+
+
+@_LOG_CB_T
+def _capturing_log_cb(level, msg, user_data):
+    if not msg:
+        return
+    try:
+        text = msg.decode("utf-8", errors="ignore")
+    except Exception:
+        return
+    _log_capture.append(text)
+    logger.debug("llama: %s", text.rstrip("\n"))
+
+
+def _lib_dir() -> Path:
+    return Path(os.path.dirname(llama_cpp.__file__)) / "lib"
+
+
+@lru_cache(maxsize=1)
+def _load_llama_lib():
+    """Load llama.dll and install our own log callback so CUDA init output
+    can be captured in _log_capture instead of printed to the real stderr."""
+    if llama_cpp is None:
+        return None
+    lib = llama_cpp.llama_cpp.load_shared_library("llama", _lib_dir())
+    if hasattr(lib, "llama_log_set"):
+        try:
+            lib.llama_log_set.argtypes = [_LOG_CB_T, ctypes.c_void_p]
+            lib.llama_log_set.restype = None
+            lib.llama_log_set(_capturing_log_cb, None)
+        except Exception as e:
+            logger.debug("llama_log_set failed: %s", e)
+    return lib
+
+
+@lru_cache(maxsize=1)
+def _all_ggml_libs() -> tuple:
+    """Load every shared lib in llama_cpp/lib/ so backend symbols are reachable."""
+    if llama_cpp is None:
+        return ()
+    if sys.platform.startswith("win"):
+        patterns = ("*.dll",)
+    elif sys.platform == "darwin":
+        patterns = ("*.dylib",)
+    else:
+        patterns = ("*.so", "*.so.*")
+
+    base = _lib_dir()
+    if not base.is_dir():
+        return ()
+
+    libs = []
+    seen = set()
+    for pat in patterns:
+        for f in base.glob(pat):
+            if f.name in seen:
+                continue
+            seen.add(f.name)
+            try:
+                libs.append(ctypes.CDLL(str(f)))
+            except OSError as e:
+                logger.debug("skip lib %s: %s", f.name, e)
+    return tuple(libs)
+
+
+def _find_symbol(libs, name):
+    for lib in libs:
+        if hasattr(lib, name):
+            return lib
+    return None
+
+
+def _parse_compute_caps(log: str) -> dict[int, str]:
+    """Extract `Device N: ..., compute capability X.Y` from captured log."""
+    pattern = r"Device\s*(\d+):\s*[^,]+,\s*compute capability\s*([\d.]+)"
+    return {int(m.group(1)): m.group(2) for m in re.finditer(pattern, log)}
+
+
+def _enum_via_cuda_api(libs, caps: dict[int, str]) -> list[str]:
+    lib = _find_symbol(libs, "ggml_backend_cuda_get_device_count")
+    if lib is None or not hasattr(lib, "ggml_backend_cuda_get_device_description"):
+        return []
+
+    lib.ggml_backend_cuda_get_device_count.restype = ctypes.c_int
+    lib.ggml_backend_cuda_get_device_description.restype = None
+    lib.ggml_backend_cuda_get_device_description.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+
+    count = lib.ggml_backend_cuda_get_device_count()
+    devices = []
+    for i in range(count):
+        buf = ctypes.create_string_buffer(256)
+        lib.ggml_backend_cuda_get_device_description(i, buf, 256)
+        name = buf.value.decode("utf-8", errors="ignore").strip() or "CUDA device"
+        cap = caps.get(i)
+        if cap:
+            devices.append(f"GPU {i}: {name} - Compute Capability {cap}")
+        else:
+            devices.append(f"GPU {i}: {name}")
+    return devices
+
+
+def _enum_via_ggml_dev_api(libs, caps: dict[int, str]) -> list[str]:
+    lib = _find_symbol(libs, "ggml_backend_dev_count")
+    required = (
+        "ggml_backend_dev_get",
+        "ggml_backend_dev_type",
+        "ggml_backend_dev_description",
+        "ggml_backend_dev_name",
+    )
+    if lib is None or not all(hasattr(lib, s) for s in required):
+        return []
+
+    lib.ggml_backend_dev_count.restype = ctypes.c_size_t
+    lib.ggml_backend_dev_get.restype = ctypes.c_void_p
+    lib.ggml_backend_dev_get.argtypes = [ctypes.c_size_t]
+    lib.ggml_backend_dev_type.restype = ctypes.c_int
+    lib.ggml_backend_dev_type.argtypes = [ctypes.c_void_p]
+    lib.ggml_backend_dev_description.restype = ctypes.c_char_p
+    lib.ggml_backend_dev_description.argtypes = [ctypes.c_void_p]
+    lib.ggml_backend_dev_name.restype = ctypes.c_char_p
+    lib.ggml_backend_dev_name.argtypes = [ctypes.c_void_p]
+
+    # GGML_BACKEND_DEVICE_TYPE_CPU = 0, GPU = 1, ACCEL = 2
+    count = lib.ggml_backend_dev_count()
+    devices = []
+    gpu_idx = 0
+    for i in range(count):
+        dev = lib.ggml_backend_dev_get(i)
+        if not dev:
+            continue
+        if lib.ggml_backend_dev_type(dev) == 0:
+            continue
+        desc = lib.ggml_backend_dev_description(dev) or lib.ggml_backend_dev_name(dev)
+        name = desc.decode("utf-8", errors="ignore").strip() if desc else "GPU"
+        cap = caps.get(gpu_idx)
+        if cap:
+            devices.append(f"GPU {gpu_idx}: {name} - Compute Capability {cap}")
+        else:
+            devices.append(f"GPU {gpu_idx}: {name}")
+        gpu_idx += 1
+    return devices
+
+
 @lru_cache(maxsize=1)
 def get_llama_gpu_devices_formatted() -> list[str]:
-    """
-    Return a list of formatted GPU device strings detected by llama_cpp.
-    Example: ["GPU 0: NVIDIA GeForce RTX 3070 - Compute Capability 8.6"]
+    """GPU device strings visible to llama_cpp (not torch).
+    Example: ["GPU 0: NVIDIA GeForce RTX 5080 - Compute Capability 12.0"]
     """
     if llama_cpp is None:
         return []
 
-    # Python code executed in a child process to trigger llama's CUDA init logging
-    code = textwrap.dedent(
-        """
-        import os, re
-        from pathlib import Path
-        import llama_cpp
+    try:
+        _load_llama_lib()  # installs log callback
+        libs = _all_ggml_libs()
+        if not libs:
+            return []
 
-        lib = llama_cpp.llama_cpp.load_shared_library(
-            "llama", Path(os.path.dirname(llama_cpp.__file__)) / "lib"
-        )
-        try:
-            _ = lib.llama_supports_gpu_offload()
-        except Exception:
-            pass
-        """
-    )
+        # Trigger CUDA init so compute-capability line lands in _log_capture
+        cuda_lib = _find_symbol(libs, "ggml_backend_cuda_get_device_count")
+        if cuda_lib is not None:
+            cuda_lib.ggml_backend_cuda_get_device_count.restype = ctypes.c_int
+            try:
+                cuda_lib.ggml_backend_cuda_get_device_count()
+            except Exception:
+                pass
 
-    proc = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-    )
-
-    captured = proc.stdout + proc.stderr
-
-    # Parse the CUDA log output
-    pattern = r"Device\s*(\d+):\s*([^,]+),\s*compute capability\s*([\d.]+)"
-    formatted_devices = []
-    for m in re.finditer(pattern, captured):
-        index = int(m.group(1))
-        name = m.group(2).strip()
-        compute_cap = m.group(3)
-        formatted_devices.append(
-            f"GPU {index}: {name} - Compute Capability {compute_cap}"
-        )
-
-    return formatted_devices
+        caps = _parse_compute_caps("".join(_log_capture))
+        devices = _enum_via_cuda_api(libs, caps)
+        if devices:
+            return devices
+        return _enum_via_ggml_dev_api(libs, caps)
+    except Exception as e:
+        logger.warning("Error enumerating llama GPUs: %s", e)
+        return []
 
 
 def is_gpu_available_for_llama_cpp() -> bool:
-    """Check whether the installed llama-cpp-python was compiled with GPU support.
-
-    Dispatches to a version-specific helper based on the ``llama_cpp`` package
-    version, because the internal API changed between 0.2.x and 0.3.x.
-
-    Returns
-    -------
-    bool
-        ``True`` if GPU offloading is available; ``False`` if ``llama-cpp-python``
-        is not installed or if the check raises an unexpected exception.
-    """
     if llama_cpp is None:
         return False
-
     try:
         if Version(llama_cpp.__version__) > Version("0.3.0"):
             return __is_gpu_available_for_llama_cpp_v03()
         else:
             return __is_gpu_available_for_llama_cpp_v02()
-
     except Exception as e:
         logger.warning(
             "Error checking GPU availability for llama_cpp. Will use CPU only.\n"
@@ -95,36 +217,10 @@ def is_gpu_available_for_llama_cpp() -> bool:
 
 
 def __is_gpu_available_for_llama_cpp_v03() -> bool:
-    """Check GPU availability using the llama.cpp v0.3 shared-library API.
-
-    Loads the ``llama`` shared library from the llama_cpp package directory and
-    calls ``llama_supports_gpu_offload`` to determine whether the build was
-    compiled with GPU support.
-
-    Returns
-    -------
-    bool
-        ``True`` if ``llama_supports_gpu_offload()`` returns a truthy value,
-        ``False`` otherwise.
-    """
-    lib = llama_cpp.llama_cpp.load_shared_library(
-        "llama", Path(os.path.dirname(llama_cpp.__file__)) / "lib"
-    )
+    lib = _load_llama_lib()
     return bool(lib.llama_supports_gpu_offload())
 
 
 def __is_gpu_available_for_llama_cpp_v02() -> bool:
-    """Check GPU availability using the llama.cpp v0.2 shared-library API.
-
-    Loads the ``llama`` shared library via the legacy ``_load_shared_library``
-    helper and inspects it for the ``ggml_init_cublas`` symbol, which is only
-    present in CUDA-enabled builds.
-
-    Returns
-    -------
-    bool
-        ``True`` if the ``ggml_init_cublas`` attribute is found in the loaded
-        library, ``False`` otherwise.
-    """
     lib = llama_cpp.llama_cpp._load_shared_library("llama")
     return hasattr(lib, "ggml_init_cublas")

--- a/DashAI/back/models/utils.py
+++ b/DashAI/back/models/utils.py
@@ -32,4 +32,4 @@ if is_gpu_available_for_llama_cpp():
     cuda_devices = get_llama_gpu_devices_formatted()
     LLAMA_DEVICE_ENUM = cuda_devices + ["CPU"]
     LLAMA_DEVICE_PLACEHOLDER = LLAMA_DEVICE_ENUM[0]
-    LLAMA_DEVICE_TO_IDX.update({name: i - 1 for i, name in enumerate(cuda_devices)})
+    LLAMA_DEVICE_TO_IDX.update({name: i for i, name in enumerate(cuda_devices)})


### PR DESCRIPTION
## Summary  
Fixes GPU device detection in PyInstaller builds and corrects device indexing. Replaces the subprocess-based approach (which failed in frozen executables) with direct `ctypes` calls to ggml backends, and fixes an incorrect `LLAMA_DEVICE_TO_IDX` mapping that caused wrong device selection (e.g., using GPU when CPU was intended).

---

## Type of Change  
Check all that apply like this [x]:

- [x] Backend change  
- [ ] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  

- `llama_utils.py`:  
  - Replaced subprocess-based GPU detection with direct `ctypes` calls to `ggml-cuda` / `ggml` backends.  
  - Implemented `llama_log_set` callback to capture initialization logs and extract compute capability.  
  - Ensures GPU detection works in both development and PyInstaller (frozen) environments.  

- `utils.py`:  
  - Fixed `LLAMA_DEVICE_TO_IDX` mapping to use correct indices, preventing incorrect device selection.  

---

## Testing (optional)  

- Run in a PyInstaller-built executable and confirm GPU devices are detected.  
- Verify correct device selection when choosing CPU vs GPU.  
- Compare detected devices with llama.cpp CLI output for consistency.  
- Verify llama models still work on a CPU only environment.