### PR TITLE
Dockerfile+docker compose for demo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git/
+__pycache__/
+*.pyc
+*.pyo
+build/
+dist/
+node_modules/
+DashAI/front/.pnp.cjs
+DashAI/front/.pnp.loader.mjs
+DashAI/front/node_modules/
+DashAI/front/build/

--- a/DashAI/__main__.py
+++ b/DashAI/__main__.py
@@ -108,7 +108,7 @@ def _start_backend_server(
 
     uvicorn.run(
         app=app,
-        host="127.0.0.1",
+        host=os.environ.get("DASHAI_HOST", "127.0.0.1"),
         port=8000,
     )
 

--- a/DashAI/front/.env.production
+++ b/DashAI/front/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:8000/api
+REACT_APP_API_URL=/api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: build frontend static assets
+FROM node:22-alpine AS frontend
+WORKDIR /app/DashAI/front
+COPY DashAI/front/ ./
+RUN corepack enable && yarn install --frozen-lockfile && yarn build
+
+# Stage 2: Python backend serving the built frontend
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+COPY --from=frontend /app/DashAI/front/build DashAI/front/build
+RUN pip install --no-cache-dir -e .
+ENV DASHAI_HOST=0.0.0.0
+EXPOSE 8000
+CMD ["python", "-m", "DashAI", "--no-browser"]

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,82 @@
+services:
+  dashai-1:
+    image: dashai:latest
+    ports:
+      - "8001:8000"
+    volumes:
+      - dashai-data-1:/root/.DashAI
+
+  dashai-2:
+    image: dashai:latest
+    ports:
+      - "8002:8000"
+    volumes:
+      - dashai-data-2:/root/.DashAI
+
+  dashai-3:
+    image: dashai:latest
+    ports:
+      - "8003:8000"
+    volumes:
+      - dashai-data-3:/root/.DashAI
+
+  dashai-4:
+    image: dashai:latest
+    ports:
+      - "8004:8000"
+    volumes:
+      - dashai-data-4:/root/.DashAI
+
+  dashai-5:
+    image: dashai:latest
+    ports:
+      - "8005:8000"
+    volumes:
+      - dashai-data-5:/root/.DashAI
+
+  dashai-6:
+    image: dashai:latest
+    ports:
+      - "8006:8000"
+    volumes:
+      - dashai-data-6:/root/.DashAI
+
+  dashai-7:
+    image: dashai:latest
+    ports:
+      - "8007:8000"
+    volumes:
+      - dashai-data-7:/root/.DashAI
+
+  dashai-8:
+    image: dashai:latest
+    ports:
+      - "8008:8000"
+    volumes:
+      - dashai-data-8:/root/.DashAI
+
+  dashai-9:
+    image: dashai:latest
+    ports:
+      - "8009:8000"
+    volumes:
+      - dashai-data-9:/root/.DashAI
+
+  dashai-10:
+    image: dashai:latest
+    ports:
+      - "8010:8000"
+    volumes:
+      - dashai-data-10:/root/.DashAI
+
+volumes:
+  dashai-data-1:
+  dashai-data-2:
+  dashai-data-3:
+  dashai-data-4:
+  dashai-data-5:
+  dashai-data-6:
+  dashai-data-7:
+  dashai-data-8:
+  dashai-data-9:
+  dashai-data-10:


### PR DESCRIPTION
## Summary

Adds Docker support to run DashAI in a containerized environment, e.g. for demos or remote deployments where multiple isolated instances are needed on the same machine. The frontend build and backend are served from a single container, keeping the setup simple.

---

## Type of Change

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `Dockerfile`: Multi-stage build — Node 22 compiles the frontend, Python 3.11 installs the package and serves everything from a single container on port 8000.
- `.dockerignore`: Excludes `.git`, `node_modules`, build artifacts, and Yarn PnP state files from the build context.
- `docker-compose.demo.yml`: Defines 10 named instances of the image on ports 8001–8010, each with its own persistent volume for `~/.DashAI`.
- `DashAI/__main__.py`: Uvicorn host is now read from `DASHAI_HOST` env var (default `127.0.0.1`). The Dockerfile sets it to `0.0.0.0` so containers are reachable from outside. No behavior change for local development.
- `DashAI/front/.env.production`: Changed `REACT_APP_API_URL` from `http://localhost:8000/api` to `/api` (relative). Fixes API calls when the app is accessed from a remote host — previously all requests went to the user's own `localhost` instead of the server.

---

## Testing

- Build the image: `docker build -t dashai:latest .`
- Run a single instance: `docker run --rm -p 8001:8000 dashai:latest`
- Verify the app loads and API calls succeed at `http://localhost:8001`

---

## Notes

For the demo deployment on GCP (`southamerica-west1`), spin up a `e2-standard-4` VM, open ports 8001–8010, and run `docker compose -f docker-compose.demo.yml up -d`. Each participant gets their own URL (`http://[ip]:800X`).
