### PR TITLE
Feat/add models to all tasks

### DIFF
--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -123,12 +123,21 @@ from DashAI.back.metrics.translation.chrf import Chrf
 from DashAI.back.metrics.translation.ter import Ter
 
 # Models
+from DashAI.back.models.hugging_face.albert_transformer import AlbertTransformer
+from DashAI.back.models.hugging_face.bert_transformer import BertTransformer
+from DashAI.back.models.hugging_face.bertin_transformer import BertinTransformer
+from DashAI.back.models.hugging_face.beto_transformer import BetoTransformer
 from DashAI.back.models.hugging_face.deberta_v3_transformer import DebertaV3Transformer
 from DashAI.back.models.hugging_face.distilbert_transformer import DistilBertTransformer
+from DashAI.back.models.hugging_face.electra_transformer import ElectraTransformer
 from DashAI.back.models.hugging_face.llama_model import LlamaModel
+from DashAI.back.models.hugging_face.minilm_transformer import MiniLMTransformer
 from DashAI.back.models.hugging_face.mistral_model import MistralModel
 from DashAI.back.models.hugging_face.mixtral_model import MixtralModel
 from DashAI.back.models.hugging_face.modernbert_transformer import ModernBertTransformer
+from DashAI.back.models.hugging_face.multilingual_bert_transformer import (
+    MultilingualBertTransformer,
+)
 from DashAI.back.models.hugging_face.nllb_transformer import NllbTransformer
 from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
     OpusMtEnESTransformer,
@@ -138,6 +147,7 @@ from DashAI.back.models.hugging_face.opus_mt_es_en_transformer import (
 )
 from DashAI.back.models.hugging_face.pixart_sigma_model import PixArtSigmaModel
 from DashAI.back.models.hugging_face.qwen_model import QwenModel
+from DashAI.back.models.hugging_face.roberta_transformer import RobertaTransformer
 from DashAI.back.models.hugging_face.sd15_depth_controlnet_model import (
     SD15DepthControlNetModel,
 )
@@ -165,23 +175,50 @@ from DashAI.back.models.hugging_face.stable_diffusion_xl_model import (
     StableDiffusionXLModel,
 )
 from DashAI.back.models.hugging_face.tongyi_z_image_model import TongyiZImageModel
+from DashAI.back.models.hugging_face.xlm_roberta_transformer import (
+    XlmRobertaTransformer,
+)
+from DashAI.back.models.hugging_face.xlnet_transformer import XlnetTransformer
+from DashAI.back.models.scikit_learn.adaboost_classifier import AdaBoostClassifier
+from DashAI.back.models.scikit_learn.adaboost_regression import AdaBoostRegression
+from DashAI.back.models.scikit_learn.bagging_classifier import BaggingClassifier
+from DashAI.back.models.scikit_learn.bayesian_ridge_regression import (
+    BayesianRidgeRegression,
+)
 from DashAI.back.models.scikit_learn.bow_text_classification_model import (
     BagOfWordsTextClassificationModel,
 )
 from DashAI.back.models.scikit_learn.decision_tree_classifier import (
     DecisionTreeClassifier,
 )
+from DashAI.back.models.scikit_learn.decision_tree_regression import (
+    DecisionTreeRegression,
+)
 from DashAI.back.models.scikit_learn.dummy_classifier import DummyClassifier
+from DashAI.back.models.scikit_learn.elastic_net_regression import ElasticNetRegression
+from DashAI.back.models.scikit_learn.extra_trees_classifier import ExtraTreesClassifier
+from DashAI.back.models.scikit_learn.extra_trees_regression import ExtraTreesRegression
+from DashAI.back.models.scikit_learn.gaussian_nb import GaussianNB
+from DashAI.back.models.scikit_learn.gradient_boosting_classifier import (
+    GradientBoostingClassifier,
+)
 from DashAI.back.models.scikit_learn.gradient_boosting_regression import (
     GradientBoostingR,
 )
 from DashAI.back.models.scikit_learn.hist_gradient_boosting_classifier import (
     HistGradientBoostingClassifier,
 )
+from DashAI.back.models.scikit_learn.hist_gradient_boosting_regression import (
+    HistGradientBoostingRegression,
+)
 from DashAI.back.models.scikit_learn.k_neighbors_classifier import KNeighborsClassifier
+from DashAI.back.models.scikit_learn.k_neighbors_regression import KNeighborsRegression
+from DashAI.back.models.scikit_learn.lasso_regression import LassoRegression
 from DashAI.back.models.scikit_learn.linear_regression import LinearRegression
+from DashAI.back.models.scikit_learn.linear_svc_classifier import LinearSVCClassifier
 from DashAI.back.models.scikit_learn.linearSVR import LinearSVR
 from DashAI.back.models.scikit_learn.logistic_regression import LogisticRegression
+from DashAI.back.models.scikit_learn.mlp_classifier import MLPClassifier
 from DashAI.back.models.scikit_learn.mlp_regression import MLPRegression
 from DashAI.back.models.scikit_learn.random_forest_classifier import (
     RandomForestClassifier,
@@ -190,7 +227,12 @@ from DashAI.back.models.scikit_learn.random_forest_regression import (
     RandomForestRegression,
 )
 from DashAI.back.models.scikit_learn.ridge_regression import RidgeRegression
+from DashAI.back.models.scikit_learn.sgd_classifier import SGDClassifier
 from DashAI.back.models.scikit_learn.svc import SVC
+from DashAI.back.models.scikit_learn.svr import SVR
+from DashAI.back.models.scikit_learn.tfidf_logreg_text_classification_model import (
+    TfIdfLogRegTextClassificationModel,
+)
 
 # Optimizers
 from DashAI.back.optimizers.hyperopt_optimizer import HyperOptOptimizer
@@ -240,42 +282,70 @@ def get_initial_components():
         TextToTextGenerationTask,
         ControlNetTask,
         # Models
-        SVC,
+        AdaBoostClassifier,
+        AlbertTransformer,
+        AdaBoostRegression,
+        BaggingClassifier,
+        BagOfWordsTextClassificationModel,
+        BertTransformer,
+        BertinTransformer,
+        BetoTransformer,
+        BayesianRidgeRegression,
+        DebertaV3Transformer,
         DecisionTreeClassifier,
+        DecisionTreeRegression,
+        DistilBertTransformer,
         DummyClassifier,
+        ElasticNetRegression,
+        ElectraTransformer,
+        ExtraTreesClassifier,
+        ExtraTreesRegression,
+        GaussianNB,
+        GradientBoostingClassifier,
         GradientBoostingR,
         HistGradientBoostingClassifier,
+        HistGradientBoostingRegression,
         KNeighborsClassifier,
-        QwenModel,
+        KNeighborsRegression,
+        LassoRegression,
+        LinearRegression,
+        LinearSVCClassifier,
+        LinearSVR,
         LlamaModel,
+        LogisticRegression,
+        MiniLMTransformer,
         MistralModel,
         MixtralModel,
+        MultilingualBertTransformer,
+        MLPClassifier,
+        MLPRegression,
+        ModernBertTransformer,
+        NllbTransformer,
+        OpusMtEnESTransformer,
+        OpusMtEsENTransformer,
+        PixArtSigmaModel,
+        QwenModel,
+        RandomForestClassifier,
+        RobertaTransformer,
+        RandomForestRegression,
+        RidgeRegression,
+        SD15DepthControlNetModel,
+        SD15HEDControlNetModel,
+        SD15OpenPoseControlNetModel,
+        SDXLCannyControlNetModel,
+        SDXLTurboModel,
+        SGDClassifier,
         SmolLMModel,
         StableDiffusionV2Model,
         StableDiffusionV3Model,
         StableDiffusionXLModel,
-        SDXLTurboModel,
-        PixArtSigmaModel,
-        TongyiZImageModel,
         StableDiffusionXLV1ControlNet,
-        SD15DepthControlNetModel,
-        SD15OpenPoseControlNetModel,
-        SD15HEDControlNetModel,
-        SDXLCannyControlNetModel,
-        LogisticRegression,
-        MLPRegression,
-        RandomForestClassifier,
-        RandomForestRegression,
-        DistilBertTransformer,
-        ModernBertTransformer,
-        DebertaV3Transformer,
-        OpusMtEnESTransformer,
-        OpusMtEsENTransformer,
-        NllbTransformer,
-        BagOfWordsTextClassificationModel,
-        RidgeRegression,
-        LinearSVR,
-        LinearRegression,
+        SVC,
+        SVR,
+        TfIdfLogRegTextClassificationModel,
+        TongyiZImageModel,
+        XlmRobertaTransformer,
+        XlnetTransformer,
         # Dataloaders
         CSVDataLoader,
         JSONDataLoader,

--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -131,6 +131,7 @@ from DashAI.back.models.hugging_face.deberta_v3_transformer import DebertaV3Tran
 from DashAI.back.models.hugging_face.distilbert_transformer import DistilBertTransformer
 from DashAI.back.models.hugging_face.electra_transformer import ElectraTransformer
 from DashAI.back.models.hugging_face.llama_model import LlamaModel
+from DashAI.back.models.hugging_face.m2m100_transformer import M2M100Transformer
 from DashAI.back.models.hugging_face.minilm_transformer import MiniLMTransformer
 from DashAI.back.models.hugging_face.mistral_model import MistralModel
 from DashAI.back.models.hugging_face.mixtral_model import MixtralModel
@@ -139,11 +140,23 @@ from DashAI.back.models.hugging_face.multilingual_bert_transformer import (
     MultilingualBertTransformer,
 )
 from DashAI.back.models.hugging_face.nllb_transformer import NllbTransformer
+from DashAI.back.models.hugging_face.opus_mt_en_de_transformer import (
+    OpusMtEnDeTransformer,
+)
 from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
     OpusMtEnESTransformer,
 )
+from DashAI.back.models.hugging_face.opus_mt_en_fr_transformer import (
+    OpusMtEnFrTransformer,
+)
+from DashAI.back.models.hugging_face.opus_mt_en_pt_transformer import (
+    OpusMtEnPtTransformer,
+)
 from DashAI.back.models.hugging_face.opus_mt_es_en_transformer import (
     OpusMtEsENTransformer,
+)
+from DashAI.back.models.hugging_face.opus_mt_fr_en_transformer import (
+    OpusMtFrEnTransformer,
 )
 from DashAI.back.models.hugging_face.pixart_sigma_model import PixArtSigmaModel
 from DashAI.back.models.hugging_face.qwen_model import QwenModel
@@ -174,6 +187,7 @@ from DashAI.back.models.hugging_face.stable_diffusion_v3_model import (
 from DashAI.back.models.hugging_face.stable_diffusion_xl_model import (
     StableDiffusionXLModel,
 )
+from DashAI.back.models.hugging_face.t5_small_transformer import T5SmallTransformer
 from DashAI.back.models.hugging_face.tongyi_z_image_model import TongyiZImageModel
 from DashAI.back.models.hugging_face.xlm_roberta_transformer import (
     XlmRobertaTransformer,
@@ -313,6 +327,7 @@ def get_initial_components():
         LinearSVR,
         LlamaModel,
         LogisticRegression,
+        M2M100Transformer,
         MiniLMTransformer,
         MistralModel,
         MixtralModel,
@@ -321,8 +336,12 @@ def get_initial_components():
         MLPRegression,
         ModernBertTransformer,
         NllbTransformer,
+        OpusMtEnDeTransformer,
         OpusMtEnESTransformer,
+        OpusMtEnFrTransformer,
+        OpusMtEnPtTransformer,
         OpusMtEsENTransformer,
+        OpusMtFrEnTransformer,
         PixArtSigmaModel,
         QwenModel,
         RandomForestClassifier,
@@ -342,6 +361,7 @@ def get_initial_components():
         StableDiffusionXLV1ControlNet,
         SVC,
         SVR,
+        T5SmallTransformer,
         TfIdfLogRegTextClassificationModel,
         TongyiZImageModel,
         XlmRobertaTransformer,

--- a/DashAI/back/metrics/classification/log_loss.py
+++ b/DashAI/back/metrics/classification/log_loss.py
@@ -86,4 +86,8 @@ class LogLoss(ClassificationMetric):
         from sklearn.metrics import log_loss
 
         true_labels, _ = prepare_to_metric(true_labels, probs_pred_labels)
-        return log_loss(true_labels, probs_pred_labels)
+        # Pass all expected class indices so log_loss works even when a split
+        # happens to contain only one class (e.g. small validation sets).
+        n_classes = probs_pred_labels.shape[1]
+        labels = list(range(n_classes))
+        return log_loss(true_labels, probs_pred_labels, labels=labels)

--- a/DashAI/back/metrics/classification/roc_auc.py
+++ b/DashAI/back/metrics/classification/roc_auc.py
@@ -80,14 +80,26 @@ class ROCAUC(ClassificationMetric):
         float
             RoC AUC score between true labels and predicted labels
         """
+        import numpy as np
+
         true_labels, _ = prepare_to_metric(true_labels, probs_pred_labels)
-        # Use the provided multiclass parameter or determine it using is_multiclass
+
+        # ROC AUC is undefined when only one class is present in y_true.
+        if len(np.unique(true_labels)) < 2:
+            return float("nan")
+
         if multiclass is None:
             multiclass = ClassificationMetric.is_multiclass(true_labels)
 
         from sklearn.metrics import roc_auc_score
 
+        n_classes = probs_pred_labels.shape[1]
         if multiclass:
-            return roc_auc_score(true_labels, probs_pred_labels, multi_class="ovr")
+            return roc_auc_score(
+                true_labels,
+                probs_pred_labels,
+                multi_class="ovr",
+                labels=list(range(n_classes)),
+            )
         else:
             return roc_auc_score(true_labels, probs_pred_labels[:, 1])

--- a/DashAI/back/metrics/classification/roc_auc.py
+++ b/DashAI/back/metrics/classification/roc_auc.py
@@ -88,12 +88,12 @@ class ROCAUC(ClassificationMetric):
         if len(np.unique(true_labels)) < 2:
             return float("nan")
 
-        if multiclass is None:
-            multiclass = ClassificationMetric.is_multiclass(true_labels)
-
         from sklearn.metrics import roc_auc_score
 
         n_classes = probs_pred_labels.shape[1]
+
+        if multiclass is None:
+            multiclass = n_classes > 2
         if multiclass:
             return roc_auc_score(
                 true_labels,

--- a/DashAI/back/models/hugging_face/albert_transformer.py
+++ b/DashAI/back/models/hugging_face/albert_transformer.py
@@ -1,0 +1,45 @@
+"""DashAI implementation of ALBERT model for English text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class AlbertTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained ALBERT model for efficient English text classification.
+
+    ALBERT (A Lite BERT) reduces BERT's parameters via cross-layer parameter
+    sharing and factorised embedding parametrisation, making it significantly
+    smaller and faster while retaining high accuracy. Requires the
+    ``sentencepiece`` package for its tokeniser.
+
+    References
+    ----------
+    - [1] Lan, Z. et al. (2020). "ALBERT: A Lite BERT for Self-supervised
+           Learning of Language Representations." ICLR 2020.
+    - [2] https://huggingface.co/albert-base-v2
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="ALBERT Transformer",
+        es="Transformer ALBERT",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Parameter-efficient BERT variant for English text classification. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Variante de BERT eficiente en parámetros para clasificación en inglés. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#00838F"
+    ICON: str = "Speed"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "albert-base-v2"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_albert"

--- a/DashAI/back/models/hugging_face/base_opus_mt_transformer.py
+++ b/DashAI/back/models/hugging_face/base_opus_mt_transformer.py
@@ -1,0 +1,261 @@
+"""Shared base class for Helsinki-NLP Opus-MT translation transformers."""
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from sklearn.exceptions import NotFittedError
+
+from DashAI.back.models.translation_model import TranslationModel
+from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class OpusMtTransformerMixin(TranslationModel):
+    """Shared implementation for Helsinki-NLP Opus-MT translation wrappers.
+
+    Subclasses must define ``MODEL_NAME`` (the HuggingFace checkpoint ID) and
+    ``SCHEMA``. ``TEMP_CHECKPOINT_DIR`` defaults to a generic path but should
+    be overridden with a model-specific directory to avoid collisions between
+    concurrent training runs of different language pairs.
+
+    All seq2seq training, tokenization, inference, save, and load logic lives
+    here so each language-pair subclass only needs to set class attributes.
+
+    .. note::
+        Requires internet access on first use to download pretrained weights
+        from the Hugging Face Hub.
+    """
+
+    MODEL_NAME: str = ""
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_opus_mt"
+
+    def __init__(self, model=None, **kwargs):
+        """Initialize tokenizer and seq2seq model.
+
+        Parameters
+        ----------
+        model : transformers.PreTrainedModel or None
+            Pre-loaded model to reuse instead of downloading weights.
+        **kwargs
+            Training hyperparameters forwarded to ``validate_and_transform``.
+        """
+        kwargs = self.validate_and_transform(kwargs)
+
+        from transformers import AutoTokenizer
+
+        if not self.MODEL_NAME:
+            raise ValueError(
+                f"{self.__class__.__name__} must define a non-empty MODEL_NAME."
+            )
+
+        self.model_name = self.MODEL_NAME
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+
+        self.training_args = {
+            "num_train_epochs": kwargs.get("num_train_epochs", 2),
+            "learning_rate": kwargs.get("learning_rate", 2e-5),
+            "weight_decay": kwargs.get("weight_decay", 0.01),
+        }
+        self.batch_size = kwargs.get("batch_size", 4)
+        self.device = kwargs.get("device") or GPU_OR_CPU_PLACEHOLDER
+        self.log_train_every_n_epochs = kwargs.get("log_train_every_n_epochs", 1)
+        self.log_train_every_n_steps = kwargs.get("log_train_every_n_steps", None)
+        self.log_validation_every_n_epochs = kwargs.get(
+            "log_validation_every_n_epochs", 1
+        )
+        self.log_validation_every_n_steps = kwargs.get(
+            "log_validation_every_n_steps", None
+        )
+
+        if model is None:
+            from transformers import AutoModelForSeq2SeqLM
+
+            self.model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name)
+        else:
+            self.model = model
+
+        self.num_train_epochs = self.training_args.get("num_train_epochs", 2)
+        self.fitted = model is not None
+
+    def tokenize_data(
+        self, x: "DashAIDataset", y: Optional["DashAIDataset"] = None
+    ) -> "DashAIDataset":
+        """Tokenize source (and optionally target) dataset for seq2seq training."""
+        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+        is_y = bool(y)
+        if not y:
+            y = DashAIDataset.from_list([{"foo": 0}] * len(x))
+
+        dataset = []
+        input_column_name = x.column_names[0]
+        output_column_name = y.column_names[0] if is_y else None
+
+        for i, input_sample in enumerate(x):
+            tokenized_input = self.tokenizer(
+                input_sample[input_column_name],
+                truncation=True,
+                padding="max_length",
+                max_length=512,
+            )
+            sample = {
+                "input_ids": tokenized_input["input_ids"],
+                "attention_mask": tokenized_input["attention_mask"],
+            }
+            if is_y:
+                output_sample = y[i]
+                tokenized_output = self.tokenizer(
+                    output_sample[output_column_name],
+                    truncation=True,
+                    padding="max_length",
+                    max_length=512,
+                )
+                sample["labels"] = tokenized_output["input_ids"]
+            dataset.append(sample)
+
+        return DashAIDataset.from_list(dataset)
+
+    def train(
+        self,
+        x_train: "DashAIDataset",
+        y_train: "DashAIDataset",
+        x_validation: "DashAIDataset" = None,
+        y_validation: "DashAIDataset" = None,
+    ):
+        """Fine-tune the Opus-MT model on translation data."""
+        from transformers import Seq2SeqTrainer, Seq2SeqTrainingArguments
+
+        from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
+
+        dataset = self.tokenize_data(x_train, y_train)
+        dataset.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
+
+        has_validation_data = x_validation is not None and y_validation is not None
+
+        output_root = Path(self.TEMP_CHECKPOINT_DIR)
+        output_root.mkdir(parents=True, exist_ok=True)
+        run_output_dir = tempfile.mkdtemp(
+            prefix=f"{self.__class__.__name__.lower()}_",
+            dir=str(output_root),
+        )
+
+        training_args_obj = Seq2SeqTrainingArguments(
+            output_dir=run_output_dir,
+            save_steps=1,
+            save_total_limit=1,
+            per_device_train_batch_size=self.batch_size,
+            per_device_eval_batch_size=self.batch_size,
+            use_cpu=self.device.lower() != "gpu",
+            **self.training_args,
+        )
+
+        metrics_callback = MetricsCallback(
+            model_instance=self,
+            x_train=x_train,
+            y_train=y_train,
+            x_val=x_validation,
+            y_val=y_validation,
+            total_epochs=self.num_train_epochs,
+            log_training_every_n_epochs=self.log_train_every_n_epochs,
+            log_training_every_n_steps=self.log_train_every_n_steps,
+            log_val_every_n_epochs=(
+                self.log_validation_every_n_epochs if has_validation_data else None
+            ),
+            log_val_every_n_steps=(
+                self.log_validation_every_n_steps if has_validation_data else None
+            ),
+        )
+
+        trainer = Seq2SeqTrainer(
+            model=self.model,
+            args=training_args_obj,
+            train_dataset=dataset,
+            callbacks=[metrics_callback],
+        )
+
+        self.fitted = True
+        try:
+            trainer.train()
+        finally:
+            shutil.rmtree(run_output_dir, ignore_errors=True)
+
+        return self
+
+    def predict(self, x_pred: "DashAIDataset") -> List:
+        """Translate source texts using the fine-tuned model."""
+        if not self.fitted:
+            raise NotFittedError(
+                f"This {self.__class__.__name__} instance is not fitted yet. "
+                "Call 'train' with appropriate arguments before using this estimator."
+            )
+
+        dataset = self.tokenize_data(x_pred)
+        dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
+
+        translations = []
+        for example in dataset:
+            inputs = {
+                k: v.unsqueeze(0).to(self.model.device) for k, v in example.items()
+            }
+            outputs = self.model.generate(**inputs)
+            translated_text = self.tokenizer.decode(
+                outputs[0], skip_special_tokens=True
+            )
+            translations.append(translated_text)
+
+        return translations
+
+    def prepare_dataset(
+        self, dataset: "DashAIDataset", is_fit: bool = False
+    ) -> "DashAIDataset":
+        """Return the dataset unchanged (no preprocessing required)."""
+        return dataset
+
+    def save(self, filename: Union[str, "Path"]) -> None:
+        """Persist model weights and hyperparameters to disk."""
+        from transformers import AutoConfig
+
+        save_dir = Path(filename)
+        if save_dir.exists() and save_dir.is_file():
+            save_dir.unlink()
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        self.model.save_pretrained(save_dir)
+        config = AutoConfig.from_pretrained(save_dir)
+        config.custom_params = {
+            "num_train_epochs": self.training_args.get("num_train_epochs"),
+            "batch_size": self.batch_size,
+            "learning_rate": self.training_args.get("learning_rate"),
+            "device": self.device,
+            "weight_decay": self.training_args.get("weight_decay"),
+            "fitted": self.fitted,
+        }
+        config.save_pretrained(save_dir)
+
+    @classmethod
+    def load(cls, filename: Union[str, "Path"]):
+        """Restore a model instance from disk."""
+        from transformers import AutoConfig, AutoModelForSeq2SeqLM
+
+        model = AutoModelForSeq2SeqLM.from_pretrained(filename)
+        config = AutoConfig.from_pretrained(filename)
+        custom_params = getattr(config, "custom_params", {})
+
+        loaded_model = cls(
+            model=model,
+            num_train_epochs=custom_params.get("num_train_epochs"),
+            batch_size=custom_params.get("batch_size"),
+            learning_rate=custom_params.get("learning_rate"),
+            device=custom_params.get("device"),
+            weight_decay=custom_params.get("weight_decay"),
+            log_train_every_n_epochs=None,
+            log_train_every_n_steps=None,
+            log_validation_every_n_epochs=None,
+            log_validation_every_n_steps=None,
+        )
+        loaded_model.fitted = custom_params.get("fitted", False)
+        return loaded_model

--- a/DashAI/back/models/hugging_face/base_text_classification_transformer.py
+++ b/DashAI/back/models/hugging_face/base_text_classification_transformer.py
@@ -30,6 +30,10 @@ class HuggingFaceTextClassificationTransformer(TextClassificationModel):
     - Training via ``transformers.Trainer`` with DashAI metric callbacks.
     - Inference returning per-class probability matrices.
     - Save/load utilities that preserve custom training parameters.
+
+    .. note::
+        Requires internet access on first use to download pre-trained weights
+        from the Hugging Face Hub.
     """
 
     MODEL_NAME: str = ""

--- a/DashAI/back/models/hugging_face/bert_transformer.py
+++ b/DashAI/back/models/hugging_face/bert_transformer.py
@@ -1,0 +1,45 @@
+"""DashAI implementation of BERT model for English text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class BertTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained BERT model for English text classification.
+
+    BERT (Bidirectional Encoder Representations from Transformers) pre-trains deep
+    bidirectional representations by jointly conditioning on both left and right
+    context in all layers. Fine-tuned BERT achieves strong results on a wide range
+    of text classification tasks.
+
+    References
+    ----------
+    - [1] Devlin, J. et al. (2019). "BERT: Pre-training of Deep Bidirectional
+           Transformers for Language Understanding." NAACL 2019.
+    - [2] https://huggingface.co/bert-base-uncased
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="BERT Transformer",
+        es="Transformer BERT",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Bidirectional BERT model for English text classification. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Modelo BERT bidireccional para clasificación de texto en inglés. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#1565C0"
+    ICON: str = "Psychology"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "bert-base-uncased"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_bert"

--- a/DashAI/back/models/hugging_face/bertin_transformer.py
+++ b/DashAI/back/models/hugging_face/bertin_transformer.py
@@ -1,0 +1,45 @@
+"""DashAI implementation of BERTIN model for Spanish text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class BertinTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained BERTIN model (Spanish RoBERTa) for Spanish text classification.
+
+    BERTIN is a Spanish RoBERTa model trained on the Spanish portion of mC4 and
+    additional Spanish corpora. It applies RoBERTa's improved training recipe to
+    Spanish and typically outperforms BETO on Spanish NLP benchmarks. Requires
+    the ``sentencepiece`` package for its tokeniser.
+
+    References
+    ----------
+    - [1] de la Rosa, J. et al. (2022). "BERTIN: Efficient Pre-Training of a
+           Spanish Language Model using Perplexity Sampling."
+    - [2] https://huggingface.co/bertin-project/bertin-roberta-base-spanish
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="BERTIN Spanish RoBERTa",
+        es="BERTIN RoBERTa en Español",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Spanish RoBERTa (BERTIN) pre-trained on large Spanish corpora. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "RoBERTa en español (BERTIN) pre-entrenada en grandes corpus en español. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#AD1457"
+    ICON: str = "RecordVoiceOver"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "bertin-project/bertin-roberta-base-spanish"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_bertin"

--- a/DashAI/back/models/hugging_face/beto_transformer.py
+++ b/DashAI/back/models/hugging_face/beto_transformer.py
@@ -1,0 +1,45 @@
+"""DashAI implementation of BETO model for Spanish text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class BetoTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained BETO model for Spanish text classification.
+
+    BETO is a Spanish BERT trained on the Spanish Wikipedia and other Spanish
+    corpora using the whole-word masking strategy. It achieves state-of-the-art
+    results on several Spanish NLP benchmarks. Particularly useful for tasks
+    involving Spanish text.
+
+    References
+    ----------
+    - [1] Cañete, J. et al. (2020). "Spanish Pre-Trained BERT Model and
+           Evaluation Data." PML4DC at ICLR 2020.
+    - [2] https://huggingface.co/dccuchile/bert-base-spanish-wwm-cased
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="BETO Spanish BERT",
+        es="BETO BERT en Español",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Spanish BERT (BETO) pre-trained on Spanish corpora. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "BERT en español (BETO) pre-entrenado en corpus en español. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#C62828"
+    ICON: str = "RecordVoiceOver"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "dccuchile/bert-base-spanish-wwm-cased"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_beto"

--- a/DashAI/back/models/hugging_face/electra_transformer.py
+++ b/DashAI/back/models/hugging_face/electra_transformer.py
@@ -1,0 +1,45 @@
+"""DashAI implementation of ELECTRA model for English text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class ElectraTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained ELECTRA model for efficient English text classification.
+
+    ELECTRA uses a replaced-token-detection pre-training objective: a generator
+    produces plausible token replacements while a discriminator is trained to
+    identify which tokens were replaced. This allows ELECTRA to train on all
+    input tokens rather than only masked ones, making pre-training more efficient.
+
+    References
+    ----------
+    - [1] Clark, K. et al. (2020). "ELECTRA: Pre-training Text Encoders as
+           Discriminators Rather Than Generators." ICLR 2020.
+    - [2] https://huggingface.co/google/electra-small-discriminator
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="ELECTRA Transformer",
+        es="Transformer ELECTRA",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Sample-efficient ELECTRA discriminator for text classification. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Discriminador ELECTRA eficiente en muestras para clasificación de texto. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#558B2F"
+    ICON: str = "ElectricBolt"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "google/electra-small-discriminator"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_electra"

--- a/DashAI/back/models/hugging_face/m2m100_transformer.py
+++ b/DashAI/back/models/hugging_face/m2m100_transformer.py
@@ -1,0 +1,327 @@
+"""M2M100 multilingual translation transformer for DashAI."""
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from sklearn.exceptions import NotFittedError
+
+from DashAI.back.core.schema_fields import schema_field, string_field
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
+    OpusMtEnESTransformerSchema,
+)
+from DashAI.back.models.translation_model import TranslationModel
+from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class M2M100TransformerSchema(OpusMtEnESTransformerSchema):
+    """Schema for the M2M100 multilingual translation model.
+
+    Extends the standard translation schema with ``source_language`` and
+    ``target_language`` fields, which accept ISO 639-1 language codes
+    (e.g. ``"en"`` for English, ``"es"`` for Spanish, ``"fr"`` for French).
+    """
+
+    source_language: schema_field(
+        string_field(),
+        placeholder="en",
+        description=MultilingualString(
+            en=(
+                "Source language ISO 639-1 code (e.g. 'en', 'es', 'fr', 'de'). "
+                "Supports 100 languages."
+            ),
+            es=(
+                "Código ISO 639-1 del idioma de origen (ej. 'en', 'es', 'fr', 'de'). "
+                "Soporta 100 idiomas."
+            ),
+        ),
+        alias=MultilingualString(en="Source language", es="Idioma de origen"),
+    )  # type: ignore
+    target_language: schema_field(
+        string_field(),
+        placeholder="es",
+        description=MultilingualString(
+            en=(
+                "Target language ISO 639-1 code (e.g. 'en', 'es', 'fr', 'de'). "
+                "Supports 100 languages."
+            ),
+            es=(
+                "Código ISO 639-1 del idioma destino (ej. 'en', 'es', 'fr', 'de'). "
+                "Soporta 100 idiomas."
+            ),
+        ),
+        alias=MultilingualString(en="Target language", es="Idioma destino"),
+    )  # type: ignore
+
+
+class M2M100Transformer(TranslationModel):
+    """M2M100 multilingual seq2seq model for configurable language-pair translation.
+
+    Fine-tunes the ``facebook/m2m100_418M`` checkpoint from Meta AI. The base
+    model supports direct translation across 100 languages using ISO 639-1
+    language codes (e.g. ``"en"``, ``"es"``, ``"fr"``). Unlike pivot-based
+    systems, M2M100 translates directly between any supported pair.
+
+    Target language generation is guided by ``forced_bos_token_id`` obtained
+    from ``tokenizer.get_lang_id(target_language)``, identical in principle
+    to the NLLB approach but using simpler ISO codes.
+
+    References
+    ----------
+    - [1] https://huggingface.co/facebook/m2m100_418M
+    - [2] Fan et al. (2021). "Beyond English-Centric Multilingual Machine
+           Translation." JMLR 2021.
+    """
+
+    SCHEMA = M2M100TransformerSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="M2M-100 Multilingual Transformer",
+        es="Transformer Multilingüe M2M-100",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Facebook M2M-100 model for direct translation across 100 languages "
+            "using ISO 639-1 codes. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Modelo M2M-100 de Facebook para traducción directa entre 100 idiomas "
+            "usando códigos ISO 639-1. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#6A1B9A"
+    ICON: str = "Language"
+
+    def __init__(self, model=None, **kwargs):
+        kwargs = self.validate_and_transform(kwargs)
+
+        from transformers import AutoTokenizer
+
+        self.model_name = "facebook/m2m100_418M"
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+
+        self.source_language = kwargs.get("source_language", "en")
+        self.target_language = kwargs.get("target_language", "es")
+
+        if hasattr(self.tokenizer, "src_lang"):
+            self.tokenizer.src_lang = self.source_language
+
+        self.training_args = {
+            "num_train_epochs": kwargs.get("num_train_epochs", 2),
+            "learning_rate": kwargs.get("learning_rate", 2e-5),
+            "weight_decay": kwargs.get("weight_decay", 0.01),
+        }
+        self.batch_size = kwargs.get("batch_size", 4)
+        self.device = kwargs.get("device") or GPU_OR_CPU_PLACEHOLDER
+        self.log_train_every_n_epochs = kwargs.get("log_train_every_n_epochs", 1)
+        self.log_train_every_n_steps = kwargs.get("log_train_every_n_steps", None)
+        self.log_validation_every_n_epochs = kwargs.get(
+            "log_validation_every_n_epochs", 1
+        )
+        self.log_validation_every_n_steps = kwargs.get(
+            "log_validation_every_n_steps", None
+        )
+
+        if model is None:
+            from transformers import AutoModelForSeq2SeqLM
+
+            self.model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name)
+        else:
+            self.model = model
+
+        self.num_train_epochs = self.training_args.get("num_train_epochs", 2)
+        self.fitted = model is not None
+
+    def tokenize_data(
+        self, x: "DashAIDataset", y: Optional["DashAIDataset"] = None
+    ) -> "DashAIDataset":
+        """Tokenize with src_lang set for M2M100."""
+        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+        if hasattr(self.tokenizer, "src_lang"):
+            self.tokenizer.src_lang = self.source_language
+
+        is_y = bool(y)
+        if not y:
+            y = DashAIDataset.from_list([{"foo": 0}] * len(x))
+
+        dataset = []
+        input_column_name = x.column_names[0]
+        output_column_name = y.column_names[0] if is_y else None
+
+        for i, input_sample in enumerate(x):
+            tokenized_input = self.tokenizer(
+                input_sample[input_column_name],
+                truncation=True,
+                padding="max_length",
+                max_length=512,
+            )
+            sample = {
+                "input_ids": tokenized_input["input_ids"],
+                "attention_mask": tokenized_input["attention_mask"],
+            }
+            if is_y:
+                output_sample = y[i]
+                tokenized_output = self.tokenizer(
+                    output_sample[output_column_name],
+                    truncation=True,
+                    padding="max_length",
+                    max_length=512,
+                )
+                sample["labels"] = tokenized_output["input_ids"]
+            dataset.append(sample)
+
+        return DashAIDataset.from_list(dataset)
+
+    def train(
+        self,
+        x_train: "DashAIDataset",
+        y_train: "DashAIDataset",
+        x_validation: "DashAIDataset" = None,
+        y_validation: "DashAIDataset" = None,
+    ):
+        """Fine-tune M2M100 on the configured language pair."""
+        from transformers import Seq2SeqTrainer, Seq2SeqTrainingArguments
+
+        from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
+
+        dataset = self.tokenize_data(x_train, y_train)
+        dataset.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
+
+        has_validation_data = x_validation is not None and y_validation is not None
+
+        output_root = Path("DashAI/back/user_models/temp_checkpoints_m2m100")
+        output_root.mkdir(parents=True, exist_ok=True)
+        run_output_dir = tempfile.mkdtemp(prefix="m2m100_", dir=str(output_root))
+
+        training_args_obj = Seq2SeqTrainingArguments(
+            output_dir=run_output_dir,
+            save_steps=1,
+            save_total_limit=1,
+            per_device_train_batch_size=self.batch_size,
+            per_device_eval_batch_size=self.batch_size,
+            use_cpu=self.device.lower() != "gpu",
+            **self.training_args,
+        )
+
+        metrics_callback = MetricsCallback(
+            model_instance=self,
+            x_train=x_train,
+            y_train=y_train,
+            x_val=x_validation,
+            y_val=y_validation,
+            total_epochs=self.num_train_epochs,
+            log_training_every_n_epochs=self.log_train_every_n_epochs,
+            log_training_every_n_steps=self.log_train_every_n_steps,
+            log_val_every_n_epochs=(
+                self.log_validation_every_n_epochs if has_validation_data else None
+            ),
+            log_val_every_n_steps=(
+                self.log_validation_every_n_steps if has_validation_data else None
+            ),
+        )
+
+        trainer = Seq2SeqTrainer(
+            model=self.model,
+            args=training_args_obj,
+            train_dataset=dataset,
+            callbacks=[metrics_callback],
+        )
+
+        self.fitted = True
+        try:
+            trainer.train()
+        finally:
+            shutil.rmtree(run_output_dir, ignore_errors=True)
+
+        return self
+
+    def predict(self, x_pred: "DashAIDataset") -> List:
+        """Translate using forced_bos_token_id for the target language."""
+        if not self.fitted:
+            raise NotFittedError(
+                f"This {self.__class__.__name__} instance is not fitted yet. "
+                "Call 'train' before using this estimator."
+            )
+
+        dataset = self.tokenize_data(x_pred)
+        dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
+
+        target_bos = self.tokenizer.get_lang_id(self.target_language)
+        translations = []
+
+        for example in dataset:
+            inputs = {
+                k: v.unsqueeze(0).to(self.model.device) for k, v in example.items()
+            }
+            outputs = self.model.generate(
+                **inputs,
+                forced_bos_token_id=target_bos,
+            )
+            translated_text = self.tokenizer.decode(
+                outputs[0], skip_special_tokens=True
+            )
+            translations.append(translated_text)
+
+        return translations
+
+    def prepare_dataset(
+        self, dataset: "DashAIDataset", is_fit: bool = False
+    ) -> "DashAIDataset":
+        """Return the dataset unchanged."""
+        return dataset
+
+    def save(self, filename: Union[str, "Path"]) -> None:
+        """Persist model weights and hyperparameters to disk."""
+        from transformers import AutoConfig
+
+        save_dir = Path(filename)
+        if save_dir.exists() and save_dir.is_file():
+            save_dir.unlink()
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        self.model.save_pretrained(save_dir)
+        config = AutoConfig.from_pretrained(save_dir)
+        config.custom_params = {
+            "num_train_epochs": self.training_args.get("num_train_epochs"),
+            "batch_size": self.batch_size,
+            "learning_rate": self.training_args.get("learning_rate"),
+            "device": self.device,
+            "weight_decay": self.training_args.get("weight_decay"),
+            "source_language": self.source_language,
+            "target_language": self.target_language,
+            "fitted": self.fitted,
+        }
+        config.save_pretrained(save_dir)
+
+    @classmethod
+    def load(cls, filename: Union[str, "Path"]):
+        """Restore an M2M100Transformer instance from disk."""
+        from transformers import AutoConfig, AutoModelForSeq2SeqLM
+
+        model = AutoModelForSeq2SeqLM.from_pretrained(filename)
+        config = AutoConfig.from_pretrained(filename)
+        custom_params = getattr(config, "custom_params", {})
+
+        loaded_model = cls(
+            model=model,
+            num_train_epochs=custom_params.get("num_train_epochs"),
+            batch_size=custom_params.get("batch_size"),
+            learning_rate=custom_params.get("learning_rate"),
+            device=custom_params.get("device"),
+            weight_decay=custom_params.get("weight_decay"),
+            source_language=custom_params.get("source_language", "en"),
+            target_language=custom_params.get("target_language", "es"),
+            log_train_every_n_epochs=None,
+            log_train_every_n_steps=None,
+            log_validation_every_n_epochs=None,
+            log_validation_every_n_steps=None,
+        )
+        loaded_model.fitted = custom_params.get("fitted", False)
+        return loaded_model

--- a/DashAI/back/models/hugging_face/minilm_transformer.py
+++ b/DashAI/back/models/hugging_face/minilm_transformer.py
@@ -1,0 +1,45 @@
+"""DashAI implementation of MiniLM model for efficient English text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class MiniLMTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained MiniLM model for lightweight English text classification.
+
+    MiniLM is a compressed BERT-like model distilled from a larger teacher
+    network using deep self-attention distillation. It achieves competitive
+    performance while being significantly smaller and faster than BERT, making
+    it a good choice for resource-constrained deployments.
+
+    References
+    ----------
+    - [1] Wang, W. et al. (2020). "MiniLM: Deep Self-Attention Distillation for
+           Task-Agnostic Compression of Pre-Trained Transformers." NeurIPS 2020.
+    - [2] https://huggingface.co/microsoft/MiniLM-L12-H384-uncased
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="MiniLM Transformer",
+        es="Transformer MiniLM",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Compact, fast MiniLM model for efficient text classification. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Modelo MiniLM compacto y rápido para clasificación de texto eficiente. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#0277BD"
+    ICON: str = "Speed"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "microsoft/MiniLM-L12-H384-uncased"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_minilm"

--- a/DashAI/back/models/hugging_face/multilingual_bert_transformer.py
+++ b/DashAI/back/models/hugging_face/multilingual_bert_transformer.py
@@ -1,0 +1,47 @@
+"""DashAI implementation of Multilingual BERT for multilingual text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class MultilingualBertTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained Multilingual BERT for cross-lingual text classification.
+
+    mBERT (Multilingual BERT) is a single BERT model pre-trained on the Wikipedia
+    text of 104 languages. It uses a shared vocabulary and can be fine-tuned on a
+    task in one language and applied to another (zero-shot cross-lingual transfer).
+
+    References
+    ----------
+    - [1] Devlin, J. et al. (2019). "BERT: Pre-training of Deep Bidirectional
+           Transformers for Language Understanding." NAACL 2019.
+    - [2] https://huggingface.co/bert-base-multilingual-cased
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="Multilingual BERT Transformer",
+        es="Transformer BERT Multilingüe",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "BERT pre-trained on 104 languages for multilingual text classification. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "BERT pre-entrenado en 104 idiomas para clasificación de texto "
+            "multilingüe. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#283593"
+    ICON: str = "Translate"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "bert-base-multilingual-cased"
+    TEMP_CHECKPOINT_DIR: str = (
+        "DashAI/back/user_models/temp_checkpoints_multilingual_bert"
+    )

--- a/DashAI/back/models/hugging_face/nllb_transformer.py
+++ b/DashAI/back/models/hugging_face/nllb_transformer.py
@@ -31,12 +31,15 @@ class NllbTransformerSchema(OpusMtEnESTransformerSchema):
         placeholder="spa_Latn",
         description=MultilingualString(
             en=(
-                "Source language code for NLLB tokenizer. "
-                "Example: spa_Latn for Spanish."
+                "Source language code for NLLB tokenizer (e.g. spa_Latn for Spanish, "
+                "eng_Latn for English). It uses BCP-47 language tags in the format"
+                "[Examples](https://dl-translate.readthedocs.io/en/latest/available_languages/#nllb-200)"
             ),
             es=(
-                "Código de idioma de origen para el tokenizer NLLB. "
-                "Ejemplo: spa_Latn para español."
+                "Código de idioma de origen para el tokenizer NLLB (ej. spa_Latn para "
+                "español, eng_Latn para inglés). Utiliza etiquetas de idioma BCP-47 "
+                "en el formato "
+                "[Ejemplos](https://dl-translate.readthedocs.io/en/latest/available_languages/#nllb-200)"
             ),
         ),
         alias=MultilingualString(en="Source language", es="Idioma de origen"),
@@ -46,12 +49,15 @@ class NllbTransformerSchema(OpusMtEnESTransformerSchema):
         placeholder="eng_Latn",
         description=MultilingualString(
             en=(
-                "Target language code for NLLB generation. "
-                "Example: eng_Latn for English."
+                "Target language code for NLLB generation (e.g. eng_Latn for English, "
+                "fra_Latn for French). It uses BCP-47 language tags in the format "
+                "[Examples](https://dl-translate.readthedocs.io/en/latest/available_languages/#nllb-200)"
             ),
             es=(
-                "Código de idioma destino para la generación NLLB. "
-                "Ejemplo: eng_Latn para inglés."
+                "Código de idioma destino para la generación NLLB (ej. eng_Latn para "
+                "inglés, fra_Latn para francés). Utiliza etiquetas de idioma BCP-47 "
+                "en el formato "
+                "[Ejemplos](https://dl-translate.readthedocs.io/en/latest/available_languages/#nllb-200)"
             ),
         ),
         alias=MultilingualString(en="Target language", es="Idioma destino"),

--- a/DashAI/back/models/hugging_face/opus_mt_en_de_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_de_transformer.py
@@ -1,0 +1,47 @@
+"""OpusMtEnDeTransformer model for English-to-German translation."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_opus_mt_transformer import (
+    OpusMtTransformerMixin,
+)
+from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
+    OpusMtEnESTransformerSchema,
+)
+
+
+class OpusMtEnDeTransformerSchema(OpusMtEnESTransformerSchema):
+    """Schema for the English-to-German Opus-MT model."""
+
+
+class OpusMtEnDeTransformer(OpusMtTransformerMixin):
+    """Pre-trained transformer for English-to-German translation.
+
+    Fine-tunes the Helsinki-NLP ``opus-mt-en-de`` checkpoint, a MarianMT
+    seq2seq model trained on parallel English-German corpora from the OPUS
+    collection.
+
+    References
+    ----------
+    - [1] https://huggingface.co/Helsinki-NLP/opus-mt-en-de
+    - [2] https://opus.nlpl.eu/
+    """
+
+    MODEL_NAME: str = "Helsinki-NLP/opus-mt-en-de"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_opus-mt-en-de"
+    SCHEMA = OpusMtEnDeTransformerSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Opus MT En-De Transformer",
+        es="Transformer Opus MT En-De",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Pre-trained transformer for English-German translation. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Transformer pre-entrenado para traducción inglés-alemán. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#455A64"
+    ICON: str = "Translate"

--- a/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_es_transformer.py
@@ -1,10 +1,4 @@
-"""OpusMtEnESTransformer model for english-spanish translation DashAI implementation."""
-
-import shutil
-from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
-
-from sklearn.exceptions import NotFittedError
+"""OpusMtEnESTransformer model for English-to-Spanish translation."""
 
 from DashAI.back.core.schema_fields import (
     BaseSchema,
@@ -15,20 +9,18 @@ from DashAI.back.core.schema_fields import (
     schema_field,
 )
 from DashAI.back.core.utils import MultilingualString
-from DashAI.back.models.translation_model import TranslationModel
+from DashAI.back.models.hugging_face.base_opus_mt_transformer import (
+    OpusMtTransformerMixin,
+)
 from DashAI.back.models.utils import GPU_OR_CPU, GPU_OR_CPU_PLACEHOLDER
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
 
 class OpusMtEnESTransformerSchema(BaseSchema):
-    """opus-mt-en-es is a transformer pre-trained model that allows translation of
-    texts from English to Spanish. The implementation is based on the Helsinki-NLP
-    opus-mt-en-es checkpoint, which uses the MarianMT architecture and was trained
-    on parallel corpora from the OPUS collection.
+    """Schema for Opus-MT translation models (MarianMT architecture).
+
+    Shared by all Helsinki-NLP Opus-MT language-pair wrappers. Controls
+    training duration, batch size, learning rate, device, regularization, and
+    metric-logging frequency.
     """
 
     num_train_epochs: schema_field(
@@ -44,8 +36,8 @@ class OpusMtEnESTransformerSchema(BaseSchema):
         int_field(ge=1),
         placeholder=4,
         description=MultilingualString(
-            en="The batch size per GPU/TPU core/CPU for training",
-            es="El tamaño de lote por núcleo GPU/TPU/CPU para entrenamiento",
+            en="The batch size per GPU/TPU core/CPU for training.",
+            es="El tamaño de lote por núcleo GPU/TPU/CPU para entrenamiento.",
         ),
         alias=MultilingualString(en="Batch size", es="Tamaño de lote"),
     )  # type: ignore
@@ -53,8 +45,8 @@ class OpusMtEnESTransformerSchema(BaseSchema):
         float_field(ge=0.0),
         placeholder=2e-5,
         description=MultilingualString(
-            en="The initial learning rate for AdamW optimizer",
-            es="La tasa de aprendizaje inicial para el optimizador AdamW",
+            en="The initial learning rate for AdamW optimizer.",
+            es="La tasa de aprendizaje inicial para el optimizador AdamW.",
         ),
         alias=MultilingualString(en="Learning rate", es="Tasa de aprendizaje"),
     )  # type: ignore
@@ -63,14 +55,13 @@ class OpusMtEnESTransformerSchema(BaseSchema):
         placeholder=GPU_OR_CPU_PLACEHOLDER,
         description=MultilingualString(
             en=(
-                "Hardware on which the training is run. If available, GPU is "
-                "recommended for efficiency reasons. Otherwise, use CPU. "
-                "If GPU is selected then it will use all gpus available. "
+                "Hardware on which training is run. GPU is recommended when "
+                "available. If GPU is selected, all available GPUs are used."
             ),
             es=(
-                "Hardware en el que se ejecuta el entrenamiento. Si está disponible, "
-                "se recomienda GPU por razones de eficiencia. De lo contrario, use "
-                "CPU. Si se selecciona GPU, usará todas las GPUs disponibles."
+                "Hardware en el que se ejecuta el entrenamiento. Se recomienda "
+                "GPU cuando está disponible. Si se selecciona GPU, se usan "
+                "todas las GPUs disponibles."
             ),
         ),
         alias=MultilingualString(en="Device", es="Dispositivo"),
@@ -80,107 +71,87 @@ class OpusMtEnESTransformerSchema(BaseSchema):
         placeholder=0.01,
         description=MultilingualString(
             en=(
-                "Weight decay is a regularization technique used in training "
-                "neural networks to prevent overfitting. In the context of the AdamW "
-                "optimizer, the 'weight_decay' parameter is the rate at which the "
-                "weights of all layers are reduced during training, provided that "
-                "this rate is not zero."
+                "L2 regularization coefficient applied via the AdamW optimizer "
+                "to prevent overfitting."
             ),
             es=(
-                "Weight decay es una técnica de regularización usada en el "
-                "entrenamiento de redes neuronales para prevenir sobreajuste. En el "
-                "contexto del optimizador AdamW, el parámetro 'weight_decay' es la "
-                "tasa a la cual los pesos de todas las capas se reducen durante el "
-                "entrenamiento, siempre que esta tasa no sea cero."
+                "Coeficiente de regularización L2 aplicado mediante el "
+                "optimizador AdamW para prevenir sobreajuste."
             ),
         ),
         alias=MultilingualString(en="Weight decay", es="Decaimiento de pesos"),
     )  # type: ignore
-
     log_train_every_n_epochs: schema_field(
         none_type(int_field(ge=1)),
         placeholder=1,
         description=MultilingualString(
-            en=(
-                "Log metrics for train split every n epochs during training. "
-                "If None, it won't log per epoch."
-            ),
+            en=("Log train metrics every N epochs. None disables per-epoch logging."),
             es=(
-                "Registrar métricas del split de entrenamiento cada n épocas. "
-                "Si es None, no registrará por época."
+                "Registrar métricas de entrenamiento cada N épocas. "
+                "None desactiva el registro por época."
             ),
         ),
         alias=MultilingualString(
             en="Log train every N epochs", es="Registrar entrenamiento cada N épocas"
         ),
     )  # type: ignore
-
     log_train_every_n_steps: schema_field(
         none_type(int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
-            en=(
-                "Log metrics for train split every n steps during training. "
-                "If None, it won't log per step."
-            ),
+            en=("Log train metrics every N steps. None disables per-step logging."),
             es=(
-                "Registrar métricas del split de entrenamiento cada n pasos. "
-                "Si es None, no registrará por paso."
+                "Registrar métricas de entrenamiento cada N pasos. "
+                "None desactiva el registro por paso."
             ),
         ),
         alias=MultilingualString(
             en="Log train every N steps", es="Registrar entrenamiento cada N pasos"
         ),
     )  # type: ignore
-
     log_validation_every_n_epochs: schema_field(
         none_type(int_field(ge=1)),
         placeholder=1,
         description=MultilingualString(
             en=(
-                "Log metrics for validation split every n epochs during training. "
-                "If None, it won't log per epoch."
+                "Log validation metrics every N epochs. "
+                "None disables per-epoch logging."
             ),
             es=(
-                "Registrar métricas del split de validación cada n épocas. "
-                "Si es None, no registrará por época."
+                "Registrar métricas de validación cada N épocas. "
+                "None desactiva el registro por época."
             ),
         ),
         alias=MultilingualString(
-            en="Log validation every N epochs", es="Registrar validación cada N épocas"
+            en="Log validation every N epochs",
+            es="Registrar validación cada N épocas",
         ),
     )  # type: ignore
-
     log_validation_every_n_steps: schema_field(
         none_type(int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en=(
-                "Log metrics for validation split every n steps during training. "
-                "If None, it won't log per step."
+                "Log validation metrics every N steps. None disables per-step logging."
             ),
             es=(
-                "Registrar métricas del split de validación cada n pasos. "
-                "Si es None, no registrará por paso."
+                "Registrar métricas de validación cada N pasos. "
+                "None desactiva el registro por paso."
             ),
         ),
         alias=MultilingualString(
-            en="Log validation every N steps", es="Registrar validación cada N pasos"
+            en="Log validation every N steps",
+            es="Registrar validación cada N pasos",
         ),
     )  # type: ignore
 
 
-class OpusMtEnESTransformer(TranslationModel):
+class OpusMtEnESTransformer(OpusMtTransformerMixin):
     """Pre-trained transformer for English-to-Spanish translation.
 
-    This model fine-tunes the Helsinki-NLP ``opus-mt-en-es`` checkpoint, which is
-    based on the MarianMT sequence-to-sequence architecture. The base model was
-    trained on parallel English-Spanish corpora from the OPUS collection and supports
-    direct translation without intermediate pivot languages.
-
-    Fine-tuning is performed with the HuggingFace ``Seq2SeqTrainer`` using the AdamW
-    optimizer. Training and validation metrics are logged at configurable epoch and
-    step intervals via a custom ``MetricsCallback``.
+    Fine-tunes the Helsinki-NLP ``opus-mt-en-es`` checkpoint, a MarianMT
+    seq2seq model trained on parallel English-Spanish corpora from the OPUS
+    collection. Supports direct translation without pivot languages.
 
     References
     ----------
@@ -188,334 +159,22 @@ class OpusMtEnESTransformer(TranslationModel):
     - [2] https://opus.nlpl.eu/
     """
 
+    MODEL_NAME: str = "Helsinki-NLP/opus-mt-en-es"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_opus-mt-en-es"
     SCHEMA = OpusMtEnESTransformerSchema
     DISPLAY_NAME: str = MultilingualString(
         en="Opus MT En-Es Transformer",
         es="Transformer Opus MT En-Es",
     )
     DESCRIPTION: str = MultilingualString(
-        en="Pre-trained transformer for English-Spanish translation.",
-        es="Transformer pre-entrenado para traducción inglés-español.",
+        en=(
+            "Pre-trained transformer for English-Spanish translation. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Transformer pre-entrenado para traducción inglés-español. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
     )
     COLOR: str = "#FFA500"
     ICON: str = "Translate"
-
-    def __init__(self, model=None, **kwargs):
-        """Initialize the transformer.
-
-        This process includes the instantiation of the pre-trained model and the
-        associated tokenizer. When ``model`` is ``None`` the Helsinki-NLP
-        ``opus-mt-en-es`` checkpoint is downloaded from HuggingFace; when a
-        model object is supplied the tokenizer is reused without re-downloading.
-
-        Parameters
-        ----------
-        model : transformers.PreTrainedModel or None, optional
-            An already-loaded HuggingFace translation model to reuse. If
-            ``None``, the pre-trained ``Helsinki-NLP/opus-mt-en-es`` checkpoint
-            is downloaded and initialised. Default ``None``.
-        **kwargs : dict
-            Additional hyperparameters forwarded to ``validate_and_transform``
-            and used to configure training arguments (e.g. ``batch_size``,
-            ``epochs``, ``learning_rate``).
-        """
-        kwargs = self.validate_and_transform(kwargs)
-        from transformers import AutoTokenizer
-
-        self.model_name = "Helsinki-NLP/opus-mt-en-es"
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
-        if model is None:
-            self.training_args = kwargs
-            self.batch_size = kwargs.pop("batch_size", 16)
-            self.device = kwargs.pop("device")
-            self.log_train_every_n_epochs = kwargs.pop("log_train_every_n_epochs", 1)
-            self.log_train_every_n_steps = kwargs.pop("log_train_every_n_steps", None)
-            self.log_validation_every_n_epochs = kwargs.pop(
-                "log_validation_every_n_epochs", 1
-            )
-            self.log_validation_every_n_steps = kwargs.pop(
-                "log_validation_every_n_steps", None
-            )
-        if model is None:
-            from transformers import AutoModelForSeq2SeqLM
-
-            self.model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name)
-        else:
-            self.model = model
-        self.num_train_epochs = kwargs.get("num_train_epochs", 2)
-        self.fitted = model is not None
-
-    def tokenize_data(
-        self, x: "DashAIDataset", y: Optional["DashAIDataset"] = None
-    ) -> "DashAIDataset":
-        """Tokenize input and optional target datasets for seq2seq training.
-
-        Each sample is tokenized with truncation and max-length padding to 512
-        tokens. When ``y`` is provided, the target tokens are stored under the
-        ``labels`` key so the ``Seq2SeqTrainer`` can compute the loss directly.
-
-        Parameters
-        ----------
-        x : DashAIDataset
-            Source-language dataset. Only the first column is used.
-        y : DashAIDataset, optional
-            Target-language dataset. When provided, tokenized targets are added
-            as ``labels``. When ``None``, only ``input_ids`` and
-            ``attention_mask`` are returned (inference mode).
-
-        Returns
-        -------
-        DashAIDataset
-            Tokenized dataset with keys ``input_ids``, ``attention_mask``, and
-            optionally ``labels``.
-        """
-        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
-
-        is_y = bool(y)
-        if not y:
-            y = DashAIDataset.from_list([{"foo": 0}] * len(x))
-        dataset = []
-        input_column_name = x.column_names[0]
-        output_column_name = y.column_names[0] if is_y else None
-
-        for i, input_sample in enumerate(x):
-            tokenized_input = self.tokenizer(
-                input_sample[input_column_name],
-                truncation=True,
-                padding="max_length",
-                max_length=512,
-            )
-
-            sample = {
-                "input_ids": tokenized_input["input_ids"],
-                "attention_mask": tokenized_input["attention_mask"],
-            }
-
-            if is_y:
-                output_sample = y[i]
-                tokenized_output = self.tokenizer(
-                    output_sample[output_column_name],
-                    truncation=True,
-                    padding="max_length",
-                    max_length=512,
-                )
-                sample["labels"] = tokenized_output["input_ids"]
-
-            dataset.append(sample)
-        return DashAIDataset.from_list(dataset)
-
-    def train(
-        self,
-        x_train: "DashAIDataset",
-        y_train: "DashAIDataset",
-        x_validation: "DashAIDataset" = None,
-        y_validation: "DashAIDataset" = None,
-    ) -> "OpusMtEnESTransformer":
-        """Fine-tune the opus-mt-en-es model on English-Spanish translation data.
-
-        Parameters
-        ----------
-        x_train : DashAIDataset
-            Input English text features for training.
-        y_train : DashAIDataset
-            Target Spanish translation labels for training.
-        x_validation : DashAIDataset, optional
-            Input English text features for validation. Defaults to None.
-        y_validation : DashAIDataset, optional
-            Target Spanish translation labels for validation. Defaults to None.
-
-        Returns
-        -------
-        OpusMtEnESTransformer
-            The fine-tuned model instance.
-        """
-        from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
-
-        dataset = self.tokenize_data(x_train, y_train)
-        dataset.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
-
-        from transformers import Seq2SeqTrainer, Seq2SeqTrainingArguments
-
-        training_args = Seq2SeqTrainingArguments(
-            output_dir="DashAI/back/user_models/temp_checkpoints_opus-mt-en-es",
-            save_steps=1,
-            save_total_limit=1,
-            per_device_train_batch_size=self.batch_size,
-            per_device_eval_batch_size=self.batch_size,
-            use_cpu=self.device.lower() != "gpu",
-            **self.training_args,
-        )
-
-        # Initialize the custom callback with epoch information
-        metrics_callback = MetricsCallback(
-            model_instance=self,
-            x_train=x_train,
-            y_train=y_train,
-            x_val=x_validation,
-            y_val=y_validation,
-            total_epochs=self.num_train_epochs,
-            log_training_every_n_epochs=self.log_train_every_n_epochs,
-            log_training_every_n_steps=self.log_train_every_n_steps,
-            log_val_every_n_epochs=self.log_validation_every_n_epochs,
-            log_val_every_n_steps=self.log_validation_every_n_steps,
-        )
-
-        trainer = Seq2SeqTrainer(
-            model=self.model,
-            args=training_args,
-            train_dataset=dataset,
-            callbacks=[metrics_callback],
-        )
-
-        self.fitted = True
-        trainer.train()
-        shutil.rmtree(
-            "DashAI/back/user_models/temp_checkpoints_opus-mt-en-es", ignore_errors=True
-        )
-        return self
-
-    def predict(self, x_pred: "DashAIDataset") -> List:
-        """Translate English source texts to Spanish.
-
-        Parameters
-        ----------
-        x_pred : DashAIDataset
-            Source-language dataset. Only the first column is used.
-
-        Returns
-        -------
-        list of str
-            One translated string per input sample, in the same order as
-            ``x_pred``.
-
-        Raises
-        ------
-        sklearn.exceptions.NotFittedError
-            If the model has not been fine-tuned yet (``fitted`` is ``False``).
-        """
-        if not self.fitted:
-            raise NotFittedError(
-                f"This {self.__class__.__name__} instance is not fitted yet. Call 'fit'"
-                " with appropriate arguments before using this "
-                "estimator."
-            )
-
-        dataset = self.tokenize_data(x_pred)
-        dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
-
-        translations = []
-
-        for example in dataset:
-            inputs = {
-                k: v.unsqueeze(0).to(self.model.device) for k, v in example.items()
-            }
-            outputs = self.model.generate(**inputs)
-            translated_text = self.tokenizer.decode(
-                outputs[0], skip_special_tokens=True
-            )
-            translations.append(translated_text)
-
-        return translations
-
-    def prepare_dataset(
-        self, dataset: "DashAIDataset", is_fit: bool = False
-    ) -> "DashAIDataset":
-        """Return the dataset unchanged.
-
-        No pre-processing transformations are required for this model. The
-        method exists for compatibility with the DashAI model interface.
-
-        Parameters
-        ----------
-        dataset : DashAIDataset
-            The dataset to be prepared.
-        is_fit : bool, optional
-            Whether the call is made during fitting. Unused here. Default
-            ``False``.
-
-        Returns
-        -------
-        DashAIDataset
-            The original dataset, unmodified.
-        """
-        try:
-            # Useless in this case, but we keep it for consistency with other models.
-            return dataset
-        except Exception as e:
-            print(f"Couldn't apply transformations to the dataset for the model: {e}")
-
-    def save(self, filename: Union[str, "Path"]) -> None:
-        """Store the fine-tuned model and its configuration to disk.
-
-        Saves the model weights via ``save_pretrained`` and embeds the
-        hyperparameters (epochs, batch size, learning rate, etc.) into the
-        Hugging Face config so they can be restored by :meth:`load`.
-
-        Parameters
-        ----------
-        filename : str or Path
-            Directory path where the model files will be written.
-        """
-        save_dir = Path(filename)
-        if save_dir.exists() and save_dir.is_file():
-            save_dir.unlink()
-        save_dir.mkdir(parents=True, exist_ok=True)
-
-        self.model.save_pretrained(save_dir)
-        from transformers import AutoConfig
-
-        config = AutoConfig.from_pretrained(save_dir)
-
-        config.custom_params = {
-            "num_train_epochs": self.training_args.get("num_train_epochs"),
-            "batch_size": self.batch_size,
-            "learning_rate": self.training_args.get("learning_rate"),
-            "device": self.device,
-            "weight_decay": self.training_args.get("weight_decay"),
-            "fitted": self.fitted,
-        }
-
-        config.save_pretrained(save_dir)
-
-    @classmethod
-    def load(cls, filename: Union[str, "Path"]):
-        """Restore an OpusMtEnESTransformer instance from disk.
-
-        Reads the Hugging Face config to recover the custom hyperparameters
-        saved by :meth:`save`, then reconstructs the seq2seq model and wraps
-        it in a new :class:`OpusMtEnESTransformer` instance.
-
-        Parameters
-        ----------
-        filename : str or Path
-            Directory path from which the model files will be read.
-
-        Returns
-        -------
-        OpusMtEnESTransformer
-            The restored model instance with ``fitted`` set to the persisted
-            value.
-        """
-        from transformers import AutoConfig, AutoModelForSeq2SeqLM
-
-        model = AutoModelForSeq2SeqLM.from_pretrained(filename)
-
-        config = AutoConfig.from_pretrained(filename)
-
-        custom_params = getattr(config, "custom_params", {})
-
-        loaded_model = cls(
-            model=model,
-            num_train_epochs=custom_params.get("num_train_epochs"),
-            batch_size=custom_params.get("batch_size"),
-            learning_rate=custom_params.get("learning_rate"),
-            device=custom_params.get("device"),
-            weight_decay=custom_params.get("weight_decay"),
-            log_train_every_n_epochs=None,
-            log_train_every_n_steps=None,
-            log_validation_every_n_epochs=None,
-            log_validation_every_n_steps=None,
-        )
-        loaded_model.fitted = custom_params.get("fitted", False)
-
-        return loaded_model

--- a/DashAI/back/models/hugging_face/opus_mt_en_fr_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_fr_transformer.py
@@ -1,0 +1,47 @@
+"""OpusMtEnFrTransformer model for English-to-French translation."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_opus_mt_transformer import (
+    OpusMtTransformerMixin,
+)
+from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
+    OpusMtEnESTransformerSchema,
+)
+
+
+class OpusMtEnFrTransformerSchema(OpusMtEnESTransformerSchema):
+    """Schema for the English-to-French Opus-MT model."""
+
+
+class OpusMtEnFrTransformer(OpusMtTransformerMixin):
+    """Pre-trained transformer for English-to-French translation.
+
+    Fine-tunes the Helsinki-NLP ``opus-mt-en-fr`` checkpoint, a MarianMT
+    seq2seq model trained on parallel English-French corpora from the OPUS
+    collection.
+
+    References
+    ----------
+    - [1] https://huggingface.co/Helsinki-NLP/opus-mt-en-fr
+    - [2] https://opus.nlpl.eu/
+    """
+
+    MODEL_NAME: str = "Helsinki-NLP/opus-mt-en-fr"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_opus-mt-en-fr"
+    SCHEMA = OpusMtEnFrTransformerSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Opus MT En-Fr Transformer",
+        es="Transformer Opus MT En-Fr",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Pre-trained transformer for English-French translation. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Transformer pre-entrenado para traducción inglés-francés. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#1976D2"
+    ICON: str = "Translate"

--- a/DashAI/back/models/hugging_face/opus_mt_en_pt_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_en_pt_transformer.py
@@ -1,0 +1,47 @@
+"""OpusMtEnPtTransformer model for English-to-Portuguese translation."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_opus_mt_transformer import (
+    OpusMtTransformerMixin,
+)
+from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
+    OpusMtEnESTransformerSchema,
+)
+
+
+class OpusMtEnPtTransformerSchema(OpusMtEnESTransformerSchema):
+    """Schema for the English-to-Portuguese Opus-MT model."""
+
+
+class OpusMtEnPtTransformer(OpusMtTransformerMixin):
+    """Pre-trained transformer for English-to-Portuguese translation.
+
+    Fine-tunes the Helsinki-NLP ``opus-mt-en-pt`` checkpoint, a MarianMT
+    seq2seq model trained on parallel English-Portuguese corpora from the OPUS
+    collection.
+
+    References
+    ----------
+    - [1] https://huggingface.co/Helsinki-NLP/opus-mt-en-pt
+    - [2] https://opus.nlpl.eu/
+    """
+
+    MODEL_NAME: str = "Helsinki-NLP/opus-mt-en-pt"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_opus-mt-en-pt"
+    SCHEMA = OpusMtEnPtTransformerSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Opus MT En-Pt Transformer",
+        es="Transformer Opus MT En-Pt",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Pre-trained transformer for English-Portuguese translation. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Transformer pre-entrenado para traducción inglés-portugués. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#2E7D32"
+    ICON: str = "Translate"

--- a/DashAI/back/models/hugging_face/opus_mt_es_en_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_es_en_transformer.py
@@ -1,42 +1,27 @@
-"""OpusMtEsENTransformer model for spanish-english translation DashAI implementation."""
-
-import shutil
-import tempfile
-from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
-
-from sklearn.exceptions import NotFittedError
+"""OpusMtEsENTransformer model for Spanish-to-English translation."""
 
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_opus_mt_transformer import (
+    OpusMtTransformerMixin,
+)
 from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
     OpusMtEnESTransformerSchema,
 )
-from DashAI.back.models.translation_model import TranslationModel
-from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
-
-if TYPE_CHECKING:
-    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
 
 class OpusMtEsENTransformerSchema(OpusMtEnESTransformerSchema):
-    """opus-mt-es-en is a transformer pre-trained model that allows translation of
-    texts from Spanish to English. The implementation is based on the Helsinki-NLP
-    opus-mt-es-en checkpoint, which uses the MarianMT architecture and was trained
-    on parallel corpora from the OPUS collection.
+    """Schema for the Spanish-to-English Opus-MT model.
+
+    Inherits all fields from ``OpusMtEnESTransformerSchema``.
     """
 
 
-class OpusMtEsENTransformer(TranslationModel):
+class OpusMtEsENTransformer(OpusMtTransformerMixin):
     """Pre-trained transformer for Spanish-to-English translation.
 
-    This model fine-tunes the Helsinki-NLP ``opus-mt-es-en`` checkpoint, which is
-    based on the MarianMT sequence-to-sequence architecture. The base model was
-    trained on parallel Spanish-English corpora from the OPUS collection and supports
-    direct translation without intermediate pivot languages.
-
-    Fine-tuning is performed with the HuggingFace ``Seq2SeqTrainer`` using the AdamW
-    optimizer. Training and validation metrics are logged at configurable epoch and
-    step intervals via a custom ``MetricsCallback``.
+    Fine-tunes the Helsinki-NLP ``opus-mt-es-en`` checkpoint, a MarianMT
+    seq2seq model trained on parallel Spanish-English corpora from the OPUS
+    collection. Supports direct translation without pivot languages.
 
     References
     ----------
@@ -44,344 +29,22 @@ class OpusMtEsENTransformer(TranslationModel):
     - [2] https://opus.nlpl.eu/
     """
 
+    MODEL_NAME: str = "Helsinki-NLP/opus-mt-es-en"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_opus-mt-es-en"
     SCHEMA = OpusMtEsENTransformerSchema
     DISPLAY_NAME: str = MultilingualString(
         en="Opus MT Es-En Transformer",
         es="Transformer Opus MT Es-En",
     )
     DESCRIPTION: str = MultilingualString(
-        en="Pre-trained transformer for Spanish-English translation.",
-        es="Transformer pre-entrenado para traducción español-inglés.",
+        en=(
+            "Pre-trained transformer for Spanish-English translation. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Transformer pre-entrenado para traducción español-inglés. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
     )
     COLOR: str = "#FF8A65"
     ICON: str = "Translate"
-
-    def __init__(self, model=None, **kwargs):
-        """Initialize the transformer.
-
-        Downloads the ``Helsinki-NLP/opus-mt-es-en`` tokenizer and, when
-        ``model`` is ``None``, the seq2seq model weights from HuggingFace.
-        When a pre-loaded model is supplied, the weights are reused directly
-        and ``fitted`` is set to ``True``.
-
-        Parameters
-        ----------
-        model : transformers.PreTrainedModel or None, optional
-            An already-loaded HuggingFace seq2seq model to reuse. If ``None``,
-            the ``Helsinki-NLP/opus-mt-es-en`` checkpoint is downloaded and
-            initialised. Default ``None``.
-        **kwargs : dict
-            Hyperparameters forwarded to ``validate_and_transform`` and used to
-            configure training (e.g. ``num_train_epochs``, ``batch_size``,
-            ``learning_rate``, ``weight_decay``, ``device``).
-        """
-        kwargs = self.validate_and_transform(kwargs)
-
-        from transformers import AutoTokenizer
-
-        self.model_name = "Helsinki-NLP/opus-mt-es-en"
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
-
-        self.training_args = {
-            "num_train_epochs": kwargs.get("num_train_epochs", 2),
-            "learning_rate": kwargs.get("learning_rate", 2e-5),
-            "weight_decay": kwargs.get("weight_decay", 0.01),
-        }
-        self.batch_size = kwargs.get("batch_size", 4)
-        self.device = kwargs.get("device") or GPU_OR_CPU_PLACEHOLDER
-        self.log_train_every_n_epochs = kwargs.get("log_train_every_n_epochs", 1)
-        self.log_train_every_n_steps = kwargs.get("log_train_every_n_steps", None)
-        self.log_validation_every_n_epochs = kwargs.get(
-            "log_validation_every_n_epochs", 1
-        )
-        self.log_validation_every_n_steps = kwargs.get(
-            "log_validation_every_n_steps", None
-        )
-
-        if model is None:
-            from transformers import AutoModelForSeq2SeqLM
-
-            self.model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name)
-        else:
-            self.model = model
-
-        self.num_train_epochs = self.training_args.get("num_train_epochs", 2)
-        self.fitted = model is not None
-
-    def tokenize_data(
-        self, x: "DashAIDataset", y: Optional["DashAIDataset"] = None
-    ) -> "DashAIDataset":
-        """Tokenize input and optional target datasets for seq2seq training.
-
-        Each sample is tokenized with truncation and max-length padding to 512
-        tokens. When ``y`` is provided, the target tokens are stored under the
-        ``labels`` key so the ``Seq2SeqTrainer`` can compute the loss directly.
-
-        Parameters
-        ----------
-        x : DashAIDataset
-            Source-language dataset. Only the first column is used.
-        y : DashAIDataset, optional
-            Target-language dataset. When provided, tokenized targets are added
-            as ``labels``. When ``None``, only ``input_ids`` and
-            ``attention_mask`` are returned (inference mode).
-
-        Returns
-        -------
-        DashAIDataset
-            Tokenized dataset with keys ``input_ids``, ``attention_mask``, and
-            optionally ``labels``.
-        """
-        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
-
-        is_y = bool(y)
-        if not y:
-            y = DashAIDataset.from_list([{"foo": 0}] * len(x))
-
-        dataset = []
-        input_column_name = x.column_names[0]
-        output_column_name = y.column_names[0] if is_y else None
-
-        for i, input_sample in enumerate(x):
-            tokenized_input = self.tokenizer(
-                input_sample[input_column_name],
-                truncation=True,
-                padding="max_length",
-                max_length=512,
-            )
-
-            sample = {
-                "input_ids": tokenized_input["input_ids"],
-                "attention_mask": tokenized_input["attention_mask"],
-            }
-
-            if is_y:
-                output_sample = y[i]
-                tokenized_output = self.tokenizer(
-                    output_sample[output_column_name],
-                    truncation=True,
-                    padding="max_length",
-                    max_length=512,
-                )
-                sample["labels"] = tokenized_output["input_ids"]
-
-            dataset.append(sample)
-
-        return DashAIDataset.from_list(dataset)
-
-    def train(
-        self,
-        x_train: "DashAIDataset",
-        y_train: "DashAIDataset",
-        x_validation: "DashAIDataset" = None,
-        y_validation: "DashAIDataset" = None,
-    ) -> "OpusMtEsENTransformer":
-        """Fine-tune the opus-mt-es-en model on Spanish-English translation data.
-
-        Parameters
-        ----------
-        x_train : DashAIDataset
-            Input Spanish text features for training.
-        y_train : DashAIDataset
-            Target English translation labels for training.
-        x_validation : DashAIDataset, optional
-            Input Spanish text features for validation. Default ``None``.
-        y_validation : DashAIDataset, optional
-            Target English translation labels for validation. Default ``None``.
-
-        Returns
-        -------
-        OpusMtEsENTransformer
-            The fine-tuned model instance.
-        """
-        from transformers import Seq2SeqTrainer, Seq2SeqTrainingArguments
-
-        from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
-
-        dataset = self.tokenize_data(x_train, y_train)
-        dataset.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
-
-        has_validation_data = x_validation is not None and y_validation is not None
-
-        output_root = Path("DashAI/back/user_models/temp_checkpoints_opus-mt-es-en")
-        output_root.mkdir(parents=True, exist_ok=True)
-        run_output_dir = tempfile.mkdtemp(prefix="opus_mt_es_en_", dir=str(output_root))
-
-        training_args = Seq2SeqTrainingArguments(
-            output_dir=run_output_dir,
-            save_steps=1,
-            save_total_limit=1,
-            per_device_train_batch_size=self.batch_size,
-            per_device_eval_batch_size=self.batch_size,
-            use_cpu=self.device.lower() != "gpu",
-            **self.training_args,
-        )
-
-        metrics_callback = MetricsCallback(
-            model_instance=self,
-            x_train=x_train,
-            y_train=y_train,
-            x_val=x_validation,
-            y_val=y_validation,
-            total_epochs=self.num_train_epochs,
-            log_training_every_n_epochs=self.log_train_every_n_epochs,
-            log_training_every_n_steps=self.log_train_every_n_steps,
-            log_val_every_n_epochs=(
-                self.log_validation_every_n_epochs if has_validation_data else None
-            ),
-            log_val_every_n_steps=(
-                self.log_validation_every_n_steps if has_validation_data else None
-            ),
-        )
-
-        trainer = Seq2SeqTrainer(
-            model=self.model,
-            args=training_args,
-            train_dataset=dataset,
-            callbacks=[metrics_callback],
-        )
-
-        self.fitted = True
-        try:
-            trainer.train()
-        finally:
-            shutil.rmtree(run_output_dir, ignore_errors=True)
-
-        return self
-
-    def predict(self, x_pred: "DashAIDataset") -> List:
-        """Translate Spanish source texts to English.
-
-        Parameters
-        ----------
-        x_pred : DashAIDataset
-            Source-language dataset. Only the first column is used.
-
-        Returns
-        -------
-        list of str
-            One translated string per input sample, in the same order as
-            ``x_pred``.
-
-        Raises
-        ------
-        sklearn.exceptions.NotFittedError
-            If the model has not been fine-tuned yet (``fitted`` is ``False``).
-        """
-        if not self.fitted:
-            raise NotFittedError(
-                f"This {self.__class__.__name__} instance is not fitted yet. Call 'fit'"
-                " with appropriate arguments before using this estimator."
-            )
-
-        dataset = self.tokenize_data(x_pred)
-        dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
-
-        translations = []
-
-        for example in dataset:
-            inputs = {
-                k: v.unsqueeze(0).to(self.model.device) for k, v in example.items()
-            }
-            outputs = self.model.generate(**inputs)
-            translated_text = self.tokenizer.decode(
-                outputs[0], skip_special_tokens=True
-            )
-            translations.append(translated_text)
-
-        return translations
-
-    def prepare_dataset(
-        self, dataset: "DashAIDataset", is_fit: bool = False
-    ) -> "DashAIDataset":
-        """Return the dataset unchanged.
-
-        No pre-processing transformations are required for this model. The
-        method exists for compatibility with the DashAI model interface.
-
-        Parameters
-        ----------
-        dataset : DashAIDataset
-            The dataset to be prepared.
-        is_fit : bool, optional
-            Whether the call is made during fitting. Unused here. Default
-            ``False``.
-
-        Returns
-        -------
-        DashAIDataset
-            The original dataset, unmodified.
-        """
-        return dataset
-
-    def save(self, filename: Union[str, "Path"]) -> None:
-        """Store the fine-tuned model and its configuration to disk.
-
-        Saves the model weights via ``save_pretrained`` and embeds the
-        hyperparameters (epochs, batch size, learning rate, etc.) into the
-        HuggingFace config so they can be restored by :meth:`load`.
-
-        Parameters
-        ----------
-        filename : str or Path
-            Directory path where the model files will be written. If a file
-            exists at that path it is removed and replaced by a directory.
-        """
-        from transformers import AutoConfig
-
-        save_dir = Path(filename)
-        if save_dir.exists() and save_dir.is_file():
-            save_dir.unlink()
-        save_dir.mkdir(parents=True, exist_ok=True)
-
-        self.model.save_pretrained(save_dir)
-        config = AutoConfig.from_pretrained(save_dir)
-        config.custom_params = {
-            "num_train_epochs": self.training_args.get("num_train_epochs"),
-            "batch_size": self.batch_size,
-            "learning_rate": self.training_args.get("learning_rate"),
-            "device": self.device,
-            "weight_decay": self.training_args.get("weight_decay"),
-            "fitted": self.fitted,
-        }
-        config.save_pretrained(save_dir)
-
-    @classmethod
-    def load(cls, filename: Union[str, "Path"]):
-        """Restore an OpusMtEsENTransformer instance from disk.
-
-        Reads the HuggingFace config to recover the custom hyperparameters
-        saved by :meth:`save`, then reconstructs the seq2seq model and wraps
-        it in a new :class:`OpusMtEsENTransformer` instance.
-
-        Parameters
-        ----------
-        filename : str or Path
-            Directory path from which the model files will be read.
-
-        Returns
-        -------
-        OpusMtEsENTransformer
-            The restored model instance with ``fitted`` set to the persisted
-            value.
-        """
-        from transformers import AutoConfig, AutoModelForSeq2SeqLM
-
-        model = AutoModelForSeq2SeqLM.from_pretrained(filename)
-        config = AutoConfig.from_pretrained(filename)
-        custom_params = getattr(config, "custom_params", {})
-
-        loaded_model = cls(
-            model=model,
-            num_train_epochs=custom_params.get("num_train_epochs"),
-            batch_size=custom_params.get("batch_size"),
-            learning_rate=custom_params.get("learning_rate"),
-            device=custom_params.get("device"),
-            weight_decay=custom_params.get("weight_decay"),
-            log_train_every_n_epochs=None,
-            log_train_every_n_steps=None,
-            log_validation_every_n_epochs=None,
-            log_validation_every_n_steps=None,
-        )
-        loaded_model.fitted = custom_params.get("fitted", False)
-        return loaded_model

--- a/DashAI/back/models/hugging_face/opus_mt_fr_en_transformer.py
+++ b/DashAI/back/models/hugging_face/opus_mt_fr_en_transformer.py
@@ -1,0 +1,47 @@
+"""OpusMtFrEnTransformer model for French-to-English translation."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_opus_mt_transformer import (
+    OpusMtTransformerMixin,
+)
+from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
+    OpusMtEnESTransformerSchema,
+)
+
+
+class OpusMtFrEnTransformerSchema(OpusMtEnESTransformerSchema):
+    """Schema for the French-to-English Opus-MT model."""
+
+
+class OpusMtFrEnTransformer(OpusMtTransformerMixin):
+    """Pre-trained transformer for French-to-English translation.
+
+    Fine-tunes the Helsinki-NLP ``opus-mt-fr-en`` checkpoint, a MarianMT
+    seq2seq model trained on parallel French-English corpora from the OPUS
+    collection.
+
+    References
+    ----------
+    - [1] https://huggingface.co/Helsinki-NLP/opus-mt-fr-en
+    - [2] https://opus.nlpl.eu/
+    """
+
+    MODEL_NAME: str = "Helsinki-NLP/opus-mt-fr-en"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_opus-mt-fr-en"
+    SCHEMA = OpusMtFrEnTransformerSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Opus MT Fr-En Transformer",
+        es="Transformer Opus MT Fr-En",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Pre-trained transformer for French-English translation. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Transformer pre-entrenado para traducción francés-inglés. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#0097A7"
+    ICON: str = "Translate"

--- a/DashAI/back/models/hugging_face/roberta_transformer.py
+++ b/DashAI/back/models/hugging_face/roberta_transformer.py
@@ -1,0 +1,45 @@
+"""DashAI implementation of RoBERTa model for English text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class RobertaTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained RoBERTa model for English text classification.
+
+    RoBERTa (Robustly Optimised BERT Pre-training Approach) improves upon BERT
+    by training longer with larger mini-batches, removing the next-sentence
+    prediction objective, and using dynamic masking. It achieves consistently
+    higher performance on NLP benchmarks than BERT.
+
+    References
+    ----------
+    - [1] Liu, Y. et al. (2019). "RoBERTa: A Robustly Optimized BERT Pretraining
+           Approach." arXiv:1907.11692.
+    - [2] https://huggingface.co/roberta-base
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="RoBERTa Transformer",
+        es="Transformer RoBERTa",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Robustly optimised BERT for English text classification. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "BERT optimizado robustamente para clasificación de texto en inglés. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#E65100"
+    ICON: str = "SmartToy"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "roberta-base"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_roberta"

--- a/DashAI/back/models/hugging_face/t5_small_transformer.py
+++ b/DashAI/back/models/hugging_face/t5_small_transformer.py
@@ -1,0 +1,306 @@
+"""T5SmallTransformer model for English-to-{German, French, Romanian} translation."""
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from sklearn.exceptions import NotFittedError
+
+from DashAI.back.core.schema_fields import enum_field, schema_field
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
+    OpusMtEnESTransformerSchema,
+)
+from DashAI.back.models.translation_model import TranslationModel
+from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+_T5_SUPPORTED_LANGUAGES = ["German", "French", "Romanian"]
+
+
+class T5SmallTransformerSchema(OpusMtEnESTransformerSchema):
+    """Schema for the T5-small translation model.
+
+    Extends the standard translation schema with a ``target_language`` field
+    restricted to the languages covered by T5's pre-training tasks:
+    German, French, and Romanian (source is always English).
+    """
+
+    target_language: schema_field(
+        enum_field(_T5_SUPPORTED_LANGUAGES),
+        placeholder="German",
+        description=MultilingualString(
+            en=(
+                "Target language for translation. "
+                "Supported: 'German', 'French', 'Romanian'. "
+                "T5-small translates from English only."
+            ),
+            es=(
+                "Idioma destino para la traducción. "
+                "Soportados: 'German', 'French', 'Romanian'. "
+                "T5-small traduce solo desde inglés."
+            ),
+        ),
+        alias=MultilingualString(en="Target language", es="Idioma destino"),
+    )  # type: ignore
+
+
+class T5SmallTransformer(TranslationModel):
+    """T5-small seq2seq model for English-to-{German, French, Romanian} translation.
+
+    Fine-tunes the ``t5-small`` checkpoint from Google. Translation direction is
+    controlled by a task prefix prepended to each source sentence, e.g.
+    ``"translate English to German: <text>"``.
+
+    Supported target languages: German, French, Romanian (T5 pre-training scope).
+    The source language is always English.
+
+    References
+    ----------
+    - [1] https://huggingface.co/t5-small
+    - [2] Raffel et al. (2020). "Exploring the Limits of Transfer Learning with a
+           Unified Text-to-Text Transformer." JMLR 2020.
+    """
+
+    SCHEMA = T5SmallTransformerSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="T5-Small Translation Transformer",
+        es="Transformer de Traducción T5-Small",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Google T5-small model for English-to-{German, French, Romanian} "
+            "translation using task prefixes. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Modelo T5-small de Google para traducción inglés-{alemán, francés, "
+            "rumano} usando prefijos de tarea. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#00695C"
+    ICON: str = "Language"
+
+    def __init__(self, model=None, **kwargs):
+        kwargs = self.validate_and_transform(kwargs)
+
+        from transformers import AutoTokenizer
+
+        self.model_name = "t5-small"
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+
+        self.target_language = kwargs.get("target_language", "German")
+
+        self.training_args = {
+            "num_train_epochs": kwargs.get("num_train_epochs", 2),
+            "learning_rate": kwargs.get("learning_rate", 2e-5),
+            "weight_decay": kwargs.get("weight_decay", 0.01),
+        }
+        self.batch_size = kwargs.get("batch_size", 4)
+        self.device = kwargs.get("device") or GPU_OR_CPU_PLACEHOLDER
+        self.log_train_every_n_epochs = kwargs.get("log_train_every_n_epochs", 1)
+        self.log_train_every_n_steps = kwargs.get("log_train_every_n_steps", None)
+        self.log_validation_every_n_epochs = kwargs.get(
+            "log_validation_every_n_epochs", 1
+        )
+        self.log_validation_every_n_steps = kwargs.get(
+            "log_validation_every_n_steps", None
+        )
+
+        if model is None:
+            from transformers import AutoModelForSeq2SeqLM
+
+            self.model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name)
+        else:
+            self.model = model
+
+        self.num_train_epochs = self.training_args.get("num_train_epochs", 2)
+        self.fitted = model is not None
+
+    def _make_prefix(self) -> str:
+        return f"translate English to {self.target_language}: "
+
+    def tokenize_data(
+        self, x: "DashAIDataset", y: Optional["DashAIDataset"] = None
+    ) -> "DashAIDataset":
+        """Prepend the T5 task prefix and tokenize source/target texts."""
+        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+        prefix = self._make_prefix()
+        is_y = bool(y)
+        if not y:
+            y = DashAIDataset.from_list([{"foo": 0}] * len(x))
+
+        dataset = []
+        input_column_name = x.column_names[0]
+        output_column_name = y.column_names[0] if is_y else None
+
+        for i, input_sample in enumerate(x):
+            text = prefix + input_sample[input_column_name]
+            tokenized_input = self.tokenizer(
+                text,
+                truncation=True,
+                padding="max_length",
+                max_length=512,
+            )
+            sample = {
+                "input_ids": tokenized_input["input_ids"],
+                "attention_mask": tokenized_input["attention_mask"],
+            }
+            if is_y:
+                output_sample = y[i]
+                tokenized_output = self.tokenizer(
+                    output_sample[output_column_name],
+                    truncation=True,
+                    padding="max_length",
+                    max_length=512,
+                )
+                sample["labels"] = tokenized_output["input_ids"]
+            dataset.append(sample)
+
+        return DashAIDataset.from_list(dataset)
+
+    def train(
+        self,
+        x_train: "DashAIDataset",
+        y_train: "DashAIDataset",
+        x_validation: "DashAIDataset" = None,
+        y_validation: "DashAIDataset" = None,
+    ):
+        """Fine-tune T5-small on the configured translation direction."""
+        from transformers import Seq2SeqTrainer, Seq2SeqTrainingArguments
+
+        from DashAI.back.models.hugging_face.metrics_callback import MetricsCallback
+
+        dataset = self.tokenize_data(x_train, y_train)
+        dataset.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
+
+        has_validation_data = x_validation is not None and y_validation is not None
+
+        output_root = Path("DashAI/back/user_models/temp_checkpoints_t5_small")
+        output_root.mkdir(parents=True, exist_ok=True)
+        run_output_dir = tempfile.mkdtemp(prefix="t5_small_", dir=str(output_root))
+
+        training_args_obj = Seq2SeqTrainingArguments(
+            output_dir=run_output_dir,
+            save_steps=1,
+            save_total_limit=1,
+            per_device_train_batch_size=self.batch_size,
+            per_device_eval_batch_size=self.batch_size,
+            use_cpu=self.device.lower() != "gpu",
+            **self.training_args,
+        )
+
+        metrics_callback = MetricsCallback(
+            model_instance=self,
+            x_train=x_train,
+            y_train=y_train,
+            x_val=x_validation,
+            y_val=y_validation,
+            total_epochs=self.num_train_epochs,
+            log_training_every_n_epochs=self.log_train_every_n_epochs,
+            log_training_every_n_steps=self.log_train_every_n_steps,
+            log_val_every_n_epochs=(
+                self.log_validation_every_n_epochs if has_validation_data else None
+            ),
+            log_val_every_n_steps=(
+                self.log_validation_every_n_steps if has_validation_data else None
+            ),
+        )
+
+        trainer = Seq2SeqTrainer(
+            model=self.model,
+            args=training_args_obj,
+            train_dataset=dataset,
+            callbacks=[metrics_callback],
+        )
+
+        self.fitted = True
+        try:
+            trainer.train()
+        finally:
+            shutil.rmtree(run_output_dir, ignore_errors=True)
+
+        return self
+
+    def predict(self, x_pred: "DashAIDataset") -> List:
+        """Translate from English to the configured target language."""
+        if not self.fitted:
+            raise NotFittedError(
+                f"This {self.__class__.__name__} instance is not fitted yet. "
+                "Call 'train' before using this estimator."
+            )
+
+        dataset = self.tokenize_data(x_pred)
+        dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
+
+        translations = []
+        for example in dataset:
+            inputs = {
+                k: v.unsqueeze(0).to(self.model.device) for k, v in example.items()
+            }
+            outputs = self.model.generate(**inputs)
+            translated_text = self.tokenizer.decode(
+                outputs[0], skip_special_tokens=True
+            )
+            translations.append(translated_text)
+
+        return translations
+
+    def prepare_dataset(
+        self, dataset: "DashAIDataset", is_fit: bool = False
+    ) -> "DashAIDataset":
+        """Return the dataset unchanged."""
+        return dataset
+
+    def save(self, filename: Union[str, "Path"]) -> None:
+        """Persist model weights and hyperparameters to disk."""
+        from transformers import AutoConfig
+
+        save_dir = Path(filename)
+        if save_dir.exists() and save_dir.is_file():
+            save_dir.unlink()
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        self.model.save_pretrained(save_dir)
+        config = AutoConfig.from_pretrained(save_dir)
+        config.custom_params = {
+            "num_train_epochs": self.training_args.get("num_train_epochs"),
+            "batch_size": self.batch_size,
+            "learning_rate": self.training_args.get("learning_rate"),
+            "device": self.device,
+            "weight_decay": self.training_args.get("weight_decay"),
+            "target_language": self.target_language,
+            "fitted": self.fitted,
+        }
+        config.save_pretrained(save_dir)
+
+    @classmethod
+    def load(cls, filename: Union[str, "Path"]):
+        """Restore a T5SmallTransformer instance from disk."""
+        from transformers import AutoConfig, AutoModelForSeq2SeqLM
+
+        model = AutoModelForSeq2SeqLM.from_pretrained(filename)
+        config = AutoConfig.from_pretrained(filename)
+        custom_params = getattr(config, "custom_params", {})
+
+        loaded_model = cls(
+            model=model,
+            num_train_epochs=custom_params.get("num_train_epochs"),
+            batch_size=custom_params.get("batch_size"),
+            learning_rate=custom_params.get("learning_rate"),
+            device=custom_params.get("device"),
+            weight_decay=custom_params.get("weight_decay"),
+            target_language=custom_params.get("target_language", "German"),
+            log_train_every_n_epochs=None,
+            log_train_every_n_steps=None,
+            log_validation_every_n_epochs=None,
+            log_validation_every_n_steps=None,
+        )
+        loaded_model.fitted = custom_params.get("fitted", False)
+        return loaded_model

--- a/DashAI/back/models/hugging_face/xlm_roberta_transformer.py
+++ b/DashAI/back/models/hugging_face/xlm_roberta_transformer.py
@@ -1,0 +1,47 @@
+"""DashAI implementation of XLM-RoBERTa model for multilingual text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class XlmRobertaTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained XLM-RoBERTa model for multilingual text classification.
+
+    XLM-RoBERTa is a multilingual version of RoBERTa trained on 2.5 TB of
+    filtered CommonCrawl data covering 100 languages. It achieves strong
+    performance on cross-lingual classification without language-specific
+    fine-tuning. Requires the ``sentencepiece`` package for its tokeniser.
+
+    References
+    ----------
+    - [1] Conneau, A. et al. (2020). "Unsupervised Cross-lingual Representation
+           Learning at Scale." ACL 2020.
+    - [2] https://huggingface.co/xlm-roberta-base
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="XLM-RoBERTa Transformer",
+        es="Transformer XLM-RoBERTa",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Multilingual RoBERTa for cross-lingual text classification "
+            "(100 languages). "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "RoBERTa multilingüe para clasificación de texto entre idiomas "
+            "(100 idiomas). "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#6A1B9A"
+    ICON: str = "Language"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "xlm-roberta-base"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_xlm_roberta"

--- a/DashAI/back/models/hugging_face/xlnet_transformer.py
+++ b/DashAI/back/models/hugging_face/xlnet_transformer.py
@@ -1,0 +1,45 @@
+"""DashAI implementation of XLNet model for English text classification."""
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.hugging_face.base_text_classification_transformer import (
+    HuggingFaceTextClassificationTransformer,
+)
+from DashAI.back.models.hugging_face.distilbert_transformer import (
+    DistilBertTransformerSchema,
+)
+
+
+class XlnetTransformer(HuggingFaceTextClassificationTransformer):
+    """Pre-trained XLNet model for English text classification.
+
+    XLNet is an autoregressive language model that maximises the expected
+    log-likelihood over all permutations of the factorisation order. Unlike BERT,
+    XLNet does not rely on a corrupted input and can model bidirectional context
+    without masking, often outperforming BERT on various NLP tasks.
+
+    References
+    ----------
+    - [1] Yang, Z. et al. (2019). "XLNet: Generalised Autoregressive Pretraining
+           for Language Understanding." NeurIPS 2019.
+    - [2] https://huggingface.co/xlnet-base-cased
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="XLNet Transformer",
+        es="Transformer XLNet",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Autoregressive XLNet model for English text classification. "
+            "Downloads weights from Hugging Face on first use (internet required)."
+        ),
+        es=(
+            "Modelo XLNet autorregresivo para clasificación de texto en inglés. "
+            "Descarga pesos de Hugging Face en el primer uso (requiere internet)."
+        ),
+    )
+    COLOR: str = "#37474F"
+    ICON: str = "AutoAwesome"
+    SCHEMA = DistilBertTransformerSchema
+    MODEL_NAME: str = "xlnet-base-cased"
+    TEMP_CHECKPOINT_DIR: str = "DashAI/back/user_models/temp_checkpoints_xlnet"

--- a/DashAI/back/models/scikit_learn/adaboost_classifier.py
+++ b/DashAI/back/models/scikit_learn/adaboost_classifier.py
@@ -1,0 +1,130 @@
+from sklearn.ensemble import AdaBoostClassifier as _AdaBoostClassifier
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
+    SklearnLikeClassifier,
+)
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class AdaBoostClassifierSchema(BaseSchema):
+    """Schema that configures the AdaBoost Classifier.
+
+    AdaBoost (Adaptive Boosting) fits a sequence of weak learners on repeatedly
+    re-weighted versions of the training data. Misclassified samples receive
+    increased weight so that subsequent learners focus on harder examples. The
+    underlying implementation is ``sklearn.ensemble.AdaBoostClassifier``.
+    """
+
+    n_estimators: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 50,
+            "lower_bound": 10,
+            "upper_bound": 500,
+        },
+        description=MultilingualString(
+            en=(
+                "The maximum number of estimators at which boosting is terminated. "
+                "In case of perfect fit, the learning procedure is stopped early."
+            ),
+            es=(
+                "El número máximo de estimadores en el que se termina el boosting. "
+                "En caso de ajuste perfecto, el procedimiento de aprendizaje se "
+                "detiene antes."
+            ),
+        ),
+        alias=MultilingualString(en="N estimators", es="N estimadores"),
+    )  # type: ignore
+
+    learning_rate: schema_field(
+        optimizer_float_field(ge=0.01),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.01,
+            "upper_bound": 2.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Weight applied to each classifier at each boosting iteration. "
+                "A higher learning rate increases the contribution of each classifier."
+            ),
+            es=(
+                "Peso aplicado a cada clasificador en cada iteración de boosting. "
+                "Una tasa de aprendizaje mayor incrementa la contribución de cada "
+                "clasificador."
+            ),
+        ),
+        alias=MultilingualString(en="Learning rate", es="Tasa de aprendizaje"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class AdaBoostClassifier(
+    TabularClassificationModel, SklearnLikeClassifier, _AdaBoostClassifier
+):
+    """AdaBoost classifier that adapts to misclassified samples iteratively.
+
+    AdaBoost fits a sequence of weak classifiers (decision stumps by default) on
+    re-weighted training data, giving more weight to misclassified examples at each
+    round. The final prediction is a weighted majority vote of all weak classifiers.
+    AdaBoost is sensitive to noisy data and outliers.
+
+    Key hyperparameters include ``n_estimators``, ``learning_rate``, and
+    ``random_state``. The implementation wraps scikit-learn's
+    ``AdaBoostClassifier``.
+
+    References
+    ----------
+    - [1] Freund, Y. & Schapire, R.E. (1997). "A Decision-Theoretic Generalization
+           of On-Line Learning and an Application to Boosting." Journal of Computer
+           and System Sciences, 55(1), 119-139.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostClassifier.html
+    """
+
+    SCHEMA = AdaBoostClassifierSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="AdaBoost Classifier",
+        es="Clasificador AdaBoost",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Adaptive boosting that focuses on misclassified samples.",
+        es="Boosting adaptivo que se enfoca en muestras mal clasificadas.",
+    )
+    COLOR: str = "#FFA726"
+    ICON: str = "Bolt"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/adaboost_regression.py
+++ b/DashAI/back/models/scikit_learn/adaboost_regression.py
@@ -1,0 +1,137 @@
+from sklearn.ensemble import AdaBoostRegressor as _AdaBoostRegressor
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    enum_field,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class AdaBoostRegressionSchema(BaseSchema):
+    """Schema that configures the AdaBoost Regressor.
+
+    AdaBoost Regressor fits a sequence of weak regressors on re-weighted versions
+    of the training data, concentrating on samples with high residuals. The
+    underlying implementation is ``sklearn.ensemble.AdaBoostRegressor``.
+    """
+
+    n_estimators: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 50,
+            "lower_bound": 10,
+            "upper_bound": 500,
+        },
+        description=MultilingualString(
+            en=(
+                "The maximum number of estimators at which boosting is terminated. "
+                "In case of perfect fit, the learning procedure stops early."
+            ),
+            es=(
+                "El número máximo de estimadores en el que se termina el boosting. "
+                "En caso de ajuste perfecto, el procedimiento se detiene antes."
+            ),
+        ),
+        alias=MultilingualString(en="N estimators", es="N estimadores"),
+    )  # type: ignore
+
+    learning_rate: schema_field(
+        optimizer_float_field(ge=0.01),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.01,
+            "upper_bound": 2.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Weight applied to each regressor at each boosting iteration. "
+                "There is a trade-off between learning_rate and n_estimators."
+            ),
+            es=(
+                "Peso aplicado a cada regresor en cada iteración de boosting. "
+                "Existe un trade-off entre learning_rate y n_estimators."
+            ),
+        ),
+        alias=MultilingualString(en="Learning rate", es="Tasa de aprendizaje"),
+    )  # type: ignore
+
+    loss: schema_field(
+        enum_field(enum=["linear", "square", "exponential"]),
+        placeholder="linear",
+        description=MultilingualString(
+            en=(
+                "The loss function to use when updating the weights after each "
+                "boosting iteration."
+            ),
+            es=(
+                "La función de pérdida a usar al actualizar los pesos después de "
+                "cada iteración de boosting."
+            ),
+        ),
+        alias=MultilingualString(en="Loss", es="Pérdida"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class AdaBoostRegression(RegressionModel, SklearnLikeRegressor, _AdaBoostRegressor):
+    """AdaBoost regressor that focuses on samples with high prediction errors.
+
+    AdaBoostRegressor fits weak regressors (decision stumps by default) sequentially
+    on re-weighted training data, assigning higher weights to samples with larger
+    errors. The final prediction is a weighted median of all weak regressors.
+
+    Key hyperparameters include ``n_estimators``, ``learning_rate``, and ``loss``.
+    The implementation wraps scikit-learn's ``AdaBoostRegressor``.
+
+    References
+    ----------
+    - [1] Drucker, H. (1997). "Improving Regressors using Boosting Techniques."
+           ICML, 107-115.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostRegressor.html
+    """
+
+    SCHEMA = AdaBoostRegressionSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="AdaBoost Regression",
+        es="Regresión AdaBoost",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Adaptive boosting that focuses on samples with large residuals.",
+        es="Boosting adaptivo que se enfoca en muestras con grandes residuos.",
+    )
+    COLOR: str = "#FFA726"
+    ICON: str = "Bolt"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/bagging_classifier.py
+++ b/DashAI/back/models/scikit_learn/bagging_classifier.py
@@ -1,0 +1,164 @@
+from sklearn.ensemble import BaggingClassifier as _BaggingClassifier
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
+    SklearnLikeClassifier,
+)
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class BaggingClassifierSchema(BaseSchema):
+    """Schema that configures the Bagging Classifier.
+
+    Bagging (Bootstrap Aggregating) fits base classifiers on random subsets of the
+    training data (drawn with replacement) and aggregates their predictions by
+    majority vote. It reduces variance and helps avoid overfitting. The underlying
+    implementation is ``sklearn.ensemble.BaggingClassifier``.
+    """
+
+    n_estimators: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 10,
+            "lower_bound": 5,
+            "upper_bound": 100,
+        },
+        description=MultilingualString(
+            en="The number of base estimators in the ensemble.",
+            es="El número de estimadores base en el conjunto.",
+        ),
+        alias=MultilingualString(en="N estimators", es="N estimadores"),
+    )  # type: ignore
+
+    max_samples: schema_field(
+        optimizer_float_field(gt=0.0, le=1.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.1,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Fraction of training samples drawn for each base estimator "
+                "(0 < max_samples ≤ 1.0)."
+            ),
+            es=(
+                "Fracción de muestras de entrenamiento para cada estimador base "
+                "(0 < max_samples ≤ 1.0)."
+            ),
+        ),
+        alias=MultilingualString(en="Max samples", es="Máximas muestras"),
+    )  # type: ignore
+
+    max_features: schema_field(
+        optimizer_float_field(gt=0.0, le=1.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.1,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Fraction of features drawn for each base estimator "
+                "(0 < max_features ≤ 1.0)."
+            ),
+            es=(
+                "Fracción de características para cada estimador base "
+                "(0 < max_features ≤ 1.0)."
+            ),
+        ),
+        alias=MultilingualString(en="Max features", es="Máximas características"),
+    )  # type: ignore
+
+    bootstrap: schema_field(
+        bool_field(),
+        placeholder=True,
+        description=MultilingualString(
+            en="Whether to draw samples with replacement.",
+            es="Si se extraen muestras con reemplazo.",
+        ),
+        alias=MultilingualString(en="Bootstrap", es="Bootstrap"),
+    )  # type: ignore
+
+    bootstrap_features: schema_field(
+        bool_field(),
+        placeholder=False,
+        description=MultilingualString(
+            en="Whether to draw features with replacement.",
+            es="Si se extraen características con reemplazo.",
+        ),
+        alias=MultilingualString(
+            en="Bootstrap features", es="Bootstrap características"
+        ),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class BaggingClassifier(
+    TabularClassificationModel, SklearnLikeClassifier, _BaggingClassifier
+):
+    """Bagging classifier that aggregates predictions from bootstrap subsets.
+
+    Bagging builds multiple base classifiers, each trained on a bootstrap sample of
+    the training data. The final class prediction is determined by majority voting.
+    Bagging is particularly effective with high-variance, low-bias estimators such
+    as decision trees.
+
+    Key hyperparameters include ``n_estimators``, ``max_samples``,
+    ``max_features``, and ``bootstrap``. The implementation wraps scikit-learn's
+    ``BaggingClassifier``.
+
+    References
+    ----------
+    - [1] Breiman, L. (1996). "Bagging Predictors." Machine Learning, 24(2), 123-140.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.BaggingClassifier.html
+    """
+
+    SCHEMA = BaggingClassifierSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Bagging Classifier",
+        es="Clasificador Bagging",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Bootstrap aggregating ensemble to reduce variance.",
+        es="Conjunto de bootstrap aggregating para reducir la varianza.",
+    )
+    COLOR: str = "#26C6DA"
+    ICON: str = "Inventory"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/bayesian_ridge_regression.py
+++ b/DashAI/back/models/scikit_learn/bayesian_ridge_regression.py
@@ -1,0 +1,173 @@
+from sklearn.linear_model import BayesianRidge as _BayesianRidge
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_model import (
+    CategoricalEncodingStrategy,
+)
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class BayesianRidgeRegressionSchema(BaseSchema):
+    """Schema that configures the Bayesian Ridge Regression model.
+
+    Bayesian Ridge estimates the parameters of a regression model using Bayesian
+    inference. It includes regularisation parameters that are estimated from the
+    data rather than set by the user. The underlying implementation is
+    ``sklearn.linear_model.BayesianRidge``.
+    """
+
+    max_iter: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 300,
+            "lower_bound": 50,
+            "upper_bound": 1000,
+        },
+        description=MultilingualString(
+            en="Maximum number of iterations over the complete dataset.",
+            es="Número máximo de iteraciones sobre el conjunto de datos completo.",
+        ),
+        alias=MultilingualString(en="Max iterations", es="Máximas iteraciones"),
+    )  # type: ignore
+
+    tol: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-3,
+            "lower_bound": 1e-6,
+            "upper_bound": 1e-1,
+        },
+        description=MultilingualString(
+            en="Stop the algorithm if the weight update is smaller than tol.",
+            es=("Detener el algoritmo si la actualización de pesos es menor que tol."),
+        ),
+        alias=MultilingualString(en="Tolerance", es="Tolerancia"),
+    )  # type: ignore
+
+    alpha_1: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-6,
+            "lower_bound": 1e-10,
+            "upper_bound": 1e-2,
+        },
+        description=MultilingualString(
+            en="Shape parameter for the Gamma distribution prior over alpha.",
+            es=("Parámetro de forma para la distribución Gamma previa sobre alfa."),
+        ),
+        alias=MultilingualString(en="Alpha 1", es="Alfa 1"),
+    )  # type: ignore
+
+    alpha_2: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-6,
+            "lower_bound": 1e-10,
+            "upper_bound": 1e-2,
+        },
+        description=MultilingualString(
+            en="Rate parameter for the Gamma distribution prior over alpha.",
+            es=("Parámetro de tasa para la distribución Gamma previa sobre alfa."),
+        ),
+        alias=MultilingualString(en="Alpha 2", es="Alfa 2"),
+    )  # type: ignore
+
+    lambda_1: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-6,
+            "lower_bound": 1e-10,
+            "upper_bound": 1e-2,
+        },
+        description=MultilingualString(
+            en="Shape parameter for the Gamma distribution prior over lambda.",
+            es=("Parámetro de forma para la distribución Gamma previa sobre lambda."),
+        ),
+        alias=MultilingualString(en="Lambda 1", es="Lambda 1"),
+    )  # type: ignore
+
+    lambda_2: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-6,
+            "lower_bound": 1e-10,
+            "upper_bound": 1e-2,
+        },
+        description=MultilingualString(
+            en="Rate parameter for the Gamma distribution prior over lambda.",
+            es=("Parámetro de tasa para la distribución Gamma previa sobre lambda."),
+        ),
+        alias=MultilingualString(en="Lambda 2", es="Lambda 2"),
+    )  # type: ignore
+
+    fit_intercept: schema_field(
+        bool_field(),
+        placeholder=True,
+        description=MultilingualString(
+            en=(
+                "Whether to calculate the intercept for this model. If False, "
+                "the data is expected to be already centred."
+            ),
+            es=(
+                "Si se calcula el intercepto para este modelo. Si es False, "
+                "se espera que los datos ya estén centrados."
+            ),
+        ),
+        alias=MultilingualString(en="Fit intercept", es="Ajustar intercepto"),
+    )  # type: ignore
+
+
+class BayesianRidgeRegression(RegressionModel, SklearnLikeRegressor, _BayesianRidge):
+    """Bayesian Ridge regression with automatic regularisation estimation.
+
+    BayesianRidge places Gamma priors over the regularisation parameters and
+    estimates them from the data using the Expectation-Maximisation algorithm.
+    This avoids the need for cross-validation to select ``alpha`` and provides
+    predictive uncertainty estimates. It tends to be robust to over-fitting.
+
+    Key hyperparameters include ``max_iter``, ``tol``, and the Gamma prior
+    parameters ``alpha_1``, ``alpha_2``, ``lambda_1``, ``lambda_2``. The
+    implementation wraps scikit-learn's ``BayesianRidge``.
+
+    References
+    ----------
+    - [1] MacKay, D.J.C. (1992). "Bayesian Interpolation." Neural Computation, 4(3).
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.BayesianRidge.html
+    """
+
+    SCHEMA = BayesianRidgeRegressionSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Bayesian Ridge Regression",
+        es="Regresión Ridge Bayesiana",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Bayesian regression with automatic regularisation estimation.",
+        es="Regresión bayesiana con estimación automática de regularización.",
+    )
+    COLOR: str = "#7E57C2"
+    ICON: str = "Psychology"
+    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/decision_tree_regression.py
+++ b/DashAI/back/models/scikit_learn/decision_tree_regression.py
@@ -1,0 +1,174 @@
+from sklearn.tree import DecisionTreeRegressor as _DecisionTreeRegressor
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class DecisionTreeRegressionSchema(BaseSchema):
+    """Schema that configures the Decision Tree Regressor.
+
+    The Decision Tree Regressor builds a tree by recursively splitting the feature
+    space to minimise MSE (or MAE) at each node. The underlying implementation is
+    ``sklearn.tree.DecisionTreeRegressor``.
+    """
+
+    max_depth: schema_field(
+        union_type(optimizer_int_field(ge=1), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The maximum depth of the tree. If None, nodes are expanded until "
+                "all leaves are pure or fewer than min_samples_split samples remain."
+            ),
+            es=(
+                "La profundidad máxima del árbol. Si es None, los nodos se expanden "
+                "hasta que todas las hojas sean puras o queden menos de "
+                "min_samples_split muestras."
+            ),
+        ),
+        alias=MultilingualString(en="Max depth", es="Profundidad máxima"),
+    )  # type: ignore
+
+    min_samples_split: schema_field(
+        optimizer_int_field(ge=2),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 2,
+            "lower_bound": 2,
+            "upper_bound": 20,
+        },
+        description=MultilingualString(
+            en="Minimum number of samples required to split an internal node.",
+            es="Número mínimo de muestras requeridas para dividir un nodo interno.",
+        ),
+        alias=MultilingualString(
+            en="Min samples split", es="Mínimas muestras de división"
+        ),
+    )  # type: ignore
+
+    min_samples_leaf: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1,
+            "lower_bound": 1,
+            "upper_bound": 20,
+        },
+        description=MultilingualString(
+            en="Minimum number of samples required to be at a leaf node.",
+            es="Número mínimo de muestras requeridas para estar en una hoja.",
+        ),
+        alias=MultilingualString(
+            en="Min samples leaf", es="Mínimas muestras para hoja"
+        ),
+    )  # type: ignore
+
+    max_leaf_nodes: schema_field(
+        union_type(optimizer_int_field(ge=2), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "Grow a tree with at most max_leaf_nodes in best-first fashion. "
+                "If None, unlimited leaf nodes."
+            ),
+            es=(
+                "Crecer un árbol con a lo sumo max_leaf_nodes de manera best-first. "
+                "Si es None, nodos hoja ilimitados."
+            ),
+        ),
+        alias=MultilingualString(en="Max leaf nodes", es="Máximos nodos hoja"),
+    )  # type: ignore
+
+    min_impurity_decrease: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.0,
+            "lower_bound": 0.0,
+            "upper_bound": 0.5,
+        },
+        description=MultilingualString(
+            en=(
+                "A node is split if the split induces a decrease of the impurity "
+                "greater than or equal to this value."
+            ),
+            es=(
+                "Un nodo se divide si la división induce una disminución de la "
+                "impureza mayor o igual a este valor."
+            ),
+        ),
+        alias=MultilingualString(
+            en="Min impurity decrease", es="Disminución mínima de impureza"
+        ),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class DecisionTreeRegression(
+    RegressionModel, SklearnLikeRegressor, _DecisionTreeRegressor
+):
+    """Decision tree regressor that recursively partitions the feature space.
+
+    DecisionTreeRegressor builds a binary tree by choosing the split that most
+    reduces the MSE (default) at each internal node. Leaf nodes predict the mean
+    of the training targets in the region. Decision trees are fast, interpretable,
+    and require no feature scaling, but tend to overfit without pruning.
+
+    Key hyperparameters include ``max_depth``, ``min_samples_split``,
+    ``min_samples_leaf``, and ``max_leaf_nodes``. The implementation wraps
+    scikit-learn's ``DecisionTreeRegressor``.
+
+    References
+    ----------
+    - [1] Breiman, L. et al. (1984). Classification and Regression Trees. Wadsworth.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html
+    """
+
+    SCHEMA = DecisionTreeRegressionSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Decision Tree Regression",
+        es="Regresión Árbol de Decisión",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Interpretable tree-based regressor that partitions the feature space.",
+        es=(
+            "Regresor basado en árbol interpretable que particiona el espacio "
+            "de características."
+        ),
+    )
+    COLOR: str = "#66BB6A"
+    ICON: str = "AccountTree"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/elastic_net_regression.py
+++ b/DashAI/back/models/scikit_learn/elastic_net_regression.py
@@ -1,0 +1,173 @@
+from sklearn.linear_model import ElasticNet as _ElasticNet
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_model import (
+    CategoricalEncodingStrategy,
+)
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class ElasticNetRegressionSchema(BaseSchema):
+    """Schema that configures the Elastic Net Regression model.
+
+    Elastic Net combines L1 and L2 penalties, inheriting Lasso's sparse solutions
+    and Ridge's grouping effect. The ``l1_ratio`` controls the balance between
+    both penalties. The underlying implementation is
+    ``sklearn.linear_model.ElasticNet``.
+    """
+
+    alpha: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.0001,
+            "upper_bound": 10.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Regularisation strength multiplier. alpha=0 is OLS; "
+                "increasing alpha increases regularisation."
+            ),
+            es=(
+                "Multiplicador de fuerza de regularización. alpha=0 es MCO; "
+                "aumentar alpha incrementa la regularización."
+            ),
+        ),
+        alias=MultilingualString(en="Alpha", es="Alfa"),
+    )  # type: ignore
+
+    l1_ratio: schema_field(
+        optimizer_float_field(ge=0.0, le=1.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.5,
+            "lower_bound": 0.0,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en=(
+                "The mixing parameter. l1_ratio=0 is pure Ridge; "
+                "l1_ratio=1 is pure Lasso."
+            ),
+            es=(
+                "El parámetro de mezcla. l1_ratio=0 es Ridge puro; "
+                "l1_ratio=1 es Lasso puro."
+            ),
+        ),
+        alias=MultilingualString(en="L1 ratio", es="Ratio L1"),
+    )  # type: ignore
+
+    fit_intercept: schema_field(
+        bool_field(),
+        placeholder=True,
+        description=MultilingualString(
+            en=(
+                "Whether to calculate the intercept for this model. If False, "
+                "the data is expected to be already centred."
+            ),
+            es=(
+                "Si se calcula el intercepto para este modelo. Si es False, "
+                "se espera que los datos ya estén centrados."
+            ),
+        ),
+        alias=MultilingualString(en="Fit intercept", es="Ajustar intercepto"),
+    )  # type: ignore
+
+    max_iter: schema_field(
+        optimizer_int_field(ge=100),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1000,
+            "lower_bound": 100,
+            "upper_bound": 10000,
+        },
+        description=MultilingualString(
+            en="The maximum number of iterations.",
+            es="El número máximo de iteraciones.",
+        ),
+        alias=MultilingualString(en="Max iterations", es="Máximas iteraciones"),
+    )  # type: ignore
+
+    tol: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-4,
+            "lower_bound": 1e-6,
+            "upper_bound": 1e-1,
+        },
+        description=MultilingualString(
+            en="The tolerance for the optimisation.",
+            es="La tolerancia para la optimización.",
+        ),
+        alias=MultilingualString(en="Tolerance", es="Tolerancia"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class ElasticNetRegression(RegressionModel, SklearnLikeRegressor, _ElasticNet):
+    """Elastic Net regression combining L1 and L2 penalties.
+
+    Elastic Net minimises ``||y - Xw||^2 / (2*n) + alpha * l1_ratio * ||w||_1
+    + alpha * (1 - l1_ratio) * 0.5 * ||w||^2``. The blend of L1 and L2 penalties
+    overcomes Lasso's limitation with correlated features while still producing
+    sparse solutions. Useful when there are many correlated features.
+
+    Key hyperparameters include ``alpha``, ``l1_ratio``, ``fit_intercept``, and
+    ``max_iter``. The implementation wraps scikit-learn's ``ElasticNet``.
+
+    References
+    ----------
+    - [1] Zou, H. & Hastie, T. (2005). "Regularization and Variable Selection
+           via the Elastic Net." JRSS-B, 67(2), 301-320.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html
+    """
+
+    SCHEMA = ElasticNetRegressionSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Elastic Net Regression",
+        es="Regresión Elastic Net",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Linear regression combining L1 and L2 regularisation.",
+        es="Regresión lineal que combina regularización L1 y L2.",
+    )
+    COLOR: str = "#26A69A"
+    ICON: str = "Hub"
+    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/extra_trees_classifier.py
+++ b/DashAI/back/models/scikit_learn/extra_trees_classifier.py
@@ -1,0 +1,174 @@
+from sklearn.ensemble import ExtraTreesClassifier as _ExtraTreesClassifier
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    none_type,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
+    SklearnLikeClassifier,
+)
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class ExtraTreesClassifierSchema(BaseSchema):
+    """Schema that configures the Extra-Trees Classifier.
+
+    Extra-Trees (Extremely Randomised Trees) builds an ensemble of decision trees
+    with fully random feature thresholds, which further reduces variance at the
+    cost of a slightly higher bias compared to Random Forests. The underlying
+    implementation is ``sklearn.ensemble.ExtraTreesClassifier``.
+    """
+
+    n_estimators: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 100,
+            "lower_bound": 50,
+            "upper_bound": 500,
+        },
+        description=MultilingualString(
+            en="The number of trees in the forest.",
+            es="El número de árboles en el bosque.",
+        ),
+        alias=MultilingualString(en="N estimators", es="N estimadores"),
+    )  # type: ignore
+
+    max_depth: schema_field(
+        union_type(optimizer_int_field(ge=1), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The maximum depth of the tree. If None, nodes are expanded until "
+                "all leaves are pure or contain fewer than min_samples_split samples."
+            ),
+            es=(
+                "La profundidad máxima del árbol. Si es None, los nodos se expanden "
+                "hasta que todas las hojas sean puras o tengan menos de "
+                "min_samples_split muestras."
+            ),
+        ),
+        alias=MultilingualString(en="Max depth", es="Profundidad máxima"),
+    )  # type: ignore
+
+    min_samples_split: schema_field(
+        optimizer_int_field(ge=2),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 2,
+            "lower_bound": 2,
+            "upper_bound": 10,
+        },
+        description=MultilingualString(
+            en="The minimum number of samples required to split an internal node.",
+            es="El número mínimo de muestras requeridas para dividir un nodo interno.",
+        ),
+        alias=MultilingualString(
+            en="Min samples split", es="Mínimas muestras de división"
+        ),
+    )  # type: ignore
+
+    min_samples_leaf: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1,
+            "lower_bound": 1,
+            "upper_bound": 10,
+        },
+        description=MultilingualString(
+            en="The minimum number of samples required to be at a leaf node.",
+            es="El número mínimo de muestras requeridas para estar en una hoja.",
+        ),
+        alias=MultilingualString(
+            en="Min samples leaf", es="Mínimas muestras para hoja"
+        ),
+    )  # type: ignore
+
+    bootstrap: schema_field(
+        bool_field(),
+        placeholder=False,
+        description=MultilingualString(
+            en=(
+                "Whether bootstrap samples are used when building trees. "
+                "If False, the whole dataset is used for each tree."
+            ),
+            es=(
+                "Si se usan muestras bootstrap al construir los árboles. "
+                "Si es False, se usa todo el conjunto de datos para cada árbol."
+            ),
+        ),
+        alias=MultilingualString(en="Bootstrap", es="Bootstrap"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class ExtraTreesClassifier(
+    TabularClassificationModel, SklearnLikeClassifier, _ExtraTreesClassifier
+):
+    """Extra-Trees classifier using fully randomised decision tree splits.
+
+    Extremely Randomised Trees differ from Random Forests in how splits are chosen:
+    instead of searching for the best threshold per feature, Extra-Trees picks
+    thresholds at random. This introduces additional randomness that, combined with
+    bootstrap aggregation, further reduces variance. Extra-Trees are typically faster
+    to train than Random Forests.
+
+    Key hyperparameters include ``n_estimators``, ``max_depth``,
+    ``min_samples_split``, ``min_samples_leaf``, and ``bootstrap``. The
+    implementation wraps scikit-learn's ``ExtraTreesClassifier``.
+
+    References
+    ----------
+    - [1] Geurts, P., Ernst, D. & Wehenkel, L. (2006). "Extremely randomized trees."
+           Machine Learning, 63(1), 3-42. https://doi.org/10.1007/s10994-006-6226-1
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html
+    """
+
+    SCHEMA = ExtraTreesClassifierSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Extra-Trees Classifier",
+        es="Clasificador Extra-Trees",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Ensemble of fully randomised decision trees for fast, "
+            "low-variance classification."
+        ),
+        es=(
+            "Conjunto de árboles de decisión completamente aleatorizados "
+            "para clasificación rápida."
+        ),
+    )
+    COLOR: str = "#66BB6A"
+    ICON: str = "Park"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/extra_trees_regression.py
+++ b/DashAI/back/models/scikit_learn/extra_trees_regression.py
@@ -1,0 +1,169 @@
+from sklearn.ensemble import ExtraTreesRegressor as _ExtraTreesRegressor
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    none_type,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class ExtraTreesRegressionSchema(BaseSchema):
+    """Schema that configures the Extra-Trees Regressor.
+
+    Extra-Trees (Extremely Randomised Trees) builds an ensemble of decision tree
+    regressors with fully random feature thresholds, further reducing variance
+    compared to Random Forests. The underlying implementation is
+    ``sklearn.ensemble.ExtraTreesRegressor``.
+    """
+
+    n_estimators: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 100,
+            "lower_bound": 50,
+            "upper_bound": 500,
+        },
+        description=MultilingualString(
+            en="The number of trees in the forest.",
+            es="El número de árboles en el bosque.",
+        ),
+        alias=MultilingualString(en="N estimators", es="N estimadores"),
+    )  # type: ignore
+
+    max_depth: schema_field(
+        union_type(optimizer_int_field(ge=1), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The maximum depth of the tree. If None, nodes are expanded until "
+                "all leaves are pure or fewer than min_samples_split samples remain."
+            ),
+            es=(
+                "La profundidad máxima del árbol. Si es None, los nodos se expanden "
+                "hasta que todas las hojas sean puras o queden menos de "
+                "min_samples_split muestras."
+            ),
+        ),
+        alias=MultilingualString(en="Max depth", es="Profundidad máxima"),
+    )  # type: ignore
+
+    min_samples_split: schema_field(
+        optimizer_int_field(ge=2),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 2,
+            "lower_bound": 2,
+            "upper_bound": 10,
+        },
+        description=MultilingualString(
+            en="Minimum number of samples required to split an internal node.",
+            es="Número mínimo de muestras requeridas para dividir un nodo interno.",
+        ),
+        alias=MultilingualString(
+            en="Min samples split", es="Mínimas muestras de división"
+        ),
+    )  # type: ignore
+
+    min_samples_leaf: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1,
+            "lower_bound": 1,
+            "upper_bound": 10,
+        },
+        description=MultilingualString(
+            en="Minimum number of samples required to be at a leaf node.",
+            es="Número mínimo de muestras requeridas para estar en una hoja.",
+        ),
+        alias=MultilingualString(
+            en="Min samples leaf", es="Mínimas muestras para hoja"
+        ),
+    )  # type: ignore
+
+    bootstrap: schema_field(
+        bool_field(),
+        placeholder=False,
+        description=MultilingualString(
+            en=(
+                "Whether bootstrap samples are used when building trees. "
+                "If False, the whole dataset is used for each tree."
+            ),
+            es=(
+                "Si se usan muestras bootstrap al construir los árboles. "
+                "Si es False, se usa todo el conjunto de datos para cada árbol."
+            ),
+        ),
+        alias=MultilingualString(en="Bootstrap", es="Bootstrap"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class ExtraTreesRegression(RegressionModel, SklearnLikeRegressor, _ExtraTreesRegressor):
+    """Extra-Trees regressor using fully randomised decision tree splits.
+
+    Extremely Randomised Trees pick thresholds at random instead of searching for
+    the optimal split, introducing extra randomness that further reduces variance.
+    Combined with averaging over many trees, Extra-Trees can achieve very low
+    generalisation error on regression tasks while being fast to train.
+
+    Key hyperparameters include ``n_estimators``, ``max_depth``,
+    ``min_samples_split``, and ``bootstrap``. The implementation wraps
+    scikit-learn's ``ExtraTreesRegressor``.
+
+    References
+    ----------
+    - [1] Geurts, P., Ernst, D. & Wehenkel, L. (2006). "Extremely randomized trees."
+           Machine Learning, 63(1), 3-42.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html
+    """
+
+    SCHEMA = ExtraTreesRegressionSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Extra-Trees Regression",
+        es="Regresión Extra-Trees",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Ensemble of fully randomised decision trees for fast, "
+            "low-variance regression."
+        ),
+        es=(
+            "Conjunto de árboles de decisión completamente aleatorizados "
+            "para regresión rápida y de baja varianza."
+        ),
+    )
+    COLOR: str = "#26A69A"
+    ICON: str = "Park"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/gaussian_nb.py
+++ b/DashAI/back/models/scikit_learn/gaussian_nb.py
@@ -1,0 +1,89 @@
+from sklearn.naive_bayes import GaussianNB as _GaussianNB
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    optimizer_float_field,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
+    SklearnLikeClassifier,
+)
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class GaussianNBSchema(BaseSchema):
+    """Schema that configures the Gaussian Naïve Bayes Classifier.
+
+    Gaussian Naïve Bayes assumes that the continuous features in each class follow
+    a Gaussian (normal) distribution and applies Bayes' theorem with the strong
+    independence assumption between features. The underlying implementation is
+    ``sklearn.naive_bayes.GaussianNB``.
+    """
+
+    var_smoothing: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-9,
+            "lower_bound": 1e-12,
+            "upper_bound": 1e-3,
+        },
+        description=MultilingualString(
+            en=(
+                "Portion of the largest variance of all features that is added to "
+                "variances for calculation stability."
+            ),
+            es=(
+                "Porción de la mayor varianza de todas las características que se "
+                "añade a las varianzas para estabilidad del cálculo."
+            ),
+        ),
+        alias=MultilingualString(en="Var smoothing", es="Suavizado de varianza"),
+    )  # type: ignore
+
+
+class GaussianNB(TabularClassificationModel, SklearnLikeClassifier, _GaussianNB):
+    """Gaussian Naïve Bayes classifier based on Bayes' theorem.
+
+    GaussianNB models the likelihood of features as Gaussian distributions per
+    class. It estimates the mean and variance of each feature in each class from
+    the training data, then uses Bayes' theorem to compute the posterior class
+    probability. Despite the strong independence assumption, it often performs well
+    and is very fast.
+
+    Key hyperparameter: ``var_smoothing`` (additive variance for numerical
+    stability). The implementation wraps scikit-learn's ``GaussianNB``.
+
+    References
+    ----------
+    - [1] https://scikit-learn.org/stable/modules/generated/sklearn.naive_bayes.GaussianNB.html
+    """
+
+    SCHEMA = GaussianNBSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Gaussian Naïve Bayes",
+        es="Naïve Bayes Gaussiano",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Probabilistic classifier based on Bayes' theorem "
+            "with Gaussian likelihoods."
+        ),
+        es=(
+            "Clasificador probabilístico basado en el teorema de Bayes "
+            "con verosimilitudes gaussianas."
+        ),
+    )
+    COLOR: str = "#AB47BC"
+    ICON: str = "Functions"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/gradient_boosting_classifier.py
+++ b/DashAI/back/models/scikit_learn/gradient_boosting_classifier.py
@@ -1,0 +1,200 @@
+from sklearn.ensemble import GradientBoostingClassifier as _GradientBoostingClassifier
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    enum_field,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
+    SklearnLikeClassifier,
+)
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class GradientBoostingClassifierSchema(BaseSchema):
+    """Schema that configures the Gradient Boosting Classifier.
+
+    Gradient Boosting is a sequential ensemble classification method that fits a new
+    decision tree at each stage to the negative gradient of a differentiable loss
+    function. The underlying implementation is
+    ``sklearn.ensemble.GradientBoostingClassifier``.
+    """
+
+    loss: schema_field(
+        enum_field(enum=["log_loss", "exponential"]),
+        placeholder="log_loss",
+        description=MultilingualString(
+            en=(
+                "The loss function to be optimized. 'log_loss' refers to binomial and "
+                "multinomial deviance; 'exponential' is equivalent to AdaBoost."
+            ),
+            es=(
+                "La función de pérdida a optimizar. 'log_loss' refiere a la desviación "
+                "binomial y multinomial; 'exponential' es equivalente a AdaBoost."
+            ),
+        ),
+        alias=MultilingualString(en="Loss", es="Pérdida"),
+    )  # type: ignore
+
+    learning_rate: schema_field(
+        optimizer_float_field(ge=0.01),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.1,
+            "lower_bound": 0.01,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en="Learning rate shrinks the contribution of each tree.",
+            es="La tasa de aprendizaje reduce la contribución de cada árbol.",
+        ),
+        alias=MultilingualString(en="Learning rate", es="Tasa de aprendizaje"),
+    )  # type: ignore
+
+    n_estimators: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 100,
+            "lower_bound": 10,
+            "upper_bound": 500,
+        },
+        description=MultilingualString(
+            en="The number of boosting stages to be run.",
+            es="El número de etapas de boosting a ejecutar.",
+        ),
+        alias=MultilingualString(en="N estimators", es="N estimadores"),
+    )  # type: ignore
+
+    max_depth: schema_field(
+        union_type(optimizer_int_field(ge=1), none_type(int)),
+        placeholder=3,
+        description=MultilingualString(
+            en="Maximum depth of the individual regression estimators.",
+            es="Profundidad máxima de los estimadores de regresión individuales.",
+        ),
+        alias=MultilingualString(en="Max depth", es="Profundidad máxima"),
+    )  # type: ignore
+
+    min_samples_split: schema_field(
+        optimizer_int_field(ge=2),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 2,
+            "lower_bound": 2,
+            "upper_bound": 20,
+        },
+        description=MultilingualString(
+            en="The minimum number of samples required to split an internal node.",
+            es="El número mínimo de muestras requeridas para dividir un nodo interno.",
+        ),
+        alias=MultilingualString(
+            en="Min samples split", es="Mínimas muestras de división"
+        ),
+    )  # type: ignore
+
+    min_samples_leaf: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1,
+            "lower_bound": 1,
+            "upper_bound": 20,
+        },
+        description=MultilingualString(
+            en="The minimum number of samples required to be at a leaf node.",
+            es="El número mínimo de muestras requeridas para estar en una hoja.",
+        ),
+        alias=MultilingualString(
+            en="Min samples leaf", es="Mínimas muestras para hoja"
+        ),
+    )  # type: ignore
+
+    subsample: schema_field(
+        optimizer_float_field(ge=0.1, le=1.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.1,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en=(
+                "The fraction of samples to be used for fitting each base learner. "
+                "Values less than 1.0 lead to stochastic gradient boosting."
+            ),
+            es=(
+                "La fracción de muestras usadas para ajustar cada aprendiz base. "
+                "Valores menores a 1.0 llevan al gradient boosting estocástico."
+            ),
+        ),
+        alias=MultilingualString(en="Subsample", es="Submuestreo"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class GradientBoostingClassifier(
+    TabularClassificationModel, SklearnLikeClassifier, _GradientBoostingClassifier
+):
+    """Gradient boosting classifier that builds an ensemble of trees sequentially.
+
+    Gradient Boosting builds an additive model stage by stage. At each stage a
+    shallow decision tree is fitted to the negative gradient of the chosen loss
+    function. A ``learning_rate`` shrinkage factor scales each tree's contribution,
+    trading slower learning for better generalisation.
+
+    Key hyperparameters include ``n_estimators``, ``learning_rate``, ``max_depth``,
+    ``subsample``, and ``loss``. The implementation wraps scikit-learn's
+    ``GradientBoostingClassifier``.
+
+    References
+    ----------
+    - [1] Friedman, J.H. (2001). "Greedy function approximation: a gradient boosting
+           machine." Annals of Statistics, 29(5), 1189-1232.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingClassifier.html
+    """
+
+    SCHEMA = GradientBoostingClassifierSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Gradient Boosting Classifier",
+        es="Clasificador Gradient Boosting",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Ensemble that builds trees sequentially to correct previous errors.",
+        es=(
+            "Conjunto que construye árboles secuencialmente para corregir "
+            "errores previos."
+        ),
+    )
+    COLOR: str = "#4CAF50"
+    ICON: str = "AutoGraph"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/hist_gradient_boosting_regression.py
+++ b/DashAI/back/models/scikit_learn/hist_gradient_boosting_regression.py
@@ -1,0 +1,173 @@
+from sklearn.ensemble import (
+    HistGradientBoostingRegressor as _HistGradientBoostingRegressor,
+)
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class HistGradientBoostingRegressionSchema(BaseSchema):
+    """Schema that configures the Histogram-based Gradient Boosting Regressor.
+
+    Histogram-based Gradient Boosting is a fast sequential ensemble method that
+    bins features into histograms before building each tree, greatly reducing cost
+    on large datasets. The underlying implementation is
+    ``sklearn.ensemble.HistGradientBoostingRegressor``.
+    """
+
+    learning_rate: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.1,
+            "lower_bound": 0.01,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en=(
+                "The learning rate (shrinkage). Used as a multiplicative factor "
+                "for leaf values. Use 1 for no shrinkage."
+            ),
+            es=(
+                "La tasa de aprendizaje (shrinkage). Se usa como factor multiplicativo "
+                "para los valores de las hojas. Use 1 para no aplicar shrinkage."
+            ),
+        ),
+        alias=MultilingualString(en="Learning rate", es="Tasa de aprendizaje"),
+    )  # type: ignore
+
+    max_iter: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 100,
+            "lower_bound": 50,
+            "upper_bound": 500,
+        },
+        description=MultilingualString(
+            en="Maximum number of iterations (trees) of the boosting process.",
+            es="Número máximo de iteraciones (árboles) del proceso de boosting.",
+        ),
+        alias=MultilingualString(en="Max iterations", es="Máximas iteraciones"),
+    )  # type: ignore
+
+    max_depth: schema_field(
+        union_type(optimizer_int_field(ge=1), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=("Maximum depth of each tree. If None, depth is not constrained."),
+            es=(
+                "Profundidad máxima de cada árbol. Si es None, la profundidad "
+                "no está restringida."
+            ),
+        ),
+        alias=MultilingualString(en="Max depth", es="Profundidad máxima"),
+    )  # type: ignore
+
+    max_leaf_nodes: schema_field(
+        union_type(optimizer_int_field(ge=2), none_type(int)),
+        placeholder=31,
+        description=MultilingualString(
+            en=(
+                "Maximum number of leaves for each tree. Must be strictly greater "
+                "than 1. If None, no maximum limit."
+            ),
+            es=(
+                "Número máximo de hojas para cada árbol. Debe ser estrictamente "
+                "mayor que 1. Si es None, no hay límite."
+            ),
+        ),
+        alias=MultilingualString(en="Max leaf nodes", es="Máximos nodos hoja"),
+    )  # type: ignore
+
+    min_samples_leaf: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 20,
+            "lower_bound": 1,
+            "upper_bound": 100,
+        },
+        description=MultilingualString(
+            en="Minimum number of samples required to be at a leaf node.",
+            es="Número mínimo de muestras requeridas para estar en una hoja.",
+        ),
+        alias=MultilingualString(
+            en="Min samples leaf", es="Mínimas muestras para hoja"
+        ),
+    )  # type: ignore
+
+    l2_regularization: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.0,
+            "lower_bound": 0.0,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en="The L2 regularisation parameter. Use 0 for no regularisation.",
+            es=(
+                "El parámetro de regularización L2. "
+                "Use 0 para no aplicar regularización."
+            ),
+        ),
+        alias=MultilingualString(en="L2 regularization", es="Regularización L2"),
+    )  # type: ignore
+
+
+class HistGradientBoostingRegression(
+    RegressionModel, SklearnLikeRegressor, _HistGradientBoostingRegressor
+):
+    """Histogram-based gradient boosting regressor for large datasets.
+
+    This regressor discretises features into integer-valued bins before tree
+    construction. The histogram representation reduces candidate split points and
+    memory footprint, enabling efficient training on datasets with tens of thousands
+    of samples or more. It natively supports missing values and is inspired by
+    LightGBM.
+
+    Key hyperparameters include ``learning_rate``, ``max_iter``, ``max_depth``,
+    ``max_leaf_nodes``, ``min_samples_leaf``, and ``l2_regularization``. The
+    implementation wraps scikit-learn's ``HistGradientBoostingRegressor``.
+
+    References
+    ----------
+    - [1] Ke, G. et al. (2017). "LightGBM: A Highly Efficient Gradient Boosting
+           Decision Tree." NeurIPS 30.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html
+    """
+
+    SCHEMA = HistGradientBoostingRegressionSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Histogram Gradient Boosting Regression",
+        es="Regresión Gradient Boosting con Histogramas",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Fast gradient boosting regression using histogram-based algorithms.",
+        es=(
+            "Regresión gradient boosting rápida usando algoritmos basados "
+            "en histogramas."
+        ),
+    )
+    COLOR: str = "#9575CD"
+    ICON: str = "RocketLaunch"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/k_neighbors_regression.py
+++ b/DashAI/back/models/scikit_learn/k_neighbors_regression.py
@@ -8,6 +8,9 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_model import (
+    CategoricalEncodingStrategy,
+)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -127,6 +130,7 @@ class KNeighborsRegression(RegressionModel, SklearnLikeRegressor, _KNeighborsReg
     )
     COLOR: str = "#FFA726"
     ICON: str = "ScatterPlot"
+    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/k_neighbors_regression.py
+++ b/DashAI/back/models/scikit_learn/k_neighbors_regression.py
@@ -1,0 +1,139 @@
+from sklearn.neighbors import KNeighborsRegressor as _KNeighborsRegressor
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    enum_field,
+    optimizer_int_field,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class KNeighborsRegressionSchema(BaseSchema):
+    """Schema that configures the K-Nearest Neighbours Regressor.
+
+    KNeighborsRegressor predicts the target by averaging the targets of the
+    ``n_neighbors`` nearest training samples. The underlying implementation is
+    ``sklearn.neighbors.KNeighborsRegressor``.
+    """
+
+    n_neighbors: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 5,
+            "lower_bound": 1,
+            "upper_bound": 50,
+        },
+        description=MultilingualString(
+            en="Number of neighbours to use for the prediction.",
+            es="Número de vecinos a usar para la predicción.",
+        ),
+        alias=MultilingualString(en="N neighbors", es="N vecinos"),
+    )  # type: ignore
+
+    weights: schema_field(
+        enum_field(enum=["uniform", "distance"]),
+        placeholder="uniform",
+        description=MultilingualString(
+            en=(
+                "Weight function used in prediction. 'uniform' weights all "
+                "neighbours equally; 'distance' weights by inverse distance."
+            ),
+            es=(
+                "Función de pesos usada en la predicción. 'uniform' pondera igual "
+                "todos los vecinos; 'distance' pondera por distancia inversa."
+            ),
+        ),
+        alias=MultilingualString(en="Weights", es="Pesos"),
+    )  # type: ignore
+
+    algorithm: schema_field(
+        enum_field(enum=["auto", "ball_tree", "kd_tree", "brute"]),
+        placeholder="auto",
+        description=MultilingualString(
+            en=(
+                "Algorithm used to compute nearest neighbours. 'auto' selects the "
+                "best based on the values passed to fit."
+            ),
+            es=(
+                "Algoritmo para computar los vecinos más cercanos. 'auto' selecciona "
+                "el mejor en función de los valores pasados a fit."
+            ),
+        ),
+        alias=MultilingualString(en="Algorithm", es="Algoritmo"),
+    )  # type: ignore
+
+    leaf_size: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 30,
+            "lower_bound": 5,
+            "upper_bound": 100,
+        },
+        description=MultilingualString(
+            en=(
+                "Leaf size passed to BallTree or KDTree. Affects query speed "
+                "and memory required to store the tree."
+            ),
+            es=(
+                "Tamaño de hoja pasado a BallTree o KDTree. Afecta la velocidad "
+                "de consulta y la memoria requerida para almacenar el árbol."
+            ),
+        ),
+        alias=MultilingualString(en="Leaf size", es="Tamaño de hoja"),
+    )  # type: ignore
+
+    metric: schema_field(
+        enum_field(enum=["minkowski", "euclidean", "manhattan", "chebyshev"]),
+        placeholder="minkowski",
+        description=MultilingualString(
+            en="Distance metric to use for the neighbour search.",
+            es="Métrica de distancia para la búsqueda de vecinos.",
+        ),
+        alias=MultilingualString(en="Metric", es="Métrica"),
+    )  # type: ignore
+
+
+class KNeighborsRegression(RegressionModel, SklearnLikeRegressor, _KNeighborsRegressor):
+    """K-Nearest Neighbours regressor that averages the targets of nearest samples.
+
+    KNeighborsRegressor predicts the target value by computing the (weighted)
+    mean of the ``n_neighbors`` closest training points. It is a non-parametric
+    method: no training phase is needed, and predictions can capture non-linear
+    patterns. Performance degrades in high-dimensional spaces.
+
+    Key hyperparameters include ``n_neighbors``, ``weights``, ``algorithm``, and
+    ``metric``. The implementation wraps scikit-learn's ``KNeighborsRegressor``.
+
+    References
+    ----------
+    - [1] https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsRegressor.html
+    """
+
+    SCHEMA = KNeighborsRegressionSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="K-Nearest Neighbours Regression",
+        es="Regresión K-Vecinos Más Cercanos",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Non-parametric regression that predicts by averaging nearest neighbours.",
+        es=(
+            "Regresión no paramétrica que predice promediando los vecinos más cercanos."
+        ),
+    )
+    COLOR: str = "#FFA726"
+    ICON: str = "ScatterPlot"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/lasso_regression.py
+++ b/DashAI/back/models/scikit_learn/lasso_regression.py
@@ -1,0 +1,153 @@
+from sklearn.linear_model import Lasso as _Lasso
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_model import (
+    CategoricalEncodingStrategy,
+)
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class LassoRegressionSchema(BaseSchema):
+    """Schema that configures the Lasso Regression model.
+
+    Lasso (Least Absolute Shrinkage and Selection Operator) adds an L1 penalty on
+    the absolute values of coefficients, driving some of them exactly to zero,
+    which performs implicit feature selection. The underlying implementation is
+    ``sklearn.linear_model.Lasso``.
+    """
+
+    alpha: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.0001,
+            "upper_bound": 10.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Regularisation strength. Larger values specify stronger "
+                "regularisation. alpha=0 is equivalent to OLS."
+            ),
+            es=(
+                "Fuerza de regularización. Valores más grandes especifican "
+                "regularización más fuerte. alpha=0 es equivalente a MCO."
+            ),
+        ),
+        alias=MultilingualString(en="Alpha", es="Alfa"),
+    )  # type: ignore
+
+    fit_intercept: schema_field(
+        bool_field(),
+        placeholder=True,
+        description=MultilingualString(
+            en=(
+                "Whether to calculate the intercept for this model. If False, "
+                "the data is expected to be already centred."
+            ),
+            es=(
+                "Si se calcula el intercepto para este modelo. Si es False, "
+                "se espera que los datos ya estén centrados."
+            ),
+        ),
+        alias=MultilingualString(en="Fit intercept", es="Ajustar intercepto"),
+    )  # type: ignore
+
+    max_iter: schema_field(
+        optimizer_int_field(ge=100),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1000,
+            "lower_bound": 100,
+            "upper_bound": 10000,
+        },
+        description=MultilingualString(
+            en="The maximum number of iterations.",
+            es="El número máximo de iteraciones.",
+        ),
+        alias=MultilingualString(en="Max iterations", es="Máximas iteraciones"),
+    )  # type: ignore
+
+    tol: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-4,
+            "lower_bound": 1e-6,
+            "upper_bound": 1e-1,
+        },
+        description=MultilingualString(
+            en="The tolerance for the optimisation.",
+            es="La tolerancia para la optimización.",
+        ),
+        alias=MultilingualString(en="Tolerance", es="Tolerancia"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class LassoRegression(RegressionModel, SklearnLikeRegressor, _Lasso):
+    """Lasso regression with L1 regularisation for sparse coefficient solutions.
+
+    Lasso minimises the OLS objective plus an L1 penalty
+    ``||y - Xw||^2 / (2*n) + alpha * ||w||_1``. The L1 term sets many
+    coefficients exactly to zero, performing automatic feature selection. Lasso is
+    particularly useful when there are many features but only a few are expected to
+    be relevant.
+
+    Key hyperparameters include ``alpha``, ``fit_intercept``, ``max_iter``, and
+    ``tol``. The implementation wraps scikit-learn's ``Lasso``.
+
+    References
+    ----------
+    - [1] Tibshirani, R. (1996). "Regression Shrinkage and Selection via the Lasso."
+           Journal of the Royal Statistical Society B, 58(1), 267-288.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lasso.html
+    """
+
+    SCHEMA = LassoRegressionSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Lasso Regression",
+        es="Regresión Lasso",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Linear regression with L1 regularisation for feature selection.",
+        es="Regresión lineal con regularización L1 para selección de características.",
+    )
+    COLOR: str = "#29B6F6"
+    ICON: str = "SelectAll"
+    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/linear_svc_classifier.py
+++ b/DashAI/back/models/scikit_learn/linear_svc_classifier.py
@@ -177,6 +177,9 @@ class LinearSVCClassifier(
         super().__init__(**kwargs)
         self._calibrated = None
 
+    def __sklearn_is_fitted__(self) -> bool:
+        return self._calibrated is not None
+
     def train(self, x_train, y_train, x_validation=None, y_validation=None):
         """Train using CalibratedClassifierCV to expose predict_proba.
 
@@ -238,4 +241,11 @@ class LinearSVCClassifier(
         elif isinstance(x_pred, pd.DataFrame):
             pass
 
+        from sklearn.exceptions import NotFittedError
+
+        if self._calibrated is None:
+            raise NotFittedError(
+                f"This {self.__class__.__name__} instance is not fitted yet. "
+                "Call 'train' with appropriate arguments before using this estimator."
+            )
         return self._calibrated.predict_proba(x_pred)

--- a/DashAI/back/models/scikit_learn/linear_svc_classifier.py
+++ b/DashAI/back/models/scikit_learn/linear_svc_classifier.py
@@ -1,0 +1,241 @@
+from sklearn.svm import LinearSVC as _LinearSVC
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    enum_field,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
+    SklearnLikeClassifier,
+)
+from DashAI.back.models.scikit_learn.sklearn_like_model import (
+    CategoricalEncodingStrategy,
+)
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class LinearSVCClassifierSchema(BaseSchema):
+    """Schema that configures the Linear SVC Classifier.
+
+    LinearSVC implements a linear Support Vector Classification trained with a
+    linear kernel. It is faster than kernel SVC for large datasets. Because
+    LinearSVC does not natively expose class probabilities, it is calibrated with
+    Platt scaling (CalibratedClassifierCV). The underlying implementation is
+    ``sklearn.svm.LinearSVC``.
+    """
+
+    C: schema_field(  # noqa: N815
+        optimizer_float_field(ge=1e-4),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.01,
+            "upper_bound": 100.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Regularisation parameter. The strength of the regularisation is "
+                "inversely proportional to C. Must be strictly positive."
+            ),
+            es=(
+                "Parámetro de regularización. La fuerza de la regularización es "
+                "inversamente proporcional a C. Debe ser estrictamente positivo."
+            ),
+        ),
+        alias=MultilingualString(en="C", es="C"),
+    )  # type: ignore
+
+    loss: schema_field(
+        enum_field(enum=["squared_hinge", "hinge"]),
+        placeholder="squared_hinge",
+        description=MultilingualString(
+            en=(
+                "Specifies the loss function. 'squared_hinge' is the default; "
+                "'hinge' is the standard SVM loss."
+            ),
+            es=(
+                "Especifica la función de pérdida. 'squared_hinge' es el "
+                "predeterminado; 'hinge' es la pérdida estándar de SVM."
+            ),
+        ),
+        alias=MultilingualString(en="Loss", es="Pérdida"),
+    )  # type: ignore
+
+    max_iter: schema_field(
+        optimizer_int_field(ge=100),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1000,
+            "lower_bound": 100,
+            "upper_bound": 10000,
+        },
+        description=MultilingualString(
+            en="The maximum number of iterations to be run.",
+            es="El número máximo de iteraciones a ejecutar.",
+        ),
+        alias=MultilingualString(en="Max iterations", es="Máximas iteraciones"),
+    )  # type: ignore
+
+    tol: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-4,
+            "lower_bound": 1e-6,
+            "upper_bound": 1e-1,
+        },
+        description=MultilingualString(
+            en="Tolerance for stopping criteria.",
+            es="Tolerancia para el criterio de parada.",
+        ),
+        alias=MultilingualString(en="Tolerance", es="Tolerancia"),
+    )  # type: ignore
+
+    fit_intercept: schema_field(
+        bool_field(),
+        placeholder=True,
+        description=MultilingualString(
+            en=(
+                "Whether to calculate the intercept for this model. If False, "
+                "the data is expected to be already centred."
+            ),
+            es=(
+                "Si se calcula el intercepto para este modelo. Si es False, "
+                "se espera que los datos ya estén centrados."
+            ),
+        ),
+        alias=MultilingualString(en="Fit intercept", es="Ajustar intercepto"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class LinearSVCClassifier(
+    TabularClassificationModel, SklearnLikeClassifier, _LinearSVC
+):
+    """Linear SVC classifier with Platt-scaling calibration for class probabilities.
+
+    LinearSVC uses a linear kernel and is trained with coordinate descent, making
+    it considerably faster than kernel SVC on large datasets. Because LinearSVC
+    does not expose ``predict_proba`` natively, this wrapper fits a
+    ``CalibratedClassifierCV`` with sigmoid calibration so that probability
+    estimates are available to the DashAI evaluation pipeline.
+
+    Key hyperparameters include ``C`` (regularisation), ``loss``, ``max_iter``,
+    and ``fit_intercept``. The implementation wraps scikit-learn's ``LinearSVC``.
+
+    References
+    ----------
+    - [1] https://scikit-learn.org/stable/modules/generated/sklearn.svm.LinearSVC.html
+    - [2] https://scikit-learn.org/stable/modules/calibration.html
+    """
+
+    SCHEMA = LinearSVCClassifierSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Linear SVC",
+        es="SVC Lineal",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Fast linear support vector classifier with probability calibration.",
+        es=(
+            "Clasificador de vectores de soporte lineal rápido con "
+            "calibración de probabilidades."
+        ),
+    )
+    COLOR: str = "#FF7043"
+    ICON: str = "LinearScale"
+    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)
+        self._calibrated = None
+
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
+        """Train using CalibratedClassifierCV to expose predict_proba.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            The input features for training.
+        y_train : DashAIDataset
+            The target labels for training.
+        x_validation : DashAIDataset, optional
+            Unused (sklearn models ignore validation split).
+        y_validation : DashAIDataset, optional
+            Unused.
+
+        Returns
+        -------
+        self
+        """
+        from sklearn.calibration import CalibratedClassifierCV
+        from sklearn.svm import LinearSVC as _LinearSVCRaw
+
+        x_processed = self.prepare_dataset(x_train, is_fit=True).to_pandas()
+        y_processed = self.prepare_output(y_train, is_fit=True).to_pandas()
+        y_arr = y_processed.values.ravel()
+
+        params = {
+            k: getattr(self, k)
+            for k in ["C", "loss", "max_iter", "tol", "fit_intercept", "random_state"]
+            if hasattr(self, k)
+        }
+        base = _LinearSVCRaw(**params)
+        self._calibrated = CalibratedClassifierCV(base, method="sigmoid", cv=3)
+        self._calibrated.fit(x_processed, y_arr)
+        return self
+
+    def predict(self, x_pred) -> "ndarray":  # noqa: F821
+        """Return class-probability matrix using the calibrated model.
+
+        Parameters
+        ----------
+        x_pred : DashAIDataset or pd.DataFrame
+            Input data.
+
+        Returns
+        -------
+        np.ndarray
+            Class probability matrix.
+        """
+        import pandas as pd
+
+        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+        if isinstance(x_pred, DashAIDataset):
+            try:
+                x_prepared = self.prepare_dataset(x_pred, is_fit=False)
+            except ValueError:
+                x_prepared = x_pred
+            x_pred = x_prepared.to_pandas()
+        elif isinstance(x_pred, pd.DataFrame):
+            pass
+
+        return self._calibrated.predict_proba(x_pred)

--- a/DashAI/back/models/scikit_learn/mlp_classifier.py
+++ b/DashAI/back/models/scikit_learn/mlp_classifier.py
@@ -1,0 +1,187 @@
+from sklearn.neural_network import MLPClassifier as _MLPClassifier
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    enum_field,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
+    SklearnLikeClassifier,
+)
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class MLPClassifierSchema(BaseSchema):
+    """Schema that configures the MLP Classifier.
+
+    The Multi-layer Perceptron Classifier is a feedforward neural network trained
+    with backpropagation. It supports multiple hidden layers and several activation
+    functions. The underlying implementation is
+    ``sklearn.neural_network.MLPClassifier``.
+    """
+
+    hidden_layer_size: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 100,
+            "lower_bound": 10,
+            "upper_bound": 500,
+        },
+        description=MultilingualString(
+            en=(
+                "Number of neurons in the single hidden layer. The model uses one "
+                "hidden layer of this size."
+            ),
+            es=(
+                "Número de neuronas en la capa oculta única. El modelo utiliza una "
+                "capa oculta de este tamaño."
+            ),
+        ),
+        alias=MultilingualString(en="Hidden layer size", es="Tamaño de capa oculta"),
+    )  # type: ignore
+
+    activation: schema_field(
+        enum_field(enum=["relu", "tanh", "logistic", "identity"]),
+        placeholder="relu",
+        description=MultilingualString(
+            en="Activation function for the hidden layer.",
+            es="Función de activación para la capa oculta.",
+        ),
+        alias=MultilingualString(en="Activation", es="Activación"),
+    )  # type: ignore
+
+    solver: schema_field(
+        enum_field(enum=["adam", "lbfgs", "sgd"]),
+        placeholder="adam",
+        description=MultilingualString(
+            en=(
+                "The solver for weight optimisation. 'adam' works well for large "
+                "datasets; 'lbfgs' converges faster on small datasets; 'sgd' "
+                "requires more tuning."
+            ),
+            es=(
+                "El solucionador para la optimización de pesos. 'adam' funciona bien "
+                "para datasets grandes; 'lbfgs' converge más rápido en datasets "
+                "pequeños; 'sgd' requiere más ajuste."
+            ),
+        ),
+        alias=MultilingualString(en="Solver", es="Solucionador"),
+    )  # type: ignore
+
+    alpha: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.0001,
+            "lower_bound": 1e-6,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en="L2 regularisation term (penalty parameter).",
+            es="Término de regularización L2 (parámetro de penalización).",
+        ),
+        alias=MultilingualString(en="Alpha", es="Alfa"),
+    )  # type: ignore
+
+    learning_rate_init: schema_field(
+        optimizer_float_field(ge=1e-6),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.001,
+            "lower_bound": 1e-5,
+            "upper_bound": 0.1,
+        },
+        description=MultilingualString(
+            en="The initial learning rate used for weight updates.",
+            es="La tasa de aprendizaje inicial usada para actualizar los pesos.",
+        ),
+        alias=MultilingualString(
+            en="Learning rate init", es="Tasa de aprendizaje inicial"
+        ),
+    )  # type: ignore
+
+    max_iter: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 200,
+            "lower_bound": 50,
+            "upper_bound": 1000,
+        },
+        description=MultilingualString(
+            en=(
+                "Maximum number of iterations. The solver iterates until "
+                "convergence or this limit."
+            ),
+            es=(
+                "Número máximo de iteraciones. El solucionador itera hasta "
+                "convergencia o este límite."
+            ),
+        ),
+        alias=MultilingualString(en="Max iterations", es="Máximas iteraciones"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class MLPClassifier(TabularClassificationModel, SklearnLikeClassifier, _MLPClassifier):
+    """Multi-layer Perceptron classifier trained with backpropagation.
+
+    MLPClassifier is a fully-connected feedforward neural network. The network
+    uses a single hidden layer whose size is controlled by ``hidden_layer_size``.
+    Training uses backpropagation with the selected ``solver``. Supports ReLU,
+    tanh, logistic, and identity activations.
+
+    Key hyperparameters include ``hidden_layer_size``, ``activation``, ``solver``,
+    ``alpha`` (L2 regularisation), ``learning_rate_init``, and ``max_iter``. The
+    implementation wraps scikit-learn's ``MLPClassifier``.
+
+    References
+    ----------
+    - [1] https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPClassifier.html
+    """
+
+    SCHEMA = MLPClassifierSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="MLP Classifier",
+        es="Clasificador MLP",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Multi-layer perceptron neural network for tabular classification.",
+        es="Red neuronal perceptrón multicapa para clasificación tabular.",
+    )
+    COLOR: str = "#EF5350"
+    ICON: str = "AccountTree"
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model, converting hidden_layer_size to a tuple for sklearn.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values; ``hidden_layer_size`` is converted to a tuple
+            ``(hidden_layer_size,)`` before being forwarded to sklearn's MLPClassifier.
+        """
+        hidden_size = kwargs.pop("hidden_layer_size", 100)
+        kwargs["hidden_layer_sizes"] = (hidden_size,)
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/sgd_classifier.py
+++ b/DashAI/back/models/scikit_learn/sgd_classifier.py
@@ -1,0 +1,260 @@
+from sklearn.linear_model import SGDClassifier as _SGDClassifier
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    enum_field,
+    none_type,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+    union_type,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
+    SklearnLikeClassifier,
+)
+from DashAI.back.models.scikit_learn.sklearn_like_model import (
+    CategoricalEncodingStrategy,
+)
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+
+
+class SGDClassifierSchema(BaseSchema):
+    """Schema that configures the SGD Classifier.
+
+    SGDClassifier implements regularised linear classifiers (SVM, logistic
+    regression, etc.) with Stochastic Gradient Descent training. The loss function
+    determines the model type. Because not all loss functions expose
+    ``predict_proba``, this wrapper always uses CalibratedClassifierCV for
+    consistent probability estimates. The underlying implementation is
+    ``sklearn.linear_model.SGDClassifier``.
+    """
+
+    loss: schema_field(
+        enum_field(
+            enum=[
+                "hinge",
+                "log_loss",
+                "modified_huber",
+                "squared_hinge",
+                "perceptron",
+            ]
+        ),
+        placeholder="hinge",
+        description=MultilingualString(
+            en=(
+                "The loss function to use. 'hinge' gives a linear SVM; 'log_loss' "
+                "gives logistic regression; 'modified_huber' is smoother; "
+                "'squared_hinge' is like hinge but quadratically penalised; "
+                "'perceptron' is the linear loss used by the perceptron algorithm."
+            ),
+            es=(
+                "La función de pérdida a usar. 'hinge' da un SVM lineal; 'log_loss' "
+                "da regresión logística; 'modified_huber' es más suave; "
+                "'squared_hinge' es como hinge pero penalizado cuadráticamente; "
+                "'perceptron' es la pérdida lineal usada por el algoritmo perceptrón."
+            ),
+        ),
+        alias=MultilingualString(en="Loss", es="Pérdida"),
+    )  # type: ignore
+
+    alpha: schema_field(
+        optimizer_float_field(ge=1e-6),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.0001,
+            "lower_bound": 1e-6,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Regularisation parameter. Higher values result in stronger "
+                "regularisation."
+            ),
+            es=(
+                "Parámetro de regularización. Valores más altos resultan en "
+                "regularización más fuerte."
+            ),
+        ),
+        alias=MultilingualString(en="Alpha", es="Alfa"),
+    )  # type: ignore
+
+    max_iter: schema_field(
+        optimizer_int_field(ge=1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1000,
+            "lower_bound": 100,
+            "upper_bound": 5000,
+        },
+        description=MultilingualString(
+            en="The maximum number of passes over the training data (epochs).",
+            es="El número máximo de pasadas sobre los datos de entrenamiento (épocas).",
+        ),
+        alias=MultilingualString(en="Max iterations", es="Máximas iteraciones"),
+    )  # type: ignore
+
+    tol: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1e-3,
+            "lower_bound": 1e-6,
+            "upper_bound": 1e-1,
+        },
+        description=MultilingualString(
+            en=("The stopping criterion. Training stops when loss > best_loss - tol."),
+            es=(
+                "El criterio de parada. El entrenamiento se detiene cuando "
+                "pérdida > mejor_pérdida - tol."
+            ),
+        ),
+        alias=MultilingualString(en="Tolerance", es="Tolerancia"),
+    )  # type: ignore
+
+    learning_rate: schema_field(
+        enum_field(enum=["constant", "optimal", "invscaling", "adaptive"]),
+        placeholder="optimal",
+        description=MultilingualString(
+            en=(
+                "The learning rate schedule. 'optimal' uses 1/(alpha*(t+t0)); "
+                "'constant' keeps eta0 constant; 'invscaling' decreases as "
+                "1/t^power; 'adaptive' halves the rate when training stops."
+            ),
+            es=(
+                "El programa de tasa de aprendizaje. 'optimal' usa "
+                "1/(alpha*(t+t0)); 'constant' mantiene eta0 constante; "
+                "'invscaling' decrece como 1/t^power; 'adaptive' reduce a la "
+                "mitad la tasa cuando el entrenamiento deja de mejorar."
+            ),
+        ),
+        alias=MultilingualString(en="Learning rate", es="Tasa de aprendizaje"),
+    )  # type: ignore
+
+    random_state: schema_field(
+        union_type(optimizer_int_field(ge=0), none_type(int)),
+        placeholder=None,
+        description=MultilingualString(
+            en=(
+                "The seed of the pseudo-random number generator. Pass an int for "
+                "reproducible output, or None to not set a specific seed."
+            ),
+            es=(
+                "La semilla del generador de números pseudoaleatorios. Pase un int "
+                "para salida reproducible, o None para no fijar una semilla."
+            ),
+        ),
+        alias=MultilingualString(en="Random state", es="Estado aleatorio"),
+    )  # type: ignore
+
+
+class SGDClassifier(TabularClassificationModel, SklearnLikeClassifier, _SGDClassifier):
+    """SGD classifier with probability calibration for consistent predict_proba output.
+
+    SGDClassifier supports multiple loss functions that correspond to different
+    linear models (SVM with 'hinge', logistic regression with 'log_loss', etc.).
+    Stochastic Gradient Descent allows efficient training on large datasets. Because
+    not all loss functions expose ``predict_proba`` natively, this wrapper
+    consistently calibrates the model with ``CalibratedClassifierCV``.
+
+    Key hyperparameters include ``loss``, ``alpha``, ``max_iter``, ``tol``, and
+    ``learning_rate``. The implementation wraps scikit-learn's ``SGDClassifier``.
+
+    References
+    ----------
+    - [1] https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html
+    """
+
+    SCHEMA = SGDClassifierSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="SGD Classifier",
+        es="Clasificador SGD",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Linear classifier trained with stochastic gradient descent.",
+        es="Clasificador lineal entrenado con descenso de gradiente estocástico.",
+    )
+    COLOR: str = "#78909C"
+    ICON: str = "TrendingDown"
+    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)
+        self._calibrated = None
+
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
+        """Train using CalibratedClassifierCV to guarantee predict_proba availability.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            The input features for training.
+        y_train : DashAIDataset
+            The target labels for training.
+        x_validation : DashAIDataset, optional
+            Unused (sklearn models ignore validation split).
+        y_validation : DashAIDataset, optional
+            Unused.
+
+        Returns
+        -------
+        self
+        """
+        from sklearn.calibration import CalibratedClassifierCV
+        from sklearn.linear_model import SGDClassifier as _SGDClassifierRaw
+
+        x_processed = self.prepare_dataset(x_train, is_fit=True).to_pandas()
+        y_processed = self.prepare_output(y_train, is_fit=True).to_pandas()
+        y_arr = y_processed.values.ravel()
+
+        params = {
+            k: getattr(self, k)
+            for k in [
+                "loss",
+                "alpha",
+                "max_iter",
+                "tol",
+                "learning_rate",
+                "random_state",
+            ]
+            if hasattr(self, k)
+        }
+        base = _SGDClassifierRaw(**params)
+        self._calibrated = CalibratedClassifierCV(base, method="sigmoid", cv=3)
+        self._calibrated.fit(x_processed, y_arr)
+        return self
+
+    def predict(self, x_pred) -> "ndarray":  # noqa: F821
+        """Return class-probability matrix using the calibrated model.
+
+        Parameters
+        ----------
+        x_pred : DashAIDataset or pd.DataFrame
+            Input data.
+
+        Returns
+        -------
+        np.ndarray
+            Class probability matrix.
+        """
+        import pandas as pd
+
+        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+        if isinstance(x_pred, DashAIDataset):
+            try:
+                x_prepared = self.prepare_dataset(x_pred, is_fit=False)
+            except ValueError:
+                x_prepared = x_pred
+            x_pred = x_prepared.to_pandas()
+        elif isinstance(x_pred, pd.DataFrame):
+            pass
+
+        return self._calibrated.predict_proba(x_pred)

--- a/DashAI/back/models/scikit_learn/sgd_classifier.py
+++ b/DashAI/back/models/scikit_learn/sgd_classifier.py
@@ -189,6 +189,9 @@ class SGDClassifier(TabularClassificationModel, SklearnLikeClassifier, _SGDClass
         super().__init__(**kwargs)
         self._calibrated = None
 
+    def __sklearn_is_fitted__(self) -> bool:
+        return self._calibrated is not None
+
     def train(self, x_train, y_train, x_validation=None, y_validation=None):
         """Train using CalibratedClassifierCV to guarantee predict_proba availability.
 
@@ -257,4 +260,11 @@ class SGDClassifier(TabularClassificationModel, SklearnLikeClassifier, _SGDClass
         elif isinstance(x_pred, pd.DataFrame):
             pass
 
+        from sklearn.exceptions import NotFittedError
+
+        if self._calibrated is None:
+            raise NotFittedError(
+                f"This {self.__class__.__name__} instance is not fitted yet. "
+                "Call 'train' with appropriate arguments before using this estimator."
+            )
         return self._calibrated.predict_proba(x_pred)

--- a/DashAI/back/models/scikit_learn/svr.py
+++ b/DashAI/back/models/scikit_learn/svr.py
@@ -1,0 +1,161 @@
+from sklearn.svm import SVR as _SVR
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    enum_field,
+    optimizer_float_field,
+    optimizer_int_field,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.scikit_learn.sklearn_like_model import (
+    CategoricalEncodingStrategy,
+)
+from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
+
+
+class SVRSchema(BaseSchema):
+    """Schema that configures the Support Vector Regressor.
+
+    SVR (Support Vector Regression) finds a function that deviates from the
+    observed targets by at most ``epsilon`` while being as flat as possible. It
+    uses kernel functions to handle non-linear relationships. The underlying
+    implementation is ``sklearn.svm.SVR``.
+    """
+
+    kernel: schema_field(
+        enum_field(enum=["rbf", "linear", "poly", "sigmoid"]),
+        placeholder="rbf",
+        description=MultilingualString(
+            en=(
+                "Specifies the kernel type to be used in the algorithm. "
+                "'rbf' is the default radial basis function."
+            ),
+            es=(
+                "Especifica el tipo de kernel a usar. "
+                "'rbf' es la función de base radial predeterminada."
+            ),
+        ),
+        alias=MultilingualString(en="Kernel", es="Kernel"),
+    )  # type: ignore
+
+    C: schema_field(  # noqa: N815
+        optimizer_float_field(ge=1e-4),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 1.0,
+            "lower_bound": 0.01,
+            "upper_bound": 100.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Regularisation parameter. Inversely proportional to the "
+                "strength of the regularisation."
+            ),
+            es=(
+                "Parámetro de regularización. Inversamente proporcional a la "
+                "fuerza de la regularización."
+            ),
+        ),
+        alias=MultilingualString(en="C", es="C"),
+    )  # type: ignore
+
+    epsilon: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.1,
+            "lower_bound": 0.0,
+            "upper_bound": 1.0,
+        },
+        description=MultilingualString(
+            en=(
+                "Specifies the epsilon-tube within which no penalty is associated "
+                "in the training loss function."
+            ),
+            es=(
+                "Especifica el tubo epsilon dentro del cual no se asocia penalización "
+                "en la función de pérdida de entrenamiento."
+            ),
+        ),
+        alias=MultilingualString(en="Epsilon", es="Épsilon"),
+    )  # type: ignore
+
+    gamma: schema_field(
+        enum_field(enum=["scale", "auto"]),
+        placeholder="scale",
+        description=MultilingualString(
+            en=(
+                "Kernel coefficient for 'rbf', 'poly' and 'sigmoid'. "
+                "'scale' uses 1/(n_features * X.var()); 'auto' uses 1/n_features."
+            ),
+            es=(
+                "Coeficiente del kernel para 'rbf', 'poly' y 'sigmoid'. "
+                "'scale' usa 1/(n_features * X.var()); 'auto' usa 1/n_features."
+            ),
+        ),
+        alias=MultilingualString(en="Gamma", es="Gamma"),
+    )  # type: ignore
+
+    max_iter: schema_field(
+        optimizer_int_field(ge=-1),
+        placeholder={
+            "optimize": False,
+            "fixed_value": -1,
+            "lower_bound": 100,
+            "upper_bound": 10000,
+        },
+        description=MultilingualString(
+            en=("Hard limit on iterations within solver. -1 means no limit."),
+            es=(
+                "Límite en iteraciones dentro del solucionador. "
+                "-1 significa sin límite."
+            ),
+        ),
+        alias=MultilingualString(en="Max iterations", es="Máximas iteraciones"),
+    )  # type: ignore
+
+
+class SVR(RegressionModel, SklearnLikeRegressor, _SVR):
+    """Support Vector Regressor using kernel-based function estimation.
+
+    SVR seeks a function that deviates from the targets by at most ``epsilon``
+    (the insensitive tube) while maintaining flatness (controlled by ``C``).
+    Kernel functions allow SVR to capture non-linear relationships. The RBF kernel
+    is effective in many practical scenarios.
+
+    Key hyperparameters include ``kernel``, ``C``, ``epsilon``, ``gamma``, and
+    ``max_iter``. The implementation wraps scikit-learn's ``SVR``.
+
+    References
+    ----------
+    - [1] Vapnik, V.N. (1995). The Nature of Statistical Learning Theory. Springer.
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html
+    """
+
+    SCHEMA = SVRSchema
+    DISPLAY_NAME: str = MultilingualString(
+        en="Support Vector Regression",
+        es="Regresión de Vectores de Soporte",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en="Kernel-based SVR that finds a function within an epsilon-insensitive tube.",
+        es=(
+            "SVR basado en kernel que encuentra una función dentro de un tubo "
+            "insensible a épsilon."
+        ),
+    )
+    COLOR: str = "#EF5350"
+    ICON: str = "ControlPoint"
+    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
+
+    def __init__(self, **kwargs) -> None:
+        """Initialise the model by forwarding all kwargs to the parent class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Hyperparameter values forwarded to the parent sklearn wrapper.
+        """
+        super().__init__(**kwargs)

--- a/DashAI/back/models/scikit_learn/tfidf_logreg_text_classification_model.py
+++ b/DashAI/back/models/scikit_learn/tfidf_logreg_text_classification_model.py
@@ -1,0 +1,186 @@
+"""DashAI TF-IDF + Logistic Regression text classification model."""
+
+from typing import TYPE_CHECKING, Union
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    enum_field,
+    float_field,
+    int_field,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.text_classification_model import TextClassificationModel
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class TfIdfLogRegTextClassificationModelSchema(BaseSchema):
+    """Configuration schema for TF-IDF + Logistic Regression text classifier."""
+
+    ngram_min_n: schema_field(
+        int_field(ge=1),
+        placeholder=1,
+        description=MultilingualString(
+            en="Minimum n-gram size for the TF-IDF vectorizer (≥ 1).",
+            es="Tamaño mínimo de n-grama para el vectorizador TF-IDF (≥ 1).",
+        ),
+        alias=MultilingualString(en="Min n-gram", es="N-grama mínimo"),
+    )  # type: ignore
+    ngram_max_n: schema_field(
+        int_field(ge=1),
+        placeholder=1,
+        description=MultilingualString(
+            en="Maximum n-gram size for the TF-IDF vectorizer (≥ 1).",
+            es="Tamaño máximo de n-grama para el vectorizador TF-IDF (≥ 1).",
+        ),
+        alias=MultilingualString(en="Max n-gram", es="N-grama máximo"),
+    )  # type: ignore
+    use_idf: schema_field(
+        bool_field(),
+        placeholder=True,
+        description=MultilingualString(
+            en="Enable inverse-document-frequency re-weighting.",
+            es="Activar re-ponderación por frecuencia inversa de documento.",
+        ),
+        alias=MultilingualString(en="Use IDF", es="Usar IDF"),
+    )  # type: ignore
+    sublinear_tf: schema_field(
+        bool_field(),
+        placeholder=False,
+        description=MultilingualString(
+            en=("Apply sublinear TF scaling (replace TF with 1 + log(TF))."),
+            es=("Aplicar escalado sublineal de TF (reemplazar TF con 1 + log(TF))."),
+        ),
+        alias=MultilingualString(en="Sublinear TF", es="TF sublineal"),
+    )  # type: ignore
+    C: schema_field(
+        float_field(gt=0.0),
+        placeholder=1.0,
+        description=MultilingualString(
+            en=(
+                "Regularization parameter for logistic regression. "
+                "Smaller values mean stronger regularization."
+            ),
+            es=(
+                "Parámetro de regularización para regresión logística. "
+                "Valores más pequeños significan mayor regularización."
+            ),
+        ),
+        alias=MultilingualString(en="C (Regularization)", es="C (Regularización)"),
+    )  # type: ignore
+    max_iter: schema_field(
+        int_field(ge=100),
+        placeholder=1000,
+        description=MultilingualString(
+            en="Maximum number of iterations for the logistic regression solver.",
+            es=("Número máximo de iteraciones para el solver de regresión logística."),
+        ),
+        alias=MultilingualString(en="Max iterations", es="Iteraciones máximas"),
+    )  # type: ignore
+    solver: schema_field(
+        enum_field(["lbfgs", "liblinear", "saga"]),
+        placeholder="lbfgs",
+        description=MultilingualString(
+            en="Optimization algorithm for logistic regression.",
+            es="Algoritmo de optimización para regresión logística.",
+        ),
+        alias=MultilingualString(en="Solver", es="Solver"),
+    )  # type: ignore
+
+
+class TfIdfLogRegTextClassificationModel(TextClassificationModel):
+    """TF-IDF vectorizer combined with Logistic Regression for text classification.
+
+    This model converts raw text into TF-IDF feature vectors using scikit-learn's
+    ``TfidfVectorizer`` with a configurable n-gram range and IDF weighting, then
+    trains a ``LogisticRegression`` classifier on the resulting sparse matrix.
+    It is a strong baseline for text classification tasks, particularly when
+    training data is limited or computational resources are constrained.
+
+    References
+    ----------
+    - [1] https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.TfidfVectorizer.html
+    - [2] https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html
+    """
+
+    DISPLAY_NAME: str = MultilingualString(
+        en="TF-IDF + Logistic Regression",
+        es="TF-IDF + Regresión Logística",
+    )
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "TF-IDF vectorizer combined with logistic regression "
+            "for text classification."
+        ),
+        es=(
+            "Vectorizador TF-IDF combinado con regresión logística "
+            "para clasificación de texto."
+        ),
+    )
+    COLOR: str = "#00695C"
+    ICON: str = "Article"
+    SCHEMA = TfIdfLogRegTextClassificationModelSchema
+
+    def __init__(self, **kwargs) -> None:
+        from sklearn.feature_extraction.text import TfidfVectorizer
+        from sklearn.linear_model import LogisticRegression
+        from sklearn.preprocessing import LabelEncoder
+
+        self.vectorizer = TfidfVectorizer(
+            ngram_range=(kwargs["ngram_min_n"], kwargs["ngram_max_n"]),
+            use_idf=kwargs["use_idf"],
+            sublinear_tf=kwargs["sublinear_tf"],
+        )
+        self.classifier = LogisticRegression(
+            C=kwargs["C"],
+            max_iter=kwargs["max_iter"],
+            solver=kwargs["solver"],
+        )
+        self.label_encoder = LabelEncoder()
+
+    def train(
+        self,
+        x,
+        y,
+        x_validation=None,
+        y_validation=None,
+    ):
+        input_col = x.column_names[0]
+        output_col = y.column_names[0]
+
+        X_tfidf = self.vectorizer.fit_transform(x[input_col])
+        y_enc = self.label_encoder.fit_transform(y[output_col])
+        self.classifier.fit(X_tfidf, y_enc)
+
+    def predict(self, x):
+        input_col = x.column_names[0]
+        X_tfidf = self.vectorizer.transform(x[input_col])
+        return self.classifier.predict_proba(X_tfidf)
+
+    def prepare_output(self, dataset: "DashAIDataset", is_fit: bool = False):
+        from datasets import Dataset as HFDataset
+
+        from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+
+        col = dataset.column_names[0]
+        if is_fit:
+            encoded = self.label_encoder.fit_transform(dataset[col]).tolist()
+        else:
+            encoded = self.label_encoder.transform(dataset[col]).tolist()
+        return to_dashai_dataset(HFDataset.from_dict({col: encoded}))
+
+    def save(self, filename: Union[str, "Path"]) -> None:
+        import joblib
+
+        joblib.dump(self, filename)
+
+    @staticmethod
+    def load(filename: Union[str, "Path"]):
+        import joblib
+
+        return joblib.load(filename)

--- a/DashAI/front/src/components/configurableObject/FormTooltip.jsx
+++ b/DashAI/front/src/components/configurableObject/FormTooltip.jsx
@@ -1,7 +1,9 @@
 import React from "react";
-import { Tooltip, IconButton, Typography } from "@mui/material";
+import { Tooltip, IconButton, Typography, Link } from "@mui/material";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import PropTypes from "prop-types";
+import ReactMarkdown from "react-markdown";
+
 /**
  * This component renders a tooltip containing a description for each parameter in a form,
  * providing users with additional information to better understand the purpose of each input field.
@@ -10,7 +12,31 @@ import PropTypes from "prop-types";
 function FormTooltip({ contentStr = "", error }) {
   return (
     <Tooltip
-      title={<Typography variant="body2">{contentStr}</Typography>}
+      title={
+        <Typography variant="body2" component="div">
+          <ReactMarkdown
+            components={{
+              p: ({ children }) => (
+                <span style={{ margin: 0 }}>{children}</span>
+              ),
+              a: ({ href, children }) => (
+                <Link
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  color="inherit"
+                  underline="always"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {children}
+                </Link>
+              ),
+            }}
+          >
+            {contentStr}
+          </ReactMarkdown>
+        </Typography>
+      }
       placement="bottom"
       arrow
     >

--- a/tests/back/models/test_tabular_class_models.py
+++ b/tests/back/models/test_tabular_class_models.py
@@ -16,10 +16,20 @@ from DashAI.back.dataloaders.classes.dashai_dataset import (
     split_indexes,
     to_dashai_dataset,
 )
+from DashAI.back.models.scikit_learn.adaboost_classifier import AdaBoostClassifier
+from DashAI.back.models.scikit_learn.bagging_classifier import BaggingClassifier
+from DashAI.back.models.scikit_learn.extra_trees_classifier import ExtraTreesClassifier
+from DashAI.back.models.scikit_learn.gaussian_nb import GaussianNB
+from DashAI.back.models.scikit_learn.gradient_boosting_classifier import (
+    GradientBoostingClassifier,
+)
 from DashAI.back.models.scikit_learn.k_neighbors_classifier import KNeighborsClassifier
+from DashAI.back.models.scikit_learn.linear_svc_classifier import LinearSVCClassifier
+from DashAI.back.models.scikit_learn.mlp_classifier import MLPClassifier
 from DashAI.back.models.scikit_learn.random_forest_classifier import (
     RandomForestClassifier,
 )
+from DashAI.back.models.scikit_learn.sgd_classifier import SGDClassifier
 from DashAI.back.models.scikit_learn.svc import SVC
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.utils import save_types_in_arrow_metadata
@@ -119,6 +129,65 @@ def fixture_model_params() -> dict:
             "tol": 0.001,
             "verbose": False,
         },
+        "gradient_boosting": {
+            "loss": "log_loss",
+            "learning_rate": 0.1,
+            "n_estimators": 5,
+            "max_depth": 2,
+            "min_samples_split": 2,
+            "min_samples_leaf": 1,
+            "subsample": 1.0,
+            "random_state": 42,
+        },
+        "extra_trees": {
+            "n_estimators": 5,
+            "max_depth": None,
+            "min_samples_split": 2,
+            "min_samples_leaf": 1,
+            "bootstrap": False,
+            "random_state": 42,
+        },
+        "adaboost": {
+            "n_estimators": 5,
+            "learning_rate": 1.0,
+            "random_state": 42,
+        },
+        "bagging": {
+            "n_estimators": 5,
+            "max_samples": 1.0,
+            "max_features": 1.0,
+            "bootstrap": True,
+            "bootstrap_features": False,
+            "random_state": 42,
+        },
+        "gaussian_nb": {
+            "var_smoothing": 1e-9,
+        },
+        "mlp": {
+            "hidden_layer_size": 10,
+            "activation": "relu",
+            "solver": "adam",
+            "alpha": 0.0001,
+            "learning_rate_init": 0.001,
+            "max_iter": 50,
+            "random_state": 42,
+        },
+        "linear_svc": {
+            "C": 1.0,
+            "loss": "squared_hinge",
+            "max_iter": 100,
+            "tol": 1e-4,
+            "fit_intercept": True,
+            "random_state": 42,
+        },
+        "sgd": {
+            "loss": "hinge",
+            "alpha": 0.0001,
+            "max_iter": 100,
+            "tol": 1e-3,
+            "learning_rate": "optimal",
+            "random_state": 42,
+        },
     }
 
 
@@ -205,3 +274,134 @@ def test_get_schema_from_model_class():
         assert model_schema["type"] == "object"
         assert "properties" in model_schema
         assert isinstance(model_schema["properties"], dict)
+
+
+def test_check_is_fitted_new_classifiers(
+    divided_dataset: Tuple[DatasetDict, DatasetDict], model_params: dict
+):
+    gb_model = GradientBoostingClassifier(**model_params["gradient_boosting"])
+    gb_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+
+    et_model = ExtraTreesClassifier(**model_params["extra_trees"])
+    et_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+
+    ab_model = AdaBoostClassifier(**model_params["adaboost"])
+    ab_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+
+    bag_model = BaggingClassifier(**model_params["bagging"])
+    bag_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+
+    gnb_model = GaussianNB(**model_params["gaussian_nb"])
+    gnb_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+
+    mlp_model = MLPClassifier(**model_params["mlp"])
+    mlp_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+
+    lsvc_model = LinearSVCClassifier(**model_params["linear_svc"])
+    lsvc_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+
+    sgd_model = SGDClassifier(**model_params["sgd"])
+    sgd_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+
+    try:
+        check_is_fitted(gb_model)
+        check_is_fitted(et_model)
+        check_is_fitted(ab_model)
+        check_is_fitted(bag_model)
+        check_is_fitted(gnb_model)
+        check_is_fitted(mlp_model)
+        check_is_fitted(lsvc_model)
+        check_is_fitted(sgd_model)
+    except Exception as e:
+        pytest.fail(
+            f"Unexpected error in test_check_is_fitted_new_classifiers: {repr(e)}"
+        )
+
+
+def test_predict_new_classifiers(
+    divided_dataset: Tuple[DatasetDict, DatasetDict], model_params: dict
+):
+    gb_model = GradientBoostingClassifier(**model_params["gradient_boosting"])
+    gb_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    y_pred_gb = gb_model.predict(divided_dataset[0]["test"])
+
+    et_model = ExtraTreesClassifier(**model_params["extra_trees"])
+    et_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    y_pred_et = et_model.predict(divided_dataset[0]["test"])
+
+    ab_model = AdaBoostClassifier(**model_params["adaboost"])
+    ab_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    y_pred_ab = ab_model.predict(divided_dataset[0]["test"])
+
+    bag_model = BaggingClassifier(**model_params["bagging"])
+    bag_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    y_pred_bag = bag_model.predict(divided_dataset[0]["test"])
+
+    gnb_model = GaussianNB(**model_params["gaussian_nb"])
+    gnb_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    y_pred_gnb = gnb_model.predict(divided_dataset[0]["test"])
+
+    mlp_model = MLPClassifier(**model_params["mlp"])
+    mlp_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    y_pred_mlp = mlp_model.predict(divided_dataset[0]["test"])
+
+    lsvc_model = LinearSVCClassifier(**model_params["linear_svc"])
+    lsvc_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    y_pred_lsvc = lsvc_model.predict(divided_dataset[0]["test"])
+
+    sgd_model = SGDClassifier(**model_params["sgd"])
+    sgd_model.train(divided_dataset[0]["train"], divided_dataset[1]["train"])
+    y_pred_sgd = sgd_model.predict(divided_dataset[0]["test"])
+
+    n_test = divided_dataset[0]["test"].num_rows
+    for y_pred in (
+        y_pred_gb,
+        y_pred_et,
+        y_pred_ab,
+        y_pred_bag,
+        y_pred_gnb,
+        y_pred_mlp,
+        y_pred_lsvc,
+        y_pred_sgd,
+    ):
+        assert isinstance(y_pred, np.ndarray)
+        assert len(y_pred) == n_test
+
+
+def test_not_fitted_new_classifiers(
+    divided_dataset: Tuple[DatasetDict, DatasetDict], model_params: dict
+):
+    with pytest.raises(NotFittedError):
+        GradientBoostingClassifier(**model_params["gradient_boosting"]).predict(
+            divided_dataset[0]["test"]
+        )
+
+    with pytest.raises(NotFittedError):
+        LinearSVCClassifier(**model_params["linear_svc"]).predict(
+            divided_dataset[0]["test"]
+        )
+
+    with pytest.raises(NotFittedError):
+        SGDClassifier(**model_params["sgd"]).predict(divided_dataset[0]["test"])
+
+
+def test_get_schema_from_new_classifier_classes():
+    new_models = (
+        GradientBoostingClassifier,
+        ExtraTreesClassifier,
+        AdaBoostClassifier,
+        BaggingClassifier,
+        GaussianNB,
+        MLPClassifier,
+        LinearSVCClassifier,
+        SGDClassifier,
+    )
+    for model_cls in new_models:
+        schema = model_cls.get_schema()
+        assert isinstance(schema, dict), f"{model_cls.__name__} schema is not a dict"
+        assert schema.get("type") == "object", (
+            f"{model_cls.__name__} schema type != object"
+        )
+        assert isinstance(schema.get("properties"), dict), (
+            f"{model_cls.__name__} schema has no properties dict"
+        )


### PR DESCRIPTION
## Summary

Expands the model catalog from 20 to 54 models across all four supported tasks, adding bilingual (`en`/`es`) schemas, display names, and descriptions for each.

## New models

**Tabular Classification (+8):** `GradientBoostingClassifier`, `ExtraTreesClassifier`, `AdaBoostClassifier`, `BaggingClassifier`, `GaussianNB`, `MLPClassifier`, `LinearSVCClassifier`, `SGDClassifier`

**Regression (+9):** `LassoRegression`, `ElasticNetRegression`, `BayesianRidgeRegression`, `KNeighborsRegression`, `DecisionTreeRegression`, `ExtraTreesRegression`, `AdaBoostRegression`, `HistGradientBoostingRegression`, `SVR`

**Text Classification (+11):** `BertTransformer`, `RobertaTransformer`, `AlbertTransformer`, `ElectraTransformer`, `XlmRobertaTransformer`, `MultilingualBertTransformer`, `BetoTransformer`, `BertinTransformer`, `XlnetTransformer`, `MiniLMTransformer`, `TfIdfLogRegTextClassificationModel`

**Translation (+6):** `OpusMtEnFrTransformer`, `OpusMtFrEnTransformer`, `OpusMtEnDeTransformer`, `OpusMtEnPtTransformer`, `M2M100Transformer`, `T5SmallTransformer`

## Refactors & fixes

- Introduced `OpusMtTransformerMixin` to share `train`/`predict`/`save`/`load` logic across all Opus-MT models, reducing duplication from ~250 lines per pair to ~20.
- `LinearSVCClassifier` and `SGDClassifier`: added `__sklearn_is_fitted__` and `NotFittedError` guard (were raising `AttributeError` when predicting without training).
- `LogLoss` and `ROCAUC` metrics: fixed crashes on single-class validation splits.
- `FormTooltip.jsx`: upgraded from plain text to `ReactMarkdown` rendering so field descriptions can include clickable links. Used in NLLB language code fields.

## Tests

Added `test_check_is_fitted_new_classifiers`, `test_predict_new_classifiers`, `test_not_fitted_new_classifiers`, and `test_get_schema_from_new_classifier_classes` to the tabular classification test suite.