### PR TITLE
ui: fixed-size selection cards with description truncation  

### DIFF
--- a/DashAI/back/tasks/regression_task.py
+++ b/DashAI/back/tasks/regression_task.py
@@ -23,17 +23,14 @@ class RegressionTask(BaseTask):
     """
 
     DESCRIPTION: str = MultilingualString(
-        en="""
-    Regression in machine learning involves predicting continuous values for
-    structured data organized in tabular form (rows and columns).
-    Models are trained to learn patterns and relationships in the data,
-    enabling accurate prediction of new instances.""",
-        es="""
-    La regresión en el aprendizaje automático implica predecir valores
-    continuos para datos estructurados organizados en
-    forma tabular (filas y columnas).
-    Los modelos se entrenan para aprender patrones y relaciones en los datos,
-    lo que permite una predicción precisa de nuevas instancias.""",
+        en=(
+            "Predict continuous numeric values from structured tabular data "
+            "using trained regression models."
+        ),
+        es=(
+            "Predice valores numéricos continuos a partir de datos tabulares "
+            "estructurados usando modelos de regresión."
+        ),
     )
     DISPLAY_NAME: str = MultilingualString(en="Regression", es="Regresión")
 

--- a/DashAI/back/tasks/tabular_classification_task.py
+++ b/DashAI/back/tasks/tabular_classification_task.py
@@ -23,18 +23,12 @@ class TabularClassificationTask(ClassificationTask):
 
     DESCRIPTION: str = MultilingualString(
         en=(
-            "Tabular classification in machine learning involves predicting "
-            "categorical labels for structured data organized in tabular form "
-            "(rows and columns). Models are trained to learn patterns and "
-            "relationships in the data, enabling accurate classification of "
-            "new instances."
+            "Predict categorical labels from structured tabular data "
+            "(rows and columns) using trained classification models."
         ),
         es=(
-            "La clasificación tabular en el aprendizaje automático implica "
-            "predecir etiquetas categóricas para datos estructurados "
-            "organizados en forma tabular (filas y columnas). Los modelos se "
-            "entrenan para aprender patrones y relaciones en los datos, "
-            ", lo que permite una clasificación precisa de nuevas instancias."
+            "Predice etiquetas categóricas a partir de datos tabulares "
+            "estructurados (filas y columnas) usando modelos de clasificación."
         ),
     )
     DISPLAY_NAME: str = MultilingualString(

--- a/DashAI/back/tasks/text_classification_task.py
+++ b/DashAI/back/tasks/text_classification_task.py
@@ -31,20 +31,13 @@ class TextClassificationTask(ClassificationTask):
 
     DESCRIPTION: str = MultilingualString(
         en=(
-            "Text classification is a Natural Language Processing (NLP) task "
-            "that assigns a predefined label to a text input. "
-            "It requires one text input column and one categorical output column. "
-            "Common use cases include sentiment analysis, spam detection, "
-            "and intent recognition."
+            "Assign predefined labels to text inputs using NLP models. "
+            "Common uses: sentiment analysis, spam detection, intent recognition."
         ),
         es=(
-            "La clasificación de texto es una tarea de Procesamiento de "
-            "Lenguaje Natural (PLN) que asigna una etiqueta predefinida a una "
-            "entrada de texto. "
-            "Requiere una columna de entrada de tipo texto y una columna de "
-            "salida categórica. "
-            "Los casos de uso más comunes incluyen análisis de sentimientos, "
-            "detección de spam y reconocimiento de intenciones."
+            "Asigna etiquetas predefinidas a textos mediante modelos de PLN. "
+            "Usos comunes: análisis de sentimientos, detección de spam, "
+            "reconocimiento de intenciones."
         ),
     )
     DISPLAY_NAME: str = MultilingualString(

--- a/DashAI/back/tasks/translation_task.py
+++ b/DashAI/back/tasks/translation_task.py
@@ -42,16 +42,14 @@ class TranslationTask(BaseTask):
         "outputs_cardinality": 1,
     }
     DESCRIPTION: str = MultilingualString(
-        en="""
-    The translation task is natural language processing (NLP) task that involves
-    converting text or speech from one language into another language while
-    preserving the meaning and context.
-    """,
-        es="""
-    La tarea de traducción es una tarea de procesamiento de lenguaje natural (PLN)
-    que implica convertir texto o habla de un idioma a otro idioma mientras se
-    preserva el significado y el contexto.
-    """,
+        en=(
+            "Convert text from one language to another while "
+            "preserving meaning and context."
+        ),
+        es=(
+            "Convierte texto de un idioma a otro preservando "
+            "el significado y el contexto."
+        ),
     )
 
     DISPLAY_NAME: str = MultilingualString(en="Translation", es="Traducción")

--- a/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
@@ -1,4 +1,7 @@
-import { Box, Typography, ButtonBase, useTheme } from "@mui/material";
+import { useRef, useState, useEffect } from "react";
+import { Box, Typography, ButtonBase, Tooltip, useTheme } from "@mui/material";
+
+const DESCRIPTION_MAX_LINES = 3;
 
 export default function OptionBox({
   optionName,
@@ -9,6 +12,15 @@ export default function OptionBox({
   dataTour,
   ...otherProps
 }) {
+  const descRef = useRef(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = descRef.current;
+    if (el) {
+      setIsTruncated(el.scrollHeight > el.clientHeight);
+    }
+  }, [description]);
   const theme = useTheme();
   const accent = theme.palette.accent.amber;
   const accentDim = theme.palette.accent.amberDim;
@@ -21,7 +33,7 @@ export default function OptionBox({
       onClick={onClick}
       sx={{
         width: "100%",
-        height: "100%",
+        height: 250,
         textAlign: "left",
         display: "flex",
         flexDirection: "column",
@@ -93,18 +105,31 @@ export default function OptionBox({
       </Typography>
 
       {/* Description */}
-      <Typography
-        sx={{
-          fontSize: "15px",
-          fontWeight: 300,
-          color: theme.palette.text.secondary,
-          lineHeight: 1.65,
-          flexGrow: 1,
-          width: "100%",
-        }}
+      <Tooltip
+        title={isTruncated ? description : ""}
+        arrow
+        enterDelay={300}
+        placement="bottom"
       >
-        {description}
-      </Typography>
+        <Typography
+          ref={descRef}
+          sx={{
+            fontSize: "15px",
+            fontWeight: 300,
+            color: theme.palette.text.secondary,
+            lineHeight: 1.65,
+            flexGrow: 1,
+            width: "100%",
+            display: "-webkit-box",
+            WebkitLineClamp: DESCRIPTION_MAX_LINES,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {description}
+        </Typography>
+      </Tooltip>
 
       {/* Footer: chips + arrow */}
       <Box


### PR DESCRIPTION
## Summary                                                                                                   
  Standardize selection card sizes across all modules (Datasets, Models, Generative). Cards now have a fixed
  height, shorter task descriptions, and long text is truncated with an ellipsis — full description is shown on
   hover via tooltip.                                                                                          
                                                                                                               
  ---                                                                                                          
   
  ## Type of Change                                                                                            
                                                            
  - [x] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [ ] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/back/tasks/tabular_classification_task.py`: Shortened DESCRIPTION (en/es) to ~2 lines              
  - `DashAI/back/tasks/text_classification_task.py`: Shortened DESCRIPTION (en/es) to ~2 lines
  - `DashAI/back/tasks/regression_task.py`: Shortened DESCRIPTION (en/es) to ~2 lines                          
  - `DashAI/back/tasks/translation_task.py`: Shortened DESCRIPTION (en/es) to ~2 lines                         
  - `DashAI/front/src/components/threeSectionLayout/OptionBox.jsx`: Set fixed card height (250px), added 3-line
   clamp truncation with ellipsis, and a Tooltip that shows the full description on hover when text is         
  truncated                                                 
                                                                                                               
  ---                                                                                                          
   
  ## Testing                                                                                                   
                                                            
  - Verify cards in **Datasets**, **Models**, and **Generative** home pages all render at the same height
  - Confirm long descriptions are truncated with `...` after 3 lines
  - Hover over a truncated description and verify the full text appears in a tooltip
  - Check that short descriptions (e.g. Datasets module) do **not** show a tooltip on hover  