### PR TITLE
fix: clear notebook state and update SaveDatasetModal style on dataset save

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -1,17 +1,9 @@
 import { useState, useEffect, useMemo } from "react";
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  TextField,
-  Box,
-  Typography,
-  IconButton,
-} from "@mui/material";
+import { Modal, TextField, Box, Typography, IconButton } from "@mui/material";
 import { Close } from "@mui/icons-material";
 import { useSnackbar } from "notistack";
 import ConverterHistoryList from "../converter/ConverterHistoryList";
-import FormSchemaButtonGroup from "../../shared/FormSchemaButtonGroup";
+import StepperNavigationFooter from "../../shared/StepperNavigationFooter";
 import NoteBox from "../NoteBox";
 import { generateSequentialName } from "../../../utils/nameGenerator";
 import { useTourContext } from "../../tour/TourProvider";
@@ -84,18 +76,48 @@ export function SaveDatasetModal({
   const nameError = getNameError();
 
   return (
-    <Dialog open={open} onClose={() => {}} maxWidth="sm" fullWidth>
-      <DialogTitle>
-        {t("datasets:label.saveProcessedDataset")}
-        <IconButton
-          onClick={handleClose}
-          sx={{ position: "absolute", right: 8, top: 8 }}
+    <Modal open={open} onClose={() => {}}>
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: { xs: "90%", sm: 560 },
+          bgcolor: "background.paper",
+          borderRadius: 2,
+          boxShadow: 12,
+          p: 0,
+          outline: "none",
+        }}
+      >
+        {/* Header */}
+        <Box
+          sx={{
+            p: 2,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            borderBottom: "1px solid rgba(255, 255, 255, 0.1)",
+          }}
         >
-          <Close />
-        </IconButton>
-      </DialogTitle>
-      <DialogContent data-tour="save-dataset-modal-notebook">
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 3, mt: 1 }}>
+          <Typography variant="h6" component="h2">
+            {t("datasets:label.saveProcessedDataset")}
+          </Typography>
+          <IconButton
+            onClick={handleClose}
+            size="small"
+            sx={{ color: "text.secondary" }}
+          >
+            <Close />
+          </IconButton>
+        </Box>
+
+        {/* Content */}
+        <Box
+          sx={{ p: 3, display: "flex", flexDirection: "column", gap: 3 }}
+          data-tour="save-dataset-modal-notebook"
+        >
           <NoteBox
             message={t("datasets:label.newDatasetCreatedWithTransformations")}
           />
@@ -122,20 +144,16 @@ export function SaveDatasetModal({
             )}
           </Box>
 
-          <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2 }}>
-            <FormSchemaButtonGroup
-              onCancel={handleClose}
-              onFormSubmit={handleSubmit}
-              formik={{
-                errors: nameError ? { name: nameError } : {},
-              }}
-              saveButtonText={t("datasets:button.saveDataset")}
-              backButtonText={t("common:cancel")}
-              dataTour="save-dataset-button-notebook"
-            />
-          </Box>
+          <StepperNavigationFooter
+            onBack={handleClose}
+            onNext={handleSubmit}
+            nextDisabled={Boolean(nameError)}
+            backLabel={t("common:cancel")}
+            nextLabel={t("datasets:button.saveDataset")}
+            variant="save"
+          />
         </Box>
-      </DialogContent>
-    </Dialog>
+      </Box>
+    </Modal>
   );
 }

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -45,6 +45,7 @@ export default function DatasetPreviewNotebook({
     fetchDatasets,
     selectDataset,
     clearSelectedDataset,
+    clearSelectedNotebook,
     deleteDataset,
     enrichDatasetsWithInfo,
     replaceDatasets,
@@ -155,6 +156,13 @@ export default function DatasetPreviewNotebook({
           { variant: "success" },
         );
 
+        const transitionToDataset = () => {
+          clearSelectedNotebook();
+          selectDataset(datasetId);
+          setStep(0);
+          setSelectedOption("dataset");
+        };
+
         try {
           const freshDatasets = await fetchDatasets(true);
           const dataset = freshDatasets.find((d) => d.id === datasetId);
@@ -165,21 +173,14 @@ export default function DatasetPreviewNotebook({
               datasets,
             );
             replaceDatasets(enriched);
-            selectDataset(datasetId);
-            setStep(0);
-            setSelectedOption("dataset");
           } else {
             await fetchDatasets();
-            selectDataset(datasetId);
-            setStep(0);
-            setSelectedOption("dataset");
           }
         } catch (error) {
           console.error("Error after dataset job completion:", error);
           await fetchDatasets();
-          selectDataset(datasetId);
-          setStep(0);
-          setSelectedOption("dataset");
+        } finally {
+          transitionToDataset();
         }
       },
 
@@ -216,6 +217,7 @@ export default function DatasetPreviewNotebook({
 
       // optimistic
       replaceDatasets((prev) => [...prev, dataset]);
+      clearSelectedNotebook();
       selectDataset(dataset.id);
       setStep(0);
       setSelectedOption("dataset");


### PR DESCRIPTION
## Summary

  Updated `SaveDatasetModal` to match the app's current modal style (replaces the old gray `Dialog` pattern) and fixed a bug where the explorers/converters panel in the right sidebar was not cleared after saving a dataset from a notebook.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx`: Replaced `Dialog`/`DialogTitle`/`DialogContent` with `Modal` + styled `Box` to match the current modal pattern used across the app (`background.paper`, `borderRadius`, header with `borderBottom`). Replaced `FormSchemaButtonGroup` with `StepperNavigationFooter` directly, consistent with other notebook modals like `ConfigureToolModal`.
  - `DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx`: Fixed a bug where `selectedNotebookId` was never cleared after saving a dataset from a notebook. This caused `DatasetsContent` to keep rendering `RightBar` with the notebook prop, leaving the explorers/converters panel visible when the dataset view opened. Added `clearSelectedNotebook()` to both the optimistic transition and the job polling success callback.

  ---

  ## Testing

  After pressing **Save Dataset** from a notebook:
  - The modal should use the same dark-themed style as other modals in the app (no gray background).
  - The right sidebar should show the dataset column insights panel, not the explorers/converters tabs.