### PR TITLE
Fix/grid layout

### DIFF
--- a/DashAI/back/tasks/regression_task.py
+++ b/DashAI/back/tasks/regression_task.py
@@ -23,14 +23,8 @@ class RegressionTask(BaseTask):
     """
 
     DESCRIPTION: str = MultilingualString(
-        en=(
-            "Predict continuous numeric values from structured tabular data "
-            "using trained regression models."
-        ),
-        es=(
-            "Predice valores numéricos continuos a partir de datos tabulares "
-            "estructurados usando modelos de regresión."
-        ),
+        en="Predict continuous numeric values from tabular data.",
+        es="Predice valores numéricos continuos a partir de datos tabulares.",
     )
     DISPLAY_NAME: str = MultilingualString(en="Regression", es="Regresión")
 

--- a/DashAI/back/tasks/tabular_classification_task.py
+++ b/DashAI/back/tasks/tabular_classification_task.py
@@ -22,13 +22,10 @@ class TabularClassificationTask(ClassificationTask):
     """
 
     DESCRIPTION: str = MultilingualString(
-        en=(
-            "Predict categorical labels from structured tabular data "
-            "(rows and columns) using trained classification models."
-        ),
+        en="Predict categorical labels from tabular data (rows and columns).",
         es=(
             "Predice etiquetas categóricas a partir de datos tabulares "
-            "estructurados (filas y columnas) usando modelos de clasificación."
+            "(filas y columnas)."
         ),
     )
     DISPLAY_NAME: str = MultilingualString(

--- a/DashAI/back/tasks/text_classification_task.py
+++ b/DashAI/back/tasks/text_classification_task.py
@@ -50,13 +50,12 @@ class TextClassificationTask(ClassificationTask):
 
     DESCRIPTION: str = MultilingualString(
         en=(
-            "Assign predefined labels to text inputs using NLP models. "
-            "Common uses: sentiment analysis, spam detection, intent recognition."
+            "Classify text into predefined categories. "
+            "E.g.: sentiment, spam, intent detection."
         ),
         es=(
-            "Asigna etiquetas predefinidas a textos mediante modelos de PLN. "
-            "Usos comunes: análisis de sentimientos, detección de spam, "
-            "reconocimiento de intenciones."
+            "Clasifica textos en categorías predefinidas. "
+            "Ej.: sentimiento, spam, intención."
         ),
     )
     DISPLAY_NAME: str = MultilingualString(

--- a/DashAI/back/tasks/translation_task.py
+++ b/DashAI/back/tasks/translation_task.py
@@ -42,14 +42,8 @@ class TranslationTask(BaseTask):
         "outputs_cardinality": 1,
     }
     DESCRIPTION: str = MultilingualString(
-        en=(
-            "Convert text from one language to another while "
-            "preserving meaning and context."
-        ),
-        es=(
-            "Convierte texto de un idioma a otro preservando "
-            "el significado y el contexto."
-        ),
+        en="Convert text from one language to another preserving meaning.",
+        es="Convierte texto de un idioma a otro preservando el significado.",
     )
 
     DISPLAY_NAME: str = MultilingualString(en="Translation", es="Traducción")

--- a/DashAI/front/src/components/generative/ModelGrid.jsx
+++ b/DashAI/front/src/components/generative/ModelGrid.jsx
@@ -33,7 +33,7 @@ export default function ModelGrid({
             model.color ?? MODEL_COLORS[globalIndex % MODEL_COLORS.length];
           return (
             <Grid
-              size={{ xl: 6, lg: 6, md: 6, sm: 12, xs: 12 }}
+              size={{ xl: 4, lg: 4, md: 6, sm: 12, xs: 12 }}
               key={model.name}
             >
               <ModelCard

--- a/DashAI/front/src/components/generative/ModelGrid.jsx
+++ b/DashAI/front/src/components/generative/ModelGrid.jsx
@@ -33,7 +33,7 @@ export default function ModelGrid({
             model.color ?? MODEL_COLORS[globalIndex % MODEL_COLORS.length];
           return (
             <Grid
-              size={{ xl: 4, lg: 4, md: 6, sm: 12, xs: 12 }}
+              size={{ xl: 6, lg: 6, md: 6, sm: 12, xs: 12 }}
               key={model.name}
             >
               <ModelCard

--- a/DashAI/front/src/components/threeSectionLayout/SelectOptionMenu.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/SelectOptionMenu.jsx
@@ -64,7 +64,6 @@ export default function SelectOptionMenu({
         <Grid
           container
           direction="row"
-          justifyContent="center"
           alignItems="stretch"
           spacing={1}
           sx={{ mt: 2, mx: 0, maxWidth: "100%" }}
@@ -72,7 +71,7 @@ export default function SelectOptionMenu({
           {loading
             ? Array.from({ length: 6 }).map((_, index) => (
                 <Grid
-                  size={{ xl: 6, lg: 6, md: 6, sm: 12, xs: 12 }}
+                  size={{ xl: 4, lg: 4, md: 6, sm: 12, xs: 12 }}
                   key={index}
                 >
                   <Skeleton variant="rounded" height={100} />
@@ -86,7 +85,7 @@ export default function SelectOptionMenu({
 
               return (
                 <Grid
-                  size={{ xl: 6, lg: 6, md: 6, sm: 12, xs: 12 }}
+                  size={{ xl: 4, lg: 4, md: 6, sm: 12, xs: 12 }}
                   key={index}
                 >
                   <OptionBox


### PR DESCRIPTION
## Summary                       
  Fixes the option card grid in the Modules, Datasets, Models, and Generative home screens so it always renders 3 stable columns with left-aligned overflow items. Also shortens the task descriptions in the Models module so they fit comfortably in the smaller cards.   

  ## Type of Change                                                                                                                                                                                          

  - [x] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation                                                                                                                                                                                        
   
  ---                                                                                                                                                                                                        
                       
  ## Changes (by file)

  - `DashAI/front/src/components/threeSectionLayout/SelectOptionMenu.jsx`: Changed grid from 2 to 3 columns on `lg`/`xl` breakpoints; removed `justifyContent="center"` to prevent lone items from centering on the last row.                                                                                      
  - `DashAI/back/tasks/text_classification_task.py`: Shortened `DESCRIPTION` (EN + ES).                                                                                                                      
  - `DashAI/back/tasks/tabular_classification_task.py`: Shortened `DESCRIPTION` (EN + ES).                                                                                                                   
  - `DashAI/back/tasks/regression_task.py`: Shortened `DESCRIPTION` (EN + ES).                                                                                                                               
  - `DashAI/back/tasks/translation_task.py`: Shortened `DESCRIPTION` (EN + ES).                                                                                                                              
                                                                                                                                                                                                             
  ---
                                                                                                                                                                                                             
  ## Testing (optional)                                     
  Verify that task/option grids display 3 columns on large screens and that a list with an odd number of items leaves the last card aligned to the left instead of centered.