### PR TITLE
remove search bar from SelectTaskMenu and ModelCenterContent components

### DIFF
--- a/DashAI/front/src/components/generative/SelectTaskMenu.jsx
+++ b/DashAI/front/src/components/generative/SelectTaskMenu.jsx
@@ -55,7 +55,7 @@ export default function SelectTaskMenu() {
         description: task.description,
         Icon: GENERATIVE_TASK_ICONS[task.name] || DefaultGenerativeIcon,
       }))}
-      searchBar={true}
+      searchBar={false}
       dataTour="task-selection"
       dataTourTarget="TextToTextGenerationTask"
     />

--- a/DashAI/front/src/components/models/ModelCenterContent.jsx
+++ b/DashAI/front/src/components/models/ModelCenterContent.jsx
@@ -136,7 +136,7 @@ export default function ModelsCenterContent() {
               task.description || task.metadata?.short_description || "",
             Icon: TASK_ICONS[task.name] || DefaultTaskIcon,
           }))}
-          searchBar={true}
+          searchBar={false}
           goToPrevStep={selectedDatasetId ? handleBackToDataset : null}
           showNoDatasetAlert={!selectedDatasetId && datasets.length === 0}
           onGoToDatasets={handleGoToDatasets}


### PR DESCRIPTION
## Summary
Removed search bars from Models and Generative task selection cards. With only 3-4 options currently available, the search bars provide no value and consume unnecessary UI space. The sidebar search remains unchanged.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/models/ModelCenterContent.jsx`: Changed `searchBar={true}` to `searchBar={false}` in SelectOptionMenu
- `DashAI/front/src/components/generative/SelectTaskMenu.jsx`: Changed `searchBar={true}` to `searchBar={false}` in SelectOptionMenu

---

## Testing (optional)
Verify that task/model selection cards render without search bars in both Models and Generative modules. Sidebar search functionality remains intact.
