### PR TITLE
Reduce redundant HTTP requests in the notebooks/datasets UI

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/components.py
+++ b/DashAI/back/api/api_v1/endpoints/components.py
@@ -353,10 +353,14 @@ async def get_component_image(
         .get("metadata", {})
         .get("image_preview", None)
     )
+    cache_headers = {"Cache-Control": "public, max-age=3600"}
+
     if not image_path:
         with open(local_path_image / "placeholder.svg", "rb") as image_file:
             return StreamingResponse(
-                io.BytesIO(image_file.read()), media_type="image/svg+xml"
+                io.BytesIO(image_file.read()),
+                media_type="image/svg+xml",
+                headers=cache_headers,
             )
 
     # If it is a URL, we obtain the image from the URL
@@ -364,22 +368,30 @@ async def get_component_image(
         response = requests.get(image_path, timeout=5)
         if response.status_code == 200:
             return StreamingResponse(
-                io.BytesIO(response.content), media_type="image/png"
+                io.BytesIO(response.content),
+                media_type="image/png",
+                headers=cache_headers,
             )
         else:
             with open(local_path_image / "placeholder.svg", "rb") as image_file:
                 return StreamingResponse(
-                    io.BytesIO(image_file.read()), media_type="image/svg+xml"
+                    io.BytesIO(image_file.read()),
+                    media_type="image/svg+xml",
+                    headers=cache_headers,
                 )
 
     # Otherwise, we assume it is a local path
     try:
         with open(local_path_image / image_path, "rb") as image_file:
             return StreamingResponse(
-                io.BytesIO(image_file.read()), media_type="image/png"
+                io.BytesIO(image_file.read()),
+                media_type="image/png",
+                headers=cache_headers,
             )
     except FileNotFoundError:
         with open(local_path_image / "placeholder.svg", "rb") as image_file:
             return StreamingResponse(
-                io.BytesIO(image_file.read()), media_type="image/svg+xml"
+                io.BytesIO(image_file.read()),
+                media_type="image/svg+xml",
+                headers=cache_headers,
             )

--- a/DashAI/back/api/api_v1/schemas/datasets_params.py
+++ b/DashAI/back/api/api_v1/schemas/datasets_params.py
@@ -42,6 +42,8 @@ class Dataset(BaseModel):
     last_modified: datetime
     file_path: str
     status: DatasetStatus
+    total_rows: Optional[int] = None
+    total_columns: Optional[int] = None
 
 
 class DatasetCreateParams(BaseModel):

--- a/DashAI/front/src/api/component.ts
+++ b/DashAI/front/src/api/component.ts
@@ -40,12 +40,15 @@ export const getComponents = async ({
     params = { ...params, has_related_of_type: hasRelatedOfType };
   }
 
-  const response = await api.get<IComponent[]>(`/v1/component/${model}/`, {
-    params,
-    paramsSerializer: {
-      indexes: null, // brackets don't appear in the url
+  const response = await api.get<IComponent[]>(
+    model ? `/v1/component/${model}/` : `/v1/component/`,
+    {
+      params,
+      paramsSerializer: {
+        indexes: null, // brackets don't appear in the url
+      },
     },
-  });
+  );
   return response.data;
 };
 

--- a/DashAI/front/src/api/component.ts
+++ b/DashAI/front/src/api/component.ts
@@ -50,6 +50,6 @@ export const getComponents = async ({
 };
 
 export const getComponentById = async (id: string): Promise<IComponent> => {
-  const response = await api.get<IComponent>(`/v1/component/${id}`);
+  const response = await api.get<IComponent>(`/v1/component/${id}/`);
   return response.data;
 };

--- a/DashAI/front/src/api/component.ts
+++ b/DashAI/front/src/api/component.ts
@@ -40,7 +40,7 @@ export const getComponents = async ({
     params = { ...params, has_related_of_type: hasRelatedOfType };
   }
 
-  const response = await api.get<IComponent[]>(`/v1/component/${model}`, {
+  const response = await api.get<IComponent[]>(`/v1/component/${model}/`, {
     params,
     paramsSerializer: {
       indexes: null, // brackets don't appear in the url

--- a/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
+++ b/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
@@ -47,6 +47,8 @@ export const DatasetsAndNotebooksProvider = ({ children }) => {
   const [selectedOption, setSelectedOption] = useState(OptionsEnum.NEW); // "datasets" or "notebooks"
 
   const [rightBarContent, setRightBarContent] = useState(null);
+  const [availableConverters, setAvailableConverters] = useState([]);
+  const [availableExplorers, setAvailableExplorers] = useState([]);
   const [uploadDataloader, setUploadDataloader] = useState(null);
   const [datasetInfo, setDatasetInfo] = useState(null);
   const [datasetTab, setDatasetTab] = useState(0);

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -42,6 +42,7 @@ function ColumnSelector({
   allowedTypes = [],
   onSelectionChange = () => {},
   onValidationChange = () => {},
+  columnTypes = null,
 }) {
   const [rows, setRows] = useState([]);
   const [rowSelectionModel, setRowSelectionModel] = useState([]);
@@ -91,25 +92,30 @@ function ColumnSelector({
   );
 
   useEffect(() => {
+    const toColumns = (types) =>
+      Object.entries(types).map(([columnName, typeInfo], idx) => ({
+        id: idx,
+        columnName: columnName,
+        valueType: typeInfo.type || t("common:unknown"),
+        dataType: typeInfo.dtype || t("common:unknown"),
+        order: idx,
+      }));
+
+    if (columnTypes !== null) {
+      const cols = toColumns(columnTypes);
+      setDatasetColumns(cols);
+      setRows(cols);
+      return;
+    }
+
     let isMounted = true;
     const fetchAllData = async () => {
       try {
         const types = await getDatasetTypesByFilePath(file_path);
-
         if (!isMounted) return;
-
-        const datasetColumns = Object.entries(types).map(
-          ([columnName, typeInfo], idx) => ({
-            id: idx,
-            columnName: columnName,
-            valueType: typeInfo.type || t("common:unknown"),
-            dataType: typeInfo.dtype || t("common:unknown"),
-            order: idx,
-          }),
-        );
-
-        setDatasetColumns(datasetColumns);
-        setRows(datasetColumns);
+        const cols = toColumns(types);
+        setDatasetColumns(cols);
+        setRows(cols);
       } catch (error) {
         console.error("Error fetching dataset info/types:", error);
       }
@@ -120,7 +126,7 @@ function ColumnSelector({
     return () => {
       isMounted = false;
     };
-  }, [file_path]);
+  }, [file_path, columnTypes]);
 
   // Validate current selection
   const isValidSelection = useCallback(

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -19,7 +19,6 @@ import ToolGrid from "./tool/ToolGrid";
 import FormExplorerSection from "./explorerCreation/FormExplorerSection";
 import FormConverterSection from "./converterCreation/FormConverterSection";
 import { getComponents } from "../../api/component";
-import { getDatasetTypesByFilePath } from "../../api/datasets";
 import { useSnackbar } from "notistack";
 import { useTourContext } from "../tour/TourProvider";
 import { useExplorersAndConverters } from "./context/ExplorersAndConvertersContext";
@@ -96,12 +95,23 @@ export default function RightBar({ notebook, onToggle }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [converters, setConverters] = useState([]);
   const [explorers, setExplorers] = useState([]);
-  const [datasetColumns, setDatasetColumns] = useState([]);
   const tourContext = useTourContext();
   const [viewMode, setViewMode] = useState("list");
   const { enqueueSnackbar } = useSnackbar();
-  const { explorersAndConverters } = useExplorersAndConverters();
+  const { explorersAndConverters, columnTypes } = useExplorersAndConverters();
   const { t } = useTranslation(["datasets", "common"]);
+
+  const datasetColumns = useMemo(
+    () =>
+      Object.entries(columnTypes).map(([columnName, typeInfo], idx) => ({
+        id: idx,
+        columnName,
+        valueType: typeInfo.type || t("common:unknown"),
+        dataType: typeInfo.dtype || t("common:unknown"),
+        order: idx,
+      })),
+    [columnTypes, t],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -129,42 +139,6 @@ export default function RightBar({ notebook, onToggle }) {
   useEffect(() => {
     setSearchQuery("");
   }, [notebook?.id]);
-
-  // Fetch dataset columns from notebook file
-  useEffect(() => {
-    let isMounted = true;
-    const fetchAllData = async () => {
-      try {
-        const types = await getDatasetTypesByFilePath(notebook.file_path);
-
-        if (!isMounted) return;
-
-        const datasetColumns = Object.entries(types).map(
-          ([columnName, typeInfo], idx) => ({
-            id: idx,
-            columnName: columnName,
-            valueType: typeInfo.type || t("common:unknown"),
-            dataType: typeInfo.dtype || t("common:unknown"),
-            order: idx,
-          }),
-        );
-
-        setDatasetColumns(datasetColumns);
-      } catch (error) {
-        console.error("Error fetching dataset info/types:", error);
-      }
-    };
-
-    if (notebook?.file_path) {
-      fetchAllData();
-    } else {
-      setDatasetColumns([]);
-    }
-
-    return () => {
-      isMounted = false;
-    };
-  }, [notebook?.file_path, explorersAndConverters]);
 
   // Validate explorers based on dataset columns
   const validateExplorer = (explorer) => {

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -123,7 +123,7 @@ export default function RightBar({ notebook, onToggle }) {
     return () => {
       cancelled = true;
     };
-  }, [explorersAndConverters, t]);
+  }, [t]);
 
   // Clear search when the selected notebook changes
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/context/ExplorersAndConvertersContext.jsx
+++ b/DashAI/front/src/components/notebooks/context/ExplorersAndConvertersContext.jsx
@@ -8,12 +8,15 @@ export const useExplorersAndConverters = () =>
 export const ExplorersAndConvertersProvider = ({ children }) => {
   const [explorersAndConverters, setExplorersAndConverters] = useState([]);
   const [convertersLoaded, setConvertersLoaded] = useState(false);
+  const [columnTypes, setColumnTypes] = useState({});
 
   const value = {
     explorersAndConverters,
     setExplorersAndConverters,
     convertersLoaded,
     setConvertersLoaded,
+    columnTypes,
+    setColumnTypes,
   };
 
   return (

--- a/DashAI/front/src/components/notebooks/context/ExplorersAndConvertersContext.jsx
+++ b/DashAI/front/src/components/notebooks/context/ExplorersAndConvertersContext.jsx
@@ -7,10 +7,13 @@ export const useExplorersAndConverters = () =>
 
 export const ExplorersAndConvertersProvider = ({ children }) => {
   const [explorersAndConverters, setExplorersAndConverters] = useState([]);
+  const [convertersLoaded, setConvertersLoaded] = useState(false);
 
   const value = {
     explorersAndConverters,
     setExplorersAndConverters,
+    convertersLoaded,
+    setConvertersLoaded,
   };
 
   return (

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -6,12 +6,10 @@ import HelpIcon from "@mui/icons-material/Help";
 import FormSchemaButtonGroup from "../../shared/FormSchemaButtonGroup";
 import ColumnSelector from "../ColumnSelector";
 import { RowSelector } from "../RowSelector";
-import {
-  getDatasetInfoByFilePath,
-  getDatasetTypesByFilePath,
-} from "../../../api/datasets";
+import { getDatasetInfoByFilePath } from "../../../api/datasets";
 import { useTourContext } from "../../tour/TourProvider";
 import { useTranslation } from "react-i18next";
+import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
 
 export default function ScopeStepConverter({
   supervised,
@@ -28,11 +26,11 @@ export default function ScopeStepConverter({
 }) {
   const theme = useTheme();
   const [datasetInfo, setDatasetInfo] = useState(0);
-  const [datasetColumns, setDatasetColumns] = useState([]);
   const tourContext = useTourContext();
   const allowedTypes = tool?.metadata?.allowed_types || [];
   const allowedDtypes = tool?.metadata?.allowed_dtypes || [];
   const { t } = useTranslation(["common", "datasets"]);
+  const { columnTypes } = useExplorersAndConverters();
 
   const handleSubmit = () => {
     nextStep();
@@ -49,28 +47,11 @@ export default function ScopeStepConverter({
 
     const fetchAllData = async () => {
       try {
-        const [data, types] = await Promise.all([
-          getDatasetInfoByFilePath(notebook.file_path),
-          getDatasetTypesByFilePath(notebook.file_path),
-        ]);
-
+        const data = await getDatasetInfoByFilePath(notebook.file_path);
         if (!isMounted) return;
-
         setDatasetInfo(data);
-
-        const datasetColumns = Object.entries(types).map(
-          ([columnName, typeInfo], idx) => ({
-            id: idx,
-            columnName: columnName,
-            valueType: typeInfo.type || t("common:unknown"),
-            dataType: typeInfo.dtype || t("common:unknown"),
-            order: idx,
-          }),
-        );
-
-        setDatasetColumns(datasetColumns);
       } catch (error) {
-        console.error("Error fetching dataset info/types:", error);
+        console.error("Error fetching dataset info:", error);
       }
     };
 
@@ -115,6 +96,7 @@ export default function ScopeStepConverter({
           tool={tool}
           allowedTypes={allowedTypes}
           allowedDtypes={allowedDtypes}
+          columnTypes={columnTypes}
           onSelectionChange={(columnsInfo) => {
             const processedColumns = columnsInfo.map((col) => ({
               idx: col.id + 1,

--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -89,6 +89,10 @@ export default function DatasetTable({
 
   const [columnFilterFns, setColumnFilterFns] = useState(getDefaultFilterFns);
   const [showColumnFilters, setShowColumnFilters] = useState(false);
+  // loadKey starts at 0 so the main loading effect can skip the initial mount
+  // run (before the deps effect has fired). The deps effect increments it to
+  // signal that initialization is done and a fetch should occur.
+  const [loadKey, setLoadKey] = useState(0);
 
   useEffect(() => {
     initialized.current = false;
@@ -122,6 +126,7 @@ export default function DatasetTable({
     );
     setColumnFilterFns(session?.columnFilterFns ?? getDefaultFilterFns());
     setPagination({ pageIndex: 0, pageSize: initialPageSize });
+    setLoadKey((k) => k + 1);
 
     initialized.current = true;
   }, deps);
@@ -205,7 +210,7 @@ export default function DatasetTable({
   // 1st load: only fetch current page (fast, like develop)
   // If filters active and dataset small: lazy-load all data for client-side filtering
   useEffect(() => {
-    if (!initialized.current) return;
+    if (!initialized.current || loadKey === 0) return;
 
     // If we have cached filtered data, use it for pagination
     if (allFilteredDataRef.current) {
@@ -294,11 +299,11 @@ export default function DatasetTable({
       cancelled = true;
     };
   }, [
+    loadKey,
     pagination.pageIndex,
     pagination.pageSize,
     columnFilters,
     sorting,
-    fetchPage,
   ]);
 
   const handleColumnRename = useCallback(

--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -111,8 +111,15 @@ export default function DatasetTable({
         f.value !== undefined &&
         f.value !== "",
     );
-    setColumnFilters(cleanFilters);
-    setSorting(session?.sorting ?? []);
+    const newSorting = session?.sorting ?? [];
+    // Preserve reference identity when values haven't changed so the main
+    // loading effect (which depends on these arrays) does not fire an extra time.
+    setColumnFilters((prev) =>
+      prev.length === 0 && cleanFilters.length === 0 ? prev : cleanFilters,
+    );
+    setSorting((prev) =>
+      prev.length === 0 && newSorting.length === 0 ? prev : newSorting,
+    );
     setColumnFilterFns(session?.columnFilterFns ?? getDefaultFilterFns());
     setPagination({ pageIndex: 0, pageSize: initialPageSize });
 
@@ -286,7 +293,13 @@ export default function DatasetTable({
     return () => {
       cancelled = true;
     };
-  }, [pagination.pageIndex, pagination.pageSize, columnFilters, sorting]);
+  }, [
+    pagination.pageIndex,
+    pagination.pageSize,
+    columnFilters,
+    sorting,
+    fetchPage,
+  ]);
 
   const handleColumnRename = useCallback(
     async (oldName, newName) => {

--- a/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
@@ -23,7 +23,6 @@ export default function DatasetsCenterContent() {
     selectedNotebookId,
     setRightBarContent,
     step,
-    fetchDatasets,
     fetchNotebooks,
     selectedOption,
   } = useDatasetsAndNotebooks();
@@ -111,7 +110,6 @@ export default function DatasetsCenterContent() {
         <DataBreadcrumbs />
         <UploadDatasetSteps
           backHome={() => {
-            fetchDatasets();
             setRightBarContent(null);
             navigate("/app/data");
           }}

--- a/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
@@ -135,7 +135,6 @@ export default function DatasetsCenterContent() {
         <DataBreadcrumbs />
         <UploadNotebookSteps
           backHome={() => {
-            fetchNotebooks();
             navigate("/app/data");
           }}
           datasets={datasets}

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -37,7 +37,6 @@ export default function DatasetPreviewNotebook({
   const {
     datasets,
     createDataset,
-    fetchDatasets,
     selectDataset,
     clearSelectedDataset,
     deleteDataset,
@@ -114,29 +113,9 @@ export default function DatasetPreviewNotebook({
           t("datasets:message.datasetCreationSuccess", { datasetName }),
           { variant: "success" },
         );
-
-        try {
-          const freshDatasets = await fetchDatasets();
-          const dataset = freshDatasets.find((d) => d.id === datasetId);
-
-          if (dataset) {
-            replaceDatasets(freshDatasets);
-            selectDataset(datasetId);
-            setStep(0);
-            setSelectedOption("dataset");
-          } else {
-            await fetchDatasets();
-            selectDataset(datasetId);
-            setStep(0);
-            setSelectedOption("dataset");
-          }
-        } catch (error) {
-          console.error("Error after dataset job completion:", error);
-          await fetchDatasets();
-          selectDataset(datasetId);
-          setStep(0);
-          setSelectedOption("dataset");
-        }
+        selectDataset(datasetId);
+        setStep(0);
+        setSelectedOption("dataset");
       },
 
       //Failure

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -39,10 +39,12 @@ export default function DatasetPreviewNotebook({
     createDataset,
     selectDataset,
     clearSelectedDataset,
+    clearSelectedNotebook,
     deleteDataset,
     replaceDatasets,
     setStep,
     setSelectedOption,
+    setRightBarContent,
   } = useDatasetsAndNotebooks();
 
   const theme = useTheme();
@@ -113,9 +115,11 @@ export default function DatasetPreviewNotebook({
           t("datasets:message.datasetCreationSuccess", { datasetName }),
           { variant: "success" },
         );
+        clearSelectedNotebook();
         selectDataset(datasetId);
         setStep(0);
         setSelectedOption("dataset");
+        setRightBarContent(null);
       },
 
       //Failure
@@ -151,9 +155,11 @@ export default function DatasetPreviewNotebook({
 
       // optimistic
       replaceDatasets((prev) => [...prev, dataset]);
+      clearSelectedNotebook();
       selectDataset(dataset.id);
       setStep(0);
       setSelectedOption("dataset");
+      setRightBarContent(null);
 
       const job = await enqueueDatasetJob(dataset.id, null, "", {}, notebookId);
 

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useSnackbar } from "notistack";
 import { startJobPolling } from "../../../utils/jobPoller";
 import { enqueueDatasetJob } from "../../../api/job";
@@ -17,7 +17,6 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import { getConvertersByNotebookId } from "../../../api/notebook";
 import {
   getDatasetFile,
   getDatasetFileFiltered,
@@ -55,9 +54,12 @@ export default function DatasetPreviewNotebook({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [showNotebookHistoryModal, setShowNotebookHistoryModal] =
     useState(false);
-  const [converters, setConverters] = useState([]);
   const [columnTypes, setColumnTypes] = useState({});
   const { explorersAndConverters } = useExplorersAndConverters();
+  const converters = useMemo(
+    () => explorersAndConverters.filter((item) => item.type === "converter"),
+    [explorersAndConverters],
+  );
   const tourContext = useTourContext();
 
   const getDatasetName = () => {
@@ -85,38 +87,6 @@ export default function DatasetPreviewNotebook({
     },
     [notebook, converters],
   );
-
-  useEffect(() => {
-    let intervalId;
-
-    const fetchConverters = async () => {
-      try {
-        const response = await getConvertersByNotebookId(notebook.id);
-        setConverters(response);
-
-        const isPollingNeeded = response.some(
-          (converter) => converter.status < 3,
-        );
-
-        if (isPollingNeeded) {
-          if (!intervalId) {
-            intervalId = setInterval(fetchConverters, 2000);
-          }
-        } else {
-          clearInterval(intervalId);
-        }
-      } catch (error) {
-        console.error("Error fetching converters:", error);
-        clearInterval(intervalId);
-      }
-    };
-
-    fetchConverters();
-
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [notebook, explorersAndConverters]);
 
   useEffect(() => {
     if (!notebook?.file_path) return;
@@ -309,7 +279,7 @@ export default function DatasetPreviewNotebook({
           <Box sx={{ width: "100%" }}>
             <DatasetTable
               fetchPage={fetchDatasetPage}
-              deps={[notebook.file_path, converters, explorersAndConverters]}
+              deps={[notebook.file_path, converters]}
               initialPageSize={5}
               datasetPath={notebook.file_path}
               columnTypes={columnTypes}

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -86,7 +86,7 @@ export default function DatasetPreviewNotebook({
         : await getDatasetFile(notebook.file_path, page, pageSize);
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook.file_path],
+    [notebook?.file_path],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -85,7 +85,7 @@ export default function DatasetPreviewNotebook({
         : await getDatasetFile(notebook.file_path, page, pageSize);
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook, converters],
+    [notebook.file_path, converters],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -79,7 +79,7 @@ export default function DatasetPreviewNotebook({
       const hasFilters =
         filterModel?.items?.length > 0 || (sortModel && sortModel.length > 0);
       const data = await getDatasetFileFiltered(
-        notebook.file_path,
+        notebook?.file_path,
         page,
         pageSize,
         filterModel,
@@ -87,7 +87,7 @@ export default function DatasetPreviewNotebook({
       );
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook.id],
+    [notebook?.id],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -87,7 +87,7 @@ export default function DatasetPreviewNotebook({
       );
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [],
+    [notebook.id],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "notistack";
 import { startJobPolling } from "../../../utils/jobPoller";
 import { enqueueDatasetJob } from "../../../api/job";
@@ -37,15 +38,12 @@ export default function DatasetPreviewNotebook({
   const {
     datasets,
     createDataset,
-    selectDataset,
     clearSelectedDataset,
-    clearSelectedNotebook,
     deleteDataset,
     replaceDatasets,
-    setStep,
-    setSelectedOption,
-    setRightBarContent,
   } = useDatasetsAndNotebooks();
+
+  const navigate = useNavigate();
 
   const theme = useTheme();
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
@@ -115,11 +113,6 @@ export default function DatasetPreviewNotebook({
           t("datasets:message.datasetCreationSuccess", { datasetName }),
           { variant: "success" },
         );
-        clearSelectedNotebook();
-        selectDataset(datasetId);
-        setStep(0);
-        setSelectedOption("dataset");
-        setRightBarContent(null);
       },
 
       //Failure
@@ -153,13 +146,9 @@ export default function DatasetPreviewNotebook({
         variant: "success",
       });
 
-      // optimistic
+      // optimistic add so the dataset view can render before the job finishes
       replaceDatasets((prev) => [...prev, dataset]);
-      clearSelectedNotebook();
-      selectDataset(dataset.id);
-      setStep(0);
-      setSelectedOption("dataset");
-      setRightBarContent(null);
+      navigate(`/app/data/datasets/${dataset.id}`);
 
       const job = await enqueueDatasetJob(dataset.id, null, "", {}, notebookId);
 

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -18,7 +18,6 @@ import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
 import {
-  getDatasetFile,
   getDatasetFileFiltered,
   getDatasetTypesByFilePath,
 } from "../../../api/datasets";
@@ -55,12 +54,16 @@ export default function DatasetPreviewNotebook({
   const [showNotebookHistoryModal, setShowNotebookHistoryModal] =
     useState(false);
   const [columnTypes, setColumnTypes] = useState({});
-  const { explorersAndConverters } = useExplorersAndConverters();
+  const { explorersAndConverters, convertersLoaded } =
+    useExplorersAndConverters();
   const converters = useMemo(
     () => explorersAndConverters.filter((item) => item.type === "converter"),
     [explorersAndConverters],
   );
-  const converterKey = converters.map((c) => `${c.id}:${c.status}`).join("|");
+  const converterKey = useMemo(
+    () => converters.map((c) => `${c.id}:${c.status}`).join("|"),
+    [converters],
+  );
   const tourContext = useTourContext();
 
   const getDatasetName = () => {
@@ -75,18 +78,16 @@ export default function DatasetPreviewNotebook({
     async (page, pageSize, filterModel, sortModel) => {
       const hasFilters =
         filterModel?.items?.length > 0 || (sortModel && sortModel.length > 0);
-      const data = hasFilters
-        ? await getDatasetFileFiltered(
-            notebook.file_path,
-            page,
-            pageSize,
-            filterModel,
-            sortModel,
-          )
-        : await getDatasetFile(notebook.file_path, page, pageSize);
+      const data = await getDatasetFileFiltered(
+        notebook.file_path,
+        page,
+        pageSize,
+        filterModel,
+        sortModel,
+      );
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook?.file_path],
+    [],
   );
 
   useEffect(() => {
@@ -278,15 +279,17 @@ export default function DatasetPreviewNotebook({
 
         <AccordionDetails>
           <Box sx={{ width: "100%" }}>
-            <DatasetTable
-              fetchPage={fetchDatasetPage}
-              deps={[notebook.file_path, converterKey]}
-              initialPageSize={5}
-              datasetPath={notebook.file_path}
-              columnTypes={columnTypes}
-              enableTopToolbar={false}
-              enableRowsPerPageSelector={false}
-            />
+            {convertersLoaded && (
+              <DatasetTable
+                fetchPage={fetchDatasetPage}
+                deps={[notebook.file_path, converterKey]}
+                initialPageSize={5}
+                datasetPath={notebook.file_path}
+                columnTypes={columnTypes}
+                enableTopToolbar={false}
+                enableRowsPerPageSelector={false}
+              />
+            )}
           </Box>
         </AccordionDetails>
       </Accordion>

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -60,6 +60,7 @@ export default function DatasetPreviewNotebook({
     () => explorersAndConverters.filter((item) => item.type === "converter"),
     [explorersAndConverters],
   );
+  const converterKey = converters.map((c) => `${c.id}:${c.status}`).join("|");
   const tourContext = useTourContext();
 
   const getDatasetName = () => {
@@ -279,7 +280,7 @@ export default function DatasetPreviewNotebook({
           <Box sx={{ width: "100%" }}>
             <DatasetTable
               fetchPage={fetchDatasetPage}
-              deps={[notebook.file_path, converters]}
+              deps={[notebook.file_path, converterKey]}
               initialPageSize={5}
               datasetPath={notebook.file_path}
               columnTypes={columnTypes}

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useSnackbar } from "notistack";
 import { startJobPolling } from "../../../utils/jobPoller";
 import { enqueueDatasetJob } from "../../../api/job";
@@ -17,10 +17,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import {
-  getDatasetFileFiltered,
-  getDatasetTypesByFilePath,
-} from "../../../api/datasets";
+import { getDatasetFileFiltered } from "../../../api/datasets";
 import DatasetTable from "../dataset/DatasetTable";
 import { NotebookHistoryModal } from "./NotebookHistoryModal";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
@@ -53,8 +50,7 @@ export default function DatasetPreviewNotebook({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [showNotebookHistoryModal, setShowNotebookHistoryModal] =
     useState(false);
-  const [columnTypes, setColumnTypes] = useState({});
-  const { explorersAndConverters, convertersLoaded } =
+  const { explorersAndConverters, convertersLoaded, columnTypes } =
     useExplorersAndConverters();
   const converters = useMemo(
     () => explorersAndConverters.filter((item) => item.type === "converter"),
@@ -89,13 +85,6 @@ export default function DatasetPreviewNotebook({
     },
     [notebook?.id],
   );
-
-  useEffect(() => {
-    if (!notebook?.file_path) return;
-    getDatasetTypesByFilePath(notebook.file_path)
-      .then(setColumnTypes)
-      .catch(() => {});
-  }, [notebook?.file_path]);
 
   if (!notebook) {
     return (

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -85,7 +85,7 @@ export default function DatasetPreviewNotebook({
         : await getDatasetFile(notebook.file_path, page, pageSize);
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook.file_path, converters],
+    [notebook.file_path],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -67,8 +67,11 @@ export default function NotebookView({ notebook }) {
     }
   }, [tourContext]);
 
-  const { explorersAndConverters, setExplorersAndConverters } =
-    useExplorersAndConverters();
+  const {
+    explorersAndConverters,
+    setExplorersAndConverters,
+    setConvertersLoaded,
+  } = useExplorersAndConverters();
   const [openDeleteExplorerConfirmation, setOpenDeleteExplorerConfirmation] =
     useState(false);
   const [openDeleteConverterConfirmation, setOpenDeleteConverterConfirmation] =
@@ -82,6 +85,7 @@ export default function NotebookView({ notebook }) {
 
   const fetchExplorersAndConverters = useCallback(async () => {
     if (!notebook?.id) return;
+    setConvertersLoaded(false);
     try {
       const [explorersData, convertersData] = await Promise.all([
         getExplorersByNotebookId(notebook.id),
@@ -101,8 +105,10 @@ export default function NotebookView({ notebook }) {
       setExplorersAndConverters(merged);
     } catch (error) {
       console.error("Failed to fetch explorers and converters:", error);
+    } finally {
+      setConvertersLoaded(true);
     }
-  }, [notebook?.id, setExplorersAndConverters]);
+  }, [notebook?.id, setExplorersAndConverters, setConvertersLoaded]);
 
   const getItemsToDelete = useCallback(
     (converterToDelete) => {

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -6,6 +6,7 @@ import {
   getExplorersByNotebookId,
   getConvertersByNotebookId,
 } from "../../../api/notebook";
+import { getDatasetTypesByFilePath } from "../../../api/datasets";
 import ExplorerBox from "../explorer/ExplorerBox";
 import ConverterBox from "../converter/ConverterBox";
 import DeleteConfirmationModal from "../../threeSectionLayout/DeleteConfirmationModal";
@@ -71,6 +72,7 @@ export default function NotebookView({ notebook }) {
     explorersAndConverters,
     setExplorersAndConverters,
     setConvertersLoaded,
+    setColumnTypes,
   } = useExplorersAndConverters();
   const [openDeleteExplorerConfirmation, setOpenDeleteExplorerConfirmation] =
     useState(false);
@@ -87,9 +89,10 @@ export default function NotebookView({ notebook }) {
     if (!notebook?.id) return;
     setConvertersLoaded(false);
     try {
-      const [explorersData, convertersData] = await Promise.all([
+      const [explorersData, convertersData, types] = await Promise.all([
         getExplorersByNotebookId(notebook.id),
         getConvertersByNotebookId(notebook.id),
+        getDatasetTypesByFilePath(notebook.file_path),
       ]);
       const explorersWithType = explorersData.map((item) => ({
         ...item,
@@ -103,12 +106,18 @@ export default function NotebookView({ notebook }) {
         (a, b) => new Date(a.created) - new Date(b.created),
       );
       setExplorersAndConverters(merged);
+      setColumnTypes(types ?? {});
     } catch (error) {
       console.error("Failed to fetch explorers and converters:", error);
     } finally {
       setConvertersLoaded(true);
     }
-  }, [notebook?.id, setExplorersAndConverters, setConvertersLoaded]);
+  }, [
+    notebook?.id,
+    setExplorersAndConverters,
+    setConvertersLoaded,
+    setColumnTypes,
+  ]);
 
   const getItemsToDelete = useCallback(
     (converterToDelete) => {

--- a/DashAI/front/src/components/notebooks/notebookCreation/DatasetAutocomplete.jsx
+++ b/DashAI/front/src/components/notebooks/notebookCreation/DatasetAutocomplete.jsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Box, Typography, Autocomplete, TextField, Chip } from "@mui/material";
 import { formatDate } from "../../../pages/results/constants/formatDate";
-import { getDatasetInfo } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
 
 export default function DatasetAutocomplete({
@@ -9,63 +8,7 @@ export default function DatasetAutocomplete({
   selectedDataset,
   setSelectedDataset,
 }) {
-  const [datasetInfo, setDatasetInfo] = useState(null);
-  const [loadingInfo, setLoadingInfo] = useState(false);
-  const [infoError, setInfoError] = useState(null);
-  const [infosById, setInfosById] = useState({});
   const { t } = useTranslation(["datasets", "common"]);
-
-  // Fetch info for selected dataset (detail panel)
-  useEffect(() => {
-    let cancelled = false;
-    const fetchInfo = async () => {
-      if (!selectedDataset?.id) {
-        setDatasetInfo(null);
-        setInfoError(null);
-        return;
-      }
-      try {
-        setLoadingInfo(true);
-        setInfoError(null);
-        const info = await getDatasetInfo(selectedDataset.id);
-        if (!cancelled) setDatasetInfo(info);
-      } catch (e) {
-        console.error("Failed to fetch dataset info:", e);
-        if (!cancelled)
-          setInfoError(t("datasets:error.failedToLoadDatasetInfo"));
-      } finally {
-        if (!cancelled) setLoadingInfo(false);
-      }
-    };
-    fetchInfo();
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedDataset?.id]);
-
-  const fetchMissingInfos = async (items) => {
-    const missing = items.filter((d) => d?.id != null && !infosById[d.id]);
-    if (missing.length === 0) return;
-    try {
-      const results = await Promise.allSettled(
-        missing.map((d) => getDatasetInfo(d.id)),
-      );
-      const map = {};
-      results.forEach((res, idx) => {
-        const id = missing[idx]?.id;
-        if (res.status === "fulfilled" && id != null) {
-          map[id] = res.value;
-        }
-      });
-      setInfosById((prev) => ({ ...prev, ...map }));
-    } catch (e) {
-      console.warn("Some dataset infos could not be fetched", e);
-    }
-  };
-
-  useEffect(() => {
-    if (!datasets || datasets.length === 0) return;
-  }, [datasets]);
 
   return (
     <Box width="100%">
@@ -76,7 +19,6 @@ export default function DatasetAutocomplete({
           getOptionLabel={(option) => option.name}
           isOptionEqualToValue={(opt, val) => opt.id === val.id}
           value={selectedDataset}
-          onOpen={() => fetchMissingInfos(datasets)}
           onChange={(event, newValue) => {
             setSelectedDataset(newValue);
           }}
@@ -90,7 +32,6 @@ export default function DatasetAutocomplete({
           )}
           renderOption={(props, option) => {
             const { key, ...rootProps } = props;
-            const info = infosById[option.id];
             return (
               <Box component="li" key={key} {...rootProps}>
                 <Box
@@ -109,8 +50,8 @@ export default function DatasetAutocomplete({
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
                     {t("datasets:label.rowsColumnsInfo", {
-                      totalRows: info ? info.total_rows : "...",
-                      totalColumns: info ? info.total_columns : "...",
+                      totalRows: option.total_rows ?? "...",
+                      totalColumns: option.total_columns ?? "...",
                     })}
                   </Typography>
                 </Box>
@@ -148,19 +89,10 @@ export default function DatasetAutocomplete({
               {/* Single line for Rows | Columns */}
               <Typography variant="body2" fontWeight="medium">
                 {t("datasets:label.rowsColumnsInfo", {
-                  totalRows: datasetInfo
-                    ? datasetInfo.total_rows
-                    : t("common:loading"),
-                  totalColumns: datasetInfo
-                    ? datasetInfo.total_columns
-                    : t("common:loading"),
+                  totalRows: selectedDataset.total_rows ?? "...",
+                  totalColumns: selectedDataset.total_columns ?? "...",
                 })}
               </Typography>
-              {infoError && (
-                <Typography variant="caption" color="error">
-                  {infoError}
-                </Typography>
-              )}
             </Box>
           </Box>
         )}

--- a/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import {
   Box,
   Typography,
@@ -15,13 +15,10 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 import DatasetTable from "../dataset/DatasetTable";
 import api from "../../../api/api";
-import {
-  getDatasetFile,
-  getDatasetFileFiltered,
-  getDatasetTypesByFilePath,
-} from "../../../api/datasets";
+import { getDatasetFile, getDatasetFileFiltered } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
 import StepperNavigationFooter from "../../shared/StepperNavigationFooter";
+import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
 
 export default function ConfigureToolModal({
   tool,
@@ -33,15 +30,8 @@ export default function ConfigureToolModal({
   const theme = useTheme();
   const { t } = useTranslation(["datasets", "common"]);
   const [step, setStep] = useState(0);
-  const [columnTypes, setColumnTypes] = useState({});
   const [imageOpen, setImageOpen] = useState(false);
-
-  useEffect(() => {
-    if (!notebook?.file_path) return;
-    getDatasetTypesByFilePath(notebook.file_path)
-      .then(setColumnTypes)
-      .catch(() => {});
-  }, [notebook?.file_path]);
+  const { columnTypes } = useExplorersAndConverters();
 
   const fetchDatasetPage = useCallback(
     async (page, pageSize, filterModel, sortModel) => {
@@ -229,7 +219,7 @@ export default function ConfigureToolModal({
               }}
             >
               <img
-                src={`${api.defaults.baseURL}/v1/component/image/${tool.name}`}
+                src={`${api.defaults.baseURL}/v1/component/image/${tool.name}/`}
                 alt={tool.display_name}
                 style={{
                   width: "100%",
@@ -273,7 +263,7 @@ export default function ConfigureToolModal({
                   <Close />
                 </IconButton>
                 <img
-                  src={`${api.defaults.baseURL}/v1/component/image/${tool.name}`}
+                  src={`${api.defaults.baseURL}/v1/component/image/${tool.name}/`}
                   alt={tool.display_name}
                   style={{
                     maxWidth: "90vw",

--- a/DashAI/front/src/components/notebooks/tool/HoverToolInfo.jsx
+++ b/DashAI/front/src/components/notebooks/tool/HoverToolInfo.jsx
@@ -54,7 +54,7 @@ export default function HoverToolInfo({
             }}
           >
             <img
-              src={`${api.defaults.baseURL}/v1/component/image/${hoveredTool.name}`}
+              src={`${api.defaults.baseURL}/v1/component/image/${hoveredTool.name}/`}
               alt={hoveredTool.display_name}
               style={{ width: "100%", height: "100%", objectFit: "cover" }}
             />

--- a/DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx
@@ -104,7 +104,7 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
             }}
           >
             <img
-              src={`${api.defaults.baseURL}/v1/component/image/${tool.name}`}
+              src={`${api.defaults.baseURL}/v1/component/image/${tool.name}/`}
               alt={tool.display_name}
               style={{
                 width: "100%",

--- a/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
@@ -208,7 +208,7 @@ export default function ToolListItem({
             }}
           >
             <img
-              src={`${api.defaults.baseURL}/v1/component/image/${tool.name}`}
+              src={`${api.defaults.baseURL}/v1/component/image/${tool.name}/`}
               alt={tool.display_name}
               style={{
                 width: "100%",

--- a/DashAI/front/src/hooks/datasets/useDatasets.js
+++ b/DashAI/front/src/hooks/datasets/useDatasets.js
@@ -102,8 +102,6 @@ export function useDatasets({ t }) {
     startJobPolling(
       datasetJob.id,
       async () => {
-        await fetchDatasets();
-
         enqueueSnackbar(
           t("datasets:message.datasetCreationSuccess", {
             datasetName: newDataset.name,

--- a/DashAI/front/src/types/dataset.ts
+++ b/DashAI/front/src/types/dataset.ts
@@ -5,6 +5,8 @@ export interface IDataset {
   created: Date;
   last_modified: Date;
   file_path: string;
+  total_rows?: number | null;
+  total_columns?: number | null;
 }
 
 export interface DatasetPage {


### PR DESCRIPTION
## Summary
Eliminates redundant HTTP requests in the notebooks/datasets UI. Column types are fetched once per notebook load and shared via context. Component images are cached and served without 307 redirects. Back-button navigation no longer triggers spurious list refetches. Duplicate `fetchDatasets` calls on job completion are removed. Fixes inability to re select a notebook after creating a dataset from it.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `endpoints/components.py`: Add `Cache-Control` header to component image responses
- `schemas/datasets_params.py`: Expose `total_rows`/`total_columns` in dataset list response
- `api/component.ts`, `api/notebook.ts`: Fix missing trailing slashes causing 307 redirects
- `ExplorersAndConvertersContext.jsx`: Add `convertersLoaded` and `columnTypes` shared state
- `NotebookView.jsx`: Fetch explorers, converters, and column types in one `Promise.all`
- `DatasetPreviewNotebook.jsx`: Gate table on `convertersLoaded`; navigate by URL on dataset creation
- `DatasetTable.jsx`: Add `deps` prop to prevent spurious grid resets
- `DatasetsCenterContent.jsx`: Remove unconditional refetches on back-button press
- `RightBar.jsx`, `ConfigureToolModal.jsx`, `ScopeStepConverter.jsx`, `ColumnSelector.jsx`: Read `columnTypes` from context instead of fetching independently
- `ToolListItem.jsx`, `ToolGridItem.jsx`, `HoverToolInfo.jsx`, `ConfigureToolModal.jsx`: Fix trailing slashes on component image URLs
- `DatasetAutocomplete.jsx`: Read `total_rows`/`total_columns` from dataset list, drop per-dataset `/info` calls
- `useDatasets.js`: Remove duplicate `fetchDatasets` from polling success callback

---

## Testing (optional)
- Opening a notebook: one `file/types` call, one `file/` call — no duplicates after converters load
- Back button from creation flows: no spurious `dataset/` or `notebook/` GET
- After creating a dataset from a notebook, the source notebook is re selectable from the left bar
