### PR TITLE
Align "Model Parameters" heading with primary text color

### DIFF
--- a/DashAI/front/src/components/generative/ParamsBar.jsx
+++ b/DashAI/front/src/components/generative/ParamsBar.jsx
@@ -140,7 +140,9 @@ export default function ParamsBar({ onToggle }) {
             height: 70,
           }}
         >
-          <Typography variant="h6">{t("common:modelParameters")}</Typography>
+          <Typography variant="h6" color="text.primary">
+            {t("common:modelParameters")}
+          </Typography>
 
           {/* Parameter History Modal */}
           {selectedSessionId && (


### PR DESCRIPTION
## Summary
Fixes the visual consistency of the `ParamsBar` component by ensuring the "Model Parameters" heading uses the application's primary text color.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `ParamsBar.jsx`: Updated the "Model Parameters" `Typography` component to explicitly use the `text.primary` color.

---

## Testing (optional)
- Verify that the "Model Parameters" heading displays using the primary text color in both light and dark themes.