### PR TITLE
Fix CPU offload initialization to run only on accelerator devices

### DIFF
--- a/DashAI/back/models/hugging_face/sd15_depth_controlnet_model.py
+++ b/DashAI/back/models/hugging_face/sd15_depth_controlnet_model.py
@@ -247,7 +247,8 @@ class SD15DepthControlNetModel(BaseControlNetModel):
         self.num_inference_steps = kwargs.get("num_inference_steps")
         self.guidance_scale = kwargs.get("guidance_scale")
 
-        self.pipe.enable_model_cpu_offload()
+        if self.device != "cpu":
+            self.pipe.enable_model_cpu_offload()
 
     def generate(self, input: Tuple["Image.Image", str]) -> List[Any]:
         """Generate output from a generative model.

--- a/DashAI/back/models/hugging_face/sd15_hed_controlnet_model.py
+++ b/DashAI/back/models/hugging_face/sd15_hed_controlnet_model.py
@@ -218,7 +218,8 @@ class SD15HEDControlNetModel(BaseControlNetModel):
         self.num_inference_steps = kwargs.get("num_inference_steps")
         self.guidance_scale = kwargs.get("guidance_scale")
 
-        self.pipe.enable_model_cpu_offload()
+        if self.device != "cpu":
+            self.pipe.enable_model_cpu_offload()
 
     def generate(self, input: Tuple["Image.Image", str]) -> List[Any]:
         """Generate output from a generative model.

--- a/DashAI/back/models/hugging_face/sd15_openpose_controlnet_model.py
+++ b/DashAI/back/models/hugging_face/sd15_openpose_controlnet_model.py
@@ -212,7 +212,8 @@ class SD15OpenPoseControlNetModel(BaseControlNetModel):
         self.num_inference_steps = kwargs.get("num_inference_steps")
         self.guidance_scale = kwargs.get("guidance_scale")
 
-        self.pipe.enable_model_cpu_offload()
+        if self.device != "cpu":
+            self.pipe.enable_model_cpu_offload()
 
     def generate(self, input: Tuple["Image.Image", str]) -> List[Any]:
         """Generate output from a generative model.

--- a/DashAI/back/models/hugging_face/sdxl_canny_controlnet_model.py
+++ b/DashAI/back/models/hugging_face/sdxl_canny_controlnet_model.py
@@ -282,7 +282,8 @@ class SDXLCannyControlNetModel(BaseControlNetModel):
         self.controlnet_conditioning_scale = kwargs.get("controlnet_conditioning_scale")
         self.num_inference_steps = kwargs.get("num_inference_steps")
 
-        self.pipe.enable_model_cpu_offload()
+        if self.device != "cpu":
+            self.pipe.enable_model_cpu_offload()
 
     def generate(self, input: Tuple["Image.Image", str]) -> List[Any]:
         """Generate output from a generative model.

--- a/DashAI/back/models/hugging_face/stable_diffusion_v1_depth_controlnet.py
+++ b/DashAI/back/models/hugging_face/stable_diffusion_v1_depth_controlnet.py
@@ -239,7 +239,8 @@ class StableDiffusionXLV1ControlNet(BaseControlNetModel):
         self.controlnet_conditioning_scale = kwargs.get("controlnet_conditioning_scale")
         self.num_inference_steps = kwargs.get("num_inference_steps")
 
-        self.pipe.enable_model_cpu_offload()
+        if self.device != "cpu":
+            self.pipe.enable_model_cpu_offload()
 
     def generate(self, input: Tuple[Any, str]) -> List[Any]:
         """Generate output from a generative model.


### PR DESCRIPTION
## Summary
Conditionally enable `enable_model_cpu_offload()` only when running on non-CPU devices across multiple ControlNet model classes. This prevents runtime errors when no accelerator (e.g., GPU) is available and improves compatibility and memory handling on CPU-only environments.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `sd15_depth_controlnet_model.py`: Added device check before calling `enable_model_cpu_offload()`.
- `sd15_hed_controlnet_model.py`: Applied conditional CPU offload based on device.
- `sd15_openpose_controlnet_model.py`: Added guard to avoid CPU offload on CPU.
- `sdxl_canny_controlnet_model.py`: Enabled CPU offload only when running on accelerator.
- `stable_diffusion_v1_depth_controlnet.py`: Added device check to prevent invalid offload call.

---

## Testing (optional)
- Run model initialization on a CPU-only environment and verify no exception is raised.
- Run on GPU-enabled environment and confirm CPU offload is still applied correctly.

---

## Notes (optional)
Fixes runtime error:  
`RuntimeError: enable_model_cpu_offload requires accelerator, but not found`  
triggered when attempting to enable CPU offload on systems without GPU/accelerator support.