### PR TITLE
style: redesign bar chart hover highlighting in dataset tabs

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/tabs/CategoricalTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/CategoricalTab.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Box, Typography, CardContent } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import TitleIcon from "@mui/icons-material/Title";
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 export const CategoricalTab = ({ categoricalStats }) => {
   const { t } = useTranslation(["datasets", "common"]);
   const theme = useTheme();
+  const [activeIndices, setActiveIndices] = useState({});
 
   return (
     <Box display="flex" flexDirection="column" gap={4}>
@@ -85,6 +86,7 @@ export const CategoricalTab = ({ categoricalStats }) => {
                       />
                       <YAxis />
                       <Tooltip
+                        cursor={false}
                         contentStyle={{
                           backgroundColor: theme.palette.background.paper,
                           borderRadius: 4,
@@ -95,9 +97,39 @@ export const CategoricalTab = ({ categoricalStats }) => {
                       />
                       <Bar
                         dataKey="count"
-                        fill="rgba(136, 132, 216, 0.7)"
+                        fill="#8884d8"
                         name={t("common:count")}
-                      />
+                        activeBar={false}
+                        onMouseEnter={(_, index) =>
+                          setActiveIndices((prev) => ({
+                            ...prev,
+                            [column]: index,
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setActiveIndices((prev) => ({
+                            ...prev,
+                            [column]: null,
+                          }))
+                        }
+                      >
+                        {stats.top_5.map((_, index) => {
+                          const activeIndex = activeIndices[column] ?? null;
+                          return (
+                            <Cell
+                              key={index}
+                              fill="#8884d8"
+                              fillOpacity={
+                                index === activeIndex
+                                  ? 1
+                                  : activeIndex !== null
+                                    ? 0.5
+                                    : 0.7
+                              }
+                            />
+                          );
+                        })}
+                      </Bar>
                     </BarChart>
                   </ResponsiveContainer>
                 </Box>

--- a/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Box, Typography, Card, CardContent, Chip } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import {
@@ -9,6 +9,7 @@ import {
   YAxis,
   Tooltip,
   Bar,
+  Cell,
 } from "recharts";
 import DatasetTable from "../DatasetTable";
 import ExportableCard from "../ExportableCard";
@@ -27,6 +28,7 @@ const OverviewTab = ({
   const { t } = useTranslation(["datasets", "common"]);
 
   const theme = useTheme();
+  const [activeBarIndex, setActiveBarIndex] = useState(null);
   const missingData = Object.entries(nan).map(([col, count]) => ({
     column: col,
     missing: count,
@@ -134,6 +136,7 @@ const OverviewTab = ({
                   />
                   <YAxis />
                   <Tooltip
+                    cursor={false}
                     contentStyle={{
                       backgroundColor: theme.palette.background.paper,
                       borderRadius: 4,
@@ -144,9 +147,26 @@ const OverviewTab = ({
                   />
                   <Bar
                     dataKey="missing"
-                    fill="rgba(136, 132, 216, 0.7)"
+                    fill="#8884d8"
                     name={t("common:missing")}
-                  />
+                    activeBar={false}
+                    onMouseEnter={(_, index) => setActiveBarIndex(index)}
+                    onMouseLeave={() => setActiveBarIndex(null)}
+                  >
+                    {missingData.map((_, index) => (
+                      <Cell
+                        key={index}
+                        fill="#8884d8"
+                        fillOpacity={
+                          index === activeBarIndex
+                            ? 1
+                            : activeBarIndex !== null
+                              ? 0.5
+                              : 0.7
+                        }
+                      />
+                    ))}
+                  </Bar>
                 </BarChart>
               </ResponsiveContainer>
             </Box>

--- a/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Box,
   Typography,
@@ -27,6 +27,7 @@ import { useTranslation } from "react-i18next";
 export const TextTab = ({ textStats }) => {
   const theme = useTheme();
   const { t } = useTranslation(["datasets", "common"]);
+  const [activeIndices, setActiveIndices] = useState({});
   return (
     <Box display="flex" flexDirection="column" gap={4}>
       {Object.entries(textStats).map(([column, stats]) => {
@@ -196,6 +197,7 @@ export const TextTab = ({ textStats }) => {
                       <XAxis dataKey="label" />
                       <YAxis />
                       <RechartsTooltip
+                        cursor={false}
                         contentStyle={{
                           backgroundColor: theme.palette.background.paper,
                           borderRadius: 4,
@@ -206,9 +208,39 @@ export const TextTab = ({ textStats }) => {
                       />
                       <Bar
                         dataKey="value"
-                        fill="rgba(136, 132, 216, 0.7)"
+                        fill="#8884d8"
                         name={t("common:value")}
-                      />
+                        activeBar={false}
+                        onMouseEnter={(_, index) =>
+                          setActiveIndices((prev) => ({
+                            ...prev,
+                            [column]: index,
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setActiveIndices((prev) => ({
+                            ...prev,
+                            [column]: null,
+                          }))
+                        }
+                      >
+                        {lengthData.map((entry, index) => {
+                          const activeIndex = activeIndices[column] ?? null;
+                          return (
+                            <Cell
+                              key={index}
+                              fill="#8884d8"
+                              fillOpacity={
+                                index === activeIndex
+                                  ? 1
+                                  : activeIndex !== null
+                                    ? 0.5
+                                    : 0.7
+                              }
+                            />
+                          );
+                        })}
+                      </Bar>
                     </BarChart>
                   </ResponsiveContainer>
                 </Box>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                 
                                                            
  Replaced Recharts' default bar hover effect (bright background glow) with a cleaner highlight: the hovered bar becomes fully opaque while the rest drop to 50% opacity. No outline or external background is added.                                                                                                                                                                
                                                                                                                                                                                                             
  ---                                                                                                                                                                                                        
                                                                                                                                                                                                             
  ## Type of Change                                         

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [ ] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx`: added `Cell` components with dynamic `fillOpacity` on hover; disabled default active bar glow (`activeBar={false}`, `cursor={false}` on Tooltip).      
  - `DashAI/front/src/components/notebooks/dataset/tabs/CategoricalTab.jsx`: same hover logic; state keyed by column name to handle multiple charts on the same page.                                                                                                                                                                                                                                                                         
  - `DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx`: same hover logic; all bars use a uniform fill color (`#8884d8`) to match the original appearance.                                                                                                                          
                                                                                   
  ---                                                                                                                                                                                                        
                                                            
  ## Testing                                                                                                                                                                                                 
                                                            
  - Open a dataset with missing values and verify the Missing Values Overview chart: hovering a bar dims the rest to 50% opacity with no background glow.                                                                                                                                     
  - Open a dataset with categorical columns and verify the Value Distribution chart behaves the same way.                                                                                                                                                                                            
  - Open a dataset with text columns and verify the Length Distribution chart behaves the same way. Confirm all bars remain the same purple color (no per-bar color variation).                                                                                                                    
  - Confirm the tooltip still appears on hover with the correct value in all three charts.        
