### PR TITLE
Correctly render inline code and modularize TextMessage code components

### DIFF
--- a/DashAI/front/src/components/generative/TextMessage.jsx
+++ b/DashAI/front/src/components/generative/TextMessage.jsx
@@ -1,82 +1,20 @@
-import { useState } from "react";
-import { Box, IconButton, Tooltip, Typography, useTheme } from "@mui/material";
-import CheckIcon from "@mui/icons-material/Check";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { Box, Typography } from "@mui/material";
 import Markdown from "react-markdown";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import {
-  oneDark,
-  oneLight,
-} from "react-syntax-highlighter/dist/esm/styles/prism";
+import { CodeBlock } from "./textMessage/CodeBlock";
+import { InlineCode } from "./textMessage/InlineCode";
 
-function CopyButton({ text }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  };
-
-  return (
-    <Tooltip title={copied ? "Copied!" : "Copy"}>
-      <IconButton
-        size="small"
-        onClick={handleCopy}
-        sx={{ color: "grey.400", "&:hover": { color: "grey.100" } }}
-      >
-        {copied ? (
-          <CheckIcon fontSize="inherit" />
-        ) : (
-          <ContentCopyIcon fontSize="inherit" />
-        )}
-      </IconButton>
-    </Tooltip>
-  );
-}
-
-function CodeBlock({ language, children }) {
-  const theme = useTheme();
-  const isDark = theme.palette.mode === "dark";
-  const code = String(children).replace(/\n$/, "");
-
-  return (
-    <Box
-      sx={{
-        borderRadius: 1,
-        overflow: "hidden",
-        my: 1,
-        border: "1px solid",
-        borderColor: "divider",
-      }}
-    >
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          px: 1.5,
-          py: 0.5,
-          bgcolor: isDark ? "grey.900" : "grey.200",
-        }}
-      >
-        <Typography variant="caption" sx={{ color: "text.secondary" }}>
-          {language || "code"}
-        </Typography>
-        <CopyButton text={code} />
-      </Box>
-      <SyntaxHighlighter
-        language={language || "text"}
-        style={isDark ? oneDark : oneLight}
-        customStyle={{ margin: 0, borderRadius: 0, fontSize: "0.85em" }}
-        PreTag="div"
-      >
-        {code}
-      </SyntaxHighlighter>
-    </Box>
-  );
-}
+const markdownComponents = {
+  code({ className, children, ...props }) {
+    const match = /language-(\w+)/.exec(className || "");
+    if (match) {
+      return <CodeBlock language={match[1]}>{children}</CodeBlock>;
+    }
+    return <InlineCode {...props}>{children}</InlineCode>;
+  },
+  pre({ children }) {
+    return <>{children}</>;
+  },
+};
 
 export function TextMessage({ message, isError = false }) {
   return (
@@ -86,37 +24,7 @@ export function TextMessage({ message, isError = false }) {
         component="div"
         color={isError ? "red" : "text.primary"}
       >
-        <Markdown
-          components={{
-            code({ node, inline, className, children, ...props }) {
-              const match = /language-(\w+)/.exec(className || "");
-              if (!inline) {
-                return (
-                  <CodeBlock language={match ? match[1] : null}>
-                    {children}
-                  </CodeBlock>
-                );
-              }
-              return (
-                <Box
-                  component="code"
-                  sx={{
-                    px: 0.5,
-                    py: 0.1,
-                    borderRadius: 0.5,
-                    bgcolor: "action.hover",
-                    fontSize: "0.85em",
-                  }}
-                  {...props}
-                >
-                  {children}
-                </Box>
-              );
-            },
-          }}
-        >
-          {message}
-        </Markdown>
+        <Markdown components={markdownComponents}>{message}</Markdown>
       </Typography>
     </Box>
   );

--- a/DashAI/front/src/components/generative/textMessage/CodeBlock.jsx
+++ b/DashAI/front/src/components/generative/textMessage/CodeBlock.jsx
@@ -1,0 +1,49 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  oneDark,
+  oneLight,
+} from "react-syntax-highlighter/dist/esm/styles/prism";
+import { CopyButton } from "./CopyButton";
+
+export function CodeBlock({ language, children }) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+  const code = String(children).replace(/\n$/, "");
+
+  return (
+    <Box
+      sx={{
+        borderRadius: 1,
+        overflow: "hidden",
+        my: 1,
+        border: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: 1.5,
+          py: 0.5,
+          bgcolor: isDark ? "grey.900" : "grey.200",
+        }}
+      >
+        <Typography variant="caption" sx={{ color: "text.secondary" }}>
+          {language || "code"}
+        </Typography>
+        <CopyButton text={code} />
+      </Box>
+      <SyntaxHighlighter
+        language={language || "text"}
+        style={isDark ? oneDark : oneLight}
+        customStyle={{ margin: 0, borderRadius: 0, fontSize: "0.85em" }}
+        PreTag="div"
+      >
+        {code}
+      </SyntaxHighlighter>
+    </Box>
+  );
+}

--- a/DashAI/front/src/components/generative/textMessage/CopyButton.jsx
+++ b/DashAI/front/src/components/generative/textMessage/CopyButton.jsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { IconButton, Tooltip } from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
+export function CopyButton({ text }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Tooltip title={copied ? "Copied!" : "Copy"}>
+      <IconButton
+        size="small"
+        onClick={handleCopy}
+        sx={{ color: "grey.400", "&:hover": { color: "grey.100" } }}
+      >
+        {copied ? (
+          <CheckIcon fontSize="inherit" />
+        ) : (
+          <ContentCopyIcon fontSize="inherit" />
+        )}
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/DashAI/front/src/components/generative/textMessage/InlineCode.jsx
+++ b/DashAI/front/src/components/generative/textMessage/InlineCode.jsx
@@ -1,0 +1,19 @@
+import { Box } from "@mui/material";
+
+export function InlineCode({ children, ...props }) {
+  return (
+    <Box
+      component="code"
+      sx={{
+        px: 0.5,
+        py: 0.1,
+        borderRadius: 0.5,
+        bgcolor: "action.hover",
+        fontSize: "0.85em",
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
Fixed an issue where inline code was incorrectly rendered as fenced code blocks in `TextMessage`. As part of this fix, the Markdown code rendering logic was refactored by extracting code blocks, inline code, and the copy-to-clipboard button into dedicated components.


### Before
<img width="2559" height="1355" alt="image" src="https://github.com/user-attachments/assets/41d640c0-854b-4d3c-a999-8197ac7c85d5" />

### After
<img width="2547" height="1348" alt="image" src="https://github.com/user-attachments/assets/b45477fc-311d-4124-96af-ff65ee3f1a8a" />

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `src/components/chat/TextMessage.jsx`: Fixed Markdown code rendering by correctly distinguishing inline code from fenced code blocks, and simplified rendering through a centralized `markdownComponents` object.
- `src/components/chat/textMessage/CodeBlock.jsx`: Added a dedicated component for rendering fenced code blocks with syntax highlighting and copy functionality.
- `src/components/chat/textMessage/CopyButton.jsx`: Added a reusable copy-to-clipboard button component for code snippets.
- `src/components/chat/textMessage/InlineCode.jsx`: Added a dedicated component for rendering inline code with consistent styling.

---

## Testing (optional)
- Verify that inline code is rendered inline rather than as a code block.
- Verify that fenced code blocks render correctly with syntax highlighting.
- Test the copy button to ensure code snippets are copied to the clipboard correctly.
- Ensure Markdown rendering behavior remains unchanged for non-code content.

---

## Notes (optional)
This change both resolves an inline code rendering bug and improves the overall modularity of the `TextMessage` code rendering implementation.