### PR TITLE
Refactor typography variants across components for consistency

### DIFF
--- a/DashAI/front/src/components/HomeButton.jsx
+++ b/DashAI/front/src/components/HomeButton.jsx
@@ -105,8 +105,8 @@ function HomeButton({
 
       {/* Title */}
       <Typography
+        variant="h5"
         sx={{
-          ...theme.typography.cardTitle,
           color: theme.palette.text.primary,
           mb: "5px",
         }}
@@ -116,8 +116,8 @@ function HomeButton({
 
       {/* Description */}
       <Typography
+        variant="body1"
         sx={{
-          fontSize: "15px",
           fontWeight: 300,
           color: theme.palette.text.secondary,
           lineHeight: 1.65,
@@ -159,7 +159,7 @@ function HomeButton({
         <Box
           className="card-arrow"
           sx={{
-            fontSize: "18px",
+            fontSize: "22px",
             color: theme.palette.text.disabled,
             transition: "color 0.15s, transform 0.15s",
             flexShrink: 0,

--- a/DashAI/front/src/components/ResponsiveAppBar.jsx
+++ b/DashAI/front/src/components/ResponsiveAppBar.jsx
@@ -87,9 +87,8 @@ function ResponsiveAppBar() {
           }}
         >
           <Typography
+            variant="h5"
             sx={{
-              fontSize: 16,
-              fontWeight: 600,
               letterSpacing: "0.02em",
               color: theme.palette.text.primary,
               lineHeight: 1,

--- a/DashAI/front/src/components/explorations/Steps/ConfigureExplorersStep.jsx
+++ b/DashAI/front/src/components/explorations/Steps/ConfigureExplorersStep.jsx
@@ -37,8 +37,8 @@ const renderOption = (props, option, _, ownerState) => {
       title={
         <Typography
           component="span"
-          variant="inherit"
-          sx={{ whiteSpace: "pre-line", fontSize: "0.9rem" }}
+          variant="body1"
+          sx={{ whiteSpace: "pre-line" }}
         >
           {option.tooltip}
         </Typography>

--- a/DashAI/front/src/components/generative/ChatBubble.jsx
+++ b/DashAI/front/src/components/generative/ChatBubble.jsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { ChatAvatar } from "./ChatAvatar";
 import { ChatTimestamp } from "./ChatTimeStamp";
 import { MessageContent } from "./MessageContent";
@@ -25,18 +25,18 @@ export function ChatBubble({
 
       <Box sx={{ maxWidth: "80%" }}>
         {!isUser && sender && (
-          <Box
+          <Typography
+            variant="body2"
             component="span"
             sx={{
               ml: 1,
               mb: 0.5,
               display: "block",
-              fontSize: "0.75rem",
               color: "text.secondary",
             }}
           >
             {sender}
-          </Box>
+          </Typography>
         )}
 
         <MessageContent

--- a/DashAI/front/src/components/generative/GenerativeChat.jsx
+++ b/DashAI/front/src/components/generative/GenerativeChat.jsx
@@ -297,7 +297,7 @@ export default function GenerativeChat() {
               mt={1}
             >
               {message.type === "history" ? (
-                <Typography sx={{ fontSize: "0.875rem", opacity: 0.8 }}>
+                <Typography variant="body1" sx={{ opacity: 0.8 }}>
                   <Trans i18nKey="generative:label.parameterChangeEvent">
                     Parameters updated: <span>{message.changedMessage}</span>
                   </Trans>

--- a/DashAI/front/src/components/generative/SessionBox.jsx
+++ b/DashAI/front/src/components/generative/SessionBox.jsx
@@ -42,18 +42,18 @@ export default function SessionBox({
       >
         <Box>
           <Typography
-            variant="body2"
+            variant="body1"
             color="text.primary"
             noWrap
-            sx={{ maxWidth: 180, fontSize: 14 }}
+            sx={{ maxWidth: 180 }}
           >
             {name ? name : t("generative:label.untitledSession")}
           </Typography>
           <Typography
-            variant="caption"
+            variant="body2"
             color="text.secondary"
             noWrap
-            sx={{ maxWidth: 150, fontSize: 10, pl: 1 }}
+            sx={{ maxWidth: 150, pl: 1 }}
           >
             {modelName}
           </Typography>

--- a/DashAI/front/src/components/generative/mediaInput/MediaOnlyPlaceholder.jsx
+++ b/DashAI/front/src/components/generative/mediaInput/MediaOnlyPlaceholder.jsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import {
   MEDIA_KINDS,
@@ -38,12 +38,12 @@ export function MediaOnlyPlaceholder({
     >
       {hasAnyMedia ? (
         <>
-          <Box sx={{ fontSize: "0.875rem" }}>
+          <Typography variant="body1">
             {t(
               "generative:label.attachMediaToContinue",
               "Attach media to continue",
             )}
-          </Box>
+          </Typography>
           <Stack direction="row" spacing={1}>
             {MEDIA_ORDER.map((kind) => {
               const { icon, tooltipKey } = MEDIA_KINDS[kind];
@@ -65,12 +65,12 @@ export function MediaOnlyPlaceholder({
           </Stack>
         </>
       ) : (
-        <Box sx={{ fontSize: "0.875rem" }}>
+        <Typography variant="body1">
           {t(
             "generative:label.noInputAvailable",
             "No input available for this task",
           )}
-        </Box>
+        </Typography>
       )}
     </Box>
   );

--- a/DashAI/front/src/components/generative/mediaInput/MediaPreviewList.jsx
+++ b/DashAI/front/src/components/generative/mediaInput/MediaPreviewList.jsx
@@ -1,4 +1,4 @@
-import { Box, IconButton } from "@mui/material";
+import { Box, IconButton, Typography } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 
 export function MediaPreviewList({ activeKinds, previewsByKind, onRemove }) {
@@ -26,7 +26,9 @@ export function MediaPreviewList({ activeKinds, previewsByKind, onRemove }) {
                 }}
               />
             ) : (
-              <Box
+              <Typography
+                variant="body2"
+                component="div"
                 sx={{
                   height: 80,
                   minWidth: 80,
@@ -37,11 +39,10 @@ export function MediaPreviewList({ activeKinds, previewsByKind, onRemove }) {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  fontSize: "0.75rem",
                 }}
               >
                 {kind} #{index + 1}
-              </Box>
+              </Typography>
             )}
             <IconButton
               size="small"

--- a/DashAI/front/src/components/generative/textMessage/CodeBlock.jsx
+++ b/DashAI/front/src/components/generative/textMessage/CodeBlock.jsx
@@ -31,7 +31,7 @@ export function CodeBlock({ language, children }) {
           bgcolor: isDark ? "grey.900" : "grey.200",
         }}
       >
-        <Typography variant="caption" sx={{ color: "text.secondary" }}>
+        <Typography variant="code" sx={{ color: "text.secondary" }}>
           {language || "code"}
         </Typography>
         <CopyButton text={code} />

--- a/DashAI/front/src/components/jobs/JobDetailsDialog.jsx
+++ b/DashAI/front/src/components/jobs/JobDetailsDialog.jsx
@@ -207,12 +207,13 @@ const JobDetailsDialog = ({ job, open, onClose }) => {
                           ? theme.palette.grey[900]
                           : theme.palette.grey[100],
                       p: 2,
-                      fontSize: "0.875rem",
                       overflow: "auto",
                       maxHeight: "200px",
                     }}
                   >
-                    {displayJob.error_msg}
+                    <Typography variant="body1">
+                      {displayJob.error_msg}
+                    </Typography>
                   </Paper>
                 </Box>
               </Grid>

--- a/DashAI/front/src/components/models/ModelComparisonTable.jsx
+++ b/DashAI/front/src/components/models/ModelComparisonTable.jsx
@@ -315,17 +315,21 @@ function ModelComparisonTable({
         const isBest = bestScore !== null && Math.abs(score - bestScore) < 1e-6;
 
         const tooltipContent = (
-          <Box sx={{ fontSize: "0.75rem", lineHeight: 1.6 }}>
-            <Box sx={{ fontWeight: "bold", mb: 0.5 }}>
+          <Typography variant="body2" component="div" sx={{ lineHeight: 1.6 }}>
+            <Typography
+              variant="body2"
+              component="div"
+              sx={{ fontWeight: "bold", mb: 0.5 }}
+            >
               {t("models:label.score")}: {score.toFixed(1)}/100
-            </Box>
+            </Typography>
             {breakdown.map(({ metric_name, value, normalized_weight }, i) => (
-              <Box key={metric_name}>
+              <Typography variant="body2" component="div" key={metric_name}>
                 {i === 0 ? "=" : "+"} {metric_name} ({value.toFixed(4)}) ×{" "}
                 {(normalized_weight * 100).toFixed(0)}%
-              </Box>
+              </Typography>
             ))}
-          </Box>
+          </Typography>
         );
 
         return (

--- a/DashAI/front/src/components/notebooks/dataset/EditableColumnHeader.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/EditableColumnHeader.jsx
@@ -164,19 +164,11 @@ export default function EditableColumnHeader({
           }}
         />
         {error && (
-          <Typography
-            variant="caption"
-            color="error"
-            sx={{ fontSize: "0.7rem" }}
-          >
+          <Typography variant="body2" color="error">
             {error}
           </Typography>
         )}
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{ fontSize: "0.7rem" }}
-        >
+        <Typography variant="body2" color="text.secondary">
           {isLoading ? t("common:loading") : columnType || t("common:unknown")}
         </Typography>
       </Box>
@@ -196,11 +188,10 @@ export default function EditableColumnHeader({
     >
       <Tooltip title={!disabled ? t("common:renameColumn") : ""} arrow>
         <Typography
-          variant="subtitle2"
+          variant="body1"
           onDoubleClick={!disabled ? handleEditClick : undefined}
           sx={{
             fontWeight: "bold",
-            fontSize: "0.875rem",
             cursor: !disabled ? "pointer" : "default",
             transition: "all 0.2s",
             "&:hover": !disabled
@@ -211,11 +202,7 @@ export default function EditableColumnHeader({
           {columnName}
         </Typography>
       </Tooltip>
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={{ fontSize: "0.7rem" }}
-      >
+      <Typography variant="body2" color="text.secondary">
         {columnType || t("common:unknown")}
       </Typography>
 
@@ -239,11 +226,7 @@ export default function EditableColumnHeader({
             </span>
           </Tooltip>
           {encoderError && (
-            <Typography
-              variant="caption"
-              color="error"
-              sx={{ fontSize: "0.7rem" }}
-            >
+            <Typography variant="body2" color="error">
               {encoderError}
             </Typography>
           )}

--- a/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/NumericTab.jsx
@@ -83,11 +83,11 @@ export const NumericTab = ({ numericStats }) => {
               {/* Distribution Metrics */}
               <Box flex="1 1 300px" minWidth="250px">
                 <Typography
-                  variant="subtitle2"
+                  variant="body1"
                   fontWeight="bold"
                   color="text.primary"
                   gutterBottom
-                  sx={{ fontSize: "0.875rem", textTransform: "uppercase" }}
+                  sx={{ textTransform: "uppercase" }}
                 >
                   {t("datasets:label.distributionMetrics")}
                 </Typography>
@@ -126,11 +126,11 @@ export const NumericTab = ({ numericStats }) => {
               {/* Shape Indicators */}
               <Box flex="1 1 300px" minWidth="250px">
                 <Typography
-                  variant="subtitle2"
+                  variant="body1"
                   fontWeight="bold"
                   color="text.primary"
                   gutterBottom
-                  sx={{ fontSize: "0.875rem", textTransform: "uppercase" }}
+                  sx={{ textTransform: "uppercase" }}
                 >
                   {t("datasets:label.shapeIndicators")}
                 </Typography>

--- a/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/TextTab.jsx
@@ -140,11 +140,11 @@ export const TextTab = ({ textStats }) => {
               <Box display="flex" flexWrap="wrap" gap={4}>
                 <Box flex="1 1 300px" minWidth="250px">
                   <Typography
-                    variant="subtitle2"
+                    variant="body1"
                     fontWeight="bold"
                     color="text.primary"
                     gutterBottom
-                    sx={{ fontSize: "0.875rem", textTransform: "uppercase" }}
+                    sx={{ textTransform: "uppercase" }}
                   >
                     {t("datasets:label.lengthMetrics")}
                   </Typography>

--- a/DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx
@@ -245,11 +245,10 @@ export default function PreviewDatasetTable({
             ) : (
               <Tooltip title={t("common:renameColumn")} arrow>
                 <Typography
-                  variant="subtitle2"
+                  variant="body1"
                   onDoubleClick={() => handleStartEdit(field)}
                   sx={{
                     fontWeight: 600,
-                    fontSize: "0.875rem",
                     cursor: "pointer",
                     transition: "all 0.2s",
                     "&:hover": {

--- a/DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx
@@ -193,13 +193,7 @@ export default function ExplorerDetailsModal({
                   <Typography variant="sectionLabel" color="text.secondary">
                     {t("common:created")}
                   </Typography>
-                  <Typography
-                    sx={{
-                      fontFamily: '"IBM Plex Mono", monospace',
-                      fontSize: "0.78rem",
-                    }}
-                    color="text.primary"
-                  >
+                  <Typography variant="caption" color="text.primary">
                     {formatDate(explorer.created)}
                   </Typography>
                 </Box>

--- a/DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx
@@ -193,7 +193,7 @@ export default function ExplorerDetailsModal({
                   <Typography variant="sectionLabel" color="text.secondary">
                     {t("common:created")}
                   </Typography>
-                  <Typography variant="caption" color="text.primary">
+                  <Typography variant="code" color="text.primary">
                     {formatDate(explorer.created)}
                   </Typography>
                 </Box>

--- a/DashAI/front/src/components/notebooks/explorer/plotLayout/ColorscaleSelector.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/plotLayout/ColorscaleSelector.jsx
@@ -102,12 +102,11 @@ export default function ColorscaleSelector({ value, onChange }) {
       <Stack spacing={2}>
         <Box>
           <Typography
-            variant="subtitle2"
+            variant="body2"
             color="text.secondary"
             sx={{
               fontWeight: 600,
               textTransform: "uppercase",
-              fontSize: "0.75rem",
               letterSpacing: "0.5px",
               mb: 1,
             }}
@@ -155,12 +154,11 @@ export default function ColorscaleSelector({ value, onChange }) {
           /* -------- PRESET MODE ---------- */
           <Box>
             <Typography
-              variant="subtitle2"
+              variant="body2"
               color="text.secondary"
               sx={{
                 fontWeight: 600,
                 textTransform: "uppercase",
-                fontSize: "0.75rem",
                 letterSpacing: "0.5px",
                 mb: 1,
               }}
@@ -208,12 +206,11 @@ export default function ColorscaleSelector({ value, onChange }) {
           /* -------- ARRAY MODE ---------- */
           <Box>
             <Typography
-              variant="subtitle2"
+              variant="body2"
               color="text.secondary"
               sx={{
                 fontWeight: 600,
                 textTransform: "uppercase",
-                fontSize: "0.75rem",
                 letterSpacing: "0.5px",
                 mb: 1,
               }}
@@ -262,7 +259,9 @@ export default function ColorscaleSelector({ value, onChange }) {
                       sx={{ width: "100%" }}
                     >
                       {/* Stop Index Label */}
-                      <Box
+                      <Typography
+                        variant="body1"
+                        component="div"
                         sx={{
                           minWidth: 32,
                           height: 32,
@@ -275,12 +274,11 @@ export default function ColorscaleSelector({ value, onChange }) {
                           alignItems: "center",
                           justifyContent: "center",
                           fontWeight: 600,
-                          fontSize: "0.875rem",
                           color: theme.palette.primary.main,
                         }}
                       >
                         {i + 1}
-                      </Box>
+                      </Typography>
 
                       <TextField
                         label={t("datasets:label.position")}

--- a/DashAI/front/src/components/notebooks/explorer/tabs/Columns.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/tabs/Columns.jsx
@@ -45,14 +45,19 @@ function Columns({ data }) {
             >
               <TableCell
                 sx={{
-                  fontFamily: '"IBM Plex Mono", monospace',
-                  fontSize: "0.8rem",
-                  color: "text.secondary",
                   borderColor: "ui.borderLight",
                   py: 0.75,
                 }}
               >
-                {name}
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontFamily: '"IBM Plex Mono", monospace',
+                    color: "text.secondary",
+                  }}
+                >
+                  {name}
+                </Typography>
               </TableCell>
               <TableCell
                 align="right"

--- a/DashAI/front/src/components/notebooks/explorer/tabs/Parameters.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/tabs/Parameters.jsx
@@ -36,24 +36,29 @@ function Parameters({ data }) {
             <TableRow key={key} sx={{ "&:last-child td": { borderBottom: 0 } }}>
               <TableCell
                 sx={{
-                  fontFamily: '"IBM Plex Mono", monospace',
-                  fontSize: "0.8rem",
-                  color: "text.secondary",
                   borderColor: "ui.borderLight",
                   py: 0.75,
                 }}
               >
-                {key}
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontFamily: '"IBM Plex Mono", monospace',
+                    color: "text.secondary",
+                  }}
+                >
+                  {key}
+                </Typography>
               </TableCell>
               <TableCell
                 sx={{
-                  fontSize: "0.8rem",
-                  color: "text.primary",
                   borderColor: "ui.borderLight",
                   py: 0.75,
                 }}
               >
-                {formatValue(value)}
+                <Typography variant="body2" color="text.primary">
+                  {formatValue(value)}
+                </Typography>
               </TableCell>
             </TableRow>
           ))}

--- a/DashAI/front/src/components/pipelines/CustomNode.jsx
+++ b/DashAI/front/src/components/pipelines/CustomNode.jsx
@@ -123,7 +123,8 @@ const CustomNode = ({ data, isConnectable }) => {
       }}
     >
       <Typography
-        sx={{ fontSize: 11, mb: 0.5, color: theme.palette.text.primary }}
+        variant="body2"
+        sx={{ mb: 0.5, color: theme.palette.text.primary }}
       >
         {data.name || data.label}
       </Typography>

--- a/DashAI/front/src/components/predictions/DatasetSelector.jsx
+++ b/DashAI/front/src/components/predictions/DatasetSelector.jsx
@@ -74,9 +74,9 @@ function DatasetSelector({
       {selectedDataset && (
         <>
           <Alert severity="info" sx={{ mt: 2 }}>
-            <Box sx={{ fontWeight: 600, mb: 1, fontSize: "1rem" }}>
+            <Typography variant="h5" sx={{ mb: 1 }}>
               {t("prediction:label.predictionInfo")}
-            </Box>
+            </Typography>
 
             <Box sx={{ mb: 1 }}>
               <strong>{t("prediction:label.inputColumns")}:</strong>

--- a/DashAI/front/src/components/predictions/PredictionsTable.jsx
+++ b/DashAI/front/src/components/predictions/PredictionsTable.jsx
@@ -92,7 +92,7 @@ function PredictionsTable({ predictions, onItemClick, onItemDelete }) {
             <Typography
               variant="body2"
               fontWeight={600}
-              sx={{ lineHeight: 1.1, fontSize: "0.75rem" }}
+              sx={{ lineHeight: 1.1 }}
             >
               {t("prediction:label.manualInput")}
             </Typography>

--- a/DashAI/front/src/components/threeSectionLayout/CollapsibleList.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/CollapsibleList.jsx
@@ -79,8 +79,8 @@ export default function CollapsibleList({
         <Icon sx={{ fontSize: 20, color: theme.palette.primary.main, mr: 1 }} />
 
         <Typography
+          variant="h5"
           sx={{
-            ...theme.typography.cardTitle,
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
@@ -92,7 +92,9 @@ export default function CollapsibleList({
           {title}
         </Typography>
 
-        <Box
+        <Typography
+          variant="body2"
+          component="div"
           sx={{
             mr: 1,
             bgcolor: theme.palette.ui.scrollbar,
@@ -103,11 +105,10 @@ export default function CollapsibleList({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            fontSize: 12,
           }}
         >
           {count}
-        </Box>
+        </Typography>
 
         {open ? (
           <KeyboardArrowDownIcon

--- a/DashAI/front/src/components/threeSectionLayout/GroupedCollapsibleList.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/GroupedCollapsibleList.jsx
@@ -102,7 +102,7 @@ export default function GroupedCollapsibleList({
         )}
         <Typography
           sx={{
-            ...theme.typography.cardTitle,
+            ...theme.typography.h5,
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
@@ -113,7 +113,9 @@ export default function GroupedCollapsibleList({
         >
           {title}
         </Typography>
-        <Box
+        <Typography
+          variant="body2"
+          component="div"
           sx={{
             bgcolor: theme.palette.ui.scrollbar,
             color: theme.palette.text.primary,
@@ -123,11 +125,10 @@ export default function GroupedCollapsibleList({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            fontSize: 12,
           }}
         >
           {totalCount}
-        </Box>
+        </Typography>
       </Box>
 
       {/* Groups - Scrollable */}
@@ -176,7 +177,7 @@ export default function GroupedCollapsibleList({
               <Typography
                 sx={{
                   ml: 1,
-                  ...theme.typography.cardTitle,
+                  ...theme.typography.h5,
                   textTransform: "capitalize",
                   overflow: "hidden",
                   textOverflow: "ellipsis",
@@ -188,7 +189,9 @@ export default function GroupedCollapsibleList({
               >
                 {groupName}
               </Typography>
-              <Box
+              <Typography
+                variant="body2"
+                component="div"
                 sx={{
                   ml: 1,
                   bgcolor: theme.palette.ui.scrollbar,
@@ -199,11 +202,10 @@ export default function GroupedCollapsibleList({
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  fontSize: 12,
                 }}
               >
                 {items?.length || 0}
-              </Box>
+              </Typography>
             </Box>
 
             {/* Group Items */}

--- a/DashAI/front/src/components/threeSectionLayout/ItemBox.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/ItemBox.jsx
@@ -135,20 +135,15 @@ const ItemBox = forwardRef(function ItemBox(
               }}
             />
           ) : (
-            <Typography
-              variant="body2"
-              color="text.primary"
-              noWrap
-              sx={{ fontSize: 14 }}
-            >
+            <Typography variant="body1" color="text.primary" noWrap>
               {editedName}
             </Typography>
           )}
           <Typography
-            variant="caption"
+            variant="body2"
             color="text.secondary"
             noWrap
-            sx={{ fontSize: 10, pl: 1 }}
+            sx={{ pl: 1 }}
           >
             {description ? description : ""}
           </Typography>

--- a/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
@@ -94,8 +94,8 @@ export default function OptionBox({
 
       {/* Title */}
       <Typography
+        variant="h5"
         sx={{
-          ...theme.typography.cardTitle,
           color: theme.palette.text.primary,
           mb: "5px",
           width: "100%",
@@ -113,8 +113,8 @@ export default function OptionBox({
       >
         <Typography
           ref={descRef}
+          variant="body1"
           sx={{
-            fontSize: "15px",
             fontWeight: 300,
             color: theme.palette.text.secondary,
             lineHeight: 1.65,
@@ -161,10 +161,11 @@ export default function OptionBox({
             </Box>
           ))}
         </Box>
-        <Box
+        <Typography
+          component="span"
+          variant="h2"
           className="card-arrow"
           sx={{
-            fontSize: "18px",
             color: theme.palette.text.disabled,
             transition: "color 0.15s, transform 0.15s",
             flexShrink: 0,
@@ -172,7 +173,7 @@ export default function OptionBox({
           }}
         >
           →
-        </Box>
+        </Typography>
       </Box>
     </ButtonBase>
   );

--- a/DashAI/front/src/components/tour/CustomTooltip.jsx
+++ b/DashAI/front/src/components/tour/CustomTooltip.jsx
@@ -36,7 +36,7 @@ export const CustomTooltip = ({
           lineHeight: "1.6",
           color: "#333",
           "& h3": {
-            fontSize: "18px",
+            fontSize: "22px",
             fontWeight: "bold",
             marginBottom: "8px",
             marginTop: 0,
@@ -136,8 +136,8 @@ export const CustomTooltip = ({
               {continuous && (
                 <Typography
                   component="span"
+                  variant="body2"
                   sx={{
-                    fontSize: "12px",
                     opacity: 0.8,
                     ml: 0.5,
                   }}

--- a/DashAI/front/src/constants/tours/datasetsTour.js
+++ b/DashAI/front/src/constants/tours/datasetsTour.js
@@ -65,7 +65,7 @@ export const datasetsTourSteps = [
               onMouseOut={(e) => (e.target.style.backgroundColor = "#ef9f27")}
             ></a>
           </p>
-          <p style={{ fontSize: "0.9em", color: "#666" }}>
+          <p style={{ fontSize: "14px", color: "#666" }}>
             <strong></strong>
           </p>
           <p style={{ marginTop: "10px" }}></p>
@@ -148,9 +148,7 @@ export const datasetsTourSteps = [
               <strong></strong>
             </li>
           </ul>
-          <p
-            style={{ fontSize: "0.9em", color: "#666", marginTop: "10px" }}
-          ></p>
+          <p style={{ fontSize: "14px", color: "#666", marginTop: "10px" }}></p>
         </div>
       </Trans>
     ),

--- a/DashAI/front/src/constants/tours/experimentsTour.js
+++ b/DashAI/front/src/constants/tours/experimentsTour.js
@@ -523,7 +523,7 @@ export const experimentsTourSteps = [
             padding: "8px",
             borderRadius: "4px",
             marginTop: "10px",
-            fontSize: "0.9em",
+            fontSize: "14px",
           }}
         >
           ⏱️ Training may take a few moments depending on your dataset size and

--- a/DashAI/front/src/constants/tours/modelsTour.js
+++ b/DashAI/front/src/constants/tours/modelsTour.js
@@ -221,9 +221,7 @@ export const modelsTourSteps = [
           <p>
             <strong></strong>
           </p>
-          <p
-            style={{ marginTop: "10px", fontSize: "0.9em", color: "#666" }}
-          ></p>
+          <p style={{ marginTop: "10px", fontSize: "14px", color: "#666" }}></p>
         </div>
       </Trans>
     ),

--- a/DashAI/front/src/pages/home/Home.jsx
+++ b/DashAI/front/src/pages/home/Home.jsx
@@ -268,18 +268,15 @@ function Home() {
                   : theme.palette.background.box,
             }}
           >
-            <Typography
-              sx={{
-                color: theme.palette.text.primary,
-                ...theme.typography.pageTitle,
-              }}
-            >
+            <Typography variant="h3" sx={{ color: theme.palette.text.primary }}>
               {t("home:label.welcomeDashboardAI")}
             </Typography>
             <Typography
+              variant="body2"
               sx={{
                 color: theme.palette.text.disabled,
-                ...theme.typography.description,
+                fontWeight: 300,
+                lineHeight: 1.65,
                 mt: "3px",
               }}
             >

--- a/DashAI/front/src/pages/plugins/components/PluginsCard.jsx
+++ b/DashAI/front/src/pages/plugins/components/PluginsCard.jsx
@@ -97,7 +97,7 @@ function PluginsCard({
 
         <Typography
           sx={{
-            ...theme.typography.cardTitle,
+            ...theme.typography.h5,
             color: theme.palette.text.primary,
             flexShrink: 0,
           }}
@@ -107,8 +107,8 @@ function PluginsCard({
 
         {version && (
           <Typography
+            variant="body1"
             sx={{
-              fontSize: "13px",
               fontWeight: 300,
               color: theme.palette.text.disabled,
               flexShrink: 0,
@@ -119,8 +119,8 @@ function PluginsCard({
         )}
 
         <Typography
+          variant="body1"
           sx={{
-            fontSize: "14px",
             fontWeight: 300,
             color: theme.palette.text.secondary,
             flexGrow: 1,
@@ -260,8 +260,8 @@ function PluginsCard({
 
         {version && (
           <Typography
+            variant="body1"
             sx={{
-              fontSize: "13px",
               fontWeight: 300,
               color: theme.palette.text.disabled,
             }}
@@ -275,7 +275,7 @@ function PluginsCard({
       <Typography
         noWrap
         sx={{
-          ...theme.typography.cardTitle,
+          ...theme.typography.h5,
           color: theme.palette.text.primary,
           mb: "5px",
           width: "100%",
@@ -292,9 +292,9 @@ function PluginsCard({
         placement="bottom"
       >
         <Typography
+          variant="subtitle2"
           ref={descRef}
           sx={{
-            fontSize: "15px",
             fontWeight: 300,
             color: theme.palette.text.secondary,
             lineHeight: 1.65,

--- a/DashAI/front/src/pages/results/components/ResultsGraphsSwitch.jsx
+++ b/DashAI/front/src/pages/results/components/ResultsGraphsSwitch.jsx
@@ -10,7 +10,7 @@ function ResultsGraphsSwitch({ showCustomMetrics, handleToggleMetrics }) {
   return (
     <Box mb={2} display="flex" justifyContent="flex-start" width="100%">
       <Box display="flex" alignItems="center">
-        <Typography variant="subtitle2" style={{ fontSize: "0.8rem" }}>
+        <Typography variant="body1">
           {t("models:label.generalMetrics")}
         </Typography>
       </Box>
@@ -29,7 +29,7 @@ function ResultsGraphsSwitch({ showCustomMetrics, handleToggleMetrics }) {
         />
       </Box>
       <Box display="flex" alignItems="center">
-        <Typography variant="subtitle2" style={{ fontSize: "0.8rem" }}>
+        <Typography variant="body1">
           {t("models:label.customMetrics")}
         </Typography>
       </Box>

--- a/DashAI/front/src/styles/theme.js
+++ b/DashAI/front/src/styles/theme.js
@@ -181,11 +181,12 @@ const getTheme = (mode) => ({
     subtitle2: { fontSize: "16px", fontWeight: 400 }, // Texto destacado
     body1: { fontSize: "14px", fontWeight: 400, lineHeight: 1.6 }, // Cuerpo / párrafos
     body2: { fontSize: "12px", fontWeight: 400, lineHeight: 1.5 }, // Texto auxiliar / labels
-    caption: {
+    caption: { fontSize: "12px", fontWeight: 400 }, // Información secundaria, captions
+    code: {
       fontFamily: '"IBM Plex Mono", monospace',
       fontSize: "12px",
       fontWeight: 400,
-    }, // Información secundaria, captions, code
+    }, // Code snippets, valores técnicos
 
     // --- VARIANTES UI FUNCIONALES ---
     navItem: { fontSize: "12px", fontWeight: 400 }, // Sidebar links/Navigation

--- a/DashAI/front/src/styles/theme.js
+++ b/DashAI/front/src/styles/theme.js
@@ -168,57 +168,48 @@ const getTheme = (mode) => ({
   typography: {
     fontFamily: '"IBM Plex Sans", sans-serif',
 
-    // --- SANS SERIF ---
-    pageTitle: {
-      fontSize: "18px",
-      fontWeight: 600,
-      letterSpacing: "-0.01em",
-    }, // Main titles
+    // --- ESCALA DE TITULARES ---
+    h1: { fontSize: "28px", fontWeight: 700, letterSpacing: "-0.01em" },
+    h2: { fontSize: "22px", fontWeight: 600, letterSpacing: "-0.01em" },
+    h3: { fontSize: "20px", fontWeight: 600, letterSpacing: "-0.01em" },
+    h4: { fontSize: "17px", fontWeight: 600, letterSpacing: "-0.01em" },
+    h5: { fontSize: "16px", fontWeight: 600 },
+    h6: { fontSize: "14px", fontWeight: 600 },
 
-    cardTitle: {
-      fontSize: "15px",
-      fontWeight: 600,
-      letterSpacing: "-0.01em",
-    }, // Module/Card titles
-
-    navItem: {
-      fontSize: "12.5px",
-      fontWeight: 400,
-    }, // Sidebar links/Navigation
-
-    description: {
+    // --- ESCALA DE CUERPO ---
+    subtitle1: { fontSize: "17px", fontWeight: 400 }, // Parámetros principales
+    subtitle2: { fontSize: "16px", fontWeight: 400 }, // Texto destacado
+    body1: { fontSize: "14px", fontWeight: 400, lineHeight: 1.6 }, // Cuerpo / párrafos
+    body2: { fontSize: "12px", fontWeight: 400, lineHeight: 1.5 }, // Texto auxiliar / labels
+    caption: {
+      fontFamily: '"IBM Plex Mono", monospace',
       fontSize: "12px",
-      fontWeight: 300,
-      lineHeight: 1.65,
-      color: "rgba(171, 178, 191, 0.45)",
-    }, // Explanatory text
+      fontWeight: 400,
+    }, // Información secundaria, captions, code
 
-    // --- MONOSPACE ---
+    // --- VARIANTES UI FUNCIONALES ---
+    navItem: { fontSize: "12px", fontWeight: 400 }, // Sidebar links/Navigation
     tabLabel: {
       fontFamily: '"IBM Plex Mono", monospace',
       fontSize: "10px",
       letterSpacing: "0.12em",
       textTransform: "uppercase",
     }, // Navigation tabs
-
     sectionLabel: {
       fontFamily: '"IBM Plex Mono", monospace',
       fontSize: "9px",
       letterSpacing: "0.2em",
       textTransform: "uppercase",
     }, // Sidebar section headers
-
     statusBadge: {
       fontFamily: '"IBM Plex Mono", monospace',
       fontSize: "8.5px",
       letterSpacing: "0.12em",
       textTransform: "uppercase",
     },
-
-    // Others
     button: {
-      fontSize: "15px",
-      fontWeight: 400,
+      fontSize: "14px",
+      fontWeight: 500,
       letterSpacing: "-0.01em",
       textTransform: "uppercase",
     },


### PR DESCRIPTION
This pull request standardizes the use of MUI `Typography` variants across many frontend components to improve visual consistency and code maintainability. The main change is replacing custom or inline font sizes and styles with appropriate `Typography` variants (such as `body1`, `body2`, `caption`, etc.), and removing redundant or conflicting style definitions. This affects components throughout the app, including those related to chat, media input, jobs, models, and notebooks.

**Typography standardization and visual consistency:**

* Replaced inline font size styles and manual font weights in multiple components with appropriate MUI `Typography` variants (e.g., `body1`, `body2`, `caption`) to ensure consistent text appearance throughout the UI. This includes updates in files such as `HomeButton.jsx`, `ResponsiveAppBar.jsx`, `ConfigureExplorersStep.jsx`, `ChatBubble.jsx`, `GenerativeChat.jsx`, `SessionBox.jsx`, `MediaOnlyPlaceholder.jsx`, `MediaPreviewList.jsx`, `JobDetailsDialog.jsx`, `ModelComparisonTable.jsx`, and various notebook-related components. [[1]](diffhunk://#diff-f3c19e64d808c0bb99de3ec44d547bce9fabf61152879d2300b82b630e435ce2R108-L109) [[2]](diffhunk://#diff-f3c19e64d808c0bb99de3ec44d547bce9fabf61152879d2300b82b630e435ce2R119-L120) [[3]](diffhunk://#diff-f3c19e64d808c0bb99de3ec44d547bce9fabf61152879d2300b82b630e435ce2L162-R162) [[4]](diffhunk://#diff-8e832988fb7b0030899a336bf49020721005801831b7f8adc6282f88dd3463e8R90-L92) [[5]](diffhunk://#diff-71ace76711a0655688aa1ddb63bf9ac6acb0b036f24f4ee4406e9fa1f83346e7L40-R41) [[6]](diffhunk://#diff-b1f7b93e8e3551843f5777477a5b7f38aacaab63fce865218810d3fe40c3411eL1-R1) [[7]](diffhunk://#diff-b1f7b93e8e3551843f5777477a5b7f38aacaab63fce865218810d3fe40c3411eL28-R39) [[8]](diffhunk://#diff-18b7da2820ba13237df253deb8b88c3fed297c99396a28b773c4df861f0ef51aL300-R300) [[9]](diffhunk://#diff-bdbef811d63e87c27896a5d586813316f3ee6b86dd1a223ad2732379af36dfc1L45-R56) [[10]](diffhunk://#diff-8bdab5f83ef3b310c59aa01a043c66e494450fcf23dff0dff3a3dd41f9bf88ecL1-R1) [[11]](diffhunk://#diff-8bdab5f83ef3b310c59aa01a043c66e494450fcf23dff0dff3a3dd41f9bf88ecL41-R46) [[12]](diffhunk://#diff-8bdab5f83ef3b310c59aa01a043c66e494450fcf23dff0dff3a3dd41f9bf88ecL68-R73) [[13]](diffhunk://#diff-6bd56c4980b7ed4196be9cf99f96590dd38a3ca56b4032eef587a8451eb84f34L1-R1) [[14]](diffhunk://#diff-6bd56c4980b7ed4196be9cf99f96590dd38a3ca56b4032eef587a8451eb84f34L29-R31) [[15]](diffhunk://#diff-6bd56c4980b7ed4196be9cf99f96590dd38a3ca56b4032eef587a8451eb84f34L40-R45) [[16]](diffhunk://#diff-112be6d03dbedba48b8f668bc93b9780730934975dd8490bd9cd6758a59c0adeL210-R216) [[17]](diffhunk://#diff-f9ddaf6bb889b3f3bc48f63a6f7e85cd6afd34df09becba8191eeff8a1247135L318-R332) [[18]](diffhunk://#diff-7f25285150810e575795d0f05a20075870736e345e6f61a443628023a6b0cb0aL167-R171) [[19]](diffhunk://#diff-7f25285150810e575795d0f05a20075870736e345e6f61a443628023a6b0cb0aL199-L203) [[20]](diffhunk://#diff-7f25285150810e575795d0f05a20075870736e345e6f61a443628023a6b0cb0aL214-R205) [[21]](diffhunk://#diff-7f25285150810e575795d0f05a20075870736e345e6f61a443628023a6b0cb0aL242-R229) [[22]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L86-R90) [[23]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L129-R133) [[24]](diffhunk://#diff-1dcaeebe01612b3d93a6728e8a51b9a076f13b41f77d866937901ce0084aa288L143-R147) [[25]](diffhunk://#diff-10f54ef1ad6420137f76829642146badf96f36f0171457d5384acf6c9af0e70cL248-L252) [[26]](diffhunk://#diff-3b7860ecf84834649946bddb641089a1e98ea144ad6f40f97802340afead7a05L196-R196) [[27]](diffhunk://#diff-b282b69b7b653cd35bc2bc70fe27ebd74f463b99f704424218c550ddcc6dc304L105-L110) [[28]](diffhunk://#diff-b282b69b7b653cd35bc2bc70fe27ebd74f463b99f704424218c550ddcc6dc304L158-L163) [[29]](diffhunk://#diff-b282b69b7b653cd35bc2bc70fe27ebd74f463b99f704424218c550ddcc6dc304L211-L216) [[30]](diffhunk://#diff-b282b69b7b653cd35bc2bc70fe27ebd74f463b99f704424218c550ddcc6dc304L265-R264)

**Code maintainability improvements:**

* Removed redundant or conflicting inline styles (such as `fontSize` or `fontWeight`) that are now handled by the selected `Typography` variant, simplifying the code and reducing the risk of style mismatches. [[1]](diffhunk://#diff-f3c19e64d808c0bb99de3ec44d547bce9fabf61152879d2300b82b630e435ce2R119-L120) [[2]](diffhunk://#diff-b1f7b93e8e3551843f5777477a5b7f38aacaab63fce865218810d3fe40c3411eL28-R39) [[3]](diffhunk://#diff-bdbef811d63e87c27896a5d586813316f3ee6b86dd1a223ad2732379af36dfc1L45-R56) [[4]](diffhunk://#diff-8bdab5f83ef3b310c59aa01a043c66e494450fcf23dff0dff3a3dd41f9bf88ecL41-R46) [[5]](diffhunk://#diff-6bd56c4980b7ed4196be9cf99f96590dd38a3ca56b4032eef587a8451eb84f34L40-R45) [[6]](diffhunk://#diff-112be6d03dbedba48b8f668bc93b9780730934975dd8490bd9cd6758a59c0adeL210-R216) [[7]](diffhunk://#diff-f9ddaf6bb889b3f3bc48f63a6f7e85cd6afd34df09becba8191eeff8a1247135L318-R332) [[8]](diffhunk://#diff-7f25285150810e575795d0f05a20075870736e345e6f61a443628023a6b0cb0aL167-R171) [[9]](diffhunk://#diff-7f25285150810e575795d0f05a20075870736e345e6f61a443628023a6b0cb0aL199-L203) [[10]](diffhunk://#diff-7f25285150810e575795d0f05a20075870736e345e6f61a443628023a6b0cb0aL214-R205) [[11]](diffhunk://#diff-7f25285150810e575795d0f05a20075870736e345e6f61a443628023a6b0cb0aL242-R229) [[12]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L86-R90) [[13]](diffhunk://#diff-f7b9e3ca01c46f9895c701bd7fc7dc0a1756cbdcf8a131838650a12c7e750c81L129-R133) [[14]](diffhunk://#diff-1dcaeebe01612b3d93a6728e8a51b9a076f13b41f77d866937901ce0084aa288L143-R147) [[15]](diffhunk://#diff-10f54ef1ad6420137f76829642146badf96f36f0171457d5384acf6c9af0e70cL248-L252) [[16]](diffhunk://#diff-3b7860ecf84834649946bddb641089a1e98ea144ad6f40f97802340afead7a05L196-R196) [[17]](diffhunk://#diff-b282b69b7b653cd35bc2bc70fe27ebd74f463b99f704424218c550ddcc6dc304L105-L110) [[18]](diffhunk://#diff-b282b69b7b653cd35bc2bc70fe27ebd74f463b99f704424218c550ddcc6dc304L158-L163) [[19]](diffhunk://#diff-b282b69b7b653cd35bc2bc70fe27ebd74f463b99f704424218c550ddcc6dc304L211-L216) [[20]](diffhunk://#diff-b282b69b7b653cd35bc2bc70fe27ebd74f463b99f704424218c550ddcc6dc304L265-R264)

These changes collectively make the UI more visually cohesive and the codebase easier to maintain.