### PR TITLE
Update tutorials sidebar link to current documentation URL

### DIFF
--- a/DashAI/front/src/pages/home/Home.jsx
+++ b/DashAI/front/src/pages/home/Home.jsx
@@ -30,7 +30,7 @@ const SIDEBAR_LINKS = {
     },
     {
       key: "tutorials",
-      href: "https://docs.dash-ai.com/tutorials/upload_dataset.html",
+      href: "https://docs.dash-ai.com/learn/tutorials/upload-dataset",
       Icon: TutorialsIcon,
     },
     {


### PR DESCRIPTION
## Summary
Updated the tutorials link in `Home.jsx` to point to the current documentation URL.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `src/pages/Home.jsx`: Updated the `SIDEBAR_LINKS` configuration to correct the URL for the "tutorials" link.

---

## Testing (optional)
- Verify that clicking the "Tutorials" link from the home page sidebar opens the correct documentation page.