### PR TITLE
fix: stop infinite job queue polling in edge cases

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/jobs.py
+++ b/DashAI/back/api/api_v1/endpoints/jobs.py
@@ -60,7 +60,10 @@ async def get_job_changes(
 
         jobs = job_queue.changes_since(since_decoded)
 
-        current_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
+        _now = datetime.now(timezone.utc)
+        current_time = _now.strftime(
+            f"%Y-%m-%d %H:%M:%S.{_now.microsecond // 1000:03d}"
+        )
 
         is_queue_empty = job_queue.is_empty()
         recently_completed = any(j.get("status") in ("finished", "error") for j in jobs)
@@ -74,7 +77,10 @@ async def get_job_changes(
         }
     except Exception as e:
         logger.exception(f"Error retrieving job changes: {e}")
-        current_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
+        _now = datetime.now(timezone.utc)
+        current_time = _now.strftime(
+            f"%Y-%m-%d %H:%M:%S.{_now.microsecond // 1000:03d}"
+        )
         return {
             "jobs": [],
             "cursor": current_time,

--- a/DashAI/back/dependencies/job_queues/huey_job_queue.py
+++ b/DashAI/back/dependencies/job_queues/huey_job_queue.py
@@ -98,11 +98,12 @@ class HueyJobQueue(BaseJobQueue):
     @staticmethod
     def _normalize_to_utc_str(ts: str) -> str:
         """
-        Accepts ISO8601 or 'YYYY-MM-DD HH:MM:SS[.ffffff]' with optional 'Z' or offset.
-        Returns UTC as 'YYYY-MM-DD HH:MM:SS.ffffff'
+        Accepts ISO8601 or 'YYYY-MM-DD HH:MM:SS[.fff]' with optional 'Z' or offset.
+        Returns UTC as 'YYYY-MM-DD HH:MM:SS.sss' (millisecond precision) to match
+        SQLite's STRFTIME('%Y-%m-%d %H:%M:%f','now') format used in last_update.
         """
         if not ts:
-            return "1970-01-01 00:00:00.000000"
+            return "1970-01-01 00:00:00.000"
 
         s = ts.strip()
 
@@ -128,14 +129,15 @@ class HueyJobQueue(BaseJobQueue):
                     continue
 
         if dt is None:
-            return "1970-01-01 00:00:00.000000"
+            return "1970-01-01 00:00:00.000"
 
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
         else:
             dt = dt.astimezone(timezone.utc)
 
-        return dt.strftime("%Y-%m-%d %H:%M:%S.%f")
+        ms = dt.microsecond // 1000
+        return dt.strftime(f"%Y-%m-%d %H:%M:%S.{ms:03d}")
 
     def _register_signals(self):
         """Attach Huey lifecycle signal handlers to keep 'task_copy' in sync:
@@ -304,7 +306,7 @@ class HueyJobQueue(BaseJobQueue):
                 SELECT id, task_type, job_name, enqueued_at, status, last_update,
                         error_msg
                 FROM task_copy
-                WHERE last_update > ?
+                WHERE last_update >= ?
                 ORDER BY last_update DESC
                 """,
                 (cutoff,),

--- a/DashAI/front/src/utils/jobPoller.js
+++ b/DashAI/front/src/utils/jobPoller.js
@@ -103,6 +103,46 @@ async function pollJobs() {
       ? Date.now() - state.lastCompletionTime
       : Infinity;
 
+    // When the queue is truly empty and the grace period has elapsed (or no
+    // completion was ever detected), do a final full-state flush so subscribers
+    // always receive the definitive job state before the poller stops.
+    // Orphaned watchers (jobs deleted before running) are resolved here too,
+    // using their real status from getJobs() instead of blindly calling onError.
+    if (
+      changeData.queue_empty &&
+      !changeData.recently_completed &&
+      timePassedSinceCompletion > MIN_POLLING_AFTER_COMPLETION
+    ) {
+      try {
+        const allJobs = await getJobs();
+        for (const subscriber of state.subscribers) {
+          try {
+            subscriber(allJobs);
+          } catch (e) {
+            console.error("[JobPoller] Subscriber error in final flush:", e);
+          }
+        }
+        for (const [jobId, watcher] of [...state.jobWatchers.entries()]) {
+          const job = allJobs.find((j) => j.id === jobId);
+          if (job?.status === "finished") {
+            if (watcher.onSuccess) watcher.onSuccess(job);
+          } else {
+            if (watcher.onError)
+              watcher.onError(job || { id: jobId, status: "deleted" });
+          }
+        }
+      } catch (e) {
+        console.error("[JobPoller] Error in final flush:", e);
+        for (const [jobId, watcher] of [...state.jobWatchers.entries()]) {
+          if (watcher.onError)
+            watcher.onError({ id: jobId, status: "deleted" });
+        }
+      }
+      state.jobWatchers.clear();
+      stopJobPoller();
+      return;
+    }
+
     if (
       !activeJobsExist &&
       state.jobWatchers.size === 0 &&

--- a/DashAI/front/src/utils/jobPoller.js
+++ b/DashAI/front/src/utils/jobPoller.js
@@ -104,24 +104,23 @@ async function pollJobs() {
       : Infinity;
 
     // When the queue is truly empty and the grace period has elapsed (or no
-    // completion was ever detected), do a final full-state flush so subscribers
-    // always receive the definitive job state before the poller stops.
-    // Orphaned watchers (jobs deleted before running) are resolved here too,
-    // using their real status from getJobs() instead of blindly calling onError.
+    // completion was ever detected), resolve any orphaned watchers (jobs deleted
+    // from the queue that will never appear in incremental changes) using the
+    // authoritative state from getJobs(). Subscribers are NOT flushed here —
+    // they receive incremental updates during the grace period via normal polling,
+    // and sending a full snapshot would leave stale deleted-job entries in their
+    // state. If getJobs() fails, leave watchers in place and retry next poll.
     if (
       changeData.queue_empty &&
       !changeData.recently_completed &&
       timePassedSinceCompletion > MIN_POLLING_AFTER_COMPLETION
     ) {
+      if (state.jobWatchers.size === 0) {
+        stopJobPoller();
+        return;
+      }
       try {
         const allJobs = await getJobs();
-        for (const subscriber of state.subscribers) {
-          try {
-            subscriber(allJobs);
-          } catch (e) {
-            console.error("[JobPoller] Subscriber error in final flush:", e);
-          }
-        }
         for (const [jobId, watcher] of [...state.jobWatchers.entries()]) {
           const job = allJobs.find((j) => j.id === jobId);
           if (job?.status === "finished") {
@@ -131,16 +130,13 @@ async function pollJobs() {
               watcher.onError(job || { id: jobId, status: "deleted" });
           }
         }
+        state.jobWatchers.clear();
+        stopJobPoller();
+        return;
       } catch (e) {
-        console.error("[JobPoller] Error in final flush:", e);
-        for (const [jobId, watcher] of [...state.jobWatchers.entries()]) {
-          if (watcher.onError)
-            watcher.onError({ id: jobId, status: "deleted" });
-        }
+        console.error("[JobPoller] Final flush failed, will retry:", e);
+        // Fall through — watchers stay intact, next poll retries the flush
       }
-      state.jobWatchers.clear();
-      stopJobPoller();
-      return;
     }
 
     if (


### PR DESCRIPTION
## Summary 
- Fixed infinite polling loop when pending jobs are deleted from the queue while another job is still running
- Fixed fast-completing jobs never being detected due to a timestamp format mismatch between the backend cursor and SQLite's last_update field
- Fixed the job queue widget getting stuck in a "running" state after jobs complete, requiring a page reload to update

## What was happening

Infinite polling after job deletion:
When jobs in not_started state were deleted from the queue, delete_from_db removed them entirely from task_copy. Any active startJobPolling watcher for those jobs would remain in state.jobWatchers forever — since the jobs no longer appeared in getJobChanges, the watcher callbacks were never called and the poller stop condition (jobWatchers.size === 0) was never satisfied.

Fast jobs not detected (cursor format mismatch):
The backend cursor was formatted with Python's %f (6 decimal places / microseconds: 12:30:45.123456), while SQLite stores last_update via STRFTIME('%Y-%m-%d %H:%M:%f','now') which only has 3 decimal places (milliseconds: 12:30:45.123). The SQL string comparison "12:30:45.123" > "12:30:45.123456" evaluates to False, so any job that completed within the same millisecond as the cursor was silently skipped on every subsequent poll. Combined with the orphaned watchers bug above, this caused the poller to run forever.

Widget stuck in "running" state:
The previous fix for infinite polling stopped the poller too aggressively — before the 5-second post-completion grace period and without flushing the final job state to subscribers. This left the widget displaying jobs as "started" indefinitely, and incorrectly triggered onError callbacks for jobs that had actually finished successfully.