### PR TITLE
Fix i18n reactivity in RightBar (converters and explorers not updating on language change)

### DIFF
--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -123,8 +123,7 @@ export default function RightBar({ notebook, onToggle }) {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [explorersAndConverters]);
+  }, [explorersAndConverters, t]);
 
   // Clear search when the selected notebook changes
   useEffect(() => {
@@ -287,7 +286,6 @@ export default function RightBar({ notebook, onToggle }) {
           notebook,
         };
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [explorers, datasetColumns, notebook?.id],
   );
 
@@ -303,7 +301,6 @@ export default function RightBar({ notebook, onToggle }) {
           notebook,
         };
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [converters, datasetColumns, notebook?.id],
   );
 


### PR DESCRIPTION
## Summary
This PR fixes an issue where converters and explorers were not updating when the application language changed.

---
## Type of Change  
Check all that apply like this [x]:

- [ ] Backend change  
- [x] Frontend change  
- [ ] CI / Workflow change  
- [ ] Build / Packaging change  
- [x] Bug fix  
- [ ] Documentation  

---

## Changes (by file)  
- `DashAI/front/src/components/notebooks/RightBar.jsx`:  
  - Added `t` (translation function) to a `useEffect` dependency array to ensure converters and explorers update correctly on language change.  
  - Removed unnecessary `eslint-disable-next-line react-hooks/exhaustive-deps` comments from `useMemo` hooks

---

## Testing (optional)  
- Change the application language and verify that converters and explorers update immediately.  
- Confirm no regressions in `RightBar` behavior or rendering.