### PR TITLE
fix: update DISPLAY_NAME for ControlNetTask to be more descriptive

### DIFF
--- a/DashAI/back/tasks/controlnet_task.py
+++ b/DashAI/back/tasks/controlnet_task.py
@@ -26,9 +26,7 @@ class ControlNetTask(BaseGenerativeTask):
         "outputs": {"Image": {"min": 1, "max": "n"}},
     }
 
-    DISPLAY_NAME: str = MultilingualString(
-        en="ControlNet Image Generation", es="Generación de Imágenes con ControlNet"
-    )
+    DISPLAY_NAME: str = MultilingualString(en="Image to Image", es="Imagen a Imagen")
     DESCRIPTION: str = MultilingualString(
         en="""
         This task generates images based on the


### PR DESCRIPTION
## Summary                                                                                                                                                
  Rename ControlNet task display name from "ControlNet Image Generation" to "Image to Image" so task cards describe what is done, not how. The mechanism
  (ControlNet) belongs to the model selection step.                                                                                                         
   
  ---                                                                                                                                                       
                                                            
  ## Type of Change                                                                                                                                         
   
  - [x] Backend change                                                                                                                                      
  - [ ] Frontend change                                     
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change                                                                                                                            
  - [ ] Bug fix
  - [ ] Documentation                                                                                                                                       
                                                            
  ---

  ## Changes (by file)                                                                                                                                      
   
  - `DashAI/back/tasks/controlnet_task.py`: Change `DISPLAY_NAME` from "ControlNet Image Generation" / "Generación de Imágenes con ControlNet" to "Image to 
  Image" / "Imagen a Imagen".                               
                                                                                                                                                            
  ---                                                       

  ## Testing (optional)                                                                                                                                     
  - Verify the Generative task selection screen shows "Image to Image" instead of "ControlNet Image Generation".