### PR TITLE
Remove duplicate step text in converter/explorer modal

### DIFF
--- a/DashAI/front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx
@@ -60,7 +60,7 @@ export default function ParameterStepConverter({
         variant="h6"
         sx={{ fontWeight: 700, color: "primary.main", mb: 1 }}
       >
-        {t("datasets:label.configureParametersStep", { step: 2 })}
+        {t("datasets:label.configureParameters")}
       </Typography>
       <FormSchemaContainer>
         <FormSchemaWithSelectedModel

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -102,12 +102,6 @@ export default function ScopeStepConverter({
         }}
       >
         <Typography
-          variant="h6"
-          sx={{ fontWeight: 700, color: theme.palette.primary.main, mb: 0.5 }}
-        >
-          {t("datasets:label.selectScopeStep", { step: 1 })}
-        </Typography>
-        <Typography
           variant="body2"
           sx={{ color: theme.palette.text.primary, mb: 0.5 }}
         >

--- a/DashAI/front/src/components/notebooks/explorerCreation/ParameterStepExplorer.jsx
+++ b/DashAI/front/src/components/notebooks/explorerCreation/ParameterStepExplorer.jsx
@@ -50,9 +50,7 @@ export default function ParameterStepExplorer({
         variant="h6"
         sx={{ fontWeight: 700, color: "primary.main", mb: 1 }}
       >
-        {t("datasets:label.configureParametersStep", {
-          step: 2,
-        })}
+        {t("datasets:label.configureParameters")}
       </Typography>
       <FormSchemaContainer>
         <FormSchemaWithSelectedModel

--- a/DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx
+++ b/DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx
@@ -38,14 +38,6 @@ export default function ScopeStepExplorer({
       {/* Content */}
       <Box sx={{ flexGrow: 1, overflowY: "auto" }}>
         <Typography
-          variant="h6"
-          sx={{ fontWeight: 700, color: theme.palette.primary.main, mb: 0.5 }}
-        >
-          {t("datasets:label.selectScopeStep", {
-            step: 1,
-          })}
-        </Typography>
-        <Typography
           variant="body2"
           sx={{ color: theme.palette.text.primary, mb: 1.5 }}
         >


### PR DESCRIPTION
This pull request updates the step titles and headings in the notebook creation flows to simplify and unify the user interface. The main changes involve removing step numbers from section titles and streamlining the displayed text for better clarity and consistency.

UI Text and Heading Updates:

* Removed step numbers from the "Configure Parameters" headings in both the converter and explorer flows, changing `{t("datasets:label.configureParametersStep", { step: 2 })}` to `{t("datasets:label.configureParameters")}` in `ParameterStepConverter.jsx` and `ParameterStepExplorer.jsx`. [[1]](diffhunk://#diff-5716226e90d2c9e3805e69294f7cb4e7d5aa2a3da07d8a39d28262d56ca0344aL63-R63) [[2]](diffhunk://#diff-8d7c2b11269a37754b1c0916f574ee325e60f679ded5b1de8859cc782678866aL53-R53)
* Removed the "Select Scope" step heading (including the step number) from both the converter and explorer flows in `ScopeStepConverter.jsx` and `ScopeStepExplorer.jsx`, leaving only the descriptive text. [[1]](diffhunk://#diff-b2a383a9624be950258619b2b78f249dcf1619c925e6d14e75bc9e05bc37a54fL104-L109) [[2]](diffhunk://#diff-8e8147f65b67fee062d470d6e9a0b1af118e88b358de8744c5b6c4201a485e93L40-L47)



<img width="1929" height="442" alt="image" src="https://github.com/user-attachments/assets/ea026a91-0d6b-47ce-a438-1a2902f2037d" />
