### PR TITLE
Fix/generative session modal and ordering

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/generative_session.py
+++ b/DashAI/back/api/api_v1/endpoints/generative_session.py
@@ -190,7 +190,7 @@ async def get_all_generative_sessions(
         try:
             sessions = (
                 db.query(GenerativeSession)
-                .order_by(GenerativeSession.created.desc())
+                .order_by(GenerativeSession.created.asc())
                 .all()
             )
         except exc.SQLAlchemyError as e:

--- a/DashAI/front/src/components/generative/SessionHistoryModal.jsx
+++ b/DashAI/front/src/components/generative/SessionHistoryModal.jsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
+  Modal,
   IconButton,
   Typography,
   Accordion,
@@ -12,27 +10,10 @@ import {
   Card,
   CardContent,
   Box,
-  styled,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useTranslation } from "react-i18next";
-
-// Styled component for the scrollable area
-const ScrollableContent = styled(DialogContent)(({ theme }) => ({
-  maxHeight: "calc(80vh - 120px)",
-  overflowY: "auto",
-  "&::-webkit-scrollbar": {
-    width: "8px",
-  },
-  "&::-webkit-scrollbar-track": {
-    background: theme.palette.background.paper,
-  },
-  "&::-webkit-scrollbar-thumb": {
-    backgroundColor: theme.palette.divider,
-    borderRadius: "4px",
-  },
-}));
 
 export default function SessionHistoryModal({
   historyChanges,
@@ -43,7 +24,6 @@ export default function SessionHistoryModal({
   const [expanded, setExpanded] = useState(false);
   const { t } = useTranslation(["generative", "common"]);
 
-  const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
   const handleChange = (panel) => (event, isExpanded) => {
@@ -51,58 +31,74 @@ export default function SessionHistoryModal({
   };
 
   return (
-    <>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        fullWidth
-        slotProps={{
-          paper: {
-            sx: {
-              bgcolor: "background.paper",
-              color: "text.primary",
-              maxHeight: "80vh",
-              maxWidth: 600,
-            },
-          },
+    <Modal open={open} onClose={handleClose}>
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: { xs: "90%", sm: 600 },
+          maxHeight: "80vh",
+          bgcolor: "background.paper",
+          borderRadius: 2,
+          boxShadow: 12,
+          p: 0,
+          outline: "none",
+          display: "flex",
+          flexDirection: "column",
         }}
       >
-        <DialogTitle>
-          <Box
-            display="flex"
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            <Box display="flex" alignItems="center" gap={1}>
-              <Typography variant="h6">Change History</Typography>
-              <Chip
-                label={taskName}
-                variant="outlined"
-                size="small"
-                sx={{ ml: 1 }}
-              />
-            </Box>
-            <IconButton onClick={handleClose} size="small">
-              <CloseIcon />
-            </IconButton>
+        {/* Header */}
+        <Box
+          sx={{
+            p: 2,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            borderBottom: "1px solid rgba(255, 255, 255, 0.1)",
+          }}
+        >
+          <Box display="flex" alignItems="center" gap={1}>
+            <Typography variant="h6">Change History</Typography>
+            <Chip
+              label={taskName}
+              variant="outlined"
+              size="small"
+              sx={{ ml: 1 }}
+            />
           </Box>
-          <Typography variant="body2" color="text.secondary" mt={1}>
+          <IconButton
+            onClick={handleClose}
+            size="small"
+            sx={{ color: "text.secondary" }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        {/* Content */}
+        <Box
+          sx={{
+            p: 3,
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            overflowY: "auto",
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
             {t("generative:label.parameterChangeHistory")}
           </Typography>
-        </DialogTitle>
 
-        <ScrollableContent dividers>
           {historyChanges?.map((event) => (
             <Accordion
               key={event.id}
               expanded={expanded === event.id}
               onChange={handleChange(event.id)}
               sx={{
-                mb: 1,
                 bgcolor: "background.paper",
-                "&:before": {
-                  display: "none",
-                },
+                "&:before": { display: "none" },
               }}
             >
               <AccordionSummary
@@ -209,8 +205,8 @@ export default function SessionHistoryModal({
               </AccordionDetails>
             </Accordion>
           ))}
-        </ScrollableContent>
-      </Dialog>
-    </>
+        </Box>
+      </Box>
+    </Modal>
   );
 }


### PR DESCRIPTION
## Summary

  Two fixes to the generative sessions module: the session list in the sidebar was displayed in reverse order (newest first) compared to every other module, caused by an explicit `.desc()` ordering in the backend query. Additionally, `SessionHistoryModal` was updated to use the new `Modal`-based layout consistent with the rest of the app's updated interface.

  ---

  ## Type of Change

  - [x] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/back/api/api_v1/endpoints/generative_session.py`: Changed `ORDER BY created DESC` to `ORDER BY created ASC` in `get_all_generative_sessions` so sessions are returned oldest-first, consistent with the model sessions and other modules.
  - `DashAI/front/src/components/generative/SessionHistoryModal.jsx`: Replaced `Dialog` / `DialogTitle` / `DialogContent` with a `Modal` + custom `Box` layout matching the style pattern introduced in `SaveDatasetModal`. Removed unused `handleOpen` function and the `styled` wrapper component.

  ---

  ## Testing

  - Open the generative module and verify sessions appear from oldest to newest in the left
  sidebar.
  - Open the parameter change history modal and confirm it renders correctly with the new layout.

  ---

  ## Notes

  The ordering inconsistency existed because `get_all_generative_sessions` was the only session
  endpoint with an explicit sort order, and it was set to descending. All other modules rely on
  default database insertion order (ascending). The fix aligns the behavior without changing any
  other endpoint.