### PR TITLE
Fix/light mode white colors and confirmation modal styles

### DIFF
--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -364,7 +364,7 @@ function ColumnSelector({
           <Typography
             variant="body2"
             sx={{
-              color: "rgba(255, 255, 255, 0.5)",
+              color: "text.secondary",
               fontStyle: "italic",
               mt: 1,
             }}

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -251,7 +251,7 @@ export default function DatasetPreviewNotebook({
         }}
       >
         <AccordionSummary
-          expandIcon={<ExpandMoreIcon sx={{ color: "white" }} />}
+          expandIcon={<ExpandMoreIcon sx={{ color: "text.secondary" }} />}
           sx={{
             display: "flex",
             alignItems: "center",

--- a/DashAI/front/src/components/threeSectionLayout/DeleteConfirmationModal.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/DeleteConfirmationModal.jsx
@@ -1,14 +1,12 @@
 import {
   Alert,
+  Box,
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  useMediaQuery,
-  useTheme,
+  IconButton,
+  Modal,
+  Typography,
 } from "@mui/material";
+import { Close } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 
 export default function DeleteConfirmationModal({
@@ -19,46 +17,77 @@ export default function DeleteConfirmationModal({
   warning,
   onExited,
 }) {
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const { t } = useTranslation(["common"]);
 
   return (
-    <Dialog
-      fullScreen={fullScreen}
+    <Modal
       open={open}
       onClose={onClose}
-      aria-labelledby="delete-confirmation-dialog-title"
-      keepMounted={false}
-      slotProps={{
-        transition: { onExited },
-      }}
+      slotProps={{ transition: { onExited } }}
     >
-      <DialogTitle id="delete-confirmation-dialog-title">
-        {t("common:confirmDeletion")}
-      </DialogTitle>
-      <DialogContent>
-        <DialogContentText sx={{ whiteSpace: "pre-line" }}>
-          {content ||
-            t(
-              "common:confirmDeletionMessage",
-              "Are you sure you want to delete this item? This action cannot be undone.",
-            )}
-        </DialogContentText>
-        {warning && (
-          <Alert severity="warning" sx={{ mt: 2 }}>
-            {warning}
-          </Alert>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} sx={{ color: "common.white" }}>
-          {t("common:cancel")}
-        </Button>
-        <Button onClick={onConfirm} color="error" autoFocus>
-          {t("common:delete")}
-        </Button>
-      </DialogActions>
-    </Dialog>
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: { xs: "90%", sm: 560 },
+          bgcolor: "background.paper",
+          borderRadius: 2,
+          boxShadow: 12,
+          p: 0,
+          outline: "none",
+        }}
+      >
+        {/* Header */}
+        <Box
+          sx={{
+            p: 2,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <Typography variant="h6" component="h2">
+            {t("common:confirmDeletion")}
+          </Typography>
+          <IconButton
+            onClick={onClose}
+            size="small"
+            sx={{ color: "text.secondary" }}
+          >
+            <Close />
+          </IconButton>
+        </Box>
+
+        {/* Content */}
+        <Box sx={{ p: 3, display: "flex", flexDirection: "column", gap: 2 }}>
+          <Typography
+            variant="body1"
+            sx={{ whiteSpace: "pre-line" }}
+            color="text.secondary"
+          >
+            {content ||
+              t(
+                "common:confirmDeletionMessage",
+                "Are you sure you want to delete this item? This action cannot be undone.",
+              )}
+          </Typography>
+          {warning && <Alert severity="warning">{warning}</Alert>}
+
+          {/* Footer */}
+          <Box
+            sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 1 }}
+          >
+            <Button onClick={onClose} sx={{ color: "text.secondary" }}>
+              {t("common:cancel")}
+            </Button>
+            <Button onClick={onConfirm} color="error" variant="text" autoFocus>
+              {t("common:delete")}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Modal>
   );
 }


### PR DESCRIPTION
## Summary

  Fixed hardcoded white colors that made UI elements invisible when switching to light mode, and refactored `DeleteConfirmationModal` to use the new `Modal`-based layout consistent with the rest of the app's updated interface.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/front/src/components/threeSectionLayout/DeleteConfirmationModal.jsx`: Replaced `Dialog`/`DialogTitle`/`DialogContent`/`DialogActions` with a `Modal` + custom `Box` layout matching the app's current modal style. Fixed Cancel button color from hardcoded `common.white` to `text.secondary`.
  - `DashAI/front/src/components/notebooks/ColumnSelector.jsx`: Fixed "Allowed value types" label color from hardcoded `rgba(255, 255, 255, 0.5)` to `text.secondary`.
  - `DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx`: Fixed accordion expand icon color from hardcoded `white` to `text.secondary`.

  ---

  ## Testing

  - Switch to light mode and open the delete confirmation modal — verify the Cancel button is visible.
  - Switch to light mode and open a converter or explorer column selector — verify the "Allowed value types" label is visible.
  - Switch to light mode in the notebook view and verify the dataset preview expand icon is visible.

  ---

  ## Notes

  All three cases shared the same root cause: colors were hardcoded as white, which only works in dark mode. Replaced with `text.secondary`, a semantic MUI token that adapts correctly to both themes.