### PR TITLE
Reduce redundant dataset fetches and standardize notebook API endpoints

### DIFF
--- a/DashAI/front/src/api/notebook.ts
+++ b/DashAI/front/src/api/notebook.ts
@@ -3,7 +3,7 @@ import { INotebook } from "../types/notebook";
 import { IExplorer } from "../types/explorer";
 import { IConverter } from "../types/converter";
 
-const notebookEndpoint = "/v1/notebook";
+const notebookEndpoint = "/v1/notebook/";
 
 export const createNotebook = async (data: INotebook) => {
   const response = await api.post(notebookEndpoint, data);
@@ -16,7 +16,7 @@ export const getNotebooks = async (): Promise<INotebook[]> => {
 };
 
 export const getNotebook = async (id: string): Promise<INotebook> => {
-  const response = await api.get<INotebook>(`${notebookEndpoint}/${id}`);
+  const response = await api.get<INotebook>(`${notebookEndpoint}${id}`);
   return response.data;
 };
 
@@ -24,7 +24,7 @@ export const getExplorersByNotebookId = async (
   notebookId: string,
 ): Promise<IExplorer[]> => {
   const response = await api.get<IExplorer[]>(
-    `${notebookEndpoint}/${notebookId}/explorers`,
+    `${notebookEndpoint}${notebookId}/explorers`,
   );
   return response.data;
 };
@@ -33,13 +33,13 @@ export const getConvertersByNotebookId = async (
   notebookId: string,
 ): Promise<IConverter[]> => {
   const response = await api.get<IConverter[]>(
-    `${notebookEndpoint}/${notebookId}/converters`,
+    `${notebookEndpoint}${notebookId}/converters`,
   );
   return response.data;
 };
 
 export const deleteNotebook = async (id: number): Promise<object> => {
-  const response = await api.delete(`${notebookEndpoint}/${id}`);
+  const response = await api.delete(`${notebookEndpoint}${id}`);
   return response;
 };
 
@@ -47,7 +47,7 @@ export const updateNotebook = async (
   id: number,
   formData: object,
 ): Promise<INotebook> => {
-  const response = await api.patch(`${notebookEndpoint}/${id}`, {
+  const response = await api.patch(`${notebookEndpoint}${id}`, {
     ...formData,
   });
   return response.data;

--- a/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
+++ b/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
@@ -52,7 +52,6 @@ export const DatasetsAndNotebooksProvider = ({ children }) => {
   const [datasetTab, setDatasetTab] = useState(0);
 
   useEffect(() => {
-    fetchDatasets();
     fetchNotebooks();
   }, []);
 

--- a/DashAI/front/src/hooks/datasets/useDatasets.js
+++ b/DashAI/front/src/hooks/datasets/useDatasets.js
@@ -27,10 +27,13 @@ export function useDatasets({ t }) {
 
   useEffect(() => {
     const unsubscribe = subscribeJobs((jobs) => {
-      const datasetJobs = Array.isArray(jobs)
-        ? jobs.filter((job) => job.task_type === "DatasetJob")
+      const finishedDatasetJobs = Array.isArray(jobs)
+        ? jobs.filter(
+            (job) =>
+              job.task_type === "DatasetJob" && job.status === "finished",
+          )
         : [];
-      if (datasetJobs.length > 0) {
+      if (finishedDatasetJobs.length > 0) {
         fetchDatasets();
       }
     });


### PR DESCRIPTION
## Summary
This pull request standardizes notebook-related API endpoint formatting by ensuring consistent trailing slash usage across notebook API calls. It also improves dataset refresh behavior by only triggering dataset fetches when dataset jobs are finished, reducing unnecessary API requests and redundant dataset reloads.

From the image (running without React StrictMode), only the three necessary fetches are performed with these changes:
- Datasets to display on the left sidebar
- Notebooks to display on the left sidebar
- Jobs

<img width="2552" height="1324" alt="image" src="https://github.com/user-attachments/assets/2332bdbe-f726-4234-b833-231f1fdbfa39" />

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

- `notebook.ts`: Updated `notebookEndpoint` to consistently use a trailing slash and adjusted notebook-related API calls to avoid malformed URLs or double slashes.
- `useDatasets.ts`: Updated job subscription logic to only trigger `fetchDatasets` when a `DatasetJob` finishes.
- `DatasetsAndNotebooksProvider.tsx`: Removed the initial dataset fetch on mount so datasets are refreshed only when relevant finished jobs are received.

---

## Testing (optional)

- Verify notebook create, retrieve, update, and delete operations work correctly with the updated endpoint formatting.
- Confirm explorer and converter requests by notebook ID still resolve correctly.
- Trigger dataset jobs and verify datasets are refreshed only after jobs finish.
- Confirm unnecessary dataset fetches are no longer triggered during intermediate job states.

---

## Notes (optional)

- These changes reduce redundant frontend API calls.