### PR TITLE
Update backend setup instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,13 +115,6 @@ First, set the python enviroment, for that you can use
     $ conda create -n dashai python=3.10
     $ conda activate dashai
 
-Then, move to `DashAI/back`
-
-.. code:: bash
-
-    $ cd DashAI/back
-
-
 Later, install the requirements:
 
 .. code:: bash
@@ -133,9 +126,9 @@ Later, install the requirements:
 Running the Backend
 ~~~~~~~~~~~~~~~~~~~
 
-There are three ways to run DashAI:
+There are two ways to run DashAI:
 
-1. By executing DashAI as a module:
+1. By executing DashAI as a module from the root of the repository:
 
 .. code:: bash
 


### PR DESCRIPTION
## Summary
Updated the `README.rst` setup and execution instructions. The documentation now reflects the correct workflow for running DashAI from the repository root and removes outdated steps that could cause confusion for new users.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [x] Documentation

---

## Changes (by file)
- `README.rst`: Removed the outdated instruction to manually change directories to `DashAI/back` during setup.
- `README.rst`: Clarified that DashAI should be run as a Python module from the root of the repository.
- `README.rst`: Updated the execution section to reflect the two currently supported methods for running DashAI, replacing the previous reference to three methods.
