### PR TITLE
Fix WebSocket URL Resolution for Live Metrics and Hardware Monitor

### DIFF
--- a/DashAI/front/src/components/models/LiveMetricsChart.jsx
+++ b/DashAI/front/src/components/models/LiveMetricsChart.jsx
@@ -86,12 +86,15 @@ export function LiveMetricsChart({ run }) {
       };
     }
 
-    const apiUrl = process.env.REACT_APP_API_URL || `${window.location.origin}`;
+    const wsOrigin = new URL(
+      process.env.REACT_APP_API_URL || "/",
+      window.location.origin,
+    ).origin;
     let wsUrl;
     try {
-      wsUrl = new URL(`/api/v1/metrics/ws/${run.id}`, apiUrl);
+      wsUrl = new URL(`/api/v1/metrics/ws/${run.id}`, wsOrigin);
     } catch (e) {
-      console.error("Invalid WebSocket base URL:", apiUrl, e);
+      console.error("Invalid WebSocket base URL:", wsOrigin, e);
       return;
     }
     if (wsUrl.protocol === "http:") {

--- a/DashAI/front/src/hooks/useHardwareMonitor.js
+++ b/DashAI/front/src/hooks/useHardwareMonitor.js
@@ -43,12 +43,15 @@ export function useHardwareMonitor(enabled) {
 
     clearReconnectTimeout();
 
-    const apiUrl = process.env.REACT_APP_API_URL || `${window.location.origin}`;
+    const wsOrigin = new URL(
+      process.env.REACT_APP_API_URL || "/",
+      window.location.origin,
+    ).origin;
     let wsUrl;
     try {
-      wsUrl = new URL("api/v1/hardware/ws", apiUrl);
+      wsUrl = new URL("/api/v1/hardware/ws", wsOrigin);
     } catch (e) {
-      console.error("Invalid WebSocket base URL:", apiUrl);
+      console.error("Invalid WebSocket base URL:", wsOrigin);
       return;
     }
 


### PR DESCRIPTION
## Summary
Fix WebSocket URL construction in the live metrics chart and hardware monitor hook to correctly resolve the WebSocket origin from either `REACT_APP_API_URL` or the current window location. This improves reliability in environments where the API URL is unset, relative, or differently configured.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `LiveMetricsChart.jsx`: Refactored WebSocket URL creation to use a new `wsOrigin` variable derived from `REACT_APP_API_URL` or `window.location.origin`.
- `useHardwareMonitor.js`: Applied the same `wsOrigin`-based WebSocket URL construction logic for consistent connection handling.

---

## Testing (optional)
- Verified WebSocket connections work correctly when `REACT_APP_API_URL` is:
  - Defined as an absolute URL
  - Defined as a relative URL
  - Undefined (fallback to current window origin)