### PR TITLE
Fix broken anchor links by converting docs to absolute paths

### DIFF
--- a/docs/docs/build/contributing.md
+++ b/docs/docs/build/contributing.md
@@ -15,7 +15,7 @@ The easiest way to extend DashAI is by building and publishing a plugin — a se
 package that adds new models, tasks, metrics, explorers, or other components to the
 platform without touching the core codebase.
 
-See the [Plugin Development](./plugin-development/overview) guide to get started.
+See the [Plugin Development](/build/plugin-development/overview) guide to get started.
 
 ## Fork and Submit a Pull Request
 
@@ -23,7 +23,7 @@ To contribute code directly to the core project:
 
 1. Fork the [DashAI repository on GitHub](https://github.com/DashAISoftware/DashAI).
 2. Create a branch for your change.
-3. Follow the [Dev Setup](./dev-setup) and [Testing](./testing) guides to run the project
+3. Follow the [Dev Setup](/build/dev-setup) and [Testing](/build/testing) guides to run the project
    locally and verify your changes.
 4. Open a pull request against the `develop` branch with a clear description of what
    you changed and why.

--- a/docs/docs/build/plugin-development/develop.md
+++ b/docs/docs/build/plugin-development/develop.md
@@ -9,8 +9,8 @@ sidebar_label: Developing a Plugin
 
 Before developing a plugin, ensure you understand:
 
-1. **[What is a Plugin?](./overview)** — High-level overview of plugin concepts and capabilities
-2. **[Plugin Structure](./structure)** — How plugins are organized and what DashAI requires
+1. **[What is a Plugin?](/build/plugin-development/overview)** — High-level overview of plugin concepts and capabilities
+2. **[Plugin Structure](/build/plugin-development/structure)** — How plugins are organized and what DashAI requires
 
 ---
 
@@ -82,7 +82,7 @@ class MyCustomModel(TabularClassificationModel):
 1. Create the plugin folder inside the `plugins` directory (if using Option 2 above)
 2. Write your Python classes extending appropriate DashAI base classes
 3. Create any required JSON configuration files
-4. Add the `pyproject.toml` with proper entry points (see [Plugin Structure](./structure))
+4. Add the `pyproject.toml` with proper entry points (see [Plugin Structure](/build/plugin-development/structure))
 5. Write a README describing your plugin
 
 ---
@@ -93,7 +93,7 @@ class MyCustomModel(TabularClassificationModel):
 
 Study working examples to understand best practices:
 
-- **[Real-world example](./overview):** `dashai-phi-model-package` adds Microsoft Phi models
+- **[Real-world example](/build/plugin-development/overview):** `dashai-phi-model-package` adds Microsoft Phi models
 - **Community plugins:** [pypi.org/search/?q=dashai](https://pypi.org/search/?q=dashai)
 
 ### Test Your Plugin During Development

--- a/docs/docs/build/plugin-development/structure.md
+++ b/docs/docs/build/plugin-development/structure.md
@@ -7,7 +7,7 @@ sidebar_label: Plugin Structure
 
 ## Overview
 
-If you haven't already, start with [What is a Plugin?](./overview) to understand the core concept.
+If you haven't already, start with [What is a Plugin?](/build/plugin-development/overview) to understand the core concept.
 
 This page details how plugins are structured, what files and configurations are required, and how DashAI discovers and loads them.
 
@@ -84,6 +84,6 @@ keywords = [
 
 ## Next Steps
 
-- See [Developing a Plugin](./develop) for step-by-step implementation guidance
-- Check [Plugin Overview](./overview) for a complete working example
-- Learn how to [upload your plugin to PyPI](./upload)
+- See [Developing a Plugin](/build/plugin-development/develop) for step-by-step implementation guidance
+- Check [Plugin Overview](/build/plugin-development/overview) for a complete working example
+- Learn how to [upload your plugin to PyPI](/build/plugin-development/upload)

--- a/docs/docs/build/plugin-development/upload.md
+++ b/docs/docs/build/plugin-development/upload.md
@@ -11,8 +11,8 @@ Once your plugin is developed and tested, you can share it with the DashAI commu
 
 Before uploading, ensure you have completed:
 
-1. **[Plugin Structure](./structure)** — Your plugin has the correct folder and configuration format
-2. **[Developing a Plugin](./develop)** — Your plugin is fully implemented and tested locally
+1. **[Plugin Structure](/build/plugin-development/structure)** — Your plugin has the correct folder and configuration format
+2. **[Developing a Plugin](/build/plugin-development/develop)** — Your plugin is fully implemented and tested locally
 
 ---
 

--- a/docs/docs/deep-dive/architecture.md
+++ b/docs/docs/deep-dive/architecture.md
@@ -46,13 +46,13 @@ so that API endpoints can receive them automatically.
 
 ## Further Reading
 
-| Topic                                                | Page                                     |
-| ---------------------------------------------------- | ---------------------------------------- |
-| REST API structure, router map, dependency injection | [API](./api)                             |
-| Component types, registry, and configurable objects  | [Components](./components)               |
-| SQLite schema, ORM tables, and data storage          | [Database](./database)                   |
-| Huey job queue and job types                         | [Job System](./job-system)               |
-| Notebook sessions, explorers, and converters         | [Notebook](./notebook)                   |
-| End-to-end training and exploration walkthroughs     | [Workflow Examples](./workflow-examples) |
-| Column semantic types and inference                  | [Semantic Types](./semantic-types)       |
-| Core dataset primitive, splits, and data lifecycle   | [DashAIDataset](./dashai-dataset)        |
+| Topic                                                | Page                                              |
+| ---------------------------------------------------- | ------------------------------------------------- |
+| REST API structure, router map, dependency injection | [API](/deep-dive/api)                             |
+| Component types, registry, and configurable objects  | [Components](/deep-dive/components)               |
+| SQLite schema, ORM tables, and data storage          | [Database](/deep-dive/database)                   |
+| Huey job queue and job types                         | [Job System](/deep-dive/job-system)               |
+| Notebook sessions, explorers, and converters         | [Notebook](/deep-dive/notebook)                   |
+| End-to-end training and exploration walkthroughs     | [Workflow Examples](/deep-dive/workflow-examples) |
+| Column semantic types and inference                  | [Semantic Types](/deep-dive/semantic-types)       |
+| Core dataset primitive, splits, and data lifecycle   | [DashAIDataset](/deep-dive/dashai-dataset)        |

--- a/docs/docs/deep-dive/dashai-dataset.md
+++ b/docs/docs/deep-dive/dashai-dataset.md
@@ -10,7 +10,7 @@ sidebar_position: 9
 
 `DashAIDataset` is DashAI's core dataset primitive. It extends the HuggingFace `Dataset` class with two additional responsibilities:
 
-- **Semantic type metadata** — a `_types` dictionary (`Dict[str, DashAIDataType]`) that maps every column name to its DashAI semantic type (see [Semantic Types](./semantic-types)). This metadata is persisted inside the Apache Arrow schema so it survives save/load round-trips.
+- **Semantic type metadata** — a `_types` dictionary (`Dict[str, DashAIDataType]`) that maps every column name to its DashAI semantic type (see [Semantic Types](/deep-dive/semantic-types)). This metadata is persisted inside the Apache Arrow schema so it survives save/load round-trips.
 - **Split metadata** — a `splits` dictionary that records which row indices belong to which split (`train`, `test`, `validation`), plus aggregate statistics computed during upload.
 
 Every piece of data that flows through DashAI — upload, notebook transformations, model training, predictions — is represented as a `DashAIDataset`.

--- a/docs/docs/deep-dive/replicability.md
+++ b/docs/docs/deep-dive/replicability.md
@@ -46,7 +46,7 @@ Full pipeline export (a portable "recipe" capturing the full preprocessing + mod
 :::info What is a Notebook?
 A Notebook in DashAI is a working session with a mutable copy of a dataset. It groups
 Explorers (visualizations) and Converters (transformations) applied to that copy. The
-original dataset is never modified. See [System Design → Notebook](./notebook)
+original dataset is never modified. See [System Design → Notebook](/deep-dive/notebook)
 for details.
 :::
 

--- a/docs/docs/learn/tutorials/Models/overview.md
+++ b/docs/docs/learn/tutorials/Models/overview.md
@@ -77,11 +77,11 @@ Other tasks have their own corresponding model catalogs.
 
 This section is divided into the following pages:
 
-- **[Train a Model](./train)** — How to create a session, configure input/output columns,
+- **[Train a Model](/learn/tutorials/Models/train)** — How to create a session, configure input/output columns,
   define data splits, add models, set hyperparameters, and run training.
-- **[Predictions](./predictions)** — How to generate predictions using trained models,
+- **[Predictions](/learn/tutorials/Models/predictions)** — How to generate predictions using trained models,
   both from a full dataset and from manually entered data.
-- **[Explainability](./explainability)** — How to use global and local explainers to
+- **[Explainability](/learn/tutorials/Models/explainability)** — How to use global and local explainers to
   understand model behavior.
-- **[Model Comparison](./comparison)** — How to compare metrics across models using
+- **[Model Comparison](/learn/tutorials/Models/comparison)** — How to compare metrics across models using
   tables and charts.

--- a/docs/docs/learn/tutorials/Models/train.md
+++ b/docs/docs/learn/tutorials/Models/train.md
@@ -190,12 +190,12 @@ Metrics are only available after training is complete. If a model shows
 ### EXPLAINABILITY
 
 Shows global and local explainers attached to this model. See the
-[Explainability](./explainability) page for details.
+[Explainability](/learn/tutorials/Models/explainability) page for details.
 
 ### PREDICTIONS
 
 Shows dataset predictions and manual predictions generated from this model. See the
-[Predictions](./predictions) page for details.
+[Predictions](/learn/tutorials/Models/predictions) page for details.
 
 ### HYPERPARAMETERS
 

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/architecture.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/architecture.md
@@ -31,13 +31,13 @@ La inyección de dependencias es gestionada por **Kink**. El contenedor DI (`bac
 
 ## Lecturas Adicionales
 
-| Tema                                                                | Página                                              |
-| ------------------------------------------------------------------- | --------------------------------------------------- |
-| Estructura de la API REST, mapa de rutas, inyección de dependencias | [API](./api)                                        |
-| Tipos de componentes, registro y objetos configurables              | [Componentes](./components)                         |
-| Esquema SQLite, tablas ORM y almacenamiento de datos                | [Base de Datos](./database)                         |
-| Cola de trabajos Huey y tipos de trabajos                           | [Sistema de Trabajos](./job-system)                 |
-| Sesiones de Notebook, exploradores y converters                     | [Notebook](./notebook)                              |
-| Recorridos completos de entrenamiento y exploración                 | [Ejemplos de Flujo de Trabajo](./workflow-examples) |
-| Tipos semánticos de columnas e inferencia                           | [Tipos Semánticos](./semantic-types)                |
-| Primitivo central de datos, splits y ciclo de vida del dato         | [DashAIDataset](./dashai-dataset)                   |
+| Tema                                                                | Página                                                       |
+| ------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Estructura de la API REST, mapa de rutas, inyección de dependencias | [API](/deep-dive/api)                                        |
+| Tipos de componentes, registro y objetos configurables              | [Componentes](/deep-dive/components)                         |
+| Esquema SQLite, tablas ORM y almacenamiento de datos                | [Base de Datos](/deep-dive/database)                         |
+| Cola de trabajos Huey y tipos de trabajos                           | [Sistema de Trabajos](/deep-dive/job-system)                 |
+| Sesiones de Notebook, exploradores y converters                     | [Notebook](/deep-dive/notebook)                              |
+| Recorridos completos de entrenamiento y exploración                 | [Ejemplos de Flujo de Trabajo](/deep-dive/workflow-examples) |
+| Tipos semánticos de columnas e inferencia                           | [Tipos Semánticos](/deep-dive/semantic-types)                |
+| Primitivo central de datos, splits y ciclo de vida del dato         | [DashAIDataset](/deep-dive/dashai-dataset)                   |

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/dashai-dataset.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/dashai-dataset.md
@@ -10,7 +10,7 @@ sidebar_position: 9
 
 `DashAIDataset` es el primitivo central de datos de DashAI. Extiende la clase `Dataset` de HuggingFace con dos responsabilidades adicionales:
 
-- **Metadatos de tipo semántico** — un diccionario `_types` (`Dict[str, DashAIDataType]`) que mapea cada nombre de columna a su tipo semántico DashAI (ver [Tipos Semánticos](./semantic-types)). Estos metadatos se persisten dentro del esquema Apache Arrow para sobrevivir ciclos de guardado/carga.
+- **Metadatos de tipo semántico** — un diccionario `_types` (`Dict[str, DashAIDataType]`) que mapea cada nombre de columna a su tipo semántico DashAI (ver [Tipos Semánticos](/deep-dive/semantic-types)). Estos metadatos se persisten dentro del esquema Apache Arrow para sobrevivir ciclos de guardado/carga.
 - **Metadatos de splits** — un diccionario `splits` que registra qué índices de fila pertenecen a qué split (`train`, `test`, `validation`), junto con estadísticas agregadas calculadas durante la carga del dataset.
 
 Cada pieza de datos que fluye por DashAI — carga, transformaciones en el notebook, entrenamiento de modelos, predicciones — se representa como un `DashAIDataset`.

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/replicability.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/deep-dive/replicability.md
@@ -44,15 +44,15 @@ La exportación completa de la pipeline (una "receta" portátil que captura toda
 :::
 
 :::info ¿Qué es un Notebook?
-Un Notebook en DashAI es una sesión de trabajo con una copia mutable de un dataset. Agrupa Exploradores (visualizaciones) y Converters (transformaciones) aplicados a esa copia. El dataset original nunca se modifica. Consulta [Diseño del Sistema → Notebook](./notebook) para más detalles.
+Un Notebook en DashAI es una sesión de trabajo con una copia mutable de un dataset. Agrupa Exploradores (visualizaciones) y Converters (transformaciones) aplicados a esa copia. El dataset original nunca se modifica. Consulta [Diseño del Sistema → Notebook](/deep-dive/notebook) para más detalles.
 :::
 
 ## Detalles del Almacenamiento de Datos
 
-| Artefacto             | Ubicación de almacenamiento                                                                          |
-| --------------------- | ---------------------------------------------------------------------------------------------------- |
-| Datasets    | Archivos Apache Arrow IPC en `~/.DashAI/`                                                            |
-| Modelos entrenados    | Archivos pickle/joblib en `~/.DashAI/runs/{run_id}/`                                                 |
-| Gráficos de optimización | Objetos Plotly serializados junto a la ejecución                                                  |
-| Métricas              | Tabla `Metric` en `db.sqlite`                                                                        |
+| Artefacto                 | Ubicación de almacenamiento                                                                          |
+| ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Datasets                  | Archivos Apache Arrow IPC en `~/.DashAI/`                                                            |
+| Modelos entrenados        | Archivos pickle/joblib en `~/.DashAI/runs/{run_id}/`                                                 |
+| Gráficos de optimización  | Objetos Plotly serializados junto a la ejecución                                                     |
+| Métricas                  | Tabla `Metric` en `db.sqlite`                                                                        |
 | Resultados de exploración | Imágenes PNG generadas por Exploradores dentro de un Notebook, referenciadas por la tabla `Explorer` |

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/learn/tutorials/Models/overview.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/learn/tutorials/Models/overview.md
@@ -22,12 +22,12 @@ El módulo de Modelos es el entorno de DashAI para entrenar, evaluar, comparar y
 
 Al abrir el módulo de Modelos, el área principal muestra los tipos de tareas disponibles con una descripción de cada una. Usa la barra de búsqueda para filtrar tareas por nombre.
 
-| Tarea                          | Descripción                                                                                                                                                      |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Clasificación Tabular**      | Predice una etiqueta categórica a partir de datos tabulares estructurados (filas y columnas).                                                                    |
-| **Clasificación de Texto**     | Asigna categorías o etiquetas predefinidas a documentos de texto según su contenido. Útil para análisis de sentimientos, filtrado de spam, categorización de temas. |
-| **Regresión**                  | Predice un valor numérico continuo a partir de datos tabulares estructurados.                                                                                    |
-| **Traducción**                 | Convierte texto de un idioma a otro preservando el significado y el contexto (tarea de NLP).                                                                     |
+| Tarea                      | Descripción                                                                                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Clasificación Tabular**  | Predice una etiqueta categórica a partir de datos tabulares estructurados (filas y columnas).                                                                       |
+| **Clasificación de Texto** | Asigna categorías o etiquetas predefinidas a documentos de texto según su contenido. Útil para análisis de sentimientos, filtrado de spam, categorización de temas. |
+| **Regresión**              | Predice un valor numérico continuo a partir de datos tabulares estructurados.                                                                                       |
+| **Traducción**             | Convierte texto de un idioma a otro preservando el significado y el contexto (tarea de NLP).                                                                        |
 
 Cada tarea impone requisitos específicos sobre los tipos de columnas para entrada y salida — estos se validan automáticamente al configurar la sesión.
 
@@ -58,7 +58,7 @@ Los modelos disponibles varían según la tarea. Para Clasificación Tabular, po
 
 Esta sección se divide en las siguientes páginas:
 
-- **[Entrenar un Modelo](./train)** — Cómo crear una sesión, configurar columnas de entrada/salida, definir divisiones de datos, añadir modelos, establecer hiperparámetros y ejecutar el entrenamiento.
-- **[Predicciones](./predictions)** — Cómo generar predicciones usando modelos entrenados, tanto desde un dataset completo como desde datos ingresados manualmente.
-- **[Explicabilidad](./explainability)** — Cómo usar explicadores globales y locales para entender el comportamiento del modelo.
-- **[Comparación de Modelos](./comparison)** — Cómo comparar métricas entre modelos usando tablas y gráficos.
+- **[Entrenar un Modelo](/learn/tutorials/Models/train)** — Cómo crear una sesión, configurar columnas de entrada/salida, definir divisiones de datos, añadir modelos, establecer hiperparámetros y ejecutar el entrenamiento.
+- **[Predicciones](/learn/tutorials/Models/predictions)** — Cómo generar predicciones usando modelos entrenados, tanto desde un dataset completo como desde datos ingresados manualmente.
+- **[Explicabilidad](/learn/tutorials/Models/explainability)** — Cómo usar explicadores globales y locales para entender el comportamiento del modelo.
+- **[Comparación de Modelos](/learn/tutorials/Models/comparison)** — Cómo comparar métricas entre modelos usando tablas y gráficos.

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/learn/tutorials/Models/train.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/learn/tutorials/Models/train.md
@@ -52,18 +52,18 @@ Cada tarea impone requisitos de tipo específicos. Para Clasificación Tabular, 
 
 Define cómo DashAI divide el dataset en subconjuntos de entrenamiento, validación y prueba. Hay tres opciones disponibles:
 
-| Opción                               | Descripción                                                                                                                                    |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Use predefined splits**            | Usa divisiones train/validación/test ya definidas en el archivo del dataset. Solo disponible si el dataset fue cargado con estructura pre-dividida. |
-| **Random split by proportion**       | Asigna filas aleatoriamente a cada subconjunto según las proporciones que especifiques. El valor por defecto es Train: 0.6, Validation: 0.2, Test: 0.2. |
-| **Manual split by row indices**      | Especifica manualmente los índices de fila de inicio y fin para cada subconjunto.                                                              |
+| Opción                          | Descripción                                                                                                                                             |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Use predefined splits**       | Usa divisiones train/validación/test ya definidas en el archivo del dataset. Solo disponible si el dataset fue cargado con estructura pre-dividida.     |
+| **Random split by proportion**  | Asigna filas aleatoriamente a cada subconjunto según las proporciones que especifiques. El valor por defecto es Train: 0.6, Validation: 0.2, Test: 0.2. |
+| **Manual split by row indices** | Especifica manualmente los índices de fila de inicio y fin para cada subconjunto.                                                                       |
 
 Al usar **Random split**, hay tres opciones adicionales disponibles:
 
-| Opción       | Descripción                                                                                                                               |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Shuffle**  | Mezcla aleatoriamente las filas antes de dividir. Recomendado para evitar sesgo de orden en los datos. Habilitado por defecto.             |
-| **Stratify** | Asegura que cada división preserve las mismas proporciones de clases que el dataset completo. Útil para datasets desbalanceados. |
+| Opción       | Descripción                                                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Shuffle**  | Mezcla aleatoriamente las filas antes de dividir. Recomendado para evitar sesgo de orden en los datos. Habilitado por defecto.                                         |
+| **Stratify** | Asegura que cada división preserve las mismas proporciones de clases que el dataset completo. Útil para datasets desbalanceados.                                       |
 | **Seed**     | Una semilla aleatoria fija para reproducibilidad. El valor por defecto es `42`. Establece un valor específico para asegurar que siempre se produzca la misma división. |
 
 Haz clic en **CREATE SESSION** para finalizar la configuración. La sesión se abre inmediatamente.
@@ -120,12 +120,12 @@ Una tabla resumen que muestra todos los modelos en la sesión con columnas:
 
 Cada modelo tiene una tarjeta expandible que muestra su nombre, algoritmo, insignia de estado actual y botones de acción:
 
-| Botón            | Descripción                                                                                   |
-| ---------------- | --------------------------------------------------------------------------------------------- |
-| **EDIT**         | Reabre el modal de configuración para cambiar el nombre del modelo o los hiperparámetros.     |
-| **TRAIN**        | Inicia el entrenamiento de este modelo. Cambia a **RE-TRAIN** después de la primera ejecución. |
-| **Insignia de estado** | Muestra el estado actual: **Not Started**, **Finalizado** o **Error**.                  |
-| 🗑               | Elimina el modelo de la sesión.                                                               |
+| Botón                  | Descripción                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| **EDIT**               | Reabre el modal de configuración para cambiar el nombre del modelo o los hiperparámetros.      |
+| **TRAIN**              | Inicia el entrenamiento de este modelo. Cambia a **RE-TRAIN** después de la primera ejecución. |
+| **Insignia de estado** | Muestra el estado actual: **Not Started**, **Finalizado** o **Error**.                         |
+| 🗑                     | Elimina el modelo de la sesión.                                                                |
 
 **Para entrenar un modelo individual:** haz clic en **TRAIN** en su tarjeta.
 
@@ -151,11 +151,11 @@ Las métricas solo están disponibles después de que el entrenamiento está com
 
 ### EXPLAINABILITY
 
-Muestra los explicadores globales y locales adjuntos a este modelo. Consulta la página [Explicabilidad](./explainability) para más detalles.
+Muestra los explicadores globales y locales adjuntos a este modelo. Consulta la página [Explicabilidad](/learn/tutorials/Models/explainability) para más detalles.
 
 ### PREDICTIONS
 
-Muestra las predicciones de dataset y las predicciones manuales generadas desde este modelo. Consulta la página [Predicciones](./predictions) para más detalles.
+Muestra las predicciones de dataset y las predicciones manuales generadas desde este modelo. Consulta la página [Predicciones](/learn/tutorials/Models/predictions) para más detalles.
 
 ### HYPERPARAMETERS
 
@@ -172,10 +172,10 @@ Muestra los valores exactos de hiperparámetros usados en la última ejecución 
 
 ## Solución de Problemas
 
-| Síntoma                                           | Causa probable                                        | Solución                                                                            |
-| ------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| El banner de compatibilidad muestra una advertencia | Los tipos de columnas no coinciden con los requisitos de la tarea | Revisa los tipos de columnas en el Explorador de Datasets y vuelve a cargar si es necesario |
-| El botón NEXT no está activo en la configuración de sesión | Los campos requeridos están vacíos           | Asegúrate de que se seleccionó un dataset y se ingresó un nombre de sesión          |
-| El modelo muestra insignia **Error** después del entrenamiento | Valores de hiperparámetros inválidos o problema con los datos | Haz clic en **EDIT** para revisar los parámetros, o revisa la Job Queue para detalles del error |
-| No hay métricas disponibles después del entrenamiento | Modelo entrenado con datos incompatibles           | Revisa la selección de columnas de entrada/salida y vuelve a entrenar                |
-| RUN ALL no es visible                             | No se han añadido modelos todavía                     | Añade al menos un modelo antes de usar RUN ALL                                      |
+| Síntoma                                                        | Causa probable                                                    | Solución                                                                                        |
+| -------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| El banner de compatibilidad muestra una advertencia            | Los tipos de columnas no coinciden con los requisitos de la tarea | Revisa los tipos de columnas en el Explorador de Datasets y vuelve a cargar si es necesario     |
+| El botón NEXT no está activo en la configuración de sesión     | Los campos requeridos están vacíos                                | Asegúrate de que se seleccionó un dataset y se ingresó un nombre de sesión                      |
+| El modelo muestra insignia **Error** después del entrenamiento | Valores de hiperparámetros inválidos o problema con los datos     | Haz clic en **EDIT** para revisar los parámetros, o revisa la Job Queue para detalles del error |
+| No hay métricas disponibles después del entrenamiento          | Modelo entrenado con datos incompatibles                          | Revisa la selección de columnas de entrada/salida y vuelve a entrenar                           |
+| RUN ALL no es visible                                          | No se han añadido modelos todavía                                 | Añade al menos un modelo antes de usar RUN ALL                                                  |

--- a/docs/scripts/generate_components.py
+++ b/docs/scripts/generate_components.py
@@ -528,7 +528,7 @@ def _render_component_mdx(info) -> str:
             comp_type = class_lookup.get(comp)
             if comp_type:
                 comp_dir = _type_to_dir(comp_type)
-                lines.append(f"- [`{comp}`](../{comp_dir}/{comp})")
+                lines.append(f"- [`{comp}`](/components/{comp_dir}/{comp})")
             else:
                 lines.append(f"- `{comp}`")
         lines.append("")


### PR DESCRIPTION
## Summary  
This pull request standardizes all internal documentation links (English and Spanish) to use absolute paths instead of relative ones. This resolves navigation issues where anchor links (`#...`) could incorrectly append trailing slashes (e.g., `/path/#section`), breaking in-page references.

---

## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [ ] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [x] Documentation  

---

## Changes (by file)  
- `docs/docs/** (English docs)`: Converted all internal links to absolute paths (`/...`) to ensure consistent navigation and correct anchor resolution.  
- `i18n/es/docusaurus-plugin-content-docs/** (Spanish docs)`: Applied the same absolute path conversion for consistency across locales.  
- Multiple documentation files: Fixed table formatting and alignment issues to improve readability.

---

## Testing (optional)  
- Verified navigation across multiple documentation pages to ensure links resolve correctly.  
- Confirmed that anchor links (`#section`) no longer break due to incorrect path resolution or trailing slash issues.  