### PR TITLE
demo:refactor: round correlation matrix results and  heatmap color scheme

### DIFF
--- a/DashAI/back/exploration/explorers/corr_matrix.py
+++ b/DashAI/back/exploration/explorers/corr_matrix.py
@@ -229,11 +229,9 @@ class CorrelationMatrixExplorer(StatisticalExplorer):
             numeric_only=self.numeric_only,
         )
 
-        result = result.round(4)
-
         if self.plot:
             result = px.imshow(
-                result,
+                result.round(4),
                 text_auto=".4~f",
                 aspect="auto",
                 title=f"Correlation Matrix of {len(explorer_info.columns)} columns",

--- a/DashAI/back/exploration/explorers/corr_matrix.py
+++ b/DashAI/back/exploration/explorers/corr_matrix.py
@@ -229,10 +229,12 @@ class CorrelationMatrixExplorer(StatisticalExplorer):
             numeric_only=self.numeric_only,
         )
 
+        result = result.round(4)
+
         if self.plot:
             result = px.imshow(
                 result,
-                text_auto=True,
+                text_auto=".4~f",
                 aspect="auto",
                 title=f"Correlation Matrix of {len(explorer_info.columns)} columns",
             )

--- a/DashAI/front/src/pages/results/constants/graphsMaking.jsx
+++ b/DashAI/front/src/pages/results/constants/graphsMaking.jsx
@@ -1,3 +1,7 @@
+import getTheme from "../../../styles/theme";
+
+const darkTheme = getTheme("dark");
+
 const getTraceColors = (theme) => [
   theme.palette.primary.main,
   theme.palette.secondary.main,
@@ -114,8 +118,9 @@ function heatmapMaking(
     metricsMetadata[m]?.maximize === false ? `${m} ↓` : m,
   );
 
-  const primaryColor = theme.palette.primary.main;
-  const secondaryColor = theme.palette.secondary.main;
+  // To use current-mode colors, replace `darkTheme` with `theme` below
+  const worstColor = darkTheme.palette.error.main;
+  const bestColor = darkTheme.palette.accent.teal;
 
   return [
     {
@@ -126,10 +131,10 @@ function heatmapMaking(
       text: annotationText,
       texttemplate: "%{text}",
       textfont: { size: 11, weight: 700, color: theme.palette.text.primary },
-      // orange (primary) = min/worst, green (secondary) = max/best
+      // amber (accent) = min/worst, teal/blue (accent) = max/best
       colorscale: [
-        [0, primaryColor],
-        [1, secondaryColor],
+        [0, worstColor],
+        [1, bestColor],
       ],
       zauto: false,
       zmin: 0,

--- a/DashAI/front/src/pages/results/constants/graphsMaking.jsx
+++ b/DashAI/front/src/pages/results/constants/graphsMaking.jsx
@@ -1,7 +1,3 @@
-import getTheme from "../../../styles/theme";
-
-const darkTheme = getTheme("dark");
-
 const getTraceColors = (theme) => [
   theme.palette.primary.main,
   theme.palette.secondary.main,
@@ -118,9 +114,11 @@ function heatmapMaking(
     metricsMetadata[m]?.maximize === false ? `${m} ↓` : m,
   );
 
-  // To use current-mode colors, replace `darkTheme` with `theme` below
-  const worstColor = darkTheme.palette.error.main;
-  const bestColor = darkTheme.palette.accent.teal;
+  // error.main dark (#ff8383) / light (#d32f2f); primary.light is #A7C7FF in both modes
+  // To use current-mode colors, change the ternary to just `theme.palette.error.main`
+  const worstColor =
+    theme.palette.mode === "dark" ? theme.palette.error.main : "#ff8383";
+  const bestColor = theme.palette.primary.light;
 
   return [
     {


### PR DESCRIPTION
This pull request updates the correlation matrix visualization and the heatmap color scheme to improve readability and ensure consistent theming across the application. The most important changes include rounding correlation values for clarity, updating plotly's display formatting, and adjusting heatmap colors to use accent colors from the dark theme.

Visualization improvements:

* The correlation matrix results are now rounded to four decimal places for easier interpretation.
* The plotly heatmap in the correlation matrix uses a format string (`.4~f`) to display values with four significant digits.

Theming and color adjustments:

* In the heatmap creation logic (`heatmapMaking`), the minimum/worst and maximum/best colors now use the dark theme's accent colors (amber for worst, teal for best) instead of the primary/secondary palette, improving visual clarity and consistency. [[1]](diffhunk://#diff-bf866f841af8a7278077039177475d0d7bc5f75abcb00433ee90ab8caea33908R1-R4) [[2]](diffhunk://#diff-bf866f841af8a7278077039177475d0d7bc5f75abcb00433ee90ab8caea33908L117-R123) [[3]](diffhunk://#diff-bf866f841af8a7278077039177475d0d7bc5f75abcb00433ee90ab8caea33908L129-R137)
* The dark theme is explicitly imported and used for color selection in the heatmap, ensuring consistent color usage in dark mode.