### PR TITLE
fix: Add step 0.1 to 0.1 in splits

### DIFF
--- a/DashAI/front/src/components/models/modelSession/SplitDatasetRows.jsx
+++ b/DashAI/front/src/components/models/modelSession/SplitDatasetRows.jsx
@@ -346,7 +346,10 @@ function SplitDatasetRows({
                     fullWidth
                     error={randomSplitError}
                     onChange={handleRowsChange}
-                    slotProps={{ inputLabel: { shrink: true } }}
+                    slotProps={{
+                      inputLabel: { shrink: true },
+                      htmlInput: { step: 0.1 },
+                    }}
                   />
                 </Grid>
               ))}


### PR DESCRIPTION
This pull request makes a minor improvement to the `SplitDatasetRows` component by updating the `slotProps` for the input component. The change ensures that the input field for row splitting now supports decimal values by setting the `step` attribute to `0.1`.

* Allows decimal input for row splitting by adding `step: 0.1` to the `slotProps.htmlInput` in the `SplitDatasetRows` component (`SplitDatasetRows.jsx`).