### PR TITLE
Fix column selector for Explorers and Converters.

### DIFF
--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -194,6 +194,15 @@ function ColumnSelector({
     [getValidColumnIds, rowSelectionModel, inputCardinality],
   );
 
+  const handleSelectAllRows = useCallback(() => {
+    const validIds = getValidColumnIds();
+    const allValidSelected =
+      validIds.length > 0 &&
+      validIds.every((id) => rowSelectionModel.includes(id));
+
+    handleSelection(allValidSelected ? {} : toMRT(validIds));
+  }, [getValidColumnIds, rowSelectionModel]);
+
   // Effect to update selection data and validation whenever rowSelectionModel changes
   useEffect(() => {
     if (rows.length > 0) {
@@ -292,6 +301,15 @@ function ColumnSelector({
           }
         : {},
     }),
+    muiSelectAllCheckboxProps: () => ({
+      checked:
+        getValidColumnIds().length > 0 &&
+        getValidColumnIds().every((id) => rowSelectionModel.includes(id)),
+      indeterminate:
+        rowSelectionModel.length > 0 &&
+        rowSelectionModel.length < getValidColumnIds().length,
+      onChange: handleSelectAllRows,
+    }),
     localization,
   });
 
@@ -319,8 +337,8 @@ function ColumnSelector({
               context: inputCardinality.exact
                 ? "exact"
                 : inputCardinality.max
-                  ? "range"
-                  : "min",
+                ? "range"
+                : "min",
             })}
           </Typography>
         )}

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -279,9 +279,9 @@ function ColumnSelector({
     enableFullScreenToggle: false,
     enableHiding: false,
     enablePagination: true,
-    muiPaginationProps: { rowsPerPageOptions: [5, 10, 20] },
+    muiPaginationProps: { rowsPerPageOptions: [10, 15, 20] },
     initialState: {
-      pagination: { pageSize: 5, pageIndex: 0 },
+      pagination: { pageSize: 10, pageIndex: 0 },
       density: "compact",
     },
     mrtTheme: {

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -337,8 +337,8 @@ function ColumnSelector({
               context: inputCardinality.exact
                 ? "exact"
                 : inputCardinality.max
-                ? "range"
-                : "min",
+                  ? "range"
+                  : "min",
             })}
           </Typography>
         )}


### PR DESCRIPTION
## Summary 
This PR fixes the issue where the select all columns button in explorers/converters creation step was not considering columns not visible. Also updates default amount of rows from 5 to 10 on mount.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `DashAI\front\src\components\notebooks\ColumnSelector.jsx`: Added a `handleSelectAllRows` function to properly select all columns and update pagination rows visible on mount.

---

## Testing (optional)
- Verify that the select all button properly select all the columns including the ones not visible on the table.
- Verify that the select columns table renders showing 10 rows on mount.
