### PR TITLE
fix: remove union_type from schema_field definitions

### DIFF
--- a/DashAI/back/models/scikit_learn/adaboost_classifier.py
+++ b/DashAI/back/models/scikit_learn/adaboost_classifier.py
@@ -6,7 +6,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
@@ -69,7 +68,7 @@ class AdaBoostClassifierSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/adaboost_regression.py
+++ b/DashAI/back/models/scikit_learn/adaboost_regression.py
@@ -7,7 +7,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -81,7 +80,7 @@ class AdaBoostRegressionSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/bagging_classifier.py
+++ b/DashAI/back/models/scikit_learn/bagging_classifier.py
@@ -7,7 +7,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
@@ -105,7 +104,7 @@ class BaggingClassifierSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/decision_tree_regression.py
+++ b/DashAI/back/models/scikit_learn/decision_tree_regression.py
@@ -6,7 +6,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -22,7 +21,7 @@ class DecisionTreeRegressionSchema(BaseSchema):
     """
 
     max_depth: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en=(
@@ -73,7 +72,7 @@ class DecisionTreeRegressionSchema(BaseSchema):
     )  # type: ignore
 
     max_leaf_nodes: schema_field(
-        union_type(optimizer_int_field(ge=2), none_type(int)),
+        none_type(optimizer_int_field(ge=2)),
         placeholder=None,
         description=MultilingualString(
             en=(
@@ -112,7 +111,7 @@ class DecisionTreeRegressionSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/elastic_net_regression.py
+++ b/DashAI/back/models/scikit_learn/elastic_net_regression.py
@@ -7,7 +7,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -115,7 +114,7 @@ class ElasticNetRegressionSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/extra_trees_classifier.py
+++ b/DashAI/back/models/scikit_learn/extra_trees_classifier.py
@@ -6,7 +6,6 @@ from DashAI.back.core.schema_fields import (
     none_type,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
@@ -40,7 +39,7 @@ class ExtraTreesClassifierSchema(BaseSchema):
     )  # type: ignore
 
     max_depth: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en=(
@@ -107,7 +106,7 @@ class ExtraTreesClassifierSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/extra_trees_regression.py
+++ b/DashAI/back/models/scikit_learn/extra_trees_regression.py
@@ -6,7 +6,6 @@ from DashAI.back.core.schema_fields import (
     none_type,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -38,7 +37,7 @@ class ExtraTreesRegressionSchema(BaseSchema):
     )  # type: ignore
 
     max_depth: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en=(
@@ -105,7 +104,7 @@ class ExtraTreesRegressionSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/gradient_boosting_classifier.py
+++ b/DashAI/back/models/scikit_learn/gradient_boosting_classifier.py
@@ -7,7 +7,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
@@ -72,7 +71,7 @@ class GradientBoostingClassifierSchema(BaseSchema):
     )  # type: ignore
 
     max_depth: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=3,
         description=MultilingualString(
             en="Maximum depth of the individual regression estimators.",
@@ -137,7 +136,7 @@ class GradientBoostingClassifierSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/gradient_boosting_regression.py
+++ b/DashAI/back/models/scikit_learn/gradient_boosting_regression.py
@@ -149,7 +149,7 @@ class GradientBoostingRSchema(BaseSchema):
     )  # type: ignore
 
     max_depth: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=3,
         description=MultilingualString(
             en="The maximum depth of the individual regression estimators.",
@@ -177,7 +177,7 @@ class GradientBoostingRSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(
@@ -244,7 +244,7 @@ class GradientBoostingRSchema(BaseSchema):
     )  # type: ignore
 
     max_leaf_nodes: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en="Grow trees with max_leaf_nodes in best-first fashion.",
@@ -291,7 +291,7 @@ class GradientBoostingRSchema(BaseSchema):
     )  # type: ignore
 
     n_iter_no_change: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/hist_gradient_boosting_regression.py
+++ b/DashAI/back/models/scikit_learn/hist_gradient_boosting_regression.py
@@ -8,7 +8,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -61,7 +60,7 @@ class HistGradientBoostingRegressionSchema(BaseSchema):
     )  # type: ignore
 
     max_depth: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en=("Maximum depth of each tree. If None, depth is not constrained."),
@@ -74,7 +73,7 @@ class HistGradientBoostingRegressionSchema(BaseSchema):
     )  # type: ignore
 
     max_leaf_nodes: schema_field(
-        union_type(optimizer_int_field(ge=2), none_type(int)),
+        none_type(optimizer_int_field(ge=2)),
         placeholder=31,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/lasso_regression.py
+++ b/DashAI/back/models/scikit_learn/lasso_regression.py
@@ -7,7 +7,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -94,7 +93,7 @@ class LassoRegressionSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/linearSVR.py
+++ b/DashAI/back/models/scikit_learn/linearSVR.py
@@ -8,7 +8,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -170,7 +169,7 @@ class LinearSVRSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/linear_regression.py
+++ b/DashAI/back/models/scikit_learn/linear_regression.py
@@ -6,7 +6,6 @@ from DashAI.back.core.schema_fields import (
     none_type,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -54,7 +53,7 @@ class LinearRegressionSchema(BaseSchema):
     )  # type: ignore
 
     n_jobs: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/linear_svc_classifier.py
+++ b/DashAI/back/models/scikit_learn/linear_svc_classifier.py
@@ -8,7 +8,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
@@ -114,7 +113,7 @@ class LinearSVCClassifierSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/mlp_classifier.py
+++ b/DashAI/back/models/scikit_learn/mlp_classifier.py
@@ -7,7 +7,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
@@ -128,7 +127,7 @@ class MLPClassifierSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/random_forest_regression.py
+++ b/DashAI/back/models/scikit_learn/random_forest_regression.py
@@ -52,7 +52,7 @@ class RandomForestRegressionSchema(BaseSchema):
     )  # type: ignore
 
     max_depth: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en="The maximum depth of the tree.",
@@ -129,7 +129,7 @@ class RandomForestRegressionSchema(BaseSchema):
     )  # type: ignore
 
     max_leaf_nodes: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en="Grow trees with max_leaf_nodes in best-first fashion.",
@@ -183,7 +183,7 @@ class RandomForestRegressionSchema(BaseSchema):
     )  # type: ignore
 
     n_jobs: schema_field(
-        union_type(optimizer_int_field(ge=1), none_type(int)),
+        none_type(optimizer_int_field(ge=1)),
         placeholder=None,
         description=MultilingualString(
             en="The number of jobs to run in parallel for both fit and predict.",
@@ -193,7 +193,7 @@ class RandomForestRegressionSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(
@@ -240,7 +240,7 @@ class RandomForestRegressionSchema(BaseSchema):
     )  # type: ignore
 
     max_samples: schema_field(
-        union_type(optimizer_float_field(gt=0.0, le=1.0), none_type(float)),
+        none_type(optimizer_float_field(gt=0.0, le=1.0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/ridge_regression.py
+++ b/DashAI/back/models/scikit_learn/ridge_regression.py
@@ -8,7 +8,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
@@ -135,7 +134,7 @@ class RidgeRegressionSchema(BaseSchema):
         alias=MultilingualString(en="Positive", es="Positivo"),
     )  # type: ignore
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(

--- a/DashAI/back/models/scikit_learn/sgd_classifier.py
+++ b/DashAI/back/models/scikit_learn/sgd_classifier.py
@@ -7,7 +7,6 @@ from DashAI.back.core.schema_fields import (
     optimizer_float_field,
     optimizer_int_field,
     schema_field,
-    union_type,
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
@@ -132,7 +131,7 @@ class SGDClassifierSchema(BaseSchema):
     )  # type: ignore
 
     random_state: schema_field(
-        union_type(optimizer_int_field(ge=0), none_type(int)),
+        none_type(optimizer_int_field(ge=0)),
         placeholder=None,
         description=MultilingualString(
             en=(


### PR DESCRIPTION
## Summary

  `union_type(optimizer_int_field(...), none_type(int))` was producing three-variant unions — `Union[Annotated[int, Field(...)], int, None]` — because `none_type(int)` expands to `Optional[int]` = `Union[int, None]`, adding a redundant plain `int` alongside the constrained one. The frontend rendered this as **Int | Int | Null** instead of the expected **Int | Null**.

  Fixed by replacing `union_type(optimizer_X_field(...), none_type(X))` with `none_type(optimizer_X_field(...))`, which produces the correct `Union[Annotated[int/float, Field(...)], None]`. Unused `union_type` imports were also removed.

  ---

  ## Type of Change

  - [x] Backend change
  - [ ] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/back/models/scikit_learn/gradient_boosting_classifier.py`: fixed `max_depth` and `random_state`
  - `DashAI/back/models/scikit_learn/gradient_boosting_regression.py`: fixed `max_depth`, `max_leaf_nodes`, `random_state`, and related fields
  - `DashAI/back/models/scikit_learn/hist_gradient_boosting_regression.py`: fixed `max_iter` and `max_depth`
  - `DashAI/back/models/scikit_learn/extra_trees_classifier.py`: fixed `max_depth` and `random_state`
  - `DashAI/back/models/scikit_learn/extra_trees_regression.py`: fixed `max_depth` and `random_state`
  - `DashAI/back/models/scikit_learn/random_forest_regression.py`: fixed `max_depth`, `max_leaf_nodes`, `random_state`, and `max_samples`
  - `DashAI/back/models/scikit_learn/decision_tree_regression.py`: fixed `max_depth`, `max_leaf_nodes`, and `random_state`
  - `DashAI/back/models/scikit_learn/adaboost_classifier.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/adaboost_regression.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/bagging_classifier.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/elastic_net_regression.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/lasso_regression.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/linear_regression.py`: fixed `n_jobs`
  - `DashAI/back/models/scikit_learn/linear_svc_classifier.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/linearSVR.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/mlp_classifier.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/ridge_regression.py`: fixed `random_state`
  - `DashAI/back/models/scikit_learn/sgd_classifier.py`: fixed `random_state`

  ---
  - `DashAI/back/models/scikit_learn/sgd_classifier.py`: fixed `random_state`

  ---

  ## Testing

  Open any affected model in the UI (e.g. **GradientBoostingClassifier**) and verify that nullable int/float
  parameters such as `max_depth` and `random_state` now show **Int | Null** instead of **Int | Int | Null**.

  ---

  ## Notes

  The root cause is a misuse of `none_type`: it is designed to be used standalone (`none_type(some_field)` → `Optional[some_field]`), not as a second argument to `union_type` alongside a field of the same base type. All 31 occurrences of the incorrect pattern across 18 files have been corrected.