### PR TITLE
Migrate frontend theme to DashAI blue branding

### DIFF
--- a/DashAI/front/package.json
+++ b/DashAI/front/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-table": "^8.21.3",
     "axios": "^1.3.4",
     "formik": "^2.2.9",
+    "geist": "^1.7.0",
     "html2canvas": "^1.4.1",
     "i18next": "^25.7.4",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/DashAI/front/public/index.html
+++ b/DashAI/front/public/index.html
@@ -15,13 +15,6 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!-- IBM Plex fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/DashAI/front/src/App.jsx
+++ b/DashAI/front/src/App.jsx
@@ -22,56 +22,48 @@ function App() {
       <BrowserRouter
         future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
       >
-        <ModuleThemeWrapper>
-          <ResponsiveAppBar />
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/app" element={<Home />} />
-            <Route path="/app/data/" element={<DatasetsPage />} />
-            <Route path="/app/data/datasets/new" element={<DatasetsPage />} />
-            <Route
-              path="/app/data/datasets/new/:dataloaderName"
-              element={<DatasetsPage />}
-            />
-            <Route path="/app/data/datasets/:id" element={<DatasetsPage />} />
-            <Route path="/app/data/notebooks/new" element={<DatasetsPage />} />
-            <Route path="/app/data/notebooks/:id" element={<DatasetsPage />} />
-            <Route path="/app/models" element={<ModelsPage />} />
-            <Route path="/app/models/datasets/:id" element={<ModelsPage />} />
-            <Route path="/app/models/sessions/:id" element={<ModelsPage />} />
-            <Route
-              path="/app/models/sessions/new/:taskName"
-              element={<ModelsPage />}
-            />
-            <Route path="/app/generative" element={<Generative />} />
-            <Route
-              path="/app/generative/sessions/new"
-              element={<Generative />}
-            />
-            <Route
-              path="/app/generative/sessions/new/:modelName"
-              element={<Generative />}
-            />
-            <Route
-              path="/app/generative/sessions/:id"
-              element={<Generative />}
-            />
-            <Route path="/app/pipelines" element={<PipelinesPage />} />
-            <Route path="/app/pipelines/new" element={<NewPipelineWrapper />} />
-            <Route
-              path="/app/pipelines/:pipelineId"
-              element={<NewPipelineWrapper />}
-            />
-            <Route path="/app/plugins">
+        <ResponsiveAppBar />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/app" element={<Home />} />
+          <Route path="/app/data/" element={<DatasetsPage />} />
+          <Route path="/app/data/datasets/new" element={<DatasetsPage />} />
+          <Route
+            path="/app/data/datasets/new/:dataloaderName"
+            element={<DatasetsPage />}
+          />
+          <Route path="/app/data/datasets/:id" element={<DatasetsPage />} />
+          <Route path="/app/data/notebooks/new" element={<DatasetsPage />} />
+          <Route path="/app/data/notebooks/:id" element={<DatasetsPage />} />
+          <Route path="/app/models" element={<ModelsPage />} />
+          <Route path="/app/models/datasets/:id" element={<ModelsPage />} />
+          <Route path="/app/models/sessions/:id" element={<ModelsPage />} />
+          <Route
+            path="/app/models/sessions/new/:taskName"
+            element={<ModelsPage />}
+          />
+          <Route path="/app/generative" element={<Generative />} />
+          <Route path="/app/generative/sessions/new" element={<Generative />} />
+          <Route
+            path="/app/generative/sessions/new/:modelName"
+            element={<Generative />}
+          />
+          <Route path="/app/generative/sessions/:id" element={<Generative />} />
+          <Route path="/app/pipelines" element={<PipelinesPage />} />
+          <Route path="/app/pipelines/new" element={<NewPipelineWrapper />} />
+          <Route
+            path="/app/pipelines/:pipelineId"
+            element={<NewPipelineWrapper />}
+          />
+          <Route path="/app/plugins">
+            <Route index element={<PluginsPage />} />
+            <Route path=":category">
               <Route index element={<PluginsPage />} />
-              <Route path=":category">
-                <Route index element={<PluginsPage />} />
-                <Route path="details/:id" element={<PluginsDetails />} />
-              </Route>
+              <Route path="details/:id" element={<PluginsDetails />} />
             </Route>
-          </Routes>
-          <JobQueueWidget />
-        </ModuleThemeWrapper>
+          </Route>
+        </Routes>
+        <JobQueueWidget />
       </BrowserRouter>
     </TourRegistryProvider>
   );

--- a/DashAI/front/src/App.jsx
+++ b/DashAI/front/src/App.jsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { TourRegistryProvider } from "./contexts/TourRegistryContext";
+import ModuleThemeWrapper from "./components/ModuleThemeWrapper";
 
 import "./App.css";
 import DatasetsPage from "./pages/datasets/Datasets";
@@ -21,48 +22,56 @@ function App() {
       <BrowserRouter
         future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
       >
-        <ResponsiveAppBar />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/app" element={<Home />} />
-          <Route path="/app/data/" element={<DatasetsPage />} />
-          <Route path="/app/data/datasets/new" element={<DatasetsPage />} />
-          <Route
-            path="/app/data/datasets/new/:dataloaderName"
-            element={<DatasetsPage />}
-          />
-          <Route path="/app/data/datasets/:id" element={<DatasetsPage />} />
-          <Route path="/app/data/notebooks/new" element={<DatasetsPage />} />
-          <Route path="/app/data/notebooks/:id" element={<DatasetsPage />} />
-          <Route path="/app/models" element={<ModelsPage />} />
-          <Route path="/app/models/datasets/:id" element={<ModelsPage />} />
-          <Route path="/app/models/sessions/:id" element={<ModelsPage />} />
-          <Route
-            path="/app/models/sessions/new/:taskName"
-            element={<ModelsPage />}
-          />
-          <Route path="/app/generative" element={<Generative />} />
-          <Route path="/app/generative/sessions/new" element={<Generative />} />
-          <Route
-            path="/app/generative/sessions/new/:modelName"
-            element={<Generative />}
-          />
-          <Route path="/app/generative/sessions/:id" element={<Generative />} />
-          <Route path="/app/pipelines" element={<PipelinesPage />} />
-          <Route path="/app/pipelines/new" element={<NewPipelineWrapper />} />
-          <Route
-            path="/app/pipelines/:pipelineId"
-            element={<NewPipelineWrapper />}
-          />
-          <Route path="/app/plugins">
-            <Route index element={<PluginsPage />} />
-            <Route path=":category">
+        <ModuleThemeWrapper>
+          <ResponsiveAppBar />
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/app" element={<Home />} />
+            <Route path="/app/data/" element={<DatasetsPage />} />
+            <Route path="/app/data/datasets/new" element={<DatasetsPage />} />
+            <Route
+              path="/app/data/datasets/new/:dataloaderName"
+              element={<DatasetsPage />}
+            />
+            <Route path="/app/data/datasets/:id" element={<DatasetsPage />} />
+            <Route path="/app/data/notebooks/new" element={<DatasetsPage />} />
+            <Route path="/app/data/notebooks/:id" element={<DatasetsPage />} />
+            <Route path="/app/models" element={<ModelsPage />} />
+            <Route path="/app/models/datasets/:id" element={<ModelsPage />} />
+            <Route path="/app/models/sessions/:id" element={<ModelsPage />} />
+            <Route
+              path="/app/models/sessions/new/:taskName"
+              element={<ModelsPage />}
+            />
+            <Route path="/app/generative" element={<Generative />} />
+            <Route
+              path="/app/generative/sessions/new"
+              element={<Generative />}
+            />
+            <Route
+              path="/app/generative/sessions/new/:modelName"
+              element={<Generative />}
+            />
+            <Route
+              path="/app/generative/sessions/:id"
+              element={<Generative />}
+            />
+            <Route path="/app/pipelines" element={<PipelinesPage />} />
+            <Route path="/app/pipelines/new" element={<NewPipelineWrapper />} />
+            <Route
+              path="/app/pipelines/:pipelineId"
+              element={<NewPipelineWrapper />}
+            />
+            <Route path="/app/plugins">
               <Route index element={<PluginsPage />} />
-              <Route path="details/:id" element={<PluginsDetails />} />
+              <Route path=":category">
+                <Route index element={<PluginsPage />} />
+                <Route path="details/:id" element={<PluginsDetails />} />
+              </Route>
             </Route>
-          </Route>
-        </Routes>
-        <JobQueueWidget />
+          </Routes>
+          <JobQueueWidget />
+        </ModuleThemeWrapper>
       </BrowserRouter>
     </TourRegistryProvider>
   );

--- a/DashAI/front/src/components/HomeButton.jsx
+++ b/DashAI/front/src/components/HomeButton.jsx
@@ -105,7 +105,7 @@ function HomeButton({
 
       {/* Title */}
       <Typography
-        variant="h5"
+        variant="h4"
         sx={{
           color: theme.palette.text.primary,
           mb: "5px",

--- a/DashAI/front/src/components/ModuleThemeWrapper.jsx
+++ b/DashAI/front/src/components/ModuleThemeWrapper.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+import { createTheme, ThemeProvider, useTheme } from "@mui/material/styles";
+
+const MODULE_PRIMARIES = {
+  "/app/data": {
+    dark: { main: "#FFA578", contrastText: "#191817", hover: "#79310C" },
+    light: { main: "#79310C", contrastText: "#FEFEFF", hover: "#FFA578" },
+  },
+  "/app/models": {
+    dark: { main: "#A7C7FF", contrastText: "#191817", hover: "#2C7AFF" },
+    light: { main: "#2C7AFF", contrastText: "#FEFEFF", hover: "#A7C7FF" },
+  },
+  "/app/generative": {
+    dark: { main: "#90F1C4", contrastText: "#191817", hover: "#005967" },
+    light: { main: "#005967", contrastText: "#FEFEFF", hover: "#90F1C4" },
+  },
+  "/app/plugins": {
+    dark: { main: "#FEE8FF", contrastText: "#191817", hover: "#A54DA9" },
+    light: { main: "#A54DA9", contrastText: "#FEFEFF", hover: "#FEE8FF" },
+  },
+};
+
+function getModuleKey(pathname) {
+  if (pathname.startsWith("/app/data")) return "/app/data";
+  if (pathname.startsWith("/app/models")) return "/app/models";
+  if (pathname.startsWith("/app/generative")) return "/app/generative";
+  if (pathname.startsWith("/app/plugins")) return "/app/plugins";
+  return null;
+}
+
+export default function ModuleThemeWrapper({ children }) {
+  const location = useLocation();
+  const baseTheme = useTheme();
+
+  const moduleKey = getModuleKey(location.pathname);
+  const colors = moduleKey ? MODULE_PRIMARIES[moduleKey] : null;
+
+  if (!colors) return children;
+
+  const { main, contrastText, hover } = colors[baseTheme.palette.mode];
+
+  const moduleTheme = createTheme(baseTheme, {
+    palette: {
+      primary: { main, light: hover, contrastText },
+      action: {
+        hover: `${hover}0F`,
+        selected: `${hover}1A`,
+      },
+    },
+  });
+
+  return <ThemeProvider theme={moduleTheme}>{children}</ThemeProvider>;
+}

--- a/DashAI/front/src/components/ResponsiveAppBar.jsx
+++ b/DashAI/front/src/components/ResponsiveAppBar.jsx
@@ -95,7 +95,7 @@ function ResponsiveAppBar() {
             }}
           >
             <Box component="span" sx={{ color: theme.palette.primary.main }}>
-              Dash
+              dash
             </Box>
             AI
           </Typography>

--- a/DashAI/front/src/components/ResponsiveAppBar.jsx
+++ b/DashAI/front/src/components/ResponsiveAppBar.jsx
@@ -104,8 +104,8 @@ function ResponsiveAppBar() {
               display: { xs: "none", sm: "block" },
               ...theme.typography.statusBadge,
               color: theme.palette.primary.main,
-              border: `1px solid ${theme.palette.accent.amberBorder}`,
-              background: theme.palette.accent.amberDim,
+              border: `1px solid ${theme.palette.primary.main}38`,
+              background: `${theme.palette.primary.main}1F`,
               borderRadius: "2px",
               px: "7px",
               py: "2px",
@@ -204,7 +204,7 @@ function ResponsiveAppBar() {
                     ? theme.palette.primary.main
                     : theme.palette.text.secondary,
                   background: active
-                    ? theme.palette.accent.amberGlow
+                    ? `${theme.palette.primary.main}0A`
                     : "transparent",
                   borderBottom: active
                     ? `2px solid ${theme.palette.primary.main}`

--- a/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
+++ b/DashAI/front/src/components/explainers/SelectDatasetStep.jsx
@@ -176,7 +176,7 @@ export default function SelectDatasetStep({
       sx: {
         cursor: "pointer",
         ...(row.original.id === selectedDatasetId && {
-          backgroundColor: theme.palette.accent.amberDim,
+          backgroundColor: `${theme.palette.primary.main}1F`,
           borderLeft: `3px solid ${theme.palette.primary.main}`,
           "&:hover td": {
             backgroundColor: "transparent",

--- a/DashAI/front/src/components/generative/CreateSessionCenter.jsx
+++ b/DashAI/front/src/components/generative/CreateSessionCenter.jsx
@@ -106,6 +106,7 @@ export default function CreateSessionCenter() {
           flexDirection: "column",
           overflowY: "auto",
           pt: 1,
+          pb: 2,
         }}
       >
         {step === 0 ? (

--- a/DashAI/front/src/components/generative/GenerativeChat.jsx
+++ b/DashAI/front/src/components/generative/GenerativeChat.jsx
@@ -270,18 +270,6 @@ export default function GenerativeChat() {
         mt={1}
         p={2}
         ref={chatContainerRef}
-        sx={{
-          "&::-webkit-scrollbar": {
-            width: "8px",
-          },
-          "&::-webkit-scrollbar-thumb": {
-            backgroundColor: theme.palette.ui.border,
-            borderRadius: "4px",
-          },
-          "&::-webkit-scrollbar-thumb:hover": {
-            backgroundColor: theme.palette.ui.hover,
-          },
-        }}
       >
         {messagesWithHistory?.map((message) => {
           return (

--- a/DashAI/front/src/components/notebooks/converter/ConverterBox.jsx
+++ b/DashAI/front/src/components/notebooks/converter/ConverterBox.jsx
@@ -161,7 +161,13 @@ export default function ConverterBox({
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             <Chip
               label={getConverterStatus(statusLabel, t)}
-              color={statusLabel === 3 ? "primary" : "default"} // Finished
+              color={
+                statusLabel === 3
+                  ? "success"
+                  : statusLabel === 4
+                    ? "error"
+                    : "default"
+              }
               size="small"
             />
             {(statusLabel === 4 || statusLabel === 3) && ( // Error or Finished

--- a/DashAI/front/src/components/notebooks/converter/ItemsToDeleteList.jsx
+++ b/DashAI/front/src/components/notebooks/converter/ItemsToDeleteList.jsx
@@ -1,20 +1,22 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
 
 const ItemsToDeleteList = React.memo(function ItemsToDeleteList({ items }) {
   if (!items || items.length === 0) return null;
 
   const { t } = useTranslation(["common", "datasets"]);
+  const theme = useTheme();
 
   return (
     <Box
       sx={{
         mt: 2,
         p: 2,
-        bgcolor: "#2e3037",
+        bgcolor: theme.palette.ui.panelDark,
         borderRadius: 1,
-        border: "1px solid rgba(255, 255, 255, 0.1)",
+        border: `1px solid ${theme.palette.ui.border}`,
       }}
     >
       <Typography variant="subtitle2" sx={{ color: "error.main", mb: 1 }}>

--- a/DashAI/front/src/components/notebooks/explorer/ExplorerBox.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/ExplorerBox.jsx
@@ -118,7 +118,13 @@ export default function ExplorerBox({
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             <Chip
               label={getExplorerStatus(statusLabel, t)}
-              color={statusLabel === 3 ? "primary" : "default"} // Finished
+              color={
+                statusLabel === 3
+                  ? "success"
+                  : statusLabel === 4
+                    ? "error"
+                    : "default"
+              }
               size="small"
             />
             <>
@@ -134,10 +140,7 @@ export default function ExplorerBox({
                   color="primary"
                   icon={<Info />}
                   sx={{
-                    bgcolor: "primary.main",
-                    "&:hover": {
-                      bgcolor: "primary.dark",
-                    },
+                    "&:hover": { bgcolor: "primary.light" },
                   }}
                 />
               )}

--- a/DashAI/front/src/components/notebooks/explorer/visualizations/PlotlyJsonVisualizer.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/visualizations/PlotlyJsonVisualizer.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
+import { useTheme } from "@mui/material/styles";
 import Plot from "react-plotly.js";
 import { Box, IconButton, Tooltip } from "@mui/material";
 import Dialog from "@mui/material/Dialog";
@@ -15,6 +16,7 @@ const MIN_HEIGHT_MINIMALIST = 200;
 const MIN_HEIGHT_NORMAL = 500;
 
 function PlotlyJsonVisualizer({ data, minimalist = false }) {
+  const theme = useTheme();
   const [expanded, setExpanded] = useState(false);
   const plotRef = useRef(null);
   const fullscreenPlotRef = useRef(null);
@@ -155,24 +157,24 @@ function PlotlyJsonVisualizer({ data, minimalist = false }) {
   };
 
   const iconBtnSx = {
-    bgcolor: "rgba(255,255,255,0.85)",
-    border: "1px solid rgba(0,0,0,0.08)",
-    color: "#9e9e9e",
+    bgcolor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.ui.borderLight}`,
+    color: theme.palette.text.disabled,
     width: 30,
     height: 30,
     "&:hover": {
-      bgcolor: "rgba(255,255,255,1)",
-      color: "#616161",
+      bgcolor: theme.palette.background.paper,
+      color: theme.palette.text.secondary,
     },
   };
 
   const downloadBtnSx = {
-    bgcolor: "#ef9f27",
-    color: "white",
+    bgcolor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
     width: 30,
     height: 30,
     "&:hover": {
-      bgcolor: "#f5b94a",
+      bgcolor: theme.palette.primary.light,
     },
   };
 

--- a/DashAI/front/src/components/pipelines/PipelineDesigner.jsx
+++ b/DashAI/front/src/components/pipelines/PipelineDesigner.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
 import { Box, Tooltip } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import ReactFlow, {
   addEdge,
   Background,
@@ -31,6 +32,7 @@ function PipelineDesigner({
   setNodeIdCounter,
   availableNodes,
 }) {
+  const theme = useTheme();
   const { screenToFlowPosition } = useReactFlow();
 
   const onConnect = (params) => {
@@ -134,8 +136,8 @@ function PipelineDesigner({
           width: "100%",
           height: "100%",
           borderRadius: 12,
-          background: "#f9f9f9",
-          border: "1px solid #ccc",
+          background: theme.palette.background.default,
+          border: `1px solid ${theme.palette.ui.border}`,
           boxShadow: "0 2px 6px rgba(0,0,0,0.1)",
         }}
       >

--- a/DashAI/front/src/components/threeSectionLayout/CollapsibleList.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/CollapsibleList.jsx
@@ -97,8 +97,8 @@ export default function CollapsibleList({
           component="div"
           sx={{
             mr: 1,
-            bgcolor: theme.palette.ui.scrollbar,
-            color: theme.palette.text.primary,
+            bgcolor: "primary.main",
+            color: "primary.light",
             borderRadius: "50%",
             width: 20,
             height: 20,

--- a/DashAI/front/src/components/threeSectionLayout/CollapsibleList.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/CollapsibleList.jsx
@@ -98,7 +98,7 @@ export default function CollapsibleList({
           sx={{
             mr: 1,
             bgcolor: "primary.main",
-            color: "primary.light",
+            color: "primary.contrastText",
             borderRadius: "50%",
             width: 20,
             height: 20,

--- a/DashAI/front/src/components/threeSectionLayout/GroupedCollapsibleList.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/GroupedCollapsibleList.jsx
@@ -117,8 +117,8 @@ export default function GroupedCollapsibleList({
           variant="body2"
           component="div"
           sx={{
-            bgcolor: theme.palette.ui.scrollbar,
-            color: theme.palette.text.primary,
+            bgcolor: "primary.main",
+            color: "primary.light",
             borderRadius: "50%",
             width: 20,
             height: 20,
@@ -194,8 +194,8 @@ export default function GroupedCollapsibleList({
                 component="div"
                 sx={{
                   ml: 1,
-                  bgcolor: theme.palette.ui.scrollbar,
-                  color: theme.palette.text.primary,
+                  bgcolor: "primary.main",
+                  color: "primary.light",
                   borderRadius: "50%",
                   width: 20,
                   height: 20,

--- a/DashAI/front/src/components/threeSectionLayout/GroupedCollapsibleList.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/GroupedCollapsibleList.jsx
@@ -118,7 +118,7 @@ export default function GroupedCollapsibleList({
           component="div"
           sx={{
             bgcolor: "primary.main",
-            color: "primary.light",
+            color: "primary.contrastText",
             borderRadius: "50%",
             width: 20,
             height: 20,
@@ -195,7 +195,7 @@ export default function GroupedCollapsibleList({
                 sx={{
                   ml: 1,
                   bgcolor: "primary.main",
-                  color: "primary.light",
+                  color: "primary.contrastText",
                   borderRadius: "50%",
                   width: 20,
                   height: 20,

--- a/DashAI/front/src/components/threeSectionLayout/NewItemButton.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/NewItemButton.jsx
@@ -21,7 +21,7 @@ export default function NewItemButton({
         height: "100%",
         width: "100%",
         textTransform: "none",
-        "&:hover": { bgcolor: "primary.dark" },
+        "&:hover": { bgcolor: "primary.light" },
       }}
       onClick={onClick}
       endIcon={<AddIcon />}

--- a/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
@@ -94,7 +94,7 @@ export default function OptionBox({
 
       {/* Title */}
       <Typography
-        variant="h5"
+        variant="h4"
         sx={{
           color: theme.palette.text.primary,
           mb: "5px",

--- a/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
@@ -22,10 +22,10 @@ export default function OptionBox({
     }
   }, [description]);
   const theme = useTheme();
-  const accent = theme.palette.accent.amber;
-  const accentDim = theme.palette.accent.amberDim;
-  const accentBorder = theme.palette.accent.amberBorder;
-  const accentGlow = theme.palette.accent.amberGlow;
+  const accent = theme.palette.primary.main;
+  const accentDim = `${theme.palette.primary.main}1F`;
+  const accentBorder = `${theme.palette.primary.main}38`;
+  const accentGlow = `${theme.palette.primary.main}0A`;
 
   return (
     <ButtonBase

--- a/DashAI/front/src/components/tour/CustomTooltip.jsx
+++ b/DashAI/front/src/components/tour/CustomTooltip.jsx
@@ -132,7 +132,7 @@ export const CustomTooltip = ({
 
       <Box
         sx={{
-          fontSize: "14px",
+          fontSize: "16px",
           lineHeight: "1.6",
           color: theme.palette.text.primary,
           pr: 2,
@@ -176,7 +176,6 @@ export const CustomTooltip = ({
               sx={{
                 color: theme.palette.text.secondary,
                 textTransform: "none",
-                fontSize: "12px",
               }}
             >
               {t("common:skipTour")}

--- a/DashAI/front/src/components/tour/TourButton.jsx
+++ b/DashAI/front/src/components/tour/TourButton.jsx
@@ -1,4 +1,5 @@
 import { IconButton, Tooltip } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import { useTourContext } from "./TourProvider";
 
@@ -8,6 +9,7 @@ export const TourButton = ({
   disabledMessage = "Tour not available",
 }) => {
   const { resetTour, startTour } = useTourContext();
+  const theme = useTheme();
   return (
     <Tooltip title={disabled ? disabledMessage : "Start Tour"} placement="left">
       <IconButton
@@ -21,12 +23,16 @@ export const TourButton = ({
           position: "fixed",
           top: 64,
           right: 16,
-          backgroundColor: disabled ? "#9e9e9e" : "#1976d2",
-          color: "white",
+          backgroundColor: disabled
+            ? theme.palette.action.disabled
+            : theme.palette.primary.main,
+          color: theme.palette.primary.contrastText,
           width: 36,
           height: 36,
           "&:hover": {
-            backgroundColor: disabled ? "#9e9e9e" : "#1565c0",
+            backgroundColor: disabled
+              ? theme.palette.action.disabled
+              : theme.palette.primary.dark,
             transform: disabled ? "none" : "scale(1.05)",
           },
           transition: "all 0.2s ease-in-out",

--- a/DashAI/front/src/components/tour/TourProvider.jsx
+++ b/DashAI/front/src/components/tour/TourProvider.jsx
@@ -11,7 +11,8 @@ import GlobalStyles from "@mui/material/GlobalStyles";
 import { useTranslation } from "react-i18next";
 import { useTour } from "../../hooks/useTour";
 import { tours } from "../../constants/tours";
-import { tourStyles } from "./tourStyles";
+import { getTourStyles } from "./tourStyles";
+import { useTheme } from "@mui/material/styles";
 import { CustomTooltip } from "./CustomTooltip";
 import { useTourRegistry } from "../../contexts/TourRegistryContext";
 
@@ -71,6 +72,7 @@ export const TourProvider = ({
   disabledMessage: disabledMessageProp = "Tour not available",
 }) => {
   const { t } = useTranslation(["common"]);
+  const theme = useTheme();
   const registry = useTourRegistry() ?? NOOP_REGISTRY;
   const regIdRef = useRef(null);
 
@@ -174,7 +176,7 @@ export const TourProvider = ({
         disableCloseOnEsc={tourData.config.disableCloseOnEsc}
         locale={locale}
         disableScrollParentFix={true}
-        styles={tourStyles}
+        styles={getTourStyles(theme)}
         tooltipComponent={CustomTooltip}
         scrollToFirstStep
         scrollOffset={100}

--- a/DashAI/front/src/components/tour/tourStyles.js
+++ b/DashAI/front/src/components/tour/tourStyles.js
@@ -1,16 +1,16 @@
-export const tourStyles = {
+export const getTourStyles = (theme) => ({
   options: {
-    arrowColor: "#111110",
-    backgroundColor: "#111110",
+    arrowColor: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
     beaconSize: 36,
     overlayColor: "rgba(0, 0, 0, 0.5)",
-    primaryColor: "#ef9f27",
+    primaryColor: theme.palette.primary.main,
     spotlightShadow: "none",
-    textColor: "#333",
+    textColor: theme.palette.text.primary,
     width: 280,
     zIndex: 10000,
   },
   beacon: {
     animation: "pulse 2s infinite",
   },
-};
+});

--- a/DashAI/front/src/index.css
+++ b/DashAI/front/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
+  font-family: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI",
     "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
     "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -8,6 +8,6 @@ body {
 }
 
 code {
-  font-family: "IBM Plex Mono", source-code-pro, Menlo, Monaco, Consolas,
+  font-family: "Geist Mono", source-code-pro, Menlo, Monaco, Consolas,
     "Courier New", monospace;
 }

--- a/DashAI/front/src/index.jsx
+++ b/DashAI/front/src/index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "./styles/geist-font.css";
 import "./index.css";
 import CssBaseline from "@mui/material/CssBaseline";
 import App from "./App";

--- a/DashAI/front/src/pages/home/Home.jsx
+++ b/DashAI/front/src/pages/home/Home.jsx
@@ -53,13 +53,16 @@ function SidebarSection({ label, links, t, theme }) {
       sx={{ pb: 2, borderBottom: `1px solid ${theme.palette.ui.borderLight}` }}
     >
       <Typography
+        variant="caption"
         sx={{
           color: theme.palette.text.disabled,
           px: "20px",
           py: "10px",
           pb: "6px",
           display: "block",
-          ...theme.typography.sectionLabel,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          fontFamily: '"Geist Mono", monospace',
         }}
       >
         {label}
@@ -203,7 +206,7 @@ function Home() {
         <Box
           component="aside"
           sx={{
-            width: 220,
+            width: 230,
             flexShrink: 0,
             borderRight: `1px solid ${theme.palette.divider}`,
             background: theme.palette.background.box,
@@ -234,14 +237,13 @@ function Home() {
             }}
           >
             <Typography
+              variant="sectionLabel"
               sx={{
-                fontSize: "9px",
                 color: theme.palette.text.disabled,
-                letterSpacing: "0.04em",
                 lineHeight: 1.9,
               }}
             >
-              v0.2.1-beta · MIT License
+              v0.9.3-alpha - MIT License
             </Typography>
           </Box>
         </Box>

--- a/DashAI/front/src/pages/home/Home.jsx
+++ b/DashAI/front/src/pages/home/Home.jsx
@@ -85,7 +85,7 @@ function SidebarSection({ label, links, t, theme }) {
             "&:hover": {
               background: theme.palette.ui.hover,
               color: theme.palette.text.primary,
-              borderLeftColor: theme.palette.accent.amberBorder,
+              borderLeftColor: `${theme.palette.primary.main}38`,
             },
             "&:hover .ext-icon": { opacity: 1 },
           }}

--- a/DashAI/front/src/pages/home/Home.jsx
+++ b/DashAI/front/src/pages/home/Home.jsx
@@ -262,10 +262,7 @@ function Home() {
               py: "20px",
               pb: "18px",
               borderBottom: `1px solid ${theme.palette.divider}`,
-              background:
-                theme.palette.mode === "dark"
-                  ? "rgba(12,12,10,0.7)"
-                  : theme.palette.background.box,
+              background: theme.palette.background.default,
             }}
           >
             <Typography variant="h3" sx={{ color: theme.palette.text.primary }}>

--- a/DashAI/front/src/pages/pipelines/NewPipeline.jsx
+++ b/DashAI/front/src/pages/pipelines/NewPipeline.jsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
   IconButton,
 } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import CloseIcon from "@mui/icons-material/Close";
 import { ReactFlowProvider } from "reactflow";
 import CustomLayout from "../../components/custom/CustomLayout";
@@ -22,6 +23,7 @@ import {
 } from "../../components/pipelines";
 
 function NewPipeline() {
+  const theme = useTheme();
   const location = useLocation();
   const { pipelineId } = useParams();
   const navigate = useNavigate();
@@ -125,7 +127,13 @@ function NewPipeline() {
                 nodeHelp={nodeHelp}
               />
 
-              <Box sx={{ flexGrow: 1, p: 2, backgroundColor: "#f5f5f5" }}>
+              <Box
+                sx={{
+                  flexGrow: 1,
+                  p: 2,
+                  backgroundColor: theme.palette.background.default,
+                }}
+              >
                 <PipelineToolbar
                   pipelineName={pipelineName}
                   setPipelineName={setPipelineName}

--- a/DashAI/front/src/pages/plugins/components/PluginsCard.jsx
+++ b/DashAI/front/src/pages/plugins/components/PluginsCard.jsx
@@ -159,7 +159,7 @@ function PluginsCard({
               updatePlugin();
             }}
             sx={{
-              fontSize: "13px",
+              fontSize: "12px",
               fontWeight: 500,
               color: accent,
               cursor: "pointer",
@@ -351,7 +351,7 @@ function PluginsCard({
                 updatePlugin();
               }}
               sx={{
-                fontSize: "13px",
+                fontSize: "12px",
                 fontWeight: 500,
                 color: accent,
                 cursor: "pointer",

--- a/DashAI/front/src/pages/plugins/components/PluginsCard.jsx
+++ b/DashAI/front/src/pages/plugins/components/PluginsCard.jsx
@@ -21,10 +21,10 @@ function PluginsCard({
   const { t } = useTranslation(["plugins"]);
   const theme = useTheme();
 
-  const accent = theme.palette.accent.coral;
-  const accentDim = theme.palette.accent.coralDim;
-  const accentBorder = theme.palette.accent.coralBorder;
-  const accentGlow = theme.palette.accent.coralGlow;
+  const accent = theme.palette.primary.main;
+  const accentDim = `${accent}1F`;
+  const accentBorder = `${accent}38`;
+  const accentGlow = `${accent}0A`;
 
   const descRef = React.useRef(null);
   const [isTruncated, setIsTruncated] = React.useState(false);

--- a/DashAI/front/src/styles/geist-font.css
+++ b/DashAI/front/src/styles/geist-font.css
@@ -1,0 +1,15 @@
+@font-face {
+  font-family: "Geist";
+  src: url("../../node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2") format("woff2");
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Geist Mono";
+  src: url("../../node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2") format("woff2");
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}

--- a/DashAI/front/src/styles/theme.js
+++ b/DashAI/front/src/styles/theme.js
@@ -3,58 +3,58 @@ const getTheme = (mode) => ({
     mode,
 
     primary: {
-      light: mode === "dark" ? "#f5b94a" : "#d98200",
-      main: mode === "dark" ? "#ef9f27" : "#b86e00",
-      dark: mode === "dark" ? "#c47d0e" : "#8f5200",
-      contrastText: mode === "dark" ? "#0c0c0a" : "#ffffff",
+      light: "#A7C7FF",
+      main: "#2C7AFF",
+      dark: "#001C34",
+      contrastText: "#FEFEFF",
     },
 
     secondary: {
-      light: "#2ec98a",
-      main: "#1d9e75",
-      dark: "#14735a",
-      contrastText: "#ffffff",
+      light: "#5B96D6",
+      main: "#1A5FA3",
+      dark: "#001C34",
+      contrastText: "#FEFEFF",
     },
 
-    divider: mode === "dark" ? "rgba(239,159,39,0.10)" : "rgba(0,0,0,0.10)",
+    divider: mode === "dark" ? "rgba(44,122,255,0.12)" : "rgba(0,28,52,0.10)",
 
     background:
       mode === "dark"
         ? {
-            default: "#0c0c0a",
-            paper: "#111110",
-            box: "#0f0f0d",
+            default: "#191817",
+            paper: "#1F1E1D",
+            box: "#1B1A19",
           }
         : {
-            default: "#f5f5f5",
-            paper: "#ffffff",
-            box: "#fafafa",
+            default: "#FEFEFF",
+            paper: "#FFFFFF",
+            box: "#F5F8FF",
           },
 
     text:
       mode === "dark"
         ? {
-            primary: "#f2ede2",
-            secondary: "rgba(232,228,217,0.75)",
-            disabled: "rgba(232,228,217,0.45)",
+            primary: "#fefeff",
+            secondary: "rgba(254,254,255,0.70)",
+            disabled: "rgba(254,254,255,0.40)",
           }
         : {
-            primary: "#111111",
-            secondary: "rgba(17,17,17,0.5)",
-            disabled: "rgba(17,17,17,0.3)",
+            primary: "#191817",
+            secondary: "rgba(25,24,23,0.60)",
+            disabled: "rgba(25,24,23,0.35)",
           },
 
     action:
       mode === "dark"
         ? {
-            hover: "rgba(239,159,39,0.04)",
-            selected: "rgba(239,159,39,0.08)",
-            disabled: "rgba(232,228,217,0.3)",
-            disabledBackground: "rgba(232,228,217,0.12)",
+            hover: "rgba(44,122,255,0.06)",
+            selected: "rgba(44,122,255,0.10)",
+            disabled: "rgba(254,254,255,0.30)",
+            disabledBackground: "rgba(254,254,255,0.12)",
           }
         : {
-            hover: "rgba(0,0,0,0.04)",
-            selected: "rgba(0,0,0,0.08)",
+            hover: "rgba(44,122,255,0.06)",
+            selected: "rgba(44,122,255,0.10)",
             disabled: "rgba(0,0,0,0.26)",
             disabledBackground: "rgba(0,0,0,0.12)",
           },
@@ -70,47 +70,63 @@ const getTheme = (mode) => ({
       light: "#4caf50",
     },
     info: {
-      main: "#2196f3",
-      light: "#3e68ff",
+      main: "#2C7AFF",
+      light: "#A7C7FF",
     },
 
-    // Card accent colors — same in both modes
+    // Module accent colors — dark uses lighter variants, light uses darker variants
     accent: {
-      amber: "#ef9f27",
-      amberDim: "rgba(239,159,39,0.12)",
-      amberBorder: "rgba(239,159,39,0.22)",
-      amberGlow: "rgba(239,159,39,0.04)",
-      teal: "#1d9e75",
-      tealDim: "rgba(29,158,117,0.10)",
-      tealBorder: "rgba(29,158,117,0.22)",
-      tealGlow: "rgba(29,158,117,0.04)",
-      purple: "#9b7de8",
-      purpleDim: "rgba(155,125,232,0.10)",
-      purpleBorder: "rgba(155,125,232,0.22)",
-      purpleGlow: "rgba(155,125,232,0.04)",
-      coral: "#d85a30",
-      coralDim: "rgba(216,90,48,0.10)",
-      coralBorder: "rgba(216,90,48,0.22)",
-      coralGlow: "rgba(216,90,48,0.04)",
+      // Datasets → blue
+      amber: mode === "dark" ? "#A7C7FF" : "#2C7AFF",
+      amberDim:
+        mode === "dark" ? "rgba(167,199,255,0.12)" : "rgba(44,122,255,0.12)",
+      amberBorder:
+        mode === "dark" ? "rgba(167,199,255,0.22)" : "rgba(44,122,255,0.22)",
+      amberGlow:
+        mode === "dark" ? "rgba(167,199,255,0.04)" : "rgba(44,122,255,0.04)",
+      // Models → orange-brown
+      teal: mode === "dark" ? "#FFA578" : "#79310C",
+      tealDim:
+        mode === "dark" ? "rgba(255,165,120,0.12)" : "rgba(121,49,12,0.12)",
+      tealBorder:
+        mode === "dark" ? "rgba(255,165,120,0.22)" : "rgba(121,49,12,0.22)",
+      tealGlow:
+        mode === "dark" ? "rgba(255,165,120,0.04)" : "rgba(121,49,12,0.04)",
+      // Generative → teal/mint
+      purple: mode === "dark" ? "#90F1C4" : "#005967",
+      purpleDim:
+        mode === "dark" ? "rgba(144,241,196,0.12)" : "rgba(0,89,103,0.12)",
+      purpleBorder:
+        mode === "dark" ? "rgba(144,241,196,0.22)" : "rgba(0,89,103,0.22)",
+      purpleGlow:
+        mode === "dark" ? "rgba(144,241,196,0.04)" : "rgba(0,89,103,0.04)",
+      // Plugins → purple
+      coral: mode === "dark" ? "#FEE8FF" : "#A54DA9",
+      coralDim:
+        mode === "dark" ? "rgba(254,232,255,0.12)" : "rgba(165,77,169,0.12)",
+      coralBorder:
+        mode === "dark" ? "rgba(254,232,255,0.22)" : "rgba(165,77,169,0.22)",
+      coralGlow:
+        mode === "dark" ? "rgba(254,232,255,0.04)" : "rgba(165,77,169,0.04)",
     },
 
     status: {
       notStarted: mode === "dark" ? "#626262" : "#9e9e9e",
-      started: "#3e68ffff",
+      started: "#2C7AFF",
       finished: "#43A047",
-      delivered: "#3e68ffff",
+      delivered: "#2C7AFF",
       error: mode === "dark" ? "#A70909" : "#c62828",
     },
 
     dataType: {
-      numerical: "#00BEBB", // Numerical data (float)
-      integer: "#5c6bc0", // Integer data
-      categorical: "#9c27b0", // Categorical data
-      text: "#d4a054", // Text/string data
-      boolean: "#8bc34a", // Boolean data
-      datetime: "#e91e63", // Date/time data
-      image: "#6E86E8", // Image data
-      default: "#757575", // Unknown or default type
+      numerical: "#00BEBB",
+      integer: "#5c6bc0",
+      categorical: "#9c27b0",
+      text: "#d4a054",
+      boolean: "#8bc34a",
+      datetime: "#e91e63",
+      image: "#6E86E8",
+      default: "#757575",
     },
 
     chart: {
@@ -132,43 +148,42 @@ const getTheme = (mode) => ({
     ui:
       mode === "dark"
         ? {
-            border: "rgba(239,159,39,0.10)",
-            borderLight: "rgba(239,159,39,0.06)",
-            borderMed: "rgba(239,159,39,0.18)",
-            borderDark: "rgba(239,159,39,0.22)",
-            panelDark: "#0f0f0d",
-            panelMedium: "#111110",
-            panelLight: "#161614",
-            scrollbar: "rgba(239,159,39,0.25)",
-            scrollbarHover: "rgba(239,159,39,0.4)",
-            hover: "rgba(239,159,39,0.03)",
-            divider: "rgba(239,159,39,0.10)",
-            box: "#0f0f0d",
-            disabled: "#161614",
+            border: "rgba(44,122,255,0.10)",
+            borderLight: "rgba(44,122,255,0.06)",
+            borderMed: "rgba(44,122,255,0.18)",
+            borderDark: "rgba(44,122,255,0.22)",
+            panelDark: "#1B1A19",
+            panelMedium: "#1F1E1D",
+            panelLight: "#232221",
+            scrollbar: "rgba(44,122,255,0.25)",
+            scrollbarHover: "rgba(44,122,255,0.40)",
+            hover: "rgba(44,122,255,0.04)",
+            divider: "rgba(44,122,255,0.10)",
+            box: "#1B1A19",
+            disabled: "#232221",
             rowDisabled: "rgba(255,255,255,0.04)",
           }
         : {
-            border: "rgba(0,0,0,0.10)",
-            borderLight: "rgba(0,0,0,0.06)",
-            borderMed: "rgba(0,0,0,0.16)",
-            borderDark: "rgba(0,0,0,0.22)",
-            panelDark: "#f5f5f5",
-            panelMedium: "#fafafa",
-            panelLight: "#ffffff",
-            scrollbar: "#bdbdbd",
-            scrollbarHover: "#9e9e9e",
-            hover: "rgba(0,0,0,0.04)",
-            divider: "rgba(0,0,0,0.10)",
-            box: "#fafafa",
-            disabled: "#f5f5f5",
-            rowDisabled: "rgba(0,0,0,0.04)",
+            border: "rgba(0,28,52,0.10)",
+            borderLight: "rgba(0,28,52,0.06)",
+            borderMed: "rgba(0,28,52,0.16)",
+            borderDark: "rgba(0,28,52,0.22)",
+            panelDark: "#EEF2FF",
+            panelMedium: "#F5F8FF",
+            panelLight: "#FFFFFF",
+            scrollbar: "#A7C7FF",
+            scrollbarHover: "#7AABFF",
+            hover: "rgba(44,122,255,0.04)",
+            divider: "rgba(0,28,52,0.10)",
+            box: "#F5F8FF",
+            disabled: "#EEF2FF",
+            rowDisabled: "rgba(44,122,255,0.04)",
           },
   },
 
   typography: {
-    fontFamily: '"IBM Plex Sans", sans-serif',
+    fontFamily: '"Geist", sans-serif',
 
-    // --- ESCALA DE TITULARES ---
     h1: { fontSize: "28px", fontWeight: 700, letterSpacing: "-0.01em" },
     h2: { fontSize: "22px", fontWeight: 600, letterSpacing: "-0.01em" },
     h3: { fontSize: "20px", fontWeight: 600, letterSpacing: "-0.01em" },
@@ -176,34 +191,32 @@ const getTheme = (mode) => ({
     h5: { fontSize: "16px", fontWeight: 600 },
     h6: { fontSize: "14px", fontWeight: 600 },
 
-    // --- ESCALA DE CUERPO ---
-    subtitle1: { fontSize: "17px", fontWeight: 400 }, // Parámetros principales
-    subtitle2: { fontSize: "16px", fontWeight: 400 }, // Texto destacado
-    body1: { fontSize: "14px", fontWeight: 400, lineHeight: 1.6 }, // Cuerpo / párrafos
-    body2: { fontSize: "12px", fontWeight: 400, lineHeight: 1.5 }, // Texto auxiliar / labels
-    caption: { fontSize: "12px", fontWeight: 400 }, // Información secundaria, captions
+    subtitle1: { fontSize: "17px", fontWeight: 400 },
+    subtitle2: { fontSize: "16px", fontWeight: 400 },
+    body1: { fontSize: "14px", fontWeight: 400, lineHeight: 1.6 },
+    body2: { fontSize: "12px", fontWeight: 400, lineHeight: 1.5 },
+    caption: { fontSize: "12px", fontWeight: 400 },
     code: {
-      fontFamily: '"IBM Plex Mono", monospace',
+      fontFamily: '"Geist Mono", monospace',
       fontSize: "12px",
       fontWeight: 400,
-    }, // Code snippets, valores técnicos
+    },
 
-    // --- VARIANTES UI FUNCIONALES ---
-    navItem: { fontSize: "12px", fontWeight: 400 }, // Sidebar links/Navigation
+    navItem: { fontSize: "12px", fontWeight: 400 },
     tabLabel: {
-      fontFamily: '"IBM Plex Mono", monospace',
+      fontFamily: '"Geist Mono", monospace',
       fontSize: "10px",
       letterSpacing: "0.12em",
       textTransform: "uppercase",
-    }, // Navigation tabs
+    },
     sectionLabel: {
-      fontFamily: '"IBM Plex Mono", monospace',
+      fontFamily: '"Geist Mono", monospace',
       fontSize: "9px",
       letterSpacing: "0.2em",
       textTransform: "uppercase",
-    }, // Sidebar section headers
+    },
     statusBadge: {
-      fontFamily: '"IBM Plex Mono", monospace',
+      fontFamily: '"Geist Mono", monospace',
       fontSize: "8.5px",
       letterSpacing: "0.12em",
       textTransform: "uppercase",
@@ -229,13 +242,13 @@ const getTheme = (mode) => ({
           -webkit-border-radius: 10px;
           border-radius: 10px;
           background: ${
-            mode === "dark" ? "rgba(239,159,39,0.25)" : "rgba(0,0,0,0.3)"
+            mode === "dark" ? "rgba(44, 122, 255, 0.25)" : "rgba(0,28,52,0.25)"
           };
-          -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
+          -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.2);
         }
         ::-webkit-scrollbar-thumb:window-inactive {
           background: ${
-            mode === "dark" ? "rgba(239,159,39,0.12)" : "rgba(0,0,0,0.2)"
+            mode === "dark" ? "rgba(44,122,255,0.12)" : "rgba(0,28,52,0.15)"
           };
         }
       `,

--- a/DashAI/front/src/styles/theme.js
+++ b/DashAI/front/src/styles/theme.js
@@ -16,7 +16,7 @@ const getTheme = (mode) => ({
       contrastText: "#FEFEFF",
     },
 
-    divider: mode === "dark" ? "rgba(44,122,255,0.12)" : "rgba(0,28,52,0.10)",
+    divider: mode === "dark" ? "rgba(254,254,255,0.10)" : "rgba(0,28,52,0.10)",
 
     background:
       mode === "dark"
@@ -76,22 +76,22 @@ const getTheme = (mode) => ({
 
     // Module accent colors — dark uses lighter variants, light uses darker variants
     accent: {
-      // Datasets → blue
-      amber: mode === "dark" ? "#A7C7FF" : "#2C7AFF",
+      // Datasets → orange-brown
+      amber: mode === "dark" ? "#FFA578" : "#79310C",
       amberDim:
-        mode === "dark" ? "rgba(167,199,255,0.12)" : "rgba(44,122,255,0.12)",
-      amberBorder:
-        mode === "dark" ? "rgba(167,199,255,0.22)" : "rgba(44,122,255,0.22)",
-      amberGlow:
-        mode === "dark" ? "rgba(167,199,255,0.04)" : "rgba(44,122,255,0.04)",
-      // Models → orange-brown
-      teal: mode === "dark" ? "#FFA578" : "#79310C",
-      tealDim:
         mode === "dark" ? "rgba(255,165,120,0.12)" : "rgba(121,49,12,0.12)",
-      tealBorder:
+      amberBorder:
         mode === "dark" ? "rgba(255,165,120,0.22)" : "rgba(121,49,12,0.22)",
-      tealGlow:
+      amberGlow:
         mode === "dark" ? "rgba(255,165,120,0.04)" : "rgba(121,49,12,0.04)",
+      // Models → blue
+      teal: mode === "dark" ? "#A7C7FF" : "#2C7AFF",
+      tealDim:
+        mode === "dark" ? "rgba(167,199,255,0.12)" : "rgba(44,122,255,0.12)",
+      tealBorder:
+        mode === "dark" ? "rgba(167,199,255,0.22)" : "rgba(44,122,255,0.22)",
+      tealGlow:
+        mode === "dark" ? "rgba(167,199,255,0.04)" : "rgba(44,122,255,0.04)",
       // Generative → teal/mint
       purple: mode === "dark" ? "#90F1C4" : "#005967",
       purpleDim:
@@ -148,17 +148,17 @@ const getTheme = (mode) => ({
     ui:
       mode === "dark"
         ? {
-            border: "rgba(44,122,255,0.10)",
-            borderLight: "rgba(44,122,255,0.06)",
-            borderMed: "rgba(44,122,255,0.18)",
-            borderDark: "rgba(44,122,255,0.22)",
+            border: "rgba(254,254,255,0.10)",
+            borderLight: "rgba(254,254,255,0.06)",
+            borderMed: "rgba(254,254,255,0.16)",
+            borderDark: "rgba(254,254,255,0.22)",
             panelDark: "#1B1A19",
             panelMedium: "#1F1E1D",
             panelLight: "#232221",
-            scrollbar: "rgba(44,122,255,0.25)",
-            scrollbarHover: "rgba(44,122,255,0.40)",
-            hover: "rgba(44,122,255,0.04)",
-            divider: "rgba(44,122,255,0.10)",
+            scrollbar: "rgba(254,254,255,0.20)",
+            scrollbarHover: "rgba(254,254,255,0.35)",
+            hover: "rgba(254,254,255,0.04)",
+            divider: "rgba(254,254,255,0.10)",
             box: "#1B1A19",
             disabled: "#232221",
             rowDisabled: "rgba(255,255,255,0.04)",
@@ -230,6 +230,24 @@ const getTheme = (mode) => ({
   },
 
   components: {
+    MuiIconButton: {
+      styleOverrides: {
+        colorPrimary: ({ theme }) => ({
+          "&:hover": {
+            backgroundColor: `${theme.palette.primary.light}1A`,
+          },
+        }),
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        containedPrimary: ({ theme }) => ({
+          "&:hover": {
+            backgroundColor: theme.palette.primary.light,
+          },
+        }),
+      },
+    },
     MuiCssBaseline: {
       styleOverrides: `
         ::-webkit-scrollbar { width: 12px; }
@@ -242,7 +260,7 @@ const getTheme = (mode) => ({
           -webkit-border-radius: 10px;
           border-radius: 10px;
           background: ${
-            mode === "dark" ? "rgba(44, 122, 255, 0.25)" : "rgba(0,28,52,0.25)"
+            mode === "dark" ? "rgba(254,254,255,0.20)" : "rgba(0,28,52,0.25)"
           };
           -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.2);
         }

--- a/DashAI/front/src/styles/theme.js
+++ b/DashAI/front/src/styles/theme.js
@@ -187,13 +187,13 @@ const getTheme = (mode) => ({
     h1: { fontSize: "28px", fontWeight: 700, letterSpacing: "-0.01em" },
     h2: { fontSize: "22px", fontWeight: 600, letterSpacing: "-0.01em" },
     h3: { fontSize: "20px", fontWeight: 600, letterSpacing: "-0.01em" },
-    h4: { fontSize: "17px", fontWeight: 600, letterSpacing: "-0.01em" },
+    h4: { fontSize: "20px", fontWeight: 600, letterSpacing: "-0.01em" },
     h5: { fontSize: "16px", fontWeight: 600 },
-    h6: { fontSize: "14px", fontWeight: 600 },
+    h6: { fontSize: "16px", fontWeight: 600 },
 
     subtitle1: { fontSize: "17px", fontWeight: 400 },
     subtitle2: { fontSize: "16px", fontWeight: 400 },
-    body1: { fontSize: "14px", fontWeight: 400, lineHeight: 1.6 },
+    body1: { fontSize: "16px", fontWeight: 400, lineHeight: 1.6 },
     body2: { fontSize: "12px", fontWeight: 400, lineHeight: 1.5 },
     caption: { fontSize: "12px", fontWeight: 400 },
     code: {
@@ -222,7 +222,7 @@ const getTheme = (mode) => ({
       textTransform: "uppercase",
     },
     button: {
-      fontSize: "14px",
+      fontSize: "16px",
       fontWeight: 500,
       letterSpacing: "-0.01em",
       textTransform: "uppercase",

--- a/DashAI/front/yarn.lock
+++ b/DashAI/front/yarn.lock
@@ -7979,6 +7979,7 @@ __metadata:
     eslint-plugin-promise: ^6.0.0
     eslint-plugin-react: ^7.34.2
     formik: ^2.2.9
+    geist: ^1.7.0
     html2canvas: ^1.4.1
     i18next: ^25.7.4
     i18next-browser-languagedetector: ^8.2.0
@@ -10293,6 +10294,15 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: c3f1f5ba20f4e962efb71344ce0a40722163e85bee2101ce25f88214e78182d2d2476aa85ef37950c579eb6cf6ee811c17b3101bb84004bb75655f3e33f3fdb5
+  languageName: node
+  linkType: hard
+
+"geist@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "geist@npm:1.7.0"
+  peerDependencies:
+    next: ">=13.2.0"
+  checksum: 0891451c11d1c06700ccd5764e883a66b8aa9936efe4ecde648779d29765b9fcc7262a46907712c112e37b7c8c0c4970b90888ca7e70b3ebdd24a9177a988060
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Applies the new DashAI brand identity (May 2026) to the frontend: replaces the orange color palette with the brand blue (`#2C7AFF`), updates backgrounds and UI chrome, assigns per-module accent colors from the design spec, and swaps IBM Plex for the Geist variable font.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/styles/theme.js`: Full palette rewrite — primary color `#2C7AFF`, dark background `#191817`, light background `#FEFEFF`, blue-based borders/actions/scrollbars, per-module mode-aware accent colors (datasets blue, models orange-brown, generative teal, plugins purple), font family updated to Geist
- `DashAI/front/src/styles/geist-font.css`: New file loading Geist and Geist Mono variable fonts from the `geist` npm package
- `DashAI/front/src/index.jsx`: Imports `geist-font.css`
- `DashAI/front/src/index.css`: Updates body/code font-family declarations to Geist
- `DashAI/front/public/index.html`: Removes IBM Plex Google Fonts link
- `DashAI/front/src/pages/home/Home.jsx`: Replaces hardcoded dark background color with `theme.palette.background.default`

---

## Notes
Module accent colors are mode-aware: dark mode uses the lighter brand variants (`#A7C7FF`, `#FFA578`, `#90F1C4`, `#FEE8FF`) for legibility on dark backgrounds; light mode uses the darker variants (`#2C7AFF`, `#79310C`, `#005967`, `#A54DA9`). The `geist` npm package was added as a dependency.
