### PR TITLE
Fix stale dataset cache and converter updates for Arrow-backed datasets

### DIFF
--- a/DashAI/alembic/versions/a1f8e3b0c2d9_add_total_rows_columns_to_dataset.py
+++ b/DashAI/alembic/versions/a1f8e3b0c2d9_add_total_rows_columns_to_dataset.py
@@ -1,0 +1,27 @@
+"""Add total_rows and total_columns to dataset
+
+Revision ID: a1f8e3b0c2d9
+Revises: b4f9e70098e7
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1f8e3b0c2d9"
+down_revision: Union[str, None] = "b4f9e70098e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("dataset", sa.Column("total_rows", sa.Integer(), nullable=True))
+    op.add_column("dataset", sa.Column("total_columns", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("dataset", "total_columns")
+    op.drop_column("dataset", "total_rows")

--- a/DashAI/back/api/api_v1/endpoints/components.py
+++ b/DashAI/back/api/api_v1/endpoints/components.py
@@ -353,10 +353,14 @@ async def get_component_image(
         .get("metadata", {})
         .get("image_preview", None)
     )
+    cache_headers = {"Cache-Control": "public, max-age=3600"}
+
     if not image_path:
         with open(local_path_image / "placeholder.svg", "rb") as image_file:
             return StreamingResponse(
-                io.BytesIO(image_file.read()), media_type="image/svg+xml"
+                io.BytesIO(image_file.read()),
+                media_type="image/svg+xml",
+                headers=cache_headers,
             )
 
     # If it is a URL, we obtain the image from the URL
@@ -364,22 +368,30 @@ async def get_component_image(
         response = requests.get(image_path, timeout=5)
         if response.status_code == 200:
             return StreamingResponse(
-                io.BytesIO(response.content), media_type="image/png"
+                io.BytesIO(response.content),
+                media_type="image/png",
+                headers=cache_headers,
             )
         else:
             with open(local_path_image / "placeholder.svg", "rb") as image_file:
                 return StreamingResponse(
-                    io.BytesIO(image_file.read()), media_type="image/svg+xml"
+                    io.BytesIO(image_file.read()),
+                    media_type="image/svg+xml",
+                    headers=cache_headers,
                 )
 
     # Otherwise, we assume it is a local path
     try:
         with open(local_path_image / image_path, "rb") as image_file:
             return StreamingResponse(
-                io.BytesIO(image_file.read()), media_type="image/png"
+                io.BytesIO(image_file.read()),
+                media_type="image/png",
+                headers=cache_headers,
             )
     except FileNotFoundError:
         with open(local_path_image / "placeholder.svg", "rb") as image_file:
             return StreamingResponse(
-                io.BytesIO(image_file.read()), media_type="image/svg+xml"
+                io.BytesIO(image_file.read()),
+                media_type="image/svg+xml",
+                headers=cache_headers,
             )

--- a/DashAI/back/api/api_v1/endpoints/converters.py
+++ b/DashAI/back/api/api_v1/endpoints/converters.py
@@ -229,6 +229,16 @@ async def delete_converter(
                 notebook.file_path,
                 dirs_exist_ok=True,
             )
+            # copytree preserves the source mtime, which may predate the API
+            # cache entry. Touch data.arrow so the cache invalidation detects
+            # the change even when no previous converters are re-run.
+            import os
+            import time
+
+            arrow_path = os.path.join(notebook.file_path, "dataset", "data.arrow")
+            if os.path.exists(arrow_path):
+                now = time.time()
+                os.utime(arrow_path, (now, now))
 
             # Enqueue all previous converters
             job_ids = []

--- a/DashAI/back/api/api_v1/endpoints/converters.py
+++ b/DashAI/back/api/api_v1/endpoints/converters.py
@@ -243,11 +243,9 @@ async def delete_converter(
             # Enqueue all previous converters
             job_ids = []
             for converter in previous_converters:
-                # Crear instancia de ConverterJob y encolarlo directamente
                 job = ConverterJob(converter_id=converter.id)
-                job_queue.put(job)
-                if hasattr(job, "id"):
-                    job_ids.append(job.id)
+                enqueued = job_queue.put(job)
+                job_ids.append(enqueued.id)
 
             # Delete all the converters after the current one
             for converter in next_converters:

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import os
 import time
 import zipfile
 from collections import OrderedDict
@@ -62,6 +63,13 @@ class _FilteredTableCache:
         if time.time() - ts > self._ttl:
             del self._store[key]
             return None
+        arrow_file_path = f"{path}/dataset/data.arrow"
+        try:
+            if os.path.getmtime(arrow_file_path) > ts:
+                del self._store[key]
+                return None
+        except OSError:
+            pass
         self._store.move_to_end(key)
         return table, total
 
@@ -106,7 +114,7 @@ def _load_and_filter_table(
     from DashAI.back.dataloaders.classes.dashai_dataset import get_dataset_info
 
     arrow_file_path = f"{path}/dataset/data.arrow"
-    with pa.memory_map(arrow_file_path, "r") as source:
+    with pa.OSFile(arrow_file_path, "rb") as source:
         reader = ipc.RecordBatchFileReader(source)
         batches = [reader.get_batch(i) for i in range(reader.num_record_batches)]
         table = pa.Table.from_batches(batches)
@@ -1360,7 +1368,7 @@ async def get_dataset_file(
     end = start + page_size
     rows_collected = 0
 
-    with pa.memory_map(arrow_file_path, "r") as source:
+    with pa.OSFile(arrow_file_path, "rb") as source:
         reader = ipc.RecordBatchFileReader(source)
 
         current_index = 0
@@ -1430,7 +1438,7 @@ async def export_dataset_as_csv(
             )
 
         # Read the complete Arrow file
-        with pa.memory_map(arrow_file_path, "r") as source:
+        with pa.OSFile(arrow_file_path, "rb") as source:
             import io
 
             reader = ipc.RecordBatchFileReader(source)
@@ -1532,7 +1540,7 @@ async def export_dataset_csv_by_id(
                 )
 
             # Read the complete Arrow file
-            with pa.memory_map(arrow_file_path, "r") as source:
+            with pa.OSFile(arrow_file_path, "rb") as source:
                 import io
 
                 reader = ipc.RecordBatchFileReader(source)

--- a/DashAI/back/api/api_v1/schemas/datasets_params.py
+++ b/DashAI/back/api/api_v1/schemas/datasets_params.py
@@ -42,6 +42,8 @@ class Dataset(BaseModel):
     last_modified: datetime
     file_path: str
     status: DatasetStatus
+    total_rows: Optional[int] = None
+    total_columns: Optional[int] = None
 
 
 class DatasetCreateParams(BaseModel):

--- a/DashAI/back/app.py
+++ b/DashAI/back/app.py
@@ -6,11 +6,13 @@ from typing import Literal, Union
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from kink import di
 
 from DashAI.back.api.api_v1.api import api_router_v1
 from DashAI.back.api.front_api import router as app_router
 from DashAI.back.container import build_container
 from DashAI.back.dependencies.config_builder import build_config_dict
+from DashAI.back.dependencies.database.backfill import backfill_dataset_counts
 from DashAI.back.dependencies.database.migrate import migrate_on_startup
 
 logger = logging.getLogger(__name__)
@@ -82,6 +84,10 @@ def create_app(
     migrate_on_startup(
         sqlite_file_path=pathlib.Path(config["SQLITE_DB_PATH"]),
     )
+
+    logger.debug("4b. Backfilling dataset row/column counts.")
+    backfill_dataset_counts(di["session_factory"])
+
     logger.debug("5. Initializing FastAPI application.")
     app = FastAPI(title="DashAI")
     api_v1 = FastAPI(title="DashAI API v1")

--- a/DashAI/back/dependencies/database/backfill.py
+++ b/DashAI/back/dependencies/database/backfill.py
@@ -23,8 +23,7 @@ def backfill_dataset_counts(session_factory: "sessionmaker") -> None:
             db.query(Dataset)
             .filter(
                 Dataset.status == DatasetStatus.FINISHED,
-                Dataset.total_rows
-                == None,  # noqa: E711 — SQLAlchemy ORM requires == for column IS NULL
+                Dataset.total_rows == None,  # noqa: E711 — SQLAlchemy ORM requires == for column IS NULL
             )
             .all()
         )

--- a/DashAI/back/dependencies/database/backfill.py
+++ b/DashAI/back/dependencies/database/backfill.py
@@ -1,0 +1,38 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def backfill_dataset_counts(session_factory) -> None:
+    """Populate total_rows/total_columns for FINISHED datasets with NULL counts.
+
+    Parameters
+    ----------
+    session_factory : sessionmaker
+        SQLAlchemy session factory from the DI container.
+    """
+    from DashAI.back.core.enums.status import DatasetStatus
+    from DashAI.back.dataloaders.classes.dashai_dataset import get_dataset_info
+    from DashAI.back.dependencies.database.models import Dataset
+
+    with session_factory() as db:
+        pending = (
+            db.query(Dataset)
+            .filter(
+                Dataset.status == DatasetStatus.FINISHED,
+                Dataset.total_rows == None,  # noqa: E711
+            )
+            .all()
+        )
+        updated = 0
+        for ds in pending:
+            try:
+                info = get_dataset_info(f"{ds.file_path}/dataset")
+                ds.total_rows = info["total_rows"]
+                ds.total_columns = info["total_columns"]
+                updated += 1
+            except Exception:
+                pass
+        if updated:
+            db.commit()
+            log.debug("Backfilled counts for %d dataset(s).", updated)

--- a/DashAI/back/dependencies/database/backfill.py
+++ b/DashAI/back/dependencies/database/backfill.py
@@ -16,7 +16,6 @@ def backfill_dataset_counts(session_factory: "sessionmaker") -> None:
         SQLAlchemy session factory from the DI container.
     """
     from DashAI.back.core.enums.status import DatasetStatus
-    from DashAI.back.dataloaders.classes.dashai_dataset import get_dataset_info
     from DashAI.back.dependencies.database.models import Dataset
 
     with session_factory() as db:
@@ -24,13 +23,22 @@ def backfill_dataset_counts(session_factory: "sessionmaker") -> None:
             db.query(Dataset)
             .filter(
                 Dataset.status == DatasetStatus.FINISHED,
-                Dataset.total_rows == None,  # noqa: E711 — SQLAlchemy ORM requires == for column IS NULL
+                Dataset.total_rows
+                == None,  # noqa: E711 — SQLAlchemy ORM requires == for column IS NULL
             )
             .all()
         )
         updated = 0
+
+        if not pending:
+            log.debug("No datasets found that require backfilling.")
+            return
         for ds in pending:
             try:
+                from DashAI.back.dataloaders.classes.dashai_dataset import (
+                    get_dataset_info,
+                )
+
                 info = get_dataset_info(f"{ds.file_path}/dataset")
                 ds.total_rows = info["total_rows"]
                 ds.total_columns = info["total_columns"]

--- a/DashAI/back/dependencies/database/backfill.py
+++ b/DashAI/back/dependencies/database/backfill.py
@@ -1,9 +1,13 @@
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import sessionmaker
 
 log = logging.getLogger(__name__)
 
 
-def backfill_dataset_counts(session_factory) -> None:
+def backfill_dataset_counts(session_factory: "sessionmaker") -> None:
     """Populate total_rows/total_columns for FINISHED datasets with NULL counts.
 
     Parameters
@@ -20,7 +24,7 @@ def backfill_dataset_counts(session_factory) -> None:
             db.query(Dataset)
             .filter(
                 Dataset.status == DatasetStatus.FINISHED,
-                Dataset.total_rows == None,  # noqa: E711
+                Dataset.total_rows == None,  # noqa: E711 — SQLAlchemy ORM requires == for column IS NULL
             )
             .all()
         )
@@ -31,8 +35,8 @@ def backfill_dataset_counts(session_factory) -> None:
                 ds.total_rows = info["total_rows"]
                 ds.total_columns = info["total_columns"]
                 updated += 1
-            except Exception:
-                pass
+            except Exception as e:
+                log.warning("Failed to backfill dataset %d: %s", ds.id, e)
         if updated:
             db.commit()
             log.debug("Backfilled counts for %d dataset(s).", updated)

--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -56,6 +56,8 @@ class Dataset(Base):
         onupdate=datetime.now,
     )
     file_path: Mapped[str] = mapped_column(String, nullable=False)
+    total_rows: Mapped[int] = mapped_column(Integer, nullable=True)
+    total_columns: Mapped[int] = mapped_column(Integer, nullable=True)
 
     notebooks: Mapped[List["Notebook"]] = relationship(
         cascade="all, delete-orphan", back_populates="dataset"

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -229,6 +229,10 @@ class DatasetJob(BaseJob):
                     folder_path = os.path.realpath(folder_path)
                     dataset = db.get(Dataset, dataset_id)
                     dataset.file_path = folder_path
+                    dataset.total_rows = new_dataset.splits.get("total_rows")
+                    dataset.total_columns = len(
+                        new_dataset.splits.get("column_names", [])
+                    )
                     dataset.set_status_as_finished()
                     db.commit()
                     db.refresh(dataset)

--- a/DashAI/front/src/api/component.ts
+++ b/DashAI/front/src/api/component.ts
@@ -40,12 +40,15 @@ export const getComponents = async ({
     params = { ...params, has_related_of_type: hasRelatedOfType };
   }
 
-  const response = await api.get<IComponent[]>(`/v1/component/${model}/`, {
-    params,
-    paramsSerializer: {
-      indexes: null, // brackets don't appear in the url
+  const response = await api.get<IComponent[]>(
+    model ? `/v1/component/${model}/` : `/v1/component/`,
+    {
+      params,
+      paramsSerializer: {
+        indexes: null, // brackets don't appear in the url
+      },
     },
-  });
+  );
   return response.data;
 };
 

--- a/DashAI/front/src/api/component.ts
+++ b/DashAI/front/src/api/component.ts
@@ -50,6 +50,6 @@ export const getComponents = async ({
 };
 
 export const getComponentById = async (id: string): Promise<IComponent> => {
-  const response = await api.get<IComponent>(`/v1/component/${id}`);
+  const response = await api.get<IComponent>(`/v1/component/${id}/`);
   return response.data;
 };

--- a/DashAI/front/src/api/component.ts
+++ b/DashAI/front/src/api/component.ts
@@ -40,7 +40,7 @@ export const getComponents = async ({
     params = { ...params, has_related_of_type: hasRelatedOfType };
   }
 
-  const response = await api.get<IComponent[]>(`/v1/component/${model}`, {
+  const response = await api.get<IComponent[]>(`/v1/component/${model}/`, {
     params,
     paramsSerializer: {
       indexes: null, // brackets don't appear in the url

--- a/DashAI/front/src/api/notebook.ts
+++ b/DashAI/front/src/api/notebook.ts
@@ -3,7 +3,7 @@ import { INotebook } from "../types/notebook";
 import { IExplorer } from "../types/explorer";
 import { IConverter } from "../types/converter";
 
-const notebookEndpoint = "/v1/notebook";
+const notebookEndpoint = "/v1/notebook/";
 
 export const createNotebook = async (data: INotebook) => {
   const response = await api.post(notebookEndpoint, data);
@@ -16,7 +16,7 @@ export const getNotebooks = async (): Promise<INotebook[]> => {
 };
 
 export const getNotebook = async (id: string): Promise<INotebook> => {
-  const response = await api.get<INotebook>(`${notebookEndpoint}/${id}`);
+  const response = await api.get<INotebook>(`${notebookEndpoint}${id}`);
   return response.data;
 };
 
@@ -24,7 +24,7 @@ export const getExplorersByNotebookId = async (
   notebookId: string,
 ): Promise<IExplorer[]> => {
   const response = await api.get<IExplorer[]>(
-    `${notebookEndpoint}/${notebookId}/explorers`,
+    `${notebookEndpoint}${notebookId}/explorers`,
   );
   return response.data;
 };
@@ -33,13 +33,13 @@ export const getConvertersByNotebookId = async (
   notebookId: string,
 ): Promise<IConverter[]> => {
   const response = await api.get<IConverter[]>(
-    `${notebookEndpoint}/${notebookId}/converters`,
+    `${notebookEndpoint}${notebookId}/converters`,
   );
   return response.data;
 };
 
 export const deleteNotebook = async (id: number): Promise<object> => {
-  const response = await api.delete(`${notebookEndpoint}/${id}`);
+  const response = await api.delete(`${notebookEndpoint}${id}`);
   return response;
 };
 
@@ -47,7 +47,7 @@ export const updateNotebook = async (
   id: number,
   formData: object,
 ): Promise<INotebook> => {
-  const response = await api.patch(`${notebookEndpoint}/${id}`, {
+  const response = await api.patch(`${notebookEndpoint}${id}`, {
     ...formData,
   });
   return response.data;

--- a/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
+++ b/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
@@ -28,7 +28,6 @@ export const DatasetsAndNotebooksProvider = ({ children }) => {
     deleteDatasetById,
     editDataset,
     addDatasetOptimistically,
-    enrichDatasetsWithInfo,
     replaceDatasets,
     startDatasetPolling,
   } = useDatasets({ t });
@@ -68,7 +67,6 @@ export const DatasetsAndNotebooksProvider = ({ children }) => {
     deleteDatasetById,
     editDataset,
     addDatasetOptimistically,
-    enrichDatasetsWithInfo,
     replaceDatasets,
     startDatasetPolling,
     notebooks,

--- a/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
+++ b/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
@@ -52,7 +52,6 @@ export const DatasetsAndNotebooksProvider = ({ children }) => {
   const [datasetTab, setDatasetTab] = useState(0);
 
   useEffect(() => {
-    fetchDatasets();
     fetchNotebooks();
   }, []);
 

--- a/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
+++ b/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
@@ -47,6 +47,8 @@ export const DatasetsAndNotebooksProvider = ({ children }) => {
   const [selectedOption, setSelectedOption] = useState(OptionsEnum.NEW); // "datasets" or "notebooks"
 
   const [rightBarContent, setRightBarContent] = useState(null);
+  const [availableConverters, setAvailableConverters] = useState([]);
+  const [availableExplorers, setAvailableExplorers] = useState([]);
   const [uploadDataloader, setUploadDataloader] = useState(null);
   const [datasetInfo, setDatasetInfo] = useState(null);
   const [datasetTab, setDatasetTab] = useState(0);

--- a/DashAI/front/src/components/models/ModelsContext.jsx
+++ b/DashAI/front/src/components/models/ModelsContext.jsx
@@ -32,7 +32,6 @@ export function ModelsProvider({ children }) {
     deleteDatasetById,
     editDataset,
     addDatasetOptimistically,
-    enrichDatasetsWithInfo,
     replaceDatasets,
     startDatasetPolling,
   } = useDatasets({ t });
@@ -114,7 +113,6 @@ export function ModelsProvider({ children }) {
     deleteDatasetById,
     editDataset,
     addDatasetOptimistically,
-    enrichDatasetsWithInfo,
     replaceDatasets,
     startDatasetPolling,
     tasks,

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -42,6 +42,7 @@ function ColumnSelector({
   allowedTypes = [],
   onSelectionChange = () => {},
   onValidationChange = () => {},
+  columnTypes = null,
 }) {
   const [rows, setRows] = useState([]);
   const [rowSelectionModel, setRowSelectionModel] = useState([]);
@@ -91,25 +92,30 @@ function ColumnSelector({
   );
 
   useEffect(() => {
+    const toColumns = (types) =>
+      Object.entries(types).map(([columnName, typeInfo], idx) => ({
+        id: idx,
+        columnName: columnName,
+        valueType: typeInfo.type || t("common:unknown"),
+        dataType: typeInfo.dtype || t("common:unknown"),
+        order: idx,
+      }));
+
+    if (columnTypes !== null) {
+      const cols = toColumns(columnTypes);
+      setDatasetColumns(cols);
+      setRows(cols);
+      return;
+    }
+
     let isMounted = true;
     const fetchAllData = async () => {
       try {
         const types = await getDatasetTypesByFilePath(file_path);
-
         if (!isMounted) return;
-
-        const datasetColumns = Object.entries(types).map(
-          ([columnName, typeInfo], idx) => ({
-            id: idx,
-            columnName: columnName,
-            valueType: typeInfo.type || t("common:unknown"),
-            dataType: typeInfo.dtype || t("common:unknown"),
-            order: idx,
-          }),
-        );
-
-        setDatasetColumns(datasetColumns);
-        setRows(datasetColumns);
+        const cols = toColumns(types);
+        setDatasetColumns(cols);
+        setRows(cols);
       } catch (error) {
         console.error("Error fetching dataset info/types:", error);
       }
@@ -120,7 +126,7 @@ function ColumnSelector({
     return () => {
       isMounted = false;
     };
-  }, [file_path]);
+  }, [file_path, columnTypes]);
 
   // Validate current selection
   const isValidSelection = useCallback(

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -19,7 +19,6 @@ import ToolGrid from "./tool/ToolGrid";
 import FormExplorerSection from "./explorerCreation/FormExplorerSection";
 import FormConverterSection from "./converterCreation/FormConverterSection";
 import { getComponents } from "../../api/component";
-import { getDatasetTypesByFilePath } from "../../api/datasets";
 import { useSnackbar } from "notistack";
 import { useTourContext } from "../tour/TourProvider";
 import { useExplorersAndConverters } from "./context/ExplorersAndConvertersContext";
@@ -96,12 +95,23 @@ export default function RightBar({ notebook, onToggle }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [converters, setConverters] = useState([]);
   const [explorers, setExplorers] = useState([]);
-  const [datasetColumns, setDatasetColumns] = useState([]);
   const tourContext = useTourContext();
   const [viewMode, setViewMode] = useState("list");
   const { enqueueSnackbar } = useSnackbar();
-  const { explorersAndConverters } = useExplorersAndConverters();
+  const { explorersAndConverters, columnTypes } = useExplorersAndConverters();
   const { t } = useTranslation(["datasets", "common"]);
+
+  const datasetColumns = useMemo(
+    () =>
+      Object.entries(columnTypes).map(([columnName, typeInfo], idx) => ({
+        id: idx,
+        columnName,
+        valueType: typeInfo.type || t("common:unknown"),
+        dataType: typeInfo.dtype || t("common:unknown"),
+        order: idx,
+      })),
+    [columnTypes, t],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -129,42 +139,6 @@ export default function RightBar({ notebook, onToggle }) {
   useEffect(() => {
     setSearchQuery("");
   }, [notebook?.id]);
-
-  // Fetch dataset columns from notebook file
-  useEffect(() => {
-    let isMounted = true;
-    const fetchAllData = async () => {
-      try {
-        const types = await getDatasetTypesByFilePath(notebook.file_path);
-
-        if (!isMounted) return;
-
-        const datasetColumns = Object.entries(types).map(
-          ([columnName, typeInfo], idx) => ({
-            id: idx,
-            columnName: columnName,
-            valueType: typeInfo.type || t("common:unknown"),
-            dataType: typeInfo.dtype || t("common:unknown"),
-            order: idx,
-          }),
-        );
-
-        setDatasetColumns(datasetColumns);
-      } catch (error) {
-        console.error("Error fetching dataset info/types:", error);
-      }
-    };
-
-    if (notebook?.file_path) {
-      fetchAllData();
-    } else {
-      setDatasetColumns([]);
-    }
-
-    return () => {
-      isMounted = false;
-    };
-  }, [notebook?.file_path, explorersAndConverters]);
 
   // Validate explorers based on dataset columns
   const validateExplorer = (explorer) => {

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -123,7 +123,7 @@ export default function RightBar({ notebook, onToggle }) {
     return () => {
       cancelled = true;
     };
-  }, [explorersAndConverters, t]);
+  }, [t]);
 
   // Clear search when the selected notebook changes
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/context/ExplorersAndConvertersContext.jsx
+++ b/DashAI/front/src/components/notebooks/context/ExplorersAndConvertersContext.jsx
@@ -8,12 +8,15 @@ export const useExplorersAndConverters = () =>
 export const ExplorersAndConvertersProvider = ({ children }) => {
   const [explorersAndConverters, setExplorersAndConverters] = useState([]);
   const [convertersLoaded, setConvertersLoaded] = useState(false);
+  const [columnTypes, setColumnTypes] = useState({});
 
   const value = {
     explorersAndConverters,
     setExplorersAndConverters,
     convertersLoaded,
     setConvertersLoaded,
+    columnTypes,
+    setColumnTypes,
   };
 
   return (

--- a/DashAI/front/src/components/notebooks/context/ExplorersAndConvertersContext.jsx
+++ b/DashAI/front/src/components/notebooks/context/ExplorersAndConvertersContext.jsx
@@ -7,10 +7,13 @@ export const useExplorersAndConverters = () =>
 
 export const ExplorersAndConvertersProvider = ({ children }) => {
   const [explorersAndConverters, setExplorersAndConverters] = useState([]);
+  const [convertersLoaded, setConvertersLoaded] = useState(false);
 
   const value = {
     explorersAndConverters,
     setExplorersAndConverters,
+    convertersLoaded,
+    setConvertersLoaded,
   };
 
   return (

--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -7,6 +7,7 @@ import ParameterStepConverter from "./ParameterStepConverter";
 import ScopeStepConverter from "./ScopeStepConverter";
 import { startJobPolling } from "../../../utils/jobPoller";
 import { enqueueConverterJob } from "../../../api/job";
+import { getDatasetTypesByFilePath } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
 
 export default function FormConverterSection({
@@ -20,7 +21,7 @@ export default function FormConverterSection({
   const [targetColumn, setTargetColumn] = useState(null);
   const [rows, setRows] = useState([]);
   const [columns, setColumns] = useState([]);
-  const { explorersAndConverters, setExplorersAndConverters } =
+  const { explorersAndConverters, setExplorersAndConverters, setColumnTypes } =
     useExplorersAndConverters();
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation(["common", "datasets"]);
@@ -74,6 +75,12 @@ export default function FormConverterSection({
                         : item,
                     ),
                   );
+
+                  if (notebook?.file_path) {
+                    getDatasetTypesByFilePath(notebook.file_path)
+                      .then((types) => setColumnTypes(types ?? {}))
+                      .catch(console.error);
+                  }
                 },
 
                 (result) => {

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -6,12 +6,10 @@ import HelpIcon from "@mui/icons-material/Help";
 import FormSchemaButtonGroup from "../../shared/FormSchemaButtonGroup";
 import ColumnSelector from "../ColumnSelector";
 import { RowSelector } from "../RowSelector";
-import {
-  getDatasetInfoByFilePath,
-  getDatasetTypesByFilePath,
-} from "../../../api/datasets";
+import { getDatasetInfoByFilePath } from "../../../api/datasets";
 import { useTourContext } from "../../tour/TourProvider";
 import { useTranslation } from "react-i18next";
+import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
 
 export default function ScopeStepConverter({
   supervised,
@@ -28,11 +26,11 @@ export default function ScopeStepConverter({
 }) {
   const theme = useTheme();
   const [datasetInfo, setDatasetInfo] = useState(0);
-  const [datasetColumns, setDatasetColumns] = useState([]);
   const tourContext = useTourContext();
   const allowedTypes = tool?.metadata?.allowed_types || [];
   const allowedDtypes = tool?.metadata?.allowed_dtypes || [];
   const { t } = useTranslation(["common", "datasets"]);
+  const { columnTypes } = useExplorersAndConverters();
 
   const handleSubmit = () => {
     nextStep();
@@ -49,28 +47,11 @@ export default function ScopeStepConverter({
 
     const fetchAllData = async () => {
       try {
-        const [data, types] = await Promise.all([
-          getDatasetInfoByFilePath(notebook.file_path),
-          getDatasetTypesByFilePath(notebook.file_path),
-        ]);
-
+        const data = await getDatasetInfoByFilePath(notebook.file_path);
         if (!isMounted) return;
-
         setDatasetInfo(data);
-
-        const datasetColumns = Object.entries(types).map(
-          ([columnName, typeInfo], idx) => ({
-            id: idx,
-            columnName: columnName,
-            valueType: typeInfo.type || t("common:unknown"),
-            dataType: typeInfo.dtype || t("common:unknown"),
-            order: idx,
-          }),
-        );
-
-        setDatasetColumns(datasetColumns);
       } catch (error) {
-        console.error("Error fetching dataset info/types:", error);
+        console.error("Error fetching dataset info:", error);
       }
     };
 
@@ -115,6 +96,7 @@ export default function ScopeStepConverter({
           tool={tool}
           allowedTypes={allowedTypes}
           allowedDtypes={allowedDtypes}
+          columnTypes={columnTypes}
           onSelectionChange={(columnsInfo) => {
             const processedColumns = columnsInfo.map((col) => ({
               idx: col.id + 1,

--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -89,6 +89,10 @@ export default function DatasetTable({
 
   const [columnFilterFns, setColumnFilterFns] = useState(getDefaultFilterFns);
   const [showColumnFilters, setShowColumnFilters] = useState(false);
+  // loadKey starts at 0 so the main loading effect can skip the initial mount
+  // run (before the deps effect has fired). The deps effect increments it to
+  // signal that initialization is done and a fetch should occur.
+  const [loadKey, setLoadKey] = useState(0);
 
   useEffect(() => {
     initialized.current = false;
@@ -122,6 +126,7 @@ export default function DatasetTable({
     );
     setColumnFilterFns(session?.columnFilterFns ?? getDefaultFilterFns());
     setPagination({ pageIndex: 0, pageSize: initialPageSize });
+    setLoadKey((k) => k + 1);
 
     initialized.current = true;
   }, deps);
@@ -205,7 +210,7 @@ export default function DatasetTable({
   // 1st load: only fetch current page (fast, like develop)
   // If filters active and dataset small: lazy-load all data for client-side filtering
   useEffect(() => {
-    if (!initialized.current) return;
+    if (!initialized.current || loadKey === 0) return;
 
     // If we have cached filtered data, use it for pagination
     if (allFilteredDataRef.current) {
@@ -294,11 +299,11 @@ export default function DatasetTable({
       cancelled = true;
     };
   }, [
+    loadKey,
     pagination.pageIndex,
     pagination.pageSize,
     columnFilters,
     sorting,
-    fetchPage,
   ]);
 
   const handleColumnRename = useCallback(

--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -111,8 +111,15 @@ export default function DatasetTable({
         f.value !== undefined &&
         f.value !== "",
     );
-    setColumnFilters(cleanFilters);
-    setSorting(session?.sorting ?? []);
+    const newSorting = session?.sorting ?? [];
+    // Preserve reference identity when values haven't changed so the main
+    // loading effect (which depends on these arrays) does not fire an extra time.
+    setColumnFilters((prev) =>
+      prev.length === 0 && cleanFilters.length === 0 ? prev : cleanFilters,
+    );
+    setSorting((prev) =>
+      prev.length === 0 && newSorting.length === 0 ? prev : newSorting,
+    );
     setColumnFilterFns(session?.columnFilterFns ?? getDefaultFilterFns());
     setPagination({ pageIndex: 0, pageSize: initialPageSize });
 
@@ -286,7 +293,13 @@ export default function DatasetTable({
     return () => {
       cancelled = true;
     };
-  }, [pagination.pageIndex, pagination.pageSize, columnFilters, sorting]);
+  }, [
+    pagination.pageIndex,
+    pagination.pageSize,
+    columnFilters,
+    sorting,
+    fetchPage,
+  ]);
 
   const handleColumnRename = useCallback(
     async (oldName, newName) => {

--- a/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
@@ -23,7 +23,6 @@ export default function DatasetsCenterContent() {
     selectedNotebookId,
     setRightBarContent,
     step,
-    fetchDatasets,
     fetchNotebooks,
     selectedOption,
   } = useDatasetsAndNotebooks();
@@ -111,7 +110,6 @@ export default function DatasetsCenterContent() {
         <DataBreadcrumbs />
         <UploadDatasetSteps
           backHome={() => {
-            fetchDatasets();
             setRightBarContent(null);
             navigate("/app/data");
           }}

--- a/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
@@ -135,7 +135,6 @@ export default function DatasetsCenterContent() {
         <DataBreadcrumbs />
         <UploadNotebookSteps
           backHome={() => {
-            fetchNotebooks();
             navigate("/app/data");
           }}
           datasets={datasets}

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -37,7 +37,6 @@ export default function DatasetPreviewNotebook({
   const {
     datasets,
     createDataset,
-    fetchDatasets,
     selectDataset,
     clearSelectedDataset,
     deleteDataset,
@@ -114,29 +113,9 @@ export default function DatasetPreviewNotebook({
           t("datasets:message.datasetCreationSuccess", { datasetName }),
           { variant: "success" },
         );
-
-        try {
-          const freshDatasets = await fetchDatasets();
-          const dataset = freshDatasets.find((d) => d.id === datasetId);
-
-          if (dataset) {
-            replaceDatasets(freshDatasets);
-            selectDataset(datasetId);
-            setStep(0);
-            setSelectedOption("dataset");
-          } else {
-            await fetchDatasets();
-            selectDataset(datasetId);
-            setStep(0);
-            setSelectedOption("dataset");
-          }
-        } catch (error) {
-          console.error("Error after dataset job completion:", error);
-          await fetchDatasets();
-          selectDataset(datasetId);
-          setStep(0);
-          setSelectedOption("dataset");
-        }
+        selectDataset(datasetId);
+        setStep(0);
+        setSelectedOption("dataset");
       },
 
       //Failure

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -39,10 +39,12 @@ export default function DatasetPreviewNotebook({
     createDataset,
     selectDataset,
     clearSelectedDataset,
+    clearSelectedNotebook,
     deleteDataset,
     replaceDatasets,
     setStep,
     setSelectedOption,
+    setRightBarContent,
   } = useDatasetsAndNotebooks();
 
   const theme = useTheme();
@@ -113,9 +115,11 @@ export default function DatasetPreviewNotebook({
           t("datasets:message.datasetCreationSuccess", { datasetName }),
           { variant: "success" },
         );
+        clearSelectedNotebook();
         selectDataset(datasetId);
         setStep(0);
         setSelectedOption("dataset");
+        setRightBarContent(null);
       },
 
       //Failure
@@ -151,9 +155,11 @@ export default function DatasetPreviewNotebook({
 
       // optimistic
       replaceDatasets((prev) => [...prev, dataset]);
+      clearSelectedNotebook();
       selectDataset(dataset.id);
       setStep(0);
       setSelectedOption("dataset");
+      setRightBarContent(null);
 
       const job = await enqueueDatasetJob(dataset.id, null, "", {}, notebookId);
 

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -46,7 +46,6 @@ export default function DatasetPreviewNotebook({
     selectDataset,
     clearSelectedDataset,
     deleteDataset,
-    enrichDatasetsWithInfo,
     replaceDatasets,
     setStep,
     setSelectedOption,
@@ -156,15 +155,11 @@ export default function DatasetPreviewNotebook({
         );
 
         try {
-          const freshDatasets = await fetchDatasets(true);
+          const freshDatasets = await fetchDatasets();
           const dataset = freshDatasets.find((d) => d.id === datasetId);
 
           if (dataset) {
-            const enriched = await enrichDatasetsWithInfo(
-              freshDatasets,
-              datasets,
-            );
-            replaceDatasets(enriched);
+            replaceDatasets(freshDatasets);
             selectDataset(datasetId);
             setStep(0);
             setSelectedOption("dataset");

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useSnackbar } from "notistack";
 import { startJobPolling } from "../../../utils/jobPoller";
 import { enqueueDatasetJob } from "../../../api/job";
@@ -17,7 +17,6 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import { getConvertersByNotebookId } from "../../../api/notebook";
 import {
   getDatasetFile,
   getDatasetFileFiltered,
@@ -55,9 +54,12 @@ export default function DatasetPreviewNotebook({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [showNotebookHistoryModal, setShowNotebookHistoryModal] =
     useState(false);
-  const [converters, setConverters] = useState([]);
   const [columnTypes, setColumnTypes] = useState({});
   const { explorersAndConverters } = useExplorersAndConverters();
+  const converters = useMemo(
+    () => explorersAndConverters.filter((item) => item.type === "converter"),
+    [explorersAndConverters],
+  );
   const tourContext = useTourContext();
 
   const getDatasetName = () => {
@@ -85,38 +87,6 @@ export default function DatasetPreviewNotebook({
     },
     [notebook, converters],
   );
-
-  useEffect(() => {
-    let intervalId;
-
-    const fetchConverters = async () => {
-      try {
-        const response = await getConvertersByNotebookId(notebook.id);
-        setConverters(response);
-
-        const isPollingNeeded = response.some(
-          (converter) => converter.status < 3,
-        );
-
-        if (isPollingNeeded) {
-          if (!intervalId) {
-            intervalId = setInterval(fetchConverters, 2000);
-          }
-        } else {
-          clearInterval(intervalId);
-        }
-      } catch (error) {
-        console.error("Error fetching converters:", error);
-        clearInterval(intervalId);
-      }
-    };
-
-    fetchConverters();
-
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [notebook, explorersAndConverters]);
 
   useEffect(() => {
     if (!notebook?.file_path) return;
@@ -309,7 +279,7 @@ export default function DatasetPreviewNotebook({
           <Box sx={{ width: "100%" }}>
             <DatasetTable
               fetchPage={fetchDatasetPage}
-              deps={[notebook.file_path, converters, explorersAndConverters]}
+              deps={[notebook.file_path, converters]}
               initialPageSize={5}
               datasetPath={notebook.file_path}
               columnTypes={columnTypes}

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -86,7 +86,7 @@ export default function DatasetPreviewNotebook({
         : await getDatasetFile(notebook.file_path, page, pageSize);
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook.file_path],
+    [notebook?.file_path],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -85,7 +85,7 @@ export default function DatasetPreviewNotebook({
         : await getDatasetFile(notebook.file_path, page, pageSize);
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook, converters],
+    [notebook.file_path, converters],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -79,7 +79,7 @@ export default function DatasetPreviewNotebook({
       const hasFilters =
         filterModel?.items?.length > 0 || (sortModel && sortModel.length > 0);
       const data = await getDatasetFileFiltered(
-        notebook.file_path,
+        notebook?.file_path,
         page,
         pageSize,
         filterModel,
@@ -87,7 +87,7 @@ export default function DatasetPreviewNotebook({
       );
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook.id],
+    [notebook?.id],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -87,7 +87,7 @@ export default function DatasetPreviewNotebook({
       );
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [],
+    [notebook.id],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "notistack";
 import { startJobPolling } from "../../../utils/jobPoller";
 import { enqueueDatasetJob } from "../../../api/job";
@@ -37,15 +38,12 @@ export default function DatasetPreviewNotebook({
   const {
     datasets,
     createDataset,
-    selectDataset,
     clearSelectedDataset,
-    clearSelectedNotebook,
     deleteDataset,
     replaceDatasets,
-    setStep,
-    setSelectedOption,
-    setRightBarContent,
   } = useDatasetsAndNotebooks();
+
+  const navigate = useNavigate();
 
   const theme = useTheme();
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
@@ -115,11 +113,6 @@ export default function DatasetPreviewNotebook({
           t("datasets:message.datasetCreationSuccess", { datasetName }),
           { variant: "success" },
         );
-        clearSelectedNotebook();
-        selectDataset(datasetId);
-        setStep(0);
-        setSelectedOption("dataset");
-        setRightBarContent(null);
       },
 
       //Failure
@@ -153,13 +146,9 @@ export default function DatasetPreviewNotebook({
         variant: "success",
       });
 
-      // optimistic
+      // optimistic add so the dataset view can render before the job finishes
       replaceDatasets((prev) => [...prev, dataset]);
-      clearSelectedNotebook();
-      selectDataset(dataset.id);
-      setStep(0);
-      setSelectedOption("dataset");
-      setRightBarContent(null);
+      navigate(`/app/data/datasets/${dataset.id}`);
 
       const job = await enqueueDatasetJob(dataset.id, null, "", {}, notebookId);
 

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "notistack";
 import { startJobPolling } from "../../../utils/jobPoller";
@@ -18,7 +18,10 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import { getDatasetFileFiltered } from "../../../api/datasets";
+import {
+  getDatasetFileFiltered,
+  getDatasetTypesByFilePath,
+} from "../../../api/datasets";
 import DatasetTable from "../dataset/DatasetTable";
 import { NotebookHistoryModal } from "./NotebookHistoryModal";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
@@ -49,8 +52,12 @@ export default function DatasetPreviewNotebook({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [showNotebookHistoryModal, setShowNotebookHistoryModal] =
     useState(false);
-  const { explorersAndConverters, convertersLoaded, columnTypes } =
-    useExplorersAndConverters();
+  const {
+    explorersAndConverters,
+    convertersLoaded,
+    columnTypes,
+    setColumnTypes,
+  } = useExplorersAndConverters();
   const converters = useMemo(
     () => explorersAndConverters.filter((item) => item.type === "converter"),
     [explorersAndConverters],
@@ -59,6 +66,13 @@ export default function DatasetPreviewNotebook({
     () => converters.map((c) => `${c.id}:${c.status}`).join("|"),
     [converters],
   );
+  useEffect(() => {
+    if (!notebook?.file_path || !convertersLoaded) return;
+    getDatasetTypesByFilePath(notebook.file_path)
+      .then((types) => setColumnTypes(types ?? {}))
+      .catch(console.error);
+  }, [converterKey]);
+
   const tourContext = useTourContext();
 
   const getDatasetName = () => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -18,7 +18,6 @@ import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
 import {
-  getDatasetFile,
   getDatasetFileFiltered,
   getDatasetTypesByFilePath,
 } from "../../../api/datasets";
@@ -55,12 +54,16 @@ export default function DatasetPreviewNotebook({
   const [showNotebookHistoryModal, setShowNotebookHistoryModal] =
     useState(false);
   const [columnTypes, setColumnTypes] = useState({});
-  const { explorersAndConverters } = useExplorersAndConverters();
+  const { explorersAndConverters, convertersLoaded } =
+    useExplorersAndConverters();
   const converters = useMemo(
     () => explorersAndConverters.filter((item) => item.type === "converter"),
     [explorersAndConverters],
   );
-  const converterKey = converters.map((c) => `${c.id}:${c.status}`).join("|");
+  const converterKey = useMemo(
+    () => converters.map((c) => `${c.id}:${c.status}`).join("|"),
+    [converters],
+  );
   const tourContext = useTourContext();
 
   const getDatasetName = () => {
@@ -75,18 +78,16 @@ export default function DatasetPreviewNotebook({
     async (page, pageSize, filterModel, sortModel) => {
       const hasFilters =
         filterModel?.items?.length > 0 || (sortModel && sortModel.length > 0);
-      const data = hasFilters
-        ? await getDatasetFileFiltered(
-            notebook.file_path,
-            page,
-            pageSize,
-            filterModel,
-            sortModel,
-          )
-        : await getDatasetFile(notebook.file_path, page, pageSize);
+      const data = await getDatasetFileFiltered(
+        notebook.file_path,
+        page,
+        pageSize,
+        filterModel,
+        sortModel,
+      );
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook?.file_path],
+    [],
   );
 
   useEffect(() => {
@@ -278,15 +279,17 @@ export default function DatasetPreviewNotebook({
 
         <AccordionDetails>
           <Box sx={{ width: "100%" }}>
-            <DatasetTable
-              fetchPage={fetchDatasetPage}
-              deps={[notebook.file_path, converterKey]}
-              initialPageSize={5}
-              datasetPath={notebook.file_path}
-              columnTypes={columnTypes}
-              enableTopToolbar={false}
-              enableRowsPerPageSelector={false}
-            />
+            {convertersLoaded && (
+              <DatasetTable
+                fetchPage={fetchDatasetPage}
+                deps={[notebook.file_path, converterKey]}
+                initialPageSize={5}
+                datasetPath={notebook.file_path}
+                columnTypes={columnTypes}
+                enableTopToolbar={false}
+                enableRowsPerPageSelector={false}
+              />
+            )}
           </Box>
         </AccordionDetails>
       </Accordion>

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -60,6 +60,7 @@ export default function DatasetPreviewNotebook({
     () => explorersAndConverters.filter((item) => item.type === "converter"),
     [explorersAndConverters],
   );
+  const converterKey = converters.map((c) => `${c.id}:${c.status}`).join("|");
   const tourContext = useTourContext();
 
   const getDatasetName = () => {
@@ -279,7 +280,7 @@ export default function DatasetPreviewNotebook({
           <Box sx={{ width: "100%" }}>
             <DatasetTable
               fetchPage={fetchDatasetPage}
-              deps={[notebook.file_path, converters]}
+              deps={[notebook.file_path, converterKey]}
               initialPageSize={5}
               datasetPath={notebook.file_path}
               columnTypes={columnTypes}

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useSnackbar } from "notistack";
 import { startJobPolling } from "../../../utils/jobPoller";
 import { enqueueDatasetJob } from "../../../api/job";
@@ -17,10 +17,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import {
-  getDatasetFileFiltered,
-  getDatasetTypesByFilePath,
-} from "../../../api/datasets";
+import { getDatasetFileFiltered } from "../../../api/datasets";
 import DatasetTable from "../dataset/DatasetTable";
 import { NotebookHistoryModal } from "./NotebookHistoryModal";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
@@ -53,8 +50,7 @@ export default function DatasetPreviewNotebook({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [showNotebookHistoryModal, setShowNotebookHistoryModal] =
     useState(false);
-  const [columnTypes, setColumnTypes] = useState({});
-  const { explorersAndConverters, convertersLoaded } =
+  const { explorersAndConverters, convertersLoaded, columnTypes } =
     useExplorersAndConverters();
   const converters = useMemo(
     () => explorersAndConverters.filter((item) => item.type === "converter"),
@@ -89,13 +85,6 @@ export default function DatasetPreviewNotebook({
     },
     [notebook?.id],
   );
-
-  useEffect(() => {
-    if (!notebook?.file_path) return;
-    getDatasetTypesByFilePath(notebook.file_path)
-      .then(setColumnTypes)
-      .catch(() => {});
-  }, [notebook?.file_path]);
 
   if (!notebook) {
     return (

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -85,7 +85,7 @@ export default function DatasetPreviewNotebook({
         : await getDatasetFile(notebook.file_path, page, pageSize);
       return { rows: data.rows ?? [], total: data.total ?? 0 };
     },
-    [notebook.file_path, converters],
+    [notebook.file_path],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -18,10 +18,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import {
-  getDatasetFileFiltered,
-  getDatasetTypesByFilePath,
-} from "../../../api/datasets";
+import { getDatasetFileFiltered } from "../../../api/datasets";
 import DatasetTable from "../dataset/DatasetTable";
 import { NotebookHistoryModal } from "./NotebookHistoryModal";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
@@ -55,8 +52,7 @@ export default function DatasetPreviewNotebook({
   const {
     explorersAndConverters,
     convertersLoaded,
-    columnTypes,
-    setColumnTypes,
+    columnTypes: contextColumnTypes,
   } = useExplorersAndConverters();
   const converters = useMemo(
     () => explorersAndConverters.filter((item) => item.type === "converter"),
@@ -66,12 +62,15 @@ export default function DatasetPreviewNotebook({
     () => converters.map((c) => `${c.id}:${c.status}`).join("|"),
     [converters],
   );
+
+  const [localColumnTypes, setLocalColumnTypes] = useState({});
+
+  // Sync types from context — updated by fetchExplorersAndConverters (initial
+  // load + delete path) and by handleStatusChange / FormConverterSection
+  // onSuccess (apply path). No direct HTTP fetch needed here.
   useEffect(() => {
-    if (!notebook?.file_path || !convertersLoaded) return;
-    getDatasetTypesByFilePath(notebook.file_path)
-      .then((types) => setColumnTypes(types ?? {}))
-      .catch(console.error);
-  }, [converterKey]);
+    setLocalColumnTypes(contextColumnTypes);
+  }, [contextColumnTypes]);
 
   const tourContext = useTourContext();
 
@@ -262,7 +261,7 @@ export default function DatasetPreviewNotebook({
                 deps={[notebook.file_path, converterKey]}
                 initialPageSize={5}
                 datasetPath={notebook.file_path}
-                columnTypes={columnTypes}
+                columnTypes={localColumnTypes}
                 enableTopToolbar={false}
                 enableRowsPerPageSelector={false}
               />

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -67,8 +67,11 @@ export default function NotebookView({ notebook }) {
     }
   }, [tourContext]);
 
-  const { explorersAndConverters, setExplorersAndConverters } =
-    useExplorersAndConverters();
+  const {
+    explorersAndConverters,
+    setExplorersAndConverters,
+    setConvertersLoaded,
+  } = useExplorersAndConverters();
   const [openDeleteExplorerConfirmation, setOpenDeleteExplorerConfirmation] =
     useState(false);
   const [openDeleteConverterConfirmation, setOpenDeleteConverterConfirmation] =
@@ -82,6 +85,7 @@ export default function NotebookView({ notebook }) {
 
   const fetchExplorersAndConverters = useCallback(async () => {
     if (!notebook?.id) return;
+    setConvertersLoaded(false);
     try {
       const [explorersData, convertersData] = await Promise.all([
         getExplorersByNotebookId(notebook.id),
@@ -101,8 +105,10 @@ export default function NotebookView({ notebook }) {
       setExplorersAndConverters(merged);
     } catch (error) {
       console.error("Failed to fetch explorers and converters:", error);
+    } finally {
+      setConvertersLoaded(true);
     }
-  }, [notebook?.id, setExplorersAndConverters]);
+  }, [notebook?.id, setExplorersAndConverters, setConvertersLoaded]);
 
   const getItemsToDelete = useCallback(
     (converterToDelete) => {

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -214,15 +214,23 @@ export default function NotebookView({ notebook }) {
     setItemsToDelete([]);
   }, []);
 
-  const handleStatusChange = useCallback((id, newStatus, type) => {
-    setExplorersAndConverters((prev) =>
-      prev.map((item) =>
-        item.id === id && item.type === type
-          ? { ...item, status: newStatus }
-          : item,
-      ),
-    );
-  });
+  const handleStatusChange = useCallback(
+    (id, newStatus, type) => {
+      setExplorersAndConverters((prev) =>
+        prev.map((item) =>
+          item.id === id && item.type === type
+            ? { ...item, status: newStatus }
+            : item,
+        ),
+      );
+      if (newStatus === 3 && type === "converter" && notebook?.file_path) {
+        getDatasetTypesByFilePath(notebook.file_path)
+          .then((types) => setColumnTypes(types ?? {}))
+          .catch(console.error);
+      }
+    },
+    [notebook?.file_path, setColumnTypes, setExplorersAndConverters],
+  );
 
   const scrollToBottom = () => {
     if (!listBoxRef.current || explorersAndConverters.length === 0) return;

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -6,6 +6,7 @@ import {
   getExplorersByNotebookId,
   getConvertersByNotebookId,
 } from "../../../api/notebook";
+import { getDatasetTypesByFilePath } from "../../../api/datasets";
 import ExplorerBox from "../explorer/ExplorerBox";
 import ConverterBox from "../converter/ConverterBox";
 import DeleteConfirmationModal from "../../threeSectionLayout/DeleteConfirmationModal";
@@ -71,6 +72,7 @@ export default function NotebookView({ notebook }) {
     explorersAndConverters,
     setExplorersAndConverters,
     setConvertersLoaded,
+    setColumnTypes,
   } = useExplorersAndConverters();
   const [openDeleteExplorerConfirmation, setOpenDeleteExplorerConfirmation] =
     useState(false);
@@ -87,9 +89,10 @@ export default function NotebookView({ notebook }) {
     if (!notebook?.id) return;
     setConvertersLoaded(false);
     try {
-      const [explorersData, convertersData] = await Promise.all([
+      const [explorersData, convertersData, types] = await Promise.all([
         getExplorersByNotebookId(notebook.id),
         getConvertersByNotebookId(notebook.id),
+        getDatasetTypesByFilePath(notebook.file_path),
       ]);
       const explorersWithType = explorersData.map((item) => ({
         ...item,
@@ -103,12 +106,18 @@ export default function NotebookView({ notebook }) {
         (a, b) => new Date(a.created) - new Date(b.created),
       );
       setExplorersAndConverters(merged);
+      setColumnTypes(types ?? {});
     } catch (error) {
       console.error("Failed to fetch explorers and converters:", error);
     } finally {
       setConvertersLoaded(true);
     }
-  }, [notebook?.id, setExplorersAndConverters, setConvertersLoaded]);
+  }, [
+    notebook?.id,
+    setExplorersAndConverters,
+    setConvertersLoaded,
+    setColumnTypes,
+  ]);
 
   const getItemsToDelete = useCallback(
     (converterToDelete) => {

--- a/DashAI/front/src/components/notebooks/notebookCreation/DatasetAutocomplete.jsx
+++ b/DashAI/front/src/components/notebooks/notebookCreation/DatasetAutocomplete.jsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Box, Typography, Autocomplete, TextField, Chip } from "@mui/material";
 import { formatDate } from "../../../pages/results/constants/formatDate";
-import { getDatasetInfo } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
 
 export default function DatasetAutocomplete({
@@ -9,63 +8,7 @@ export default function DatasetAutocomplete({
   selectedDataset,
   setSelectedDataset,
 }) {
-  const [datasetInfo, setDatasetInfo] = useState(null);
-  const [loadingInfo, setLoadingInfo] = useState(false);
-  const [infoError, setInfoError] = useState(null);
-  const [infosById, setInfosById] = useState({});
   const { t } = useTranslation(["datasets", "common"]);
-
-  // Fetch info for selected dataset (detail panel)
-  useEffect(() => {
-    let cancelled = false;
-    const fetchInfo = async () => {
-      if (!selectedDataset?.id) {
-        setDatasetInfo(null);
-        setInfoError(null);
-        return;
-      }
-      try {
-        setLoadingInfo(true);
-        setInfoError(null);
-        const info = await getDatasetInfo(selectedDataset.id);
-        if (!cancelled) setDatasetInfo(info);
-      } catch (e) {
-        console.error("Failed to fetch dataset info:", e);
-        if (!cancelled)
-          setInfoError(t("datasets:error.failedToLoadDatasetInfo"));
-      } finally {
-        if (!cancelled) setLoadingInfo(false);
-      }
-    };
-    fetchInfo();
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedDataset?.id]);
-
-  const fetchMissingInfos = async (items) => {
-    const missing = items.filter((d) => d?.id != null && !infosById[d.id]);
-    if (missing.length === 0) return;
-    try {
-      const results = await Promise.allSettled(
-        missing.map((d) => getDatasetInfo(d.id)),
-      );
-      const map = {};
-      results.forEach((res, idx) => {
-        const id = missing[idx]?.id;
-        if (res.status === "fulfilled" && id != null) {
-          map[id] = res.value;
-        }
-      });
-      setInfosById((prev) => ({ ...prev, ...map }));
-    } catch (e) {
-      console.warn("Some dataset infos could not be fetched", e);
-    }
-  };
-
-  useEffect(() => {
-    if (!datasets || datasets.length === 0) return;
-  }, [datasets]);
 
   return (
     <Box width="100%">
@@ -76,7 +19,6 @@ export default function DatasetAutocomplete({
           getOptionLabel={(option) => option.name}
           isOptionEqualToValue={(opt, val) => opt.id === val.id}
           value={selectedDataset}
-          onOpen={() => fetchMissingInfos(datasets)}
           onChange={(event, newValue) => {
             setSelectedDataset(newValue);
           }}
@@ -90,7 +32,6 @@ export default function DatasetAutocomplete({
           )}
           renderOption={(props, option) => {
             const { key, ...rootProps } = props;
-            const info = infosById[option.id];
             return (
               <Box component="li" key={key} {...rootProps}>
                 <Box
@@ -109,8 +50,8 @@ export default function DatasetAutocomplete({
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
                     {t("datasets:label.rowsColumnsInfo", {
-                      totalRows: info ? info.total_rows : "...",
-                      totalColumns: info ? info.total_columns : "...",
+                      totalRows: option.total_rows ?? "...",
+                      totalColumns: option.total_columns ?? "...",
                     })}
                   </Typography>
                 </Box>
@@ -148,19 +89,10 @@ export default function DatasetAutocomplete({
               {/* Single line for Rows | Columns */}
               <Typography variant="body2" fontWeight="medium">
                 {t("datasets:label.rowsColumnsInfo", {
-                  totalRows: datasetInfo
-                    ? datasetInfo.total_rows
-                    : t("common:loading"),
-                  totalColumns: datasetInfo
-                    ? datasetInfo.total_columns
-                    : t("common:loading"),
+                  totalRows: selectedDataset.total_rows ?? "...",
+                  totalColumns: selectedDataset.total_columns ?? "...",
                 })}
               </Typography>
-              {infoError && (
-                <Typography variant="caption" color="error">
-                  {infoError}
-                </Typography>
-              )}
             </Box>
           </Box>
         )}

--- a/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ConfigureToolModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import {
   Box,
   Typography,
@@ -15,13 +15,10 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 import DatasetTable from "../dataset/DatasetTable";
 import api from "../../../api/api";
-import {
-  getDatasetFile,
-  getDatasetFileFiltered,
-  getDatasetTypesByFilePath,
-} from "../../../api/datasets";
+import { getDatasetFile, getDatasetFileFiltered } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
 import StepperNavigationFooter from "../../shared/StepperNavigationFooter";
+import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
 
 export default function ConfigureToolModal({
   tool,
@@ -33,15 +30,8 @@ export default function ConfigureToolModal({
   const theme = useTheme();
   const { t } = useTranslation(["datasets", "common"]);
   const [step, setStep] = useState(0);
-  const [columnTypes, setColumnTypes] = useState({});
   const [imageOpen, setImageOpen] = useState(false);
-
-  useEffect(() => {
-    if (!notebook?.file_path) return;
-    getDatasetTypesByFilePath(notebook.file_path)
-      .then(setColumnTypes)
-      .catch(() => {});
-  }, [notebook?.file_path]);
+  const { columnTypes } = useExplorersAndConverters();
 
   const fetchDatasetPage = useCallback(
     async (page, pageSize, filterModel, sortModel) => {
@@ -229,7 +219,7 @@ export default function ConfigureToolModal({
               }}
             >
               <img
-                src={`${api.defaults.baseURL}/v1/component/image/${tool.name}`}
+                src={`${api.defaults.baseURL}/v1/component/image/${tool.name}/`}
                 alt={tool.display_name}
                 style={{
                   width: "100%",
@@ -273,7 +263,7 @@ export default function ConfigureToolModal({
                   <Close />
                 </IconButton>
                 <img
-                  src={`${api.defaults.baseURL}/v1/component/image/${tool.name}`}
+                  src={`${api.defaults.baseURL}/v1/component/image/${tool.name}/`}
                   alt={tool.display_name}
                   style={{
                     maxWidth: "90vw",

--- a/DashAI/front/src/components/notebooks/tool/HoverToolInfo.jsx
+++ b/DashAI/front/src/components/notebooks/tool/HoverToolInfo.jsx
@@ -54,7 +54,7 @@ export default function HoverToolInfo({
             }}
           >
             <img
-              src={`${api.defaults.baseURL}/v1/component/image/${hoveredTool.name}`}
+              src={`${api.defaults.baseURL}/v1/component/image/${hoveredTool.name}/`}
               alt={hoveredTool.display_name}
               style={{ width: "100%", height: "100%", objectFit: "cover" }}
             />

--- a/DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx
@@ -104,7 +104,7 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
             }}
           >
             <img
-              src={`${api.defaults.baseURL}/v1/component/image/${tool.name}`}
+              src={`${api.defaults.baseURL}/v1/component/image/${tool.name}/`}
               alt={tool.display_name}
               style={{
                 width: "100%",

--- a/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
@@ -208,7 +208,7 @@ export default function ToolListItem({
             }}
           >
             <img
-              src={`${api.defaults.baseURL}/v1/component/image/${tool.name}`}
+              src={`${api.defaults.baseURL}/v1/component/image/${tool.name}/`}
               alt={tool.display_name}
               style={{
                 width: "100%",

--- a/DashAI/front/src/hooks/datasets/useDatasets.js
+++ b/DashAI/front/src/hooks/datasets/useDatasets.js
@@ -1,9 +1,8 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useSnackbar } from "notistack";
 import {
   getDatasets,
   deleteDataset,
-  getDatasetInfo,
   updateDataset,
   createDataset,
 } from "../../api/datasets";
@@ -13,51 +12,17 @@ export function useDatasets({ t }) {
   const { enqueueSnackbar } = useSnackbar();
   const [datasets, setDatasets] = useState([]);
   const [selectedDatasetId, setSelectedDatasetId] = useState(null);
-  const datasetsRef = useRef(datasets);
-
-  useEffect(() => {
-    datasetsRef.current = datasets;
-  }, [datasets]);
 
   useEffect(() => {
     fetchDatasets();
   }, []);
 
-  // ---------------- helpers ----------------
-
-  const enrichDatasetsWithInfo = useCallback(
-    async (newDatasets, existingDatasets = []) => {
-      return Promise.all(
-        newDatasets.map(async (dataset) => {
-          const existing = existingDatasets.find((d) => d.id === dataset.id);
-
-          if (existing?.total_rows !== undefined) return existing;
-
-          if (dataset.status !== 3) return dataset;
-
-          try {
-            const info = await getDatasetInfo(dataset.id);
-            return {
-              ...dataset,
-              total_rows: info.total_rows,
-              total_columns: info.total_columns,
-            };
-          } catch (error) {
-            return dataset;
-          }
-        }),
-      );
-    },
-    [],
-  );
-
   // ---------------- actions ----------------
 
   const fetchDatasets = useCallback(async () => {
     const data = await getDatasets();
-    const enriched = await enrichDatasetsWithInfo(data, datasetsRef.current);
-    setDatasets(enriched);
-  }, [enrichDatasetsWithInfo]);
+    setDatasets(data);
+  }, []);
 
   useEffect(() => {
     const unsubscribe = subscribeJobs((jobs) => {
@@ -159,7 +124,6 @@ export function useDatasets({ t }) {
   return {
     datasets,
     selectedDatasetId,
-    enrichDatasetsWithInfo,
     createDataset,
     fetchDatasets,
     selectDataset,

--- a/DashAI/front/src/hooks/datasets/useDatasets.js
+++ b/DashAI/front/src/hooks/datasets/useDatasets.js
@@ -27,10 +27,13 @@ export function useDatasets({ t }) {
 
   useEffect(() => {
     const unsubscribe = subscribeJobs((jobs) => {
-      const datasetJobs = Array.isArray(jobs)
-        ? jobs.filter((job) => job.task_type === "DatasetJob")
+      const finishedDatasetJobs = Array.isArray(jobs)
+        ? jobs.filter(
+            (job) =>
+              job.task_type === "DatasetJob" && job.status === "finished",
+          )
         : [];
-      if (datasetJobs.length > 0) {
+      if (finishedDatasetJobs.length > 0) {
         fetchDatasets();
       }
     });

--- a/DashAI/front/src/hooks/datasets/useDatasets.js
+++ b/DashAI/front/src/hooks/datasets/useDatasets.js
@@ -22,6 +22,7 @@ export function useDatasets({ t }) {
   const fetchDatasets = useCallback(async () => {
     const data = await getDatasets();
     setDatasets(data);
+    return data;
   }, []);
 
   useEffect(() => {

--- a/DashAI/front/src/hooks/datasets/useDatasets.js
+++ b/DashAI/front/src/hooks/datasets/useDatasets.js
@@ -102,8 +102,6 @@ export function useDatasets({ t }) {
     startJobPolling(
       datasetJob.id,
       async () => {
-        await fetchDatasets();
-
         enqueueSnackbar(
           t("datasets:message.datasetCreationSuccess", {
             datasetName: newDataset.name,

--- a/DashAI/front/src/types/dataset.ts
+++ b/DashAI/front/src/types/dataset.ts
@@ -5,6 +5,8 @@ export interface IDataset {
   created: Date;
   last_modified: Date;
   file_path: string;
+  total_rows?: number | null;
+  total_columns?: number | null;
 }
 
 export interface DatasetPage {

--- a/tests/back/api/test_dataset_api.py
+++ b/tests/back/api/test_dataset_api.py
@@ -197,6 +197,26 @@ def test_update_column_encoder_dataset_not_started(
     assert response.status_code == 422, response.text
 
 
+def test_backfill_populates_null_counts(client: TestClient, dataset_1: Dataset) -> None:
+    container = client.app.container
+    session_factory = container["session_factory"]
+
+    with session_factory() as db:
+        ds = db.get(Dataset, dataset_1.id)
+        ds.total_rows = None
+        ds.total_columns = None
+        db.commit()
+
+    from DashAI.back.dependencies.database.backfill import backfill_dataset_counts
+
+    backfill_dataset_counts(session_factory)
+
+    with session_factory() as db:
+        ds = db.get(Dataset, dataset_1.id)
+        assert ds.total_rows == 150
+        assert ds.total_columns == 5
+
+
 def test_delete_dataset(client: TestClient, dataset_1: Dataset) -> None:
     response = client.delete(f"/api/v1/dataset/{dataset_1.id}")
     assert response.status_code == 204, response.text

--- a/tests/back/api/test_dataset_api.py
+++ b/tests/back/api/test_dataset_api.py
@@ -56,6 +56,14 @@ def test_get_all_datasets(client: TestClient, dataset_1: Dataset) -> None:
     assert "test_csv_1" in dataset_names
 
 
+def test_dataset_has_row_column_fields(client: TestClient, dataset_1: Dataset) -> None:
+    response = client.get(f"/api/v1/dataset/{dataset_1.id}")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert "total_rows" in data
+    assert "total_columns" in data
+
+
 def test_get_dataset(client: TestClient, dataset_1: Dataset) -> None:
     response = client.get(f"/api/v1/dataset/{dataset_1.id}")
     assert response.status_code == 200, response.text

--- a/tests/back/api/test_dataset_api.py
+++ b/tests/back/api/test_dataset_api.py
@@ -64,6 +64,14 @@ def test_dataset_has_row_column_fields(client: TestClient, dataset_1: Dataset) -
     assert "total_columns" in data
 
 
+def test_dataset_job_writes_counts(client: TestClient, dataset_1: Dataset) -> None:
+    response = client.get(f"/api/v1/dataset/{dataset_1.id}")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["total_rows"] == 150
+    assert data["total_columns"] == 5
+
+
 def test_get_dataset(client: TestClient, dataset_1: Dataset) -> None:
     response = client.get(f"/api/v1/dataset/{dataset_1.id}")
     assert response.status_code == 200, response.text


### PR DESCRIPTION
## Summary
This pull request improves Arrow file handling in dataset API endpoints by replacing `pa.memory_map` with `pa.OSFile`, fixing converter updates not being reflected in the frontend, and adding cache invalidation based on Arrow file modification times to avoid serving stale data.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/api/datasets.py`:
  - Replaced `pa.memory_map` with `pa.OSFile` in:
    - `_load_and_filter_table`
    - `get_dataset_file`
    - `export_dataset_as_csv`
    - `export_dataset_csv_by_id`
  - Added cache invalidation logic that checks the modification time of `data.arrow` files and refreshes cached entries if the file has changed.
  - Fixed dataset reload behavior so converters are correctly applied and reflected in frontend responses.
  - Imported the `os` module to support file modification time checks.

---

## Testing (optional)
- Verify dataset export endpoints still correctly return CSV and Arrow-backed data.
- Verify dataset cache entries are invalidated after modifying a `data.arrow` file.
- Verify converters are correctly applied after dataset updates and visible in the frontend.
- Verify dataset loading and filtering still behave correctly for large Arrow files.