### PR TITLE
Fix/right panel padding and chip overflow

### DIFF
--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -81,7 +81,7 @@ function RightBarDatasetView() {
   }
 
   return (
-    <Box sx={{ flex: 1, overflowY: "auto", p: 2 }}>
+    <Box sx={{ flex: 1, overflowY: "auto" }}>
       <ColumnInsights
         numericStats={datasetInfo?.numeric_stats}
         textStats={datasetInfo?.text_stats}

--- a/DashAI/front/src/components/notebooks/dataset/ColumnInsights.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/ColumnInsights.jsx
@@ -127,7 +127,7 @@ export default function ColumnInsights({
           label={insights.length}
           size="small"
           color="warning"
-          sx={{ height: 22, minWidth: 22, fontWeight: "bold" }}
+          sx={{ height: 22, minWidth: 22, fontWeight: "bold", flexShrink: 0 }}
         />
       </Box>
 


### PR DESCRIPTION
## Summary

  Two small UI fixes in the right panel when viewing dataset visualization:

  1. The `ColumnInsights` wrapper in `RightBar` had an extra `p: 2` on top of the component's own internal `px: 2`, causing double padding compared to the models module. Removed the outer padding so both modules look consistent.
  2. The insights count `Chip` was missing `flexShrink: 0`, causing it to compress and truncate its label (e.g. "1...") when the section title was long — visible in Spanish ("Observaciones por Columna") but not in English.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/front/src/components/notebooks/RightBar.jsx`: removed `p: 2` from the `ColumnInsights` wrapper box in `RightBarDatasetView` — the component already handles its own internal padding.
  - `DashAI/front/src/components/notebooks/dataset/ColumnInsights.jsx`: added `flexShrink: 0` to the count `Chip` so it never compresses regardless of the section title length.

  ---

  ## Testing

  - Open dataset visualization from the **Datasets** module and verify the right panel padding matches the
  **Models** module.
  - Switch the UI language to **Spanish** and confirm the insights count badge displays the full number without
  truncation.
