### PR TITLE
Make URLs in model descriptions clickable in ModelCard

### DIFF
--- a/DashAI/front/src/components/generative/ModelCard.jsx
+++ b/DashAI/front/src/components/generative/ModelCard.jsx
@@ -1,10 +1,32 @@
 import { useEffect, useRef, useState } from "react";
-import { Box, Paper, Typography } from "@mui/material";
+import { Box, Link, Paper, Typography } from "@mui/material";
 import { alpha, useTheme } from "@mui/material/styles";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import { useTranslation } from "react-i18next";
 
 const DESCRIPTION_LINE_CLAMP = 3;
+const URL_SPLIT_REGEX = /(https?:\/\/[^\s<>"']+[^\s<>"'.,;:!?)\]}])/g;
+const URL_TEST_REGEX = /^https?:\/\//;
+
+function renderDescription(text) {
+  return text.split(URL_SPLIT_REGEX).map((part, i) => {
+    if (URL_TEST_REGEX.test(part)) {
+      return (
+        <Link
+          key={i}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          sx={{ wordBreak: "break-all" }}
+        >
+          {part}
+        </Link>
+      );
+    }
+    return part;
+  });
+}
 
 export default function ModelCard({
   model,
@@ -92,7 +114,7 @@ export default function ModelCard({
         }}
       >
         {model.description
-          ? model.description
+          ? renderDescription(model.description)
           : t("generative:label.noDescriptionAvailable")}
       </Typography>
 


### PR DESCRIPTION
## Summary
Improved the `ModelCard` component by automatically detecting URLs in model descriptions and rendering them as clickable links.

<img width="1680" height="554" alt="image" src="https://github.com/user-attachments/assets/0ad611b6-2bfe-4e60-8994-88a73a10b1eb" />

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `ModelCard.jsx`: Added a `renderDescription` helper to parse model descriptions and convert URLs into clickable links.
- `ModelCard.jsx`: Updated description rendering to use the new helper function.
- `ModelCard.jsx`: Imported `Link` from `@mui/material` to support external link rendering.

---

## Testing (optional)
- Verify that URLs in model descriptions are rendered as clickable links.
- Confirm that clicking a link opens it in a new browser tab.
- Ensure that clicking a link does not trigger the card's parent click event.
- Validate that descriptions without URLs continue to render normally.