### PR TITLE
Remove forced reinstall of llama-cpp-python in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,7 +199,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.txt
           pip install pyinstaller pywebview
-          pip install --force-reinstall llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
           brew install create-dmg
 
       - name: Build x86_64 App Bundle


### PR DESCRIPTION
## Summary
This PR removes unnecesary reinstall of `llama-cpp-python` library from GitHub action.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done:

- `.github\workflows\publish.yml`: Removed unnecesary reinstall of `llama-cpp-python`

