### PR TITLE
refactor: "Run all" doesnt expand show results in card models

### DIFF
--- a/DashAI/front/src/components/models/RunCard.jsx
+++ b/DashAI/front/src/components/models/RunCard.jsx
@@ -81,6 +81,7 @@ function RunCard({
   const [operationsCount, setOperationsCount] = useState(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveConfirmOpen, setSaveConfirmOpen] = useState(false);
+  const [autoExpand, setAutoExpand] = useState(false);
 
   const { defaultValues: defaultOptimizerParams } = useSchema({
     modelName: editedOptimizer,
@@ -266,6 +267,12 @@ function RunCard({
     }
   };
 
+  useEffect(() => {
+    if (run.status !== 1 && run.status !== 2) {
+      setAutoExpand(false);
+    }
+  }, [run.status]);
+
   const canTrain = run.status === 0 || run.status === 3 || run.status === 4; // Not Started, Finished, Error
   const isRunning = run.status === 1 || run.status === 2; // Delivered, Started
 
@@ -411,7 +418,10 @@ function RunCard({
                   color="primary"
                   size="small"
                   startIcon={<PlayArrow />}
-                  onClick={() => onTrain(run, operationsCount)}
+                  onClick={() => {
+                    setAutoExpand(true);
+                    onTrain(run, operationsCount);
+                  }}
                   data-tour={isLastRun ? "train-button" : undefined}
                   disabled={isEditing}
                 >
@@ -699,6 +709,7 @@ function RunCard({
             session={session}
             onRefresh={onOperationsRefresh}
             explainerRefreshTrigger={explainerRefreshTrigger}
+            autoExpand={autoExpand}
           />
         </Box>
         <RetrainConfirmDialog

--- a/DashAI/front/src/components/models/RunResults.jsx
+++ b/DashAI/front/src/components/models/RunResults.jsx
@@ -36,6 +36,7 @@ export default function RunResults({
   session,
   onRefresh,
   explainerRefreshTrigger,
+  autoExpand = false,
 }) {
   const [globalExplainers, setGlobalExplainers] = useState([]);
   const [localExplainers, setLocalExplainers] = useState([]);
@@ -106,11 +107,11 @@ export default function RunResults({
   }, [run.id]);
 
   useEffect(() => {
-    if (isRunning) {
+    if (isRunning && autoExpand) {
       setResultsVisible(true);
       setActiveTab(0); // Live Metrics tab
     }
-  }, [isRunning]);
+  }, [isRunning, autoExpand]);
 
   useEffect(() => {
     localStorage.setItem(
@@ -611,4 +612,5 @@ RunResults.propTypes = {
   }),
   onRefresh: PropTypes.func,
   explainerRefreshTrigger: PropTypes.number,
+  autoExpand: PropTypes.bool,
 };


### PR DESCRIPTION
This pull request improves the user experience in the model training workflow by automatically expanding the results panel when a run is started. The main changes involve adding an `autoExpand` state to control the expansion behavior and ensuring that the results panel only auto-expands when appropriate.

**User Interface Improvements:**

* Added a new `autoExpand` state in `RunCard.jsx` to track whether the results panel should auto-expand. This state is set to `true` when the user initiates training and reset to `false` when the run is not in a running state. [[1]](diffhunk://#diff-f00e220d21553073c56b4c6bdee42f541be74f8c63f69c080baf6fd63172f74cR84) [[2]](diffhunk://#diff-f00e220d21553073c56b4c6bdee42f541be74f8c63f69c080baf6fd63172f74cR270-R275) [[3]](diffhunk://#diff-f00e220d21553073c56b4c6bdee42f541be74f8c63f69c080baf6fd63172f74cL414-R424)
* Passed the `autoExpand` prop from `RunCard.jsx` to `RunResults.jsx` to control the expansion of the results panel. [[1]](diffhunk://#diff-f00e220d21553073c56b4c6bdee42f541be74f8c63f69c080baf6fd63172f74cR712) [[2]](diffhunk://#diff-3efa40513da7516f567f97f32be938d43278174c86f5bb93fe209151d2765d59R39) [[3]](diffhunk://#diff-3efa40513da7516f567f97f32be938d43278174c86f5bb93fe209151d2765d59R615)

**Results Panel Behavior:**

* Updated `RunResults.jsx` so that the results panel only auto-expands when a run starts and `autoExpand` is `true`, preventing unwanted expansions in other scenarios.

These changes make the UI more responsive and intuitive by automatically showing live metrics when a training run is started.