### PR TITLE
Fixed async form loading

### DIFF
--- a/DashAI/front/src/components/shared/FormSchemaDialog.jsx
+++ b/DashAI/front/src/components/shared/FormSchemaDialog.jsx
@@ -38,7 +38,7 @@ function FormSchemaDialog({
         },
       }}
     >
-      <FormSchemaContainer>
+      <FormSchemaContainer key={modelToConfigure}>
         <DialogTitle>
           <FormSchemaHeader
             title={t("common:modelToConfig", { model: modelToConfigure })}

--- a/DashAI/front/src/hooks/useSchema.js
+++ b/DashAI/front/src/hooks/useSchema.js
@@ -14,6 +14,8 @@ export default function useSchema({ modelName = null } = {}) {
   const { t } = useTranslation();
 
   useEffect(() => {
+    setModel(null);
+
     const getModel = async () => {
       try {
         setLoading(true);


### PR DESCRIPTION
## Summary

Fixes a bug where parameters from a previously-selected model leaked into a newly-added model when configuring an experiment, causing training to fail with schema validation errors (e.g. `DummyClassifier` receiving `n_estimators`, `learning_rate`). The bug only manifested in production builds because dev mode (HMR + Strict Mode) was masking the stale state.

---

## Type of Change

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/hooks/useSchema.js`: Reset the cached `model` state to `null` at the start of the effect when `modelName` changes. Previously the hook kept the old schema while fetching the new one, so `defaultValues` returned the previous model's params until the async fetch completed — if the user clicked "Add" quickly, those stale params were saved on the new model.
- `DashAI/front/src/components/shared/FormSchemaDialog.jsx`: Added `key={modelToConfigure}` to `FormSchemaContainer` so the `FormSchemaProvider` remounts when switching models in the edit dialog (matching the pattern already used in `AddModelDialog`). Prevents `formValues` from carrying over between different models.

---

## Testing

- In a production build, create an experiment with a tabular classification task.
- Add a model with rich params (e.g. RandomForest), click "Add".
- Switch the model dropdown to one with different params (e.g. DummyClassifier), click "Add".
- Open the new model's edit dialog and confirm only its own params are present.
- Run training — it should not fail with `Field required` schema validation errors.

---

## Notes

The bug only reproduced in production builds because React Strict Mode and HMR in dev caused enough remounts to mask the stale-state issue. Worth keeping in mind for similar hooks that hold async-fetched state — clearing the cache when the input changes is safer than relying on the consumer to handle the transition.
