### PR TITLE
Fix prediction preview serialization and manual input row initialization bugs

### DIFF
--- a/DashAI/back/job/predict_job.py
+++ b/DashAI/back/job/predict_job.py
@@ -49,11 +49,14 @@ def _build_preview_rows(
     """Build JSON-safe tabular rows for manual preview responses."""
     columns = list(input_columns) + [output_col]
 
+    def _to_native(v: Any) -> Any:
+        return v.item() if hasattr(v, "item") else v
+
     rows: List[List] = []
     input_data = prepared_dataset.to_dict()
     for i in range(len(y_pred)):
-        row = [input_data[col][i] for col in input_columns]
-        row.append(y_pred[i])
+        row = [_to_native(input_data[col][i]) for col in input_columns]
+        row.append(_to_native(y_pred[i]))
         rows.append(row)
 
     columns_json = jsonable_encoder(columns)

--- a/DashAI/front/src/components/predictions/ManualInputForm.jsx
+++ b/DashAI/front/src/components/predictions/ManualInputForm.jsx
@@ -33,8 +33,9 @@ export default function ManualInputForm({
     if (manualInputData && manualInputData.length > 0) {
       return manualInputData;
     }
-    setManualInputData([createEmptyRow()]);
-    return [createEmptyRow()];
+    const initialRow = createEmptyRow();
+    setManualInputData([initialRow]);
+    return [initialRow];
   }
 
   function createEmptyRow() {


### PR DESCRIPTION
## Summary
This pull request fixes two prediction related bugs affecting both backend serialization and frontend manual input initialization.

On the backend, prediction preview generation could crash with a 500 error when model inputs or outputs contained NumPy scalar types (`int64`, `float32`, etc.), because `jsonable_encoder` could not serialize them directly. A helper was added to convert NumPy scalars into native Python types before encoding.

On the frontend, the manual prediction form initialized two different randomly generated rows due to `createEmptyRow()` being called twice independently. As a result, the row displayed to the user could differ from the one sent to the backend. The initialization flow was updated to generate the row once and reuse the same reference for both states.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/job/predict_job.py`: Added `_to_native` helper in `_build_preview_rows` to convert NumPy scalar values using `.item()` before passing them to `jsonable_encoder`. Applied to both input column values and prediction outputs.
- `DashAI/front/src/components/predictions/ManualInputForm.jsx`: Refactored initialization logic to call `createEmptyRow()` only once, storing the result in `initialRow` and reusing it for both `setManualInputData` and local row state initialization.

---

## Testing (optional)
- Run a manual prediction on a model that outputs integer or NumPy-based prediction values (e.g. classification models). Verify the preview endpoint no longer returns a 500 error and the table renders correctly.
- Open the manual prediction panel without existing rows. Verify the row shown in the UI matches the row sent to the backend (via Network tab or prediction preview response).