### PR TITLE
Fix optimizer parameter switching and Hyperopt trial parameter casting

### DIFF
--- a/DashAI/back/optimizers/hyperopt_optimizer.py
+++ b/DashAI/back/optimizers/hyperopt_optimizer.py
@@ -73,13 +73,16 @@ class HyperOptOptimizer(BaseOptimizer):
         """
         Configure the search space.
 
-        Args:
-            hyperparams_data (dict[str, any]): Dict with the range values
-            for the possible search space
+        Parameters
+        ----------
+        hyperparams_data : list
+            Tuples of (obj, hyperparameter, values, dtype) describing the
+            search space bounds.
 
         Returns
         -------
-            search_space: Dict with the information for the search space .
+        dict
+            Search space dict compatible with hyperopt.
         """
         from hyperopt import hp
 
@@ -99,19 +102,22 @@ class HyperOptOptimizer(BaseOptimizer):
 
     def optimize(self, model, input_dataset, output_dataset, parameters, metric, task):
         """
-        Optimization process
+        Run hyperparameter optimization and retrain the model with best params.
 
-        Args:
-            model (class): class for the model from the current experiment
-            input_dataset (dict): dict with train dataset
-            output_dataset (dict): dict with validation dataset
-            parameters (dict): dict with the information to create the search space
-            metric (class): class for the metric to optimize
-            task (string): Name of the current task
-
-        Returns
-        -------
-            None
+        Parameters
+        ----------
+        model : object
+            Model instance to optimize.
+        input_dataset : dict
+            Dataset splits keyed by "train" and "validation".
+        output_dataset : dict
+            Label splits keyed by "train" and "validation".
+        parameters : list
+            Tuples of (obj, key, bounds, dtype) for each hyperparameter.
+        metric : dict
+            Dict with keys "class" (metric instance) and "metadata".
+        task : str
+            Name of the current task.
         """
         import importlib
 
@@ -122,16 +128,23 @@ class HyperOptOptimizer(BaseOptimizer):
         self.output_dataset = output_dataset
         self.parameters = parameters
         self.metric = metric["class"]
+        self.maximize = metric["metadata"]["maximize"]
 
         sampler = importlib.import_module(f"hyperopt.{self.sampler}").suggest
 
-        param_mapping = {key: (obj, key) for obj, key, _, _ in self.parameters}
+        param_mapping = {
+            key: (obj, key, dtype) for obj, key, _, dtype in self.parameters
+        }
 
         search_space = self.search_space(self.parameters)
 
         def objective(params):
             for param_name, value in params.items():
-                obj, key = param_mapping[param_name]
+                obj, key, dtype = param_mapping[param_name]
+                if dtype == "integer":
+                    value = int(value)
+                elif dtype == "number":
+                    value = float(value)
                 setattr(obj, key, value)
 
             self.model.train(self.input_dataset["train"], self.output_dataset["train"])
@@ -152,7 +165,7 @@ class HyperOptOptimizer(BaseOptimizer):
             return -score if metric["metadata"]["maximize"] else score
 
         trials = Trials()
-        fmin(
+        best_params_raw = fmin(
             fn=objective,
             space=search_space,
             algo=sampler,
@@ -160,6 +173,13 @@ class HyperOptOptimizer(BaseOptimizer):
             trials=trials,
         )
         self.trials = trials
+
+        # Apply best params and retrain with the best configuration
+        for param_name, raw_value in best_params_raw.items():
+            obj, key, dtype = param_mapping[param_name]
+            value = int(raw_value) if dtype == "integer" else float(raw_value)
+            setattr(obj, key, value)
+        self.model.train(self.input_dataset["train"], self.output_dataset["train"])
 
     def get_model(self):
         return self.model
@@ -169,7 +189,9 @@ class HyperOptOptimizer(BaseOptimizer):
         for trial in self.trials:
             if trial["result"]["status"] == "ok":
                 params = {key: val[0] for key, val in trial["misc"]["vals"].items()}
-                trials.append({"params": params, "value": trial["result"]["loss"]})
+                loss = trial["result"]["loss"]
+                value = -loss if self.maximize else loss
+                trials.append({"params": params, "value": value})
         return trials
 
     def get_best_params(self):
@@ -177,4 +199,12 @@ class HyperOptOptimizer(BaseOptimizer):
         best_trial = min(
             self.trials, key=lambda t: t["result"].get("loss", float("inf"))
         )
-        return {key: val[0] for key, val in best_trial["misc"]["vals"].items()}
+        param_mapping = {
+            key: (obj, key, dtype) for obj, key, _, dtype in self.parameters
+        }
+        result = {}
+        for key, vals in best_trial["misc"]["vals"].items():
+            raw = vals[0]
+            dtype = param_mapping[key][2]
+            result[key] = int(raw) if dtype == "integer" else float(raw)
+        return result

--- a/DashAI/front/src/components/models/AddModelDialog.jsx
+++ b/DashAI/front/src/components/models/AddModelDialog.jsx
@@ -60,7 +60,7 @@ function AddModelDialog({
     defaultValues: defaultOptimizerParams,
     loading: optimizerSchemaLoading,
   } = useSchema({
-    modelName: selectedOptimizer,
+    modelName: open && activeStep === 1 ? selectedOptimizer : null,
   });
 
   const tourContext = useTourContext();

--- a/DashAI/front/src/components/models/AddModelDialog.jsx
+++ b/DashAI/front/src/components/models/AddModelDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback, use } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import {
   Dialog,
@@ -87,14 +87,6 @@ function AddModelDialog({
     ? [t("models:label.configureModel"), t("models:label.configureOptimizer")]
     : [t("models:label.configureModel")];
 
-  const handleModelParametersChange = useCallback((values) => {
-    setModelParameters(values);
-  }, []);
-
-  const handleOptimizerParametersChange = useCallback((values) => {
-    setOptimizerParameters((prevParams) => ({ ...prevParams, ...values }));
-  }, []);
-
   useEffect(() => {
     if (preselectedModel && preselectedModel !== selectedModel) {
       setSelectedModel(preselectedModel);
@@ -115,16 +107,6 @@ function AddModelDialog({
       setHasLoadedInitialParams(true);
     }
   }, [selectedModel, defaultModelParams, hasLoadedInitialParams]);
-
-  useEffect(() => {
-    if (
-      !optimizerSchemaLoading &&
-      defaultOptimizerParams &&
-      Object.keys(defaultOptimizerParams).length > 0
-    ) {
-      setOptimizerParameters(defaultOptimizerParams);
-    }
-  }, [selectedOptimizer, optimizerSchemaLoading]);
 
   const handleClose = () => {
     setTimeout(() => {
@@ -195,7 +177,7 @@ function AddModelDialog({
         name.trim(),
         modelParameters || {},
         selectedOptimizer || "",
-        optimizerParameters || {},
+        { ...defaultOptimizerParams, ...optimizerParameters },
         "",
         "",
         "",
@@ -325,7 +307,7 @@ function AddModelDialog({
                     modelToConfigure={selectedModel}
                     initialValues={modelParameters}
                     onFormSubmit={() => {}}
-                    onValuesChange={handleModelParametersChange}
+                    onValuesChange={setModelParameters}
                     onCancel={() => {}}
                     hideButtons
                   />
@@ -359,7 +341,7 @@ function AddModelDialog({
               handleSelectedOptimizer={handleOptimizerSelected}
             />
 
-            {selectedOptimizer && (
+            {selectedOptimizer && !optimizerSchemaLoading && (
               <Box sx={{ mt: 2 }}>
                 <Typography variant="subtitle2" sx={{ mb: 2 }}>
                   {t("models:label.optimizerParameters")}
@@ -367,9 +349,9 @@ function AddModelDialog({
                 <FormSchemaContainer key={selectedOptimizer}>
                   <FormSchemaWithSelectedModel
                     modelToConfigure={selectedOptimizer}
-                    initialValues={optimizerParameters}
+                    initialValues={defaultOptimizerParams}
                     onFormSubmit={() => {}}
-                    onValuesChange={handleOptimizerParametersChange}
+                    onValuesChange={setOptimizerParameters}
                     onCancel={() => {}}
                     hideButtons
                   />

--- a/DashAI/front/src/components/models/RunCard.jsx
+++ b/DashAI/front/src/components/models/RunCard.jsx
@@ -44,6 +44,7 @@ import { updateRunParameters, getRunOperationsCount } from "../../api/run";
 import RetrainConfirmDialog from "./RetrainConfirmDialog";
 import { renderParamValue } from "./ModelParamBlock";
 import { useTranslation } from "react-i18next";
+import { checkIfHaveOptimazers } from "../../utils/schema";
 
 /**
  * Card component displaying a model run with actions and details
@@ -110,13 +111,7 @@ function RunCard({
   }, [run.id, explainerRefreshTrigger]);
 
   const hasOptimizableParams = useMemo(() => {
-    return Object.values(editedParameters).some(
-      (value) =>
-        value &&
-        typeof value === "object" &&
-        !Array.isArray(value) &&
-        value.optimize === true,
-    );
+    return checkIfHaveOptimazers(editedParameters);
   }, [editedParameters]);
 
   useEffect(() => {

--- a/DashAI/front/src/components/models/RunCard.jsx
+++ b/DashAI/front/src/components/models/RunCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import {
   Card,
@@ -83,8 +83,11 @@ function RunCard({
   const [isSaving, setIsSaving] = useState(false);
   const [saveConfirmOpen, setSaveConfirmOpen] = useState(false);
 
-  const { defaultValues: defaultOptimizerParams } = useSchema({
-    modelName: editedOptimizer,
+  const {
+    defaultValues: defaultOptimizerParams,
+    loading: optimizerSchemaLoading,
+  } = useSchema({
+    modelName: isEditing ? editedOptimizer : null,
   });
 
   useEffect(() => {
@@ -114,21 +117,6 @@ function RunCard({
     return checkIfHaveOptimazers(editedParameters);
   }, [editedParameters]);
 
-  useEffect(() => {
-    if (
-      editedOptimizer &&
-      defaultOptimizerParams &&
-      Object.keys(defaultOptimizerParams).length > 0
-    ) {
-      setEditedOptimizerParams((prev) => {
-        if (Object.keys(prev).length === 0) {
-          return defaultOptimizerParams;
-        }
-        return prev;
-      });
-    }
-  }, [editedOptimizer, defaultOptimizerParams]);
-
   const handleStartEdit = () => {
     setIsEditing(true);
     setExpanded(true);
@@ -152,7 +140,7 @@ function RunCard({
         editedName.trim(),
         editedParameters,
         editedOptimizer || "",
-        editedOptimizerParams || {},
+        { ...defaultOptimizerParams, ...editedOptimizerParams },
         editedGoalMetric || "",
       );
 
@@ -226,19 +214,9 @@ function RunCard({
     await doSave();
   };
 
-  const handleParametersChange = useCallback((values) => {
-    setEditedParameters(values);
-  }, []);
-
-  const handleOptimizerParamsChange = useCallback((values) => {
-    setEditedOptimizerParams((prev) => ({ ...prev, ...values }));
-  }, []);
-
-  const handleOptimizerSelected = (optimizerName, defaultValues) => {
+  const handleOptimizerSelected = (optimizerName) => {
     setEditedOptimizer(optimizerName);
-    if (defaultValues && Object.keys(defaultValues).length > 0) {
-      setEditedOptimizerParams(defaultValues);
-    }
+    setEditedOptimizerParams({});
   };
 
   const statusText = getRunStatus(run.status, t);
@@ -519,8 +497,8 @@ function RunCard({
                       <FormSchemaWithSelectedModel
                         modelToConfigure={run.model_name}
                         initialValues={editedParameters}
-                        onFormSubmit={handleParametersChange}
-                        onValuesChange={handleParametersChange}
+                        onFormSubmit={() => {}}
+                        onValuesChange={setEditedParameters}
                         onCancel={() => {}}
                         hideButtons
                       />
@@ -559,25 +537,29 @@ function RunCard({
                       handleSelectedOptimizer={handleOptimizerSelected}
                     />
 
-                    {editedOptimizer && (
-                      <Box>
-                        <Typography variant="subtitle2" sx={{ mb: 2 }}>
-                          {t("common:optimizerParameters")}
-                        </Typography>
-                        <FormSchemaContainer>
-                          <FormSchemaWithSelectedModel
-                            modelToConfigure={editedOptimizer}
-                            initialValues={editedOptimizerParams}
-                            onFormSubmit={(values) =>
-                              setEditedOptimizerParams(values)
-                            }
-                            onValuesChange={handleOptimizerParamsChange}
-                            onCancel={() => {}}
-                            hideButtons
-                          />
-                        </FormSchemaContainer>
-                      </Box>
-                    )}
+                    {editedOptimizer &&
+                      (Object.keys(editedOptimizerParams).length > 0 ||
+                        !optimizerSchemaLoading) && (
+                        <Box>
+                          <Typography variant="subtitle2" sx={{ mb: 2 }}>
+                            {t("common:optimizerParameters")}
+                          </Typography>
+                          <FormSchemaContainer key={editedOptimizer}>
+                            <FormSchemaWithSelectedModel
+                              modelToConfigure={editedOptimizer}
+                              initialValues={
+                                Object.keys(editedOptimizerParams).length > 0
+                                  ? editedOptimizerParams
+                                  : defaultOptimizerParams
+                              }
+                              onFormSubmit={() => {}}
+                              onValuesChange={setEditedOptimizerParams}
+                              onCancel={() => {}}
+                              hideButtons
+                            />
+                          </FormSchemaContainer>
+                        </Box>
+                      )}
                   </Box>
                 )}
 


### PR DESCRIPTION
## Summary
This pull request fixes several issues in the hyperparameter optimization flow across both backend and frontend components.

On the frontend, it fixes incorrect optimizer parameter defaults when switching between optimizers. Previously, changing from one optimizer to another could send stale parameter values from the previously selected optimizer instead of the new optimizer defaults. This affected both creating new runs and editing existing runs. The optimizer dialogs now correctly reset and merge schema defaults with user-edited values when switching optimizers.

On the backend, this PR fixes issues in the Hyperopt optimizer where maximizing metrics were incorrectly plotted using negative values, and model hyperparameters were not always applied correctly during trials because integer values were being returned as floats (e.g. `13.0`). Integer parameters are now properly cast before being applied to models, ensuring correct optimization and retraining behavior.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/optimizers/hyperopt_optimizer.py`:
  - Fixed incorrect handling of maximizing metrics in optimization plots.
  - Properly cast integer hyperparameters returned as floats before applying them to models.
  - Ensured best hyperparameters are correctly applied before retraining.
  - Updated `search_space` and `optimize` docstrings.

- `frontend/src/components/.../OptimizerDialog.tsx`:
  - Fixed stale optimizer default values when switching optimizers.
  - Correctly resets optimizer defaults when changing optimizers.
  - Fixed loading and conditional rendering issues while optimizer schemas are fetched.

- `frontend/src/components/.../RunDialog.tsx`:
  - Fixed optimizer parameter initialization for both new runs and existing runs.
  - Fixed incorrect parameter reuse when changing optimizers.
  - Fixed optimizer state updates when switching optimizers.

- `frontend/src/components/.../RunCard.tsx`:
  - Fixed optimizable-parameter detection in existing run editing by using the shared recursive detection function.

---

## Testing (optional)
Reviewers should verify:

- Switching between optimizers in a new run correctly resets parameters to the selected optimizer defaults.
- Switching between optimizers while editing an existing run also correctly resets defaults.
- Existing user-edited optimizer values are preserved when appropriate.
- Hyperopt optimization plots display correct metric values for maximization tasks.
- Integer hyperparameters are correctly applied during optimization trials and retraining.

---

## Notes (optional)
The frontend issue affected both run creation and run editing flows due to stale optimizer state being reused across optimizer changes.

The backend integer casting fix was necessary because Hyperopt returns numeric values as floats, even for integer search spaces.