### PR TITLE
fix: redirect to upload flow when no datasets available

### DIFF
--- a/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
@@ -242,7 +242,7 @@ export default function SelectDatasetStep({
             <Trans i18nKey="explainers:label.noDatasetsAvailable">
               <AlertTitle>There are no datasets available.</AlertTitle>
               Go to
-              <Link component={RouterLink} to="/app/data">
+              <Link component={RouterLink} to="/app/data?action=upload">
                 data tab
               </Link>
               to upload one first.

--- a/DashAI/front/src/components/models/ModelCenterContent.jsx
+++ b/DashAI/front/src/components/models/ModelCenterContent.jsx
@@ -67,7 +67,7 @@ export default function ModelsCenterContent() {
   };
 
   const handleGoToDatasets = () => {
-    navigate("/app/data");
+    navigate("/app/data?action=upload");
   };
 
   const handleSessionCreated = (newSession) => {

--- a/DashAI/front/src/components/models/modelSession/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/models/modelSession/SelectDatasetStep.jsx
@@ -155,7 +155,7 @@ function SelectDatasetStep({ newExp, setNewExp, setNextEnabled }) {
             </AlertTitle>
             <Trans i18nKey="experiments:label.noDatasetsAvailableGoToDataTab">
               Go to
-              <Link component={RouterLink} to="/app/data">
+              <Link component={RouterLink} to="/app/data?action=upload">
                 data tab
               </Link>
               to upload one first.

--- a/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
@@ -1,4 +1,5 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 import NotebookVisualization from "../notebook/NotebookVisualization";
 import UploadDatasetSteps from "../datasetCreation/UploadDatasetSteps";
 import UploadNotebookSteps from "../notebookCreation/UploadNotebookSteps";
@@ -32,6 +33,16 @@ export default function DatasetsCenterContent() {
 
   const tourContext = useTourContext();
   const { t } = useTranslation(["datasets", "common"]);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get("action") === "upload" && step === 0) {
+      setStep(1);
+      setSelectedOption("dataset");
+      searchParams.delete("action");
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, [searchParams]);
 
   const selectedDataset = datasets.find((n) => n.id === selectedDatasetId);
   const selectedNotebook = notebooks.find((n) => n.id === selectedNotebookId);


### PR DESCRIPTION
## Summary                                                                                                   
  When users enter Models or Explainers without any datasets, the "Go to Datasets" link now navigates directly
  to the upload flow instead of the Datasets home, saving an extra click.                                      
                                                            
  ---                                                                                                          
                                                            
  ## Type of Change                                                                                            
                                                            
  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation
                                                                                                               
  ---
                                                                                                               
  ## Changes (by file)                                      

  - `DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx`: Read `?action=upload` query     
  param to enter the upload flow directly, then clean the param from the URL
  - `DashAI/front/src/components/models/ModelCenterContent.jsx`: Navigate to `/app/data?action=upload` instead 
  of `/app/data`                                                                                               
  - `DashAI/front/src/components/models/modelSession/SelectDatasetStep.jsx`: Same redirect fix in the "no
  datasets" alert link                                                                                         
  - `DashAI/front/src/components/explainers/SelectDatasetStep.jsx`: Same redirect fix in the "no datasets"
  alert link                                                                                                   
                                                            
  ---                                                                                                          
                                                            
  ## Testing

  - Enter **Models** with no datasets uploaded → click "Go to Datasets" → should land directly on the upload   
  form
  - Enter **Models** → create a session → dataset selection step with no datasets → click the "data tab" link →
   should land on the upload form                                                                              
  - Enter **Explainers** with no datasets → click the "data tab" link → same behavior
  - Navigate to `/app/data` without query params → should show the normal Datasets home (no side effects)    