### PR TITLE
Fix stale dataset cache and converter updates for Arrow-backed datasets

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/converters.py
+++ b/DashAI/back/api/api_v1/endpoints/converters.py
@@ -229,6 +229,16 @@ async def delete_converter(
                 notebook.file_path,
                 dirs_exist_ok=True,
             )
+            # copytree preserves the source mtime, which may predate the API
+            # cache entry. Touch data.arrow so the cache invalidation detects
+            # the change even when no previous converters are re-run.
+            import os
+            import time
+
+            arrow_path = os.path.join(notebook.file_path, "dataset", "data.arrow")
+            if os.path.exists(arrow_path):
+                now = time.time()
+                os.utime(arrow_path, (now, now))
 
             # Enqueue all previous converters
             job_ids = []

--- a/DashAI/back/api/api_v1/endpoints/converters.py
+++ b/DashAI/back/api/api_v1/endpoints/converters.py
@@ -243,11 +243,9 @@ async def delete_converter(
             # Enqueue all previous converters
             job_ids = []
             for converter in previous_converters:
-                # Crear instancia de ConverterJob y encolarlo directamente
                 job = ConverterJob(converter_id=converter.id)
-                job_queue.put(job)
-                if hasattr(job, "id"):
-                    job_ids.append(job.id)
+                enqueued = job_queue.put(job)
+                job_ids.append(enqueued.id)
 
             # Delete all the converters after the current one
             for converter in next_converters:

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import os
 import time
 import zipfile
 from collections import OrderedDict
@@ -62,6 +63,13 @@ class _FilteredTableCache:
         if time.time() - ts > self._ttl:
             del self._store[key]
             return None
+        arrow_file_path = f"{path}/dataset/data.arrow"
+        try:
+            if os.path.getmtime(arrow_file_path) > ts:
+                del self._store[key]
+                return None
+        except OSError:
+            pass
         self._store.move_to_end(key)
         return table, total
 
@@ -106,7 +114,7 @@ def _load_and_filter_table(
     from DashAI.back.dataloaders.classes.dashai_dataset import get_dataset_info
 
     arrow_file_path = f"{path}/dataset/data.arrow"
-    with pa.memory_map(arrow_file_path, "r") as source:
+    with pa.OSFile(arrow_file_path, "rb") as source:
         reader = ipc.RecordBatchFileReader(source)
         batches = [reader.get_batch(i) for i in range(reader.num_record_batches)]
         table = pa.Table.from_batches(batches)
@@ -1360,7 +1368,7 @@ async def get_dataset_file(
     end = start + page_size
     rows_collected = 0
 
-    with pa.memory_map(arrow_file_path, "r") as source:
+    with pa.OSFile(arrow_file_path, "rb") as source:
         reader = ipc.RecordBatchFileReader(source)
 
         current_index = 0
@@ -1430,7 +1438,7 @@ async def export_dataset_as_csv(
             )
 
         # Read the complete Arrow file
-        with pa.memory_map(arrow_file_path, "r") as source:
+        with pa.OSFile(arrow_file_path, "rb") as source:
             import io
 
             reader = ipc.RecordBatchFileReader(source)
@@ -1532,7 +1540,7 @@ async def export_dataset_csv_by_id(
                 )
 
             # Read the complete Arrow file
-            with pa.memory_map(arrow_file_path, "r") as source:
+            with pa.OSFile(arrow_file_path, "rb") as source:
                 import io
 
                 reader = ipc.RecordBatchFileReader(source)

--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -7,6 +7,7 @@ import ParameterStepConverter from "./ParameterStepConverter";
 import ScopeStepConverter from "./ScopeStepConverter";
 import { startJobPolling } from "../../../utils/jobPoller";
 import { enqueueConverterJob } from "../../../api/job";
+import { getDatasetTypesByFilePath } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
 
 export default function FormConverterSection({
@@ -20,7 +21,7 @@ export default function FormConverterSection({
   const [targetColumn, setTargetColumn] = useState(null);
   const [rows, setRows] = useState([]);
   const [columns, setColumns] = useState([]);
-  const { explorersAndConverters, setExplorersAndConverters } =
+  const { explorersAndConverters, setExplorersAndConverters, setColumnTypes } =
     useExplorersAndConverters();
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation(["common", "datasets"]);
@@ -74,6 +75,12 @@ export default function FormConverterSection({
                         : item,
                     ),
                   );
+
+                  if (notebook?.file_path) {
+                    getDatasetTypesByFilePath(notebook.file_path)
+                      .then((types) => setColumnTypes(types ?? {}))
+                      .catch(console.error);
+                  }
                 },
 
                 (result) => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "notistack";
 import { startJobPolling } from "../../../utils/jobPoller";
@@ -18,7 +18,10 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import { getDatasetFileFiltered } from "../../../api/datasets";
+import {
+  getDatasetFileFiltered,
+  getDatasetTypesByFilePath,
+} from "../../../api/datasets";
 import DatasetTable from "../dataset/DatasetTable";
 import { NotebookHistoryModal } from "./NotebookHistoryModal";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
@@ -49,8 +52,12 @@ export default function DatasetPreviewNotebook({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [showNotebookHistoryModal, setShowNotebookHistoryModal] =
     useState(false);
-  const { explorersAndConverters, convertersLoaded, columnTypes } =
-    useExplorersAndConverters();
+  const {
+    explorersAndConverters,
+    convertersLoaded,
+    columnTypes,
+    setColumnTypes,
+  } = useExplorersAndConverters();
   const converters = useMemo(
     () => explorersAndConverters.filter((item) => item.type === "converter"),
     [explorersAndConverters],
@@ -59,6 +66,13 @@ export default function DatasetPreviewNotebook({
     () => converters.map((c) => `${c.id}:${c.status}`).join("|"),
     [converters],
   );
+  useEffect(() => {
+    if (!notebook?.file_path || !convertersLoaded) return;
+    getDatasetTypesByFilePath(notebook.file_path)
+      .then((types) => setColumnTypes(types ?? {}))
+      .catch(console.error);
+  }, [converterKey]);
+
   const tourContext = useTourContext();
 
   const getDatasetName = () => {

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -18,10 +18,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import {
-  getDatasetFileFiltered,
-  getDatasetTypesByFilePath,
-} from "../../../api/datasets";
+import { getDatasetFileFiltered } from "../../../api/datasets";
 import DatasetTable from "../dataset/DatasetTable";
 import { NotebookHistoryModal } from "./NotebookHistoryModal";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
@@ -55,8 +52,7 @@ export default function DatasetPreviewNotebook({
   const {
     explorersAndConverters,
     convertersLoaded,
-    columnTypes,
-    setColumnTypes,
+    columnTypes: contextColumnTypes,
   } = useExplorersAndConverters();
   const converters = useMemo(
     () => explorersAndConverters.filter((item) => item.type === "converter"),
@@ -66,12 +62,15 @@ export default function DatasetPreviewNotebook({
     () => converters.map((c) => `${c.id}:${c.status}`).join("|"),
     [converters],
   );
+
+  const [localColumnTypes, setLocalColumnTypes] = useState({});
+
+  // Sync types from context — updated by fetchExplorersAndConverters (initial
+  // load + delete path) and by handleStatusChange / FormConverterSection
+  // onSuccess (apply path). No direct HTTP fetch needed here.
   useEffect(() => {
-    if (!notebook?.file_path || !convertersLoaded) return;
-    getDatasetTypesByFilePath(notebook.file_path)
-      .then((types) => setColumnTypes(types ?? {}))
-      .catch(console.error);
-  }, [converterKey]);
+    setLocalColumnTypes(contextColumnTypes);
+  }, [contextColumnTypes]);
 
   const tourContext = useTourContext();
 
@@ -262,7 +261,7 @@ export default function DatasetPreviewNotebook({
                 deps={[notebook.file_path, converterKey]}
                 initialPageSize={5}
                 datasetPath={notebook.file_path}
-                columnTypes={columnTypes}
+                columnTypes={localColumnTypes}
                 enableTopToolbar={false}
                 enableRowsPerPageSelector={false}
               />

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -214,15 +214,23 @@ export default function NotebookView({ notebook }) {
     setItemsToDelete([]);
   }, []);
 
-  const handleStatusChange = useCallback((id, newStatus, type) => {
-    setExplorersAndConverters((prev) =>
-      prev.map((item) =>
-        item.id === id && item.type === type
-          ? { ...item, status: newStatus }
-          : item,
-      ),
-    );
-  });
+  const handleStatusChange = useCallback(
+    (id, newStatus, type) => {
+      setExplorersAndConverters((prev) =>
+        prev.map((item) =>
+          item.id === id && item.type === type
+            ? { ...item, status: newStatus }
+            : item,
+        ),
+      );
+      if (newStatus === 3 && type === "converter" && notebook?.file_path) {
+        getDatasetTypesByFilePath(notebook.file_path)
+          .then((types) => setColumnTypes(types ?? {}))
+          .catch(console.error);
+      }
+    },
+    [notebook?.file_path, setColumnTypes, setExplorersAndConverters],
+  );
 
   const scrollToBottom = () => {
     if (!listBoxRef.current || explorersAndConverters.length === 0) return;


### PR DESCRIPTION
## Summary
This pull request improves Arrow file handling in dataset API endpoints by replacing `pa.memory_map` with `pa.OSFile`, fixing converter updates not being reflected in the frontend, and adding cache invalidation based on Arrow file modification times to avoid serving stale data.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/api/datasets.py`:
  - Replaced `pa.memory_map` with `pa.OSFile` in:
    - `_load_and_filter_table`
    - `get_dataset_file`
    - `export_dataset_as_csv`
    - `export_dataset_csv_by_id`
  - Added cache invalidation logic that checks the modification time of `data.arrow` files and refreshes cached entries if the file has changed.
  - Fixed dataset reload behavior so converters are correctly applied and reflected in frontend responses.
  - Imported the `os` module to support file modification time checks.

---

## Testing (optional)
- Verify dataset export endpoints still correctly return CSV and Arrow-backed data.
- Verify dataset cache entries are invalidated after modifying a `data.arrow` file.
- Verify converters are correctly applied after dataset updates and visible in the frontend.
- Verify dataset loading and filtering still behave correctly for large Arrow files.