### PR TITLE
refactor: update icon sizes and improve theme toggle accessibility

### DIFF
--- a/DashAI/front/src/components/LanguageSelector.jsx
+++ b/DashAI/front/src/components/LanguageSelector.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FormControl, Select, MenuItem, Box } from "@mui/material";
-import LanguageIcon from "@mui/icons-material/Language";
 
 export default function LanguageSelector() {
   const { i18n } = useTranslation();
@@ -14,35 +13,33 @@ export default function LanguageSelector() {
   };
 
   return (
-    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-      <LanguageIcon sx={{ color: "text.secondary" }} />
-      <FormControl size="small" sx={{ minWidth: 120 }}>
-        <Select
-          value={language}
-          onChange={handleLanguageChange}
-          displayEmpty
-          sx={{
-            "& .MuiSelect-select": {
-              display: "flex",
-              alignItems: "center",
-              gap: 1,
-            },
-          }}
-        >
-          <MenuItem value="es">
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <span>🇨🇱</span>
-              <span>Español</span>
-            </Box>
-          </MenuItem>
-          <MenuItem value="en">
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <span>🇺🇸</span>
-              <span>English</span>
-            </Box>
-          </MenuItem>
-        </Select>
-      </FormControl>
-    </Box>
+    <FormControl size="small" sx={{ minWidth: 120 }}>
+      <Select
+        value={language}
+        onChange={handleLanguageChange}
+        displayEmpty
+        sx={{
+          height: 32,
+          "& .MuiSelect-select": {
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+          },
+        }}
+      >
+        <MenuItem value="es">
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <span>🇨🇱</span>
+            <span>Español</span>
+          </Box>
+        </MenuItem>
+        <MenuItem value="en">
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <span>🇺🇸</span>
+            <span>English</span>
+          </Box>
+        </MenuItem>
+      </Select>
+    </FormControl>
   );
 }

--- a/DashAI/front/src/components/ResponsiveAppBar.jsx
+++ b/DashAI/front/src/components/ResponsiveAppBar.jsx
@@ -13,8 +13,9 @@ import HomeIcon from "@mui/icons-material/HomeOutlined";
 import { useTranslation } from "react-i18next";
 import LanguageSelector from "./LanguageSelector";
 import { ColorModeContext } from "../contexts/ThemeContext";
-import Brightness4Icon from "@mui/icons-material/Brightness4";
-import Brightness7Icon from "@mui/icons-material/Brightness7";
+import DarkModeOutlinedIcon from "@mui/icons-material/DarkModeOutlined";
+import LightModeOutlinedIcon from "@mui/icons-material/LightModeOutlined";
+import Tooltip from "@mui/material/Tooltip";
 import HardwareMonitorButton from "./hardware/HardwareMonitorButton";
 import NavbarTourButton from "./tour/NavbarTourButton";
 
@@ -41,8 +42,8 @@ function ResponsiveAppBar() {
 
   const iconBtnSx = React.useMemo(
     () => ({
-      width: 28,
-      height: 28,
+      width: 32,
+      height: 32,
       borderRadius: "4px",
       border: `1px solid ${theme.palette.divider}`,
       color: theme.palette.text.secondary,
@@ -238,17 +239,25 @@ function ResponsiveAppBar() {
           <LanguageSelector />
           <HardwareMonitorButton />
           <NavbarTourButton />
-          <IconButton
-            onClick={colorMode.toggleColorMode}
-            aria-label="toggle theme"
-            sx={iconBtnSx}
+          <Tooltip
+            title={
+              theme.palette.mode === "dark"
+                ? t("common:switchToLightMode")
+                : t("common:switchToDarkMode")
+            }
           >
-            {theme.palette.mode === "dark" ? (
-              <Brightness7Icon sx={{ fontSize: 16 }} />
-            ) : (
-              <Brightness4Icon sx={{ fontSize: 16 }} />
-            )}
-          </IconButton>
+            <IconButton
+              onClick={colorMode.toggleColorMode}
+              aria-label="toggle theme"
+              sx={iconBtnSx}
+            >
+              {theme.palette.mode === "dark" ? (
+                <LightModeOutlinedIcon sx={{ fontSize: 18 }} />
+              ) : (
+                <DarkModeOutlinedIcon sx={{ fontSize: 18 }} />
+              )}
+            </IconButton>
+          </Tooltip>
         </Box>
       </Toolbar>
     </AppBar>

--- a/DashAI/front/src/components/hardware/HardwareMonitorButton.jsx
+++ b/DashAI/front/src/components/hardware/HardwareMonitorButton.jsx
@@ -31,8 +31,8 @@ export default function HardwareMonitorButton() {
           onClick={handleClick}
           aria-label={t("common:hardwareMonitor.title")}
           sx={{
-            width: 28,
-            height: 28,
+            width: 32,
+            height: 32,
             borderRadius: "4px",
             border: `1px solid ${theme.palette.divider}`,
             color: theme.palette.text.secondary,
@@ -42,7 +42,7 @@ export default function HardwareMonitorButton() {
             },
           }}
         >
-          <MonitorHeartIcon sx={{ fontSize: 16 }} />
+          <MonitorHeartIcon sx={{ fontSize: 18 }} />
         </IconButton>
       </Tooltip>
       <Popover

--- a/DashAI/front/src/components/tour/NavbarTourButton.jsx
+++ b/DashAI/front/src/components/tour/NavbarTourButton.jsx
@@ -43,8 +43,8 @@ export default function NavbarTourButton() {
         onClick={isDisabled ? undefined : handleClick}
         aria-label="start tour"
         sx={{
-          width: 28,
-          height: 28,
+          width: 32,
+          height: 32,
           borderRadius: "4px",
           border: `1px solid ${theme.palette.divider}`,
           color: isDisabled
@@ -60,7 +60,7 @@ export default function NavbarTourButton() {
               },
         }}
       >
-        <HelpOutlineIcon sx={{ fontSize: 16 }} />
+        <HelpOutlineIcon sx={{ fontSize: 18 }} />
       </IconButton>
     </Tooltip>
   );

--- a/DashAI/front/src/utils/i18n/locales/en/common.json
+++ b/DashAI/front/src/utils/i18n/locales/en/common.json
@@ -215,5 +215,7 @@
   "expand": "Expand",
   "optimize": "Optimize",
   "viewMore": "View more",
-  "viewLess": "View less"
+  "viewLess": "View less",
+  "switchToDarkMode": "Switch to dark mode",
+  "switchToLightMode": "Switch to light mode"
 }

--- a/DashAI/front/src/utils/i18n/locales/es/common.json
+++ b/DashAI/front/src/utils/i18n/locales/es/common.json
@@ -215,5 +215,7 @@
   "expand": "Expandir",
   "optimize": "Optimizar",
   "viewMore": "Ver más",
-  "viewLess": "Ver menos"
+  "viewLess": "Ver menos",
+  "switchToDarkMode": "Cambiar a modo oscuro",
+  "switchToLightMode": "Cambiar a modo claro"
 }


### PR DESCRIPTION
Summary               

Polishes the navbar's right-side controls for visual consistency: all icon buttons are unified to 32×32 px, the theme toggle switches from the generic `Brightness4/7` icons to the more descriptive `DarkModeOutlined` / `LightModeOutlined` variants and gains a translated tooltip, and the orphaned globe icon in the language selector is removed.
                                                                                                                                                                                                             
  ---                  

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [ ] Bug fix
  - [ ] Documentation                                                                                                                                                                                        
   
  ---                                                                                                                                                                                                        
                       
  ## Changes (by file)

  - `src/components/ResponsiveAppBar.jsx`: unified `iconBtnSx` size from 28→32 px; replaced `Brightness4/7Icon` with `DarkModeOutlinedIcon` / `LightModeOutlinedIcon`; wrapped theme toggle in `<Tooltip>`.  
  - `src/components/hardware/HardwareMonitorButton.jsx`: button size 28→32 px, icon `fontSize` 16→18.
  - `src/components/tour/NavbarTourButton.jsx`: button size 28→32 px, icon `fontSize` 16→18.                                                                                                                 
  - `src/components/LanguageSelector.jsx`: removed orphaned `LanguageIcon` and its wrapper `Box`; added explicit `height: 32` to the `Select` so it aligns with the icon buttons.
  - `src/utils/i18n/locales/en/common.json`: added `switchToDarkMode` / `switchToLightMode` keys.                                                                                                            
  - `src/utils/i18n/locales/es/common.json`: added Spanish translations for the same keys.                                                                                                                   
                                                                                                                                                                                                             
  ---                                                                                                                                                                                                        
                                                                                                                                                                                                             
  ## Notes                                                  

  The `LanguageIcon` was rendered as a standalone decorative element outside the `Select` with no interactivity or semantic role — removing it simplifies the markup without any functional loss. The flag emoji inside each `MenuItem` already serves as a visual language indicator.