### PR TITLE
Refactor converter row count metadata and add frontend warnings for row-changing converters

### DIFF
--- a/DashAI/back/converters/base_converter.py
+++ b/DashAI/back/converters/base_converter.py
@@ -41,6 +41,7 @@ class BaseConverter(ConfigObject, ABC):
     ICON: Final[str] = Icon.Extension.value
     COLOR: Final[str] = "rgb(255, 255, 255)"
     SUPERVISED: bool = False
+    CHANGES_ROW_COUNT: bool = False
     SCHEMA: BaseConverterSchema
 
     @classmethod
@@ -70,6 +71,7 @@ class BaseConverter(ConfigObject, ABC):
         meta["icon"] = cls.ICON if cls.ICON else Icon.Extension.value
         meta["color"] = cls.COLOR if cls.COLOR else "rgb(255, 255, 255)"
         meta["supervised"] = cls.SUPERVISED
+        meta["changes_row_count"] = cls.CHANGES_ROW_COUNT
 
         # Serialize allowed_types class references → class name strings for the frontend
         raw_types = meta.get("allowed_types", [])
@@ -83,19 +85,6 @@ class BaseConverter(ConfigObject, ABC):
         meta.pop("restricted_dtypes", None)
 
         return meta
-
-    def changes_row_count(self) -> bool:
-        """Indicate whether this converter changes the number of dataset rows.
-
-        Samplers (e.g. SMOTE, RandomUnderSampler) return True because they
-        add or remove rows. Most transformers return False.
-
-        Returns
-        -------
-        bool
-            True if the converter may add or remove rows, False otherwise.
-        """
-        return False
 
     @abstractmethod
     def get_output_type(self, column_name: str = None) -> DashAIDataType:

--- a/DashAI/back/converters/imbalanced_learn_wrapper.py
+++ b/DashAI/back/converters/imbalanced_learn_wrapper.py
@@ -23,6 +23,7 @@ class ImbalancedLearnWrapper(BaseConverter, metaclass=ABCMeta):
     """
 
     SUPERVISED = True
+    CHANGES_ROW_COUNT = True
 
     def __init__(self, **kwargs):
         """Initialise the imbalanced-learn wrapper and reset internal state.
@@ -37,16 +38,6 @@ class ImbalancedLearnWrapper(BaseConverter, metaclass=ABCMeta):
         self._resampled_table = None
         self.original_X_column_names_: list = []
         self.original_target_column_name_: str = ""
-
-    def changes_row_count(self) -> bool:
-        """Return ``True`` because all samplers add or remove rows.
-
-        Returns
-        -------
-        bool
-            Always ``True``.
-        """
-        return True
 
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Not implemented; type preservation is handled in ``transform``.

--- a/DashAI/back/converters/simple_converters/character_replacer.py
+++ b/DashAI/back/converters/simple_converters/character_replacer.py
@@ -253,16 +253,6 @@ class CharacterReplacer(BasicPreprocessingConverter, BaseConverter):
             splits=x.splits,
         )
 
-    def changes_row_count(self) -> bool:
-        """Return ``False`` because this converter never adds or removes rows.
-
-        Returns
-        -------
-        bool
-            Always ``False``.
-        """
-        return False
-
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the default output type for a transformed column.
 

--- a/DashAI/back/converters/simple_converters/nan_remover.py
+++ b/DashAI/back/converters/simple_converters/nan_remover.py
@@ -41,6 +41,7 @@ class NanRemover(BasicPreprocessingConverter, BaseConverter):
     """
 
     SCHEMA = NanRemoverSchema
+    CHANGES_ROW_COUNT = True
     DESCRIPTION = MultilingualString(
         en=(
             "Removes the rows with NaN values from the dataset. Keep in mind that "
@@ -177,16 +178,6 @@ class NanRemover(BasicPreprocessingConverter, BaseConverter):
         }
 
         return to_dashai_dataset(cleaned_dataset, types=preserved_types)
-
-    def changes_row_count(self) -> bool:
-        """Return ``True`` because this converter removes rows with null values.
-
-        Returns
-        -------
-        bool
-            Always ``True``.
-        """
-        return True
 
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the preserved type for a column, or a Text placeholder.

--- a/DashAI/back/job/converter_job.py
+++ b/DashAI/back/job/converter_job.py
@@ -382,7 +382,7 @@ class ConverterJob(BaseJob):
                             f"Error transforming data with {converter_name}: {e}"
                         ) from e
 
-                    if converter_instance.changes_row_count():
+                    if type(converter_instance).CHANGES_ROW_COUNT:
                         loaded_dataset = transformed_dataset
                     else:
                         loaded_dataset = _rebuild_dataset_with_transformed_columns(

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
-import { Box, Typography } from "@mui/material";
+import { Alert, Box, Typography } from "@mui/material";
 import {
   MaterialReactTable,
   useMaterialReactTable,
@@ -36,6 +36,7 @@ import { Trans, useTranslation } from "react-i18next";
  */
 function ColumnSelector({
   file_path,
+  tool,
   inputCardinality = {},
   allowedDtypes = [],
   allowedTypes = [],
@@ -337,8 +338,8 @@ function ColumnSelector({
               context: inputCardinality.exact
                 ? "exact"
                 : inputCardinality.max
-                  ? "range"
-                  : "min",
+                ? "range"
+                : "min",
             })}
           </Typography>
         )}
@@ -394,7 +395,26 @@ function ColumnSelector({
             </Box>
           </Typography>
         )}
-      </Box>{" "}
+      </Box>
+
+      {tool?.metadata?.changes_row_count && (
+        <Alert
+          severity="warning"
+          sx={{
+            "& .MuiAlert-icon": { fontSize: 24 },
+            bgcolor: (theme) => `${theme.palette.warning.main}40`,
+            border: (theme) => `1px solid ${theme.palette.warning.main}`,
+            "& \t.MuiAlert-message": {
+              display: "flex",
+              alignItems: "center",
+            },
+            mb: 1.5,
+          }}
+        >
+          {t("datasets:message.changesRowCountWarning")}
+        </Alert>
+      )}
+
       {/* Data Grid */}
       <MaterialReactTable
         data-tour="column-selector"
@@ -406,6 +426,11 @@ function ColumnSelector({
 
 ColumnSelector.propTypes = {
   file_path: PropTypes.string.isRequired,
+  tool: PropTypes.shape({
+    metadata: PropTypes.shape({
+      changes_row_count: PropTypes.bool,
+    }),
+  }),
   inputCardinality: PropTypes.shape({
     min: PropTypes.number,
     max: PropTypes.number,

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -338,8 +338,8 @@ function ColumnSelector({
               context: inputCardinality.exact
                 ? "exact"
                 : inputCardinality.max
-                ? "range"
-                : "min",
+                  ? "range"
+                  : "min",
             })}
           </Typography>
         )}

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -110,6 +110,7 @@ export default function ScopeStepConverter({
         {/* Scope selection UI */}
         <ColumnSelector
           file_path={notebook.file_path}
+          tool={tool}
           allowedTypes={allowedTypes}
           allowedDtypes={allowedDtypes}
           onSelectionChange={(columnsInfo) => {

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -368,6 +368,7 @@
   },
   "message": {
     "columnTypesUpdated": "Column types updated successfully",
+    "changesRowCountWarning": "This converter modifies the number of rows in the dataset (adds or removes rows). Note that only the selected columns will be kept. Any columns not included in the scope will be removed from the dataset.",
     "converterCreated": "Converter {{name}} created successfully",
     "converterProcessed": "Converter {{name}} processed successfully",
     "datasetCreationStarted": "Dataset creation started",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -374,6 +374,7 @@
   },
   "message": {
     "columnTypesUpdated": "Tipos de columnas actualizados exitosamente",
+    "changesRowCountWarning": "Este convertidor modifica la cantidad de filas del dataset (agrega o elimina filas). Ten en cuenta que solo se conservarán las columnas seleccionadas. Las columnas no incluidas en el alcance serán eliminadas del dataset.",
     "converterCreated": "Convertidor {{name}} creado exitosamente",
     "converterProcessed": "Convertidor {{name}} procesado exitosamente",
     "datasetCreationStarted": "Creación de dataset iniciada",


### PR DESCRIPTION
## Summary
Refactors converters to use a class-level `CHANGES_ROW_COUNT` attribute instead of the `changes_row_count` method, simplifying row count metadata handling across the backend and frontend. The frontend now surfaces this metadata in the column selector UI with a warning alert when a converter may add or remove dataset rows.

<img width="2555" height="1318" alt="image" src="https://github.com/user-attachments/assets/84ca9cf0-5c90-43fa-904f-c5874293600b" />

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `dashai/processes/converters/base_converter.py`: Replaced `changes_row_count()` with the `CHANGES_ROW_COUNT` class attribute and exposed it through `get_metadata()`.
- `dashai/processes/converters/imbalanced_learn_wrapper.py`: Added `CHANGES_ROW_COUNT` class attribute and removed the old method implementation.
- `dashai/processes/converters/nan_remover.py`: Added `CHANGES_ROW_COUNT` class attribute and removed the old method implementation.
- `dashai/api/...`: Updated converter metadata usage to rely on the new class attribute instead of calling `changes_row_count()`.
- `front/src/components/.../ColumnSelector.tsx`: Added support for receiving the `tool` prop and displaying a warning alert when the selected converter changes the dataset row count.
- `front/src/components/...`: Updated converter-related UI logic to consume the new `changes_row_count` metadata field.
- `front/src/i18n/en/...`: Added English translation for the row count warning alert.
- `front/src/i18n/es/...`: Added Spanish translation for the row count warning alert.
- Multiple converter implementations: Removed obsolete `changes_row_count()` method overrides.

---

## Testing (optional)
- Verify converters that modify dataset rows correctly expose `changes_row_count` in metadata.
- Verify the warning alert appears in the column selector UI for converters that add or remove rows.
- Verify translations render correctly in both English and Spanish.