### PR TITLE
Remove ARM force reinstall of llama-cpp-python

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -146,7 +146,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-cpu.txt
           pip install pyinstaller pywebview
-          pip install --force-reinstall llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
           brew install create-dmg
 
       - name: Build ARM64 App Bundle


### PR DESCRIPTION
## Summary
This pull request makes a small update to the workflow configuration by removing the forced reinstallation of the `llama-cpp-python` package from the publish pipeline.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [X] Build / Packaging change
- [X] Bug fix
- [ ] Documentation
