### PR TITLE
fix: adjust layout and spacing for model comparison header buttons

### DIFF
--- a/DashAI/front/src/components/models/SessionVisualization.jsx
+++ b/DashAI/front/src/components/models/SessionVisualization.jsx
@@ -247,7 +247,9 @@ export default function SessionVisualization() {
               </Tooltip>
             }
             sx={{
+              alignItems: "flex-start",
               "& .MuiAccordionSummary-content": { my: "8px", mr: 1 },
+              "& .MuiAccordionSummary-expandIconWrapper": { mt: "10px" },
             }}
           >
             <Box
@@ -256,13 +258,20 @@ export default function SessionVisualization() {
                 justifyContent: "space-between",
                 alignItems: "center",
                 width: "100%",
+                flexWrap: "wrap",
+                gap: 1,
               }}
             >
               <Typography variant="h6" color="text.primary">
                 {t("models:label.modelComparison")}
               </Typography>
               <Box
-                sx={{ display: "flex", gap: 2, alignItems: "center" }}
+                sx={{
+                  display: "flex",
+                  gap: 1,
+                  alignItems: "center",
+                  flexWrap: "wrap",
+                }}
                 onClick={(e) => e.stopPropagation()}
               >
                 {/* Metric Split Selector — controls both table and graph views */}
@@ -278,17 +287,17 @@ export default function SessionVisualization() {
                     size="small"
                   >
                     {hasTrainMetrics && (
-                      <ToggleButton value="train" sx={{ width: 120 }}>
+                      <ToggleButton value="train">
                         {t("common:train")}
                       </ToggleButton>
                     )}
                     {hasValidationMetrics && (
-                      <ToggleButton value="validation" sx={{ width: 120 }}>
+                      <ToggleButton value="validation">
                         {t("common:validation")}
                       </ToggleButton>
                     )}
                     {hasTestMetrics && (
-                      <ToggleButton value="test" sx={{ width: 120 }}>
+                      <ToggleButton value="test">
                         {t("common:test")}
                       </ToggleButton>
                     )}
@@ -301,7 +310,6 @@ export default function SessionVisualization() {
                     variant={showTable ? "contained" : "outlined"}
                     onClick={() => handleToggleView(true)}
                     startIcon={<TableChart />}
-                    sx={{ width: 110 }}
                   >
                     {t("common:table")}
                   </Button>
@@ -310,7 +318,6 @@ export default function SessionVisualization() {
                     variant={!showTable ? "contained" : "outlined"}
                     onClick={() => handleToggleView(false)}
                     startIcon={<BarChart />}
-                    sx={{ width: 110 }}
                   >
                     {t("common:graphs")}
                   </Button>


### PR DESCRIPTION
## Summary
  Fixed button overflow in the model comparison panel header. On small screens, the action buttons (metric split, table/graphs toggle, run all) now wrap to a second row instead of being clipped.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)
  - `DashAI/front/src/components/models/SessionVisualization.jsx`: Added `flexWrap: "wrap"` to the comparison header button container, removed fixed widths from toggle buttons, and pinned the expand icon to the top-right when content wraps.

  ---

  ## Testing (optional)
  Resize the browser window while on a session with trained models to verify buttons wrap cleanly without being cut off.