### PR TITLE
fix: include pywebview in dependencies and update macOS build configurations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.txt
-          pip install pyinstaller
+          pip install pyinstaller pywebview
           pip install --force-reinstall llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
           brew install create-dmg
 
@@ -198,7 +198,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.txt
-          pip install pyinstaller
+          pip install pyinstaller pywebview
           pip install --force-reinstall llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
           brew install create-dmg
 

--- a/dashai.spec
+++ b/dashai.spec
@@ -1,11 +1,17 @@
 import os
 import platform
 import site
+from PyInstaller.utils.hooks import collect_all
 
 SITEPKG = str(site.getsitepackages()[-1])
 
 # Check for llama_cpp/lib presence to determine if we can include the binaries
 llama_lib = os.path.exists(os.path.join(SITEPKG, "llama_cpp/lib"))
+
+if platform.system() == "Darwin":
+    webview_datas, webview_binaries, webview_hiddenimports = collect_all('webview')
+else:
+    webview_datas, webview_binaries, webview_hiddenimports = [], [], []
 
 # Ensure the temp_checkpoints directory exists before building
 if not os.path.exists(os.path.join("DashAI/back/user_models/temp_checkpoints")):
@@ -14,7 +20,7 @@ if not os.path.exists(os.path.join("DashAI/back/user_models/temp_checkpoints")):
 a = Analysis(
     platform.system() == "Windows" and ["DashAI/__main__.py"] or ["DashAI/webview.py"],
     pathex=["."],
-    binaries=llama_lib and [(f"{SITEPKG}/llama_cpp/lib/*", "llama_cpp/lib")] or [],
+    binaries=(llama_lib and [(f"{SITEPKG}/llama_cpp/lib/*", "llama_cpp/lib")] or []) + webview_binaries,
     datas=[
         ("DashAI/__main__.py", "DashAI/__main__.py"),
         ("DashAI/alembic", "DashAI/alembic"),
@@ -27,8 +33,8 @@ a = Analysis(
             "DashAI/back/user_models/temp_checkpoints",
         ),
         (f"{SITEPKG}/transformers", "transformers"),
-    ],
-    hiddenimports=[],
+    ] + webview_datas,
+    hiddenimports=webview_hiddenimports,
     hookspath=["hooks"],
     runtime_hooks=None,
     excludes=None,


### PR DESCRIPTION
## Summary                 

  The macOS `.app` bundle built by CI was silently failing to open after installation. Running the binary from the terminal revealed `ModuleNotFoundError: No module named 'webview'` — `pywebview` was not installed in the CI environment and therefore not included in the PyInstaller bundle.
                                                                                                                                                            
  The fix installs `pywebview` in the macOS CI jobs and explicitly tells PyInstaller to bundle the entire `webview` package, since its platform-specific backends (`webview.platforms.cocoa`) are loaded dynamically and are not detected by static analysis.
                                                                                                                                                            
  ---                  

  ## Type of Change

  - [ ] Backend change
  - [ ] Frontend change
  - [x] CI / Workflow change
  - [x] Build / Packaging change
  - [x] Bug fix                                                                                                                                             
  - [ ] Documentation
                                                                                                                                                            
  ---                                                       

  ## Changes (by file)

  - `.github/workflows/publish.yml`: Added `pywebview` to the `pip install` step in both macOS build jobs (`build-macos-arm64`, `build-macos-x86_64`)       
  - `dashai.spec`: Used `collect_all('webview')` to include all pywebview files/binaries/hidden imports in the bundle; scoped to macOS only since Windows uses `__main__.py` as entry point and does not use pywebview                                                                                              
                                                                                                                                                            
  ---                                                       
                                                                                                                                                            
  ## Testing                                                

  - Built locally with `pyinstaller --clean --noconfirm dashai.spec` and verified `dist/DashAI.app` opens correctly.                                        
   
  ---                                                                                                                                                       
                                                            
  ## Notes

  `pywebview` was intentionally kept out of `requirements-cpu.txt` since it is only needed for the macOS desktop bundle, not for the Windows build or the PyPI package.