### PR TITLE
Add ARFF dataset loader support

### DIFF
--- a/DashAI/back/dataloaders/classes/arff_dataloader.py
+++ b/DashAI/back/dataloaders/classes/arff_dataloader.py
@@ -1,0 +1,176 @@
+"""DashAI ARFF Dataloader."""
+
+import glob
+import shutil
+from typing import TYPE_CHECKING, Any, Dict
+
+from DashAI.back.core.schema_fields.base_schema import BaseSchema
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.dataloaders.classes.dataloader import BaseDataLoader
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class ARFFDataloaderSchema(BaseSchema):
+    """Schema for ARFFDataLoader hyperparameters.
+
+    ARFF files are self-describing; no parameters are required.
+    """
+
+
+class ARFFDataLoader(BaseDataLoader):
+    """Data loader that ingests tabular data from ARFF files into DashAI datasets.
+
+    Reads Weka ARFF files using scipy, decodes nominal attributes from bytes
+    to UTF-8 strings, and converts the result into DashAI datasets. Handles
+    multi-file uploads via ZIP archives containing train/test/val split folders.
+    """
+
+    SUPPORTED_EXTENSIONS: frozenset[str] = frozenset({".arff"})
+    COMPATIBLE_COMPONENTS = ["TabularClassificationTask"]
+    SCHEMA = ARFFDataloaderSchema
+
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Data loader for tabular data in ARFF files "
+            "(Weka Attribute-Relation File Format). "
+            "ARFF files are self-describing and require no additional parameters."
+        ),
+        es=(
+            "Cargador de datos para datos tabulares en archivos ARFF "
+            "(formato Weka Attribute-Relation File Format). "
+            "Los archivos ARFF son autodescriptivos y no requieren "
+            "parámetros adicionales."
+        ),
+    )
+    DISPLAY_NAME: str = MultilingualString(
+        en="ARFF Data Loader",
+        es="Cargador de Datos ARFF",
+    )
+
+    def _read_arff_file(self, filepath: str):
+        """Read an ARFF file and return a pandas DataFrame.
+
+        Parameters
+        ----------
+        filepath : str
+            Path to the ARFF file.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with nominal columns decoded from bytes to UTF-8.
+
+        Raises
+        ------
+        datasets.builder.DatasetGenerationError
+            If the file cannot be parsed as valid ARFF.
+        """
+        import pandas as pd
+        from datasets.builder import DatasetGenerationError
+        from scipy.io import arff
+
+        try:
+            data, _ = arff.loadarff(filepath)
+        except Exception as e:
+            raise DatasetGenerationError from e
+
+        arff_df = pd.DataFrame(data)
+        for col in arff_df.columns:
+            if arff_df[col].dtype == object:
+                arff_df[col] = arff_df[col].str.decode("utf-8")
+        return arff_df
+
+    def load_data(
+        self,
+        filepath_or_buffer: str,
+        temp_path: str,
+        params: Dict[str, Any],
+        n_sample: int | None = None,
+    ) -> "DashAIDataset":
+        """Load uploaded ARFF files into a DatasetDict.
+
+        Parameters
+        ----------
+        filepath_or_buffer : str
+            Path or URL to an ARFF file or a ZIP archive with split folders.
+        temp_path : str
+            Temporary directory for file extraction.
+        params : Dict[str, Any]
+            Dataloader parameters (unused; ARFF is self-describing).
+        n_sample : int | None
+            Maximum rows to load, or None for all.
+
+        Returns
+        -------
+        DashAIDataset
+            Dataset with loaded data.
+        """
+        import pandas as pd
+        from datasets import Dataset, DatasetDict
+
+        from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+
+        prepared_path = self.prepare_files(filepath_or_buffer, temp_path)
+
+        if prepared_path[1] == "file":
+            arff_df = self._read_arff_file(prepared_path[0])
+            if n_sample is not None:
+                arff_df = arff_df.head(n_sample)
+            dataset_dict = DatasetDict(
+                {"train": Dataset.from_pandas(arff_df, preserve_index=False)}
+            )
+        else:
+            train_files = glob.glob(prepared_path[0] + "/train/*")
+            test_files = glob.glob(prepared_path[0] + "/test/*")
+            val_files = glob.glob(prepared_path[0] + "/val/*") + glob.glob(
+                prepared_path[0] + "/validation/*"
+            )
+            try:
+                train_df = pd.concat(
+                    [self._read_arff_file(f) for f in sorted(train_files)]
+                )
+                test_df = pd.concat(
+                    [self._read_arff_file(f) for f in sorted(test_files)]
+                )
+                val_df = pd.concat([self._read_arff_file(f) for f in sorted(val_files)])
+                if n_sample is not None:
+                    train_df = train_df.head(n_sample)
+                    test_df = test_df.head(n_sample)
+                    val_df = val_df.head(n_sample)
+                dataset_dict = DatasetDict(
+                    {
+                        "train": Dataset.from_pandas(train_df, preserve_index=False),
+                        "test": Dataset.from_pandas(test_df, preserve_index=False),
+                        "validation": Dataset.from_pandas(val_df, preserve_index=False),
+                    }
+                )
+            finally:
+                shutil.rmtree(prepared_path[0])
+        return to_dashai_dataset(dataset_dict)
+
+    def load_preview(
+        self,
+        filepath_or_buffer: str,
+        params: Dict[str, Any],
+        n_rows: int = 100,
+    ):
+        """Load a preview of the ARFF dataset.
+
+        Parameters
+        ----------
+        filepath_or_buffer : str
+            Path to the ARFF file.
+        params : Dict[str, Any]
+            Unused parameters.
+        n_rows : int, optional
+            Maximum rows to return. Default is 100.
+
+        Returns
+        -------
+        pd.DataFrame
+            Preview DataFrame.
+        """
+        arff_df = self._read_arff_file(filepath_or_buffer)
+        return arff_df.head(n_rows)

--- a/DashAI/back/dataloaders/classes/arff_dataloader.py
+++ b/DashAI/back/dataloaders/classes/arff_dataloader.py
@@ -27,7 +27,7 @@ class ARFFDataLoader(BaseDataLoader):
     multi-file uploads via ZIP archives containing train/test/val split folders.
     """
 
-    SUPPORTED_EXTENSIONS: frozenset[str] = frozenset({".arff"})
+    SUPPORTED_EXTENSIONS: frozenset[str] = frozenset({".arff", ".zip"})
     COMPATIBLE_COMPONENTS = ["TabularClassificationTask"]
     SCHEMA = ARFFDataloaderSchema
 

--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -62,6 +62,7 @@ from DashAI.back.converters.simple_converters.column_remover import ColumnRemove
 from DashAI.back.converters.simple_converters.nan_remover import NanRemover
 
 # DataLoaders
+from DashAI.back.dataloaders.classes.arff_dataloader import ARFFDataLoader
 from DashAI.back.dataloaders.classes.csv_dataloader import CSVDataLoader
 from DashAI.back.dataloaders.classes.excel_dataloader import ExcelDataLoader
 from DashAI.back.dataloaders.classes.json_dataloader import JSONDataLoader
@@ -367,9 +368,10 @@ def get_initial_components():
         XlmRobertaTransformer,
         XlnetTransformer,
         # Dataloaders
+        ARFFDataLoader,
         CSVDataLoader,
-        JSONDataLoader,
         ExcelDataLoader,
+        JSONDataLoader,
         # Metrics
         F1,
         Accuracy,

--- a/tests/back/dataloaders/test_arff_dataloader.py
+++ b/tests/back/dataloaders/test_arff_dataloader.py
@@ -1,0 +1,130 @@
+"""ARFF DataLoader tests module."""
+
+import pathlib
+from typing import Any, Dict
+
+import pytest
+from sklearn.datasets import load_diabetes, load_iris, load_wine
+
+from DashAI.back.dataloaders.classes.arff_dataloader import ARFFDataLoader
+from tests.back.dataloaders.base_tabular_dataloader_tests import (
+    BaseTabularDataLoaderTester,
+)
+from tests.back.test_datasets_generator import ARFFTestDatasetGenerator
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _setup(test_datasets_path: pathlib.Path, random_state: int) -> None:
+    """Generate the ARFF test datasets."""
+    df_iris = load_iris(return_X_y=False, as_frame=True)["frame"]  # type: ignore
+    df_wine = load_wine(return_X_y=False, as_frame=True)["frame"]  # type: ignore
+    df_diabetes = load_diabetes(return_X_y=False, as_frame=True)["frame"]  # type: ignore
+
+    for df, name in [(df_iris, "iris"), (df_wine, "wine"), (df_diabetes, "diabetes")]:
+        ARFFTestDatasetGenerator(
+            df=df,
+            dataset_name=name,
+            ouptut_path=test_datasets_path,
+            random_state=random_state,
+        )
+
+
+class TestARFFDataloader(BaseTabularDataLoaderTester):
+    @property
+    def dataloader_cls(self):
+        return ARFFDataLoader
+
+    @property
+    def data_type_name(self):
+        return "arff"
+
+    @pytest.mark.parametrize(
+        ("dataset_path", "params", "nrows", "ncols"),
+        [
+            ("iris/basic.arff", {}, 150, 5),
+            ("wine/basic.arff", {}, 178, 14),
+            ("diabetes/basic.arff", {}, 442, 11),
+        ],
+        ids=[
+            "test_load_arff_iris",
+            "test_load_arff_wine",
+            "test_load_arff_diabetes",
+        ],
+    )
+    def test_load_data_from_file(
+        self,
+        test_datasets_path: pathlib.Path,
+        dataset_path: str,
+        params: Dict[str, Any],
+        nrows: int,
+        ncols: int,
+    ) -> None:
+        super()._test_load_data_from_file(
+            dataset_path=test_datasets_path / self.data_type_name / dataset_path,
+            params=params,
+            nrows=nrows,
+            ncols=ncols,
+        )
+
+    @pytest.mark.parametrize(
+        (
+            "dataset_path",
+            "params",
+            "train_nrows",
+            "test_nrows",
+            "val_nrows",
+            "ncols",
+        ),
+        [
+            ("iris/split.zip", {}, 50, 50, 50, 5),
+            ("wine/split.zip", {}, 60, 60, 60, 14),
+            ("diabetes/split.zip", {}, 148, 148, 148, 11),
+        ],
+        ids=[
+            "test_load_arff_iris_from_split_zip",
+            "test_load_arff_wine_from_split_zip",
+            "test_load_arff_diabetes_from_split_zip",
+        ],
+    )
+    def test_load_data_from_zip(
+        self,
+        test_datasets_path: pathlib.Path,
+        dataset_path: str,
+        params: Dict[str, Any],
+        train_nrows: int,
+        test_nrows: int,
+        val_nrows: int,
+        ncols: int,
+    ):
+        super()._test_load_data_from_zip(
+            dataset_path=test_datasets_path / self.data_type_name / dataset_path,
+            params=params,
+            train_nrows=train_nrows,
+            test_nrows=test_nrows,
+            val_nrows=val_nrows,
+            ncols=ncols,
+        )
+
+    @pytest.mark.parametrize(
+        ("dataset_path", "params"),
+        [
+            ("iris/bad_format.arff", {}),
+            ("wine/bad_format.arff", {}),
+            ("diabetes/bad_format.arff", {}),
+        ],
+        ids=[
+            "test_load_arff_iris_with_bad_format",
+            "test_load_arff_wine_with_bad_format",
+            "test_load_arff_diabetes_with_bad_format",
+        ],
+    )
+    def test_dataloader_try_to_load_a_invalid_datasets(
+        self,
+        test_datasets_path: pathlib.Path,
+        dataset_path: str,
+        params: Dict[str, Any],
+    ):
+        super()._test_dataloader_try_to_load_a_invalid_datasets(
+            dataset_path=test_datasets_path / self.data_type_name / dataset_path,
+            params=params,
+        )

--- a/tests/back/test_datasets_generator.py
+++ b/tests/back/test_datasets_generator.py
@@ -334,6 +334,62 @@ class JSONTestDatasetGenerator:
         )
 
 
+class ARFFTestDatasetGenerator:
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        dataset_name: str,
+        ouptut_path: pathlib.Path,
+        random_state: int,
+    ) -> None:
+        base_path = pathlib.Path(ouptut_path) / "arff" / dataset_name
+        os.makedirs(base_path, exist_ok=True)
+
+        self._generate_common_cases(base_path=base_path, df=df)
+        self._generate_bad_formats(base_path=base_path)
+        self._generate_splits(base_path=base_path, df=df, random_state=random_state)
+
+    @staticmethod
+    def _write_arff(
+        df: pd.DataFrame, filepath: pathlib.Path, relation: str = "dataset"
+    ):
+        with open(filepath, "w") as f:
+            f.write(f"@relation {relation}\n\n")
+            for col in df.columns:
+                safe_col = f"'{col}'"
+                if pd.api.types.is_numeric_dtype(df[col]):
+                    f.write(f"@attribute {safe_col} NUMERIC\n")
+                else:
+                    values = ",".join(f"'{v}'" for v in df[col].unique())
+                    f.write(f"@attribute {safe_col} {{{values}}}\n")
+            f.write("\n@data\n")
+            for _, row in df.iterrows():
+                f.write(",".join(str(v) for v in row) + "\n")
+
+    def _generate_common_cases(self, base_path: pathlib.Path, df: pd.DataFrame):
+        self._write_arff(df, base_path / "basic.arff")
+
+    def _generate_bad_formats(self, base_path: pathlib.Path):
+        with open(base_path / "bad_format.arff", "wb") as f:
+            f.write(b"not a valid arff file #$%&--")
+        with open(base_path / "empty_file.arff", "w") as f:
+            f.write("")
+
+    def _generate_splits(
+        self, base_path: pathlib.Path, df: pd.DataFrame, random_state: int
+    ):
+        os.makedirs(base_path / "split" / "train", exist_ok=True)
+        os.makedirs(base_path / "split" / "test", exist_ok=True)
+        os.makedirs(base_path / "split" / "val", exist_ok=True)
+
+        train, test, val = _get_test_splits(df, random_state)
+
+        self._write_arff(train, base_path / "split" / "train" / "train.arff")
+        self._write_arff(test, base_path / "split" / "test" / "test.arff")
+        self._write_arff(val, base_path / "split" / "val" / "val.arff")
+        shutil.make_archive(str(base_path / "split"), "zip", base_path / "split")
+
+
 class ExcelTestDatasetGenerator:
     def __init__(
         self,


### PR DESCRIPTION
## Summary
Adds support for loading ARFF (Attribute-Relation File Format) datasets into DashAI through a new `ARFFDataLoader`. The implementation supports both standalone `.arff` files and ZIP archives containing dataset splits, and includes comprehensive automated tests and test dataset generation utilities.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `arff_dataloader.py`: Added the new `ARFFDataLoader` implementation and schema with support for single ARFF files and ZIP archives containing train/test/validation splits.
- `initial_components.py`: Registered `ARFFDataLoader` so it is available as a built-in DashAI dataloader.
- `test_arff_dataloader.py`: Added parameterized tests covering valid ARFF loading, ZIP split loading, and invalid ARFF handling.
- `ARFFTestDatasetGenerator`: Added utilities for generating valid, split, and malformed ARFF test datasets for automated testing.

---

## Testing (optional)
- Verified loading of standalone `.arff` datasets.
- Verified loading of ZIP archives with dataset splits.
- Verified proper handling and validation of malformed ARFF files.