### PR TITLE
fix: implement search threshold for displaying search bars in components

### DIFF
--- a/DashAI/front/src/components/custom/ComponentSelector.jsx
+++ b/DashAI/front/src/components/custom/ComponentSelector.jsx
@@ -20,6 +20,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 const ALL_CATEGORY = "All";
+const SEARCH_THRESHOLD = 10;
 
 function getLabel(component) {
   return component.display_name || component.name;
@@ -102,29 +103,31 @@ function ComponentSelector({
 
   return (
     <Stack direction="column" sx={{ height: "100%", minHeight: 0 }} spacing={2}>
-      <TextField
-        size="small"
-        fullWidth
-        placeholder={searchPlaceholder ?? t("search")}
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        slotProps={{
-          input: {
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-            endAdornment: search ? (
-              <InputAdornment position="end">
-                <IconButton size="small" onClick={() => setSearch("")}>
-                  <ClearIcon fontSize="small" />
-                </IconButton>
-              </InputAdornment>
-            ) : null,
-          },
-        }}
-      />
+      {components.length > SEARCH_THRESHOLD && (
+        <TextField
+          size="small"
+          fullWidth
+          placeholder={searchPlaceholder ?? t("search")}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+              endAdornment: search ? (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={() => setSearch("")}>
+                    <ClearIcon fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              ) : null,
+            },
+          }}
+        />
+      )}
 
       <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
         {categories.map((cat) => {

--- a/DashAI/front/src/components/generative/SessionBar.jsx
+++ b/DashAI/front/src/components/generative/SessionBar.jsx
@@ -23,6 +23,12 @@ export default function SessionBar({ onToggle }) {
   const [openSections, setOpenSections] = useState({});
   const { t } = useTranslation(["generative", "common"]);
 
+  const SEARCH_THRESHOLD = 10;
+
+  useEffect(() => {
+    if (sessions.length <= SEARCH_THRESHOLD) setSearchQuery("");
+  }, [sessions.length]);
+
   // Create a map of task_name to display_name for quick lookup
   const taskDisplayNameMap =
     tasks?.reduce((map, task) => {
@@ -149,13 +155,15 @@ export default function SessionBar({ onToggle }) {
         </Box>
 
         {/* Search Bar */}
-        <Box px={2} pb={2} flex={"0 0 auto"}>
-          <SearchBar
-            placeholder={t("generative:label.searchSessions")}
-            value={searchQuery}
-            onChange={handleSearchChange}
-          />
-        </Box>
+        {sessions.length > SEARCH_THRESHOLD && (
+          <Box px={2} pb={2} flex={"0 0 auto"}>
+            <SearchBar
+              placeholder={t("generative:label.searchSessions")}
+              value={searchQuery}
+              onChange={handleSearchChange}
+            />
+          </Box>
+        )}
 
         <Divider sx={{ width: "90%", bgcolor: "divider", mx: "auto" }} />
 

--- a/DashAI/front/src/components/models/ModelsLeftBar.jsx
+++ b/DashAI/front/src/components/models/ModelsLeftBar.jsx
@@ -43,6 +43,13 @@ export default function ModelsLeftBar({ onToggle }) {
   const [selectedInfoSession, setSelectedInfoSession] = useState(null);
   const { t } = useTranslation(["models", "datasets", "common"]);
 
+  const SEARCH_THRESHOLD = 10;
+  const totalItems = datasets.length + sessions.length;
+
+  useEffect(() => {
+    if (totalItems <= SEARCH_THRESHOLD) setSearchQuery("");
+  }, [totalItems]);
+
   const getTaskDisplayName = React.useCallback(
     (taskName) => {
       if (!taskName) return t("common:other");
@@ -232,13 +239,15 @@ export default function ModelsLeftBar({ onToggle }) {
       </Box>
 
       {/* Search bar global */}
-      <Box px={2} pb={2} flex={"0 0 auto"}>
-        <SearchBar
-          placeholder={t("models:label.searchDatasetsSessions")}
-          value={searchQuery}
-          onChange={handleSearchChange}
-        />
-      </Box>
+      {totalItems > SEARCH_THRESHOLD && (
+        <Box px={2} pb={2} flex={"0 0 auto"}>
+          <SearchBar
+            placeholder={t("models:label.searchDatasetsSessions")}
+            value={searchQuery}
+            onChange={handleSearchChange}
+          />
+        </Box>
+      )}
 
       <Divider
         sx={{ width: "90%", bgcolor: theme.palette.ui.borderDark, mx: "auto" }}

--- a/DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx
+++ b/DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx
@@ -33,6 +33,13 @@ export default function DatasetsNotebooksLeftBar({ onToggle }) {
   const [searchQuery, setSearchQuery] = useState("");
   const { t } = useTranslation(["datasets", "common"]);
 
+  const SEARCH_THRESHOLD = 10;
+  const totalItems = datasets.length + notebooks.length;
+
+  useEffect(() => {
+    if (totalItems <= SEARCH_THRESHOLD) setSearchQuery("");
+  }, [totalItems]);
+
   useEffect(() => {
     const q = searchQuery.trim().toLowerCase();
 
@@ -146,13 +153,15 @@ export default function DatasetsNotebooksLeftBar({ onToggle }) {
       </Box>
 
       {/* Search bar global */}
-      <Box px={2} pb={2} flex={"0 0 auto"}>
-        <SearchBar
-          placeholder={t("datasets:label.searchDatasetsNotebooks")}
-          value={searchQuery}
-          onChange={handleSearchChange}
-        />
-      </Box>
+      {totalItems > SEARCH_THRESHOLD && (
+        <Box px={2} pb={2} flex={"0 0 auto"}>
+          <SearchBar
+            placeholder={t("datasets:label.searchDatasetsNotebooks")}
+            value={searchQuery}
+            onChange={handleSearchChange}
+          />
+        </Box>
+      )}
 
       <Divider sx={{ width: "90%", bgcolor: "divider", mx: "auto" }} />
 


### PR DESCRIPTION
## Summary

  Enforces a design system rule: search bars should only appear when a list exceeds 10 items. Removed unnecessary search inputs from selectors and sidebars that typically hold far fewer items.

  ---

  ## Type of Change

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation
  ---

  ## Changes (by file)

  - `DashAI/front/src/components/custom/ComponentSelector.jsx`: Added `SEARCH_THRESHOLD = 10` constant. Search `TextField` now renders conditionally based on `components.length`.
  - `DashAI/front/src/components/notebooks/notebookCreation/DatasetAutocomplete.jsx`: Replaced `Autocomplete` (which has built-in search) with a plain `Select` when `datasets.length <= 10`. Keeps `Autocomplete` for larger lists.
  - `DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx`: `SearchBar` now only renders when `datasets + notebooks > 10`. Resets query when list drops back below threshold.
  - `DashAI/front/src/components/models/ModelsLeftBar.jsx`: `SearchBar` now only renders when `datasets + sessions > 10`. Resets query when list drops back below threshold.
  - `DashAI/front/src/components/generative/SessionBar.jsx`: `SearchBar` now only renders when `sessions > 10`. Resets query when list drops back below threshold.

  ---

  ## Testing

  - With fewer than 10 datasets/notebooks/sessions: confirm no search bar appears in the respective sidebar or selector.
  - With more than 10 items: confirm the search bar appears and filters correctly.
  - Delete items from a list that was above the threshold down to 10 or fewer: confirm the search bar disappears and the full list is shown.