### PR TITLE
demo:feat: enhance explorers to support numeric categorical types

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/explorers.py
+++ b/DashAI/back/api/api_v1/endpoints/explorers.py
@@ -90,13 +90,19 @@ def validate_explorer_params(
         columns_spec = get_columns_spec(dataset_path)
 
         try:
-            explorer_class.validate_columns(explorer, columns_spec)
+            valid = explorer_class.validate_columns(explorer, columns_spec)
         except Exception as e:
             log.exception(e)
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Error while validating explorer columns",
             ) from e
+        if not valid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Selected columns do not satisfy the explorer's type "
+                "constraints",
+            )
 
     return True
 

--- a/DashAI/back/exploration/base_explorer.py
+++ b/DashAI/back/exploration/base_explorer.py
@@ -167,7 +167,9 @@ class BaseExplorer(ConfigObject, ABC):
         if "max" in input_cardinality and n > input_cardinality["max"]:
             return False
 
-        # Check each column against allowed_types (semantic) AND allowed_dtypes (dtype)
+        # When an explorer sets "numeric_categorical_only" in its metadata, Categorical
+        # columns are only accepted if their dtype is numeric (not string/bool).
+        reject_string_categorical = bool(metadata.get("numeric_categorical_only"))
         for column in selected_columns:
             column_name = column["columnName"]
             col_info = column_spec.get(column_name, {})
@@ -175,6 +177,12 @@ class BaseExplorer(ConfigObject, ABC):
             col_dtype = col_info.get("dtype", "")
 
             if allowed_types and col_type not in allowed_types:
+                return False
+            if (
+                reject_string_categorical
+                and col_type == "Categorical"
+                and col_dtype in ("string", "bool", "")
+            ):
                 return False
             if allowed_dtypes and col_dtype not in allowed_dtypes:
                 return False

--- a/DashAI/back/exploration/explorers/box_plot.py
+++ b/DashAI/back/exploration/explorers/box_plot.py
@@ -5,7 +5,6 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.distribution_explorer import DistributionExplorer
-from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -110,7 +109,7 @@ class BoxPlotExplorer(DistributionExplorer):
 
     SCHEMA = BoxPlotSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer, Categorical],
+        "allowed_types": [Float, Integer],
         "allowed_dtypes": [],
         "input_cardinality": {"min": 1, "max": 2},
     }

--- a/DashAI/back/exploration/explorers/box_plot.py
+++ b/DashAI/back/exploration/explorers/box_plot.py
@@ -5,6 +5,7 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.distribution_explorer import DistributionExplorer
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -109,7 +110,7 @@ class BoxPlotExplorer(DistributionExplorer):
 
     SCHEMA = BoxPlotSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
         "input_cardinality": {"min": 1, "max": 2},
     }

--- a/DashAI/back/exploration/explorers/corr_matrix.py
+++ b/DashAI/back/exploration/explorers/corr_matrix.py
@@ -11,6 +11,7 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.statistical_explorer import StatisticalExplorer
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -164,8 +165,9 @@ class CorrelationMatrixExplorer(StatisticalExplorer):
 
     SCHEMA = CorrelationMatrixExplorerSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
+        "numeric_categorical_only": True,
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/cov_matrix.py
+++ b/DashAI/back/exploration/explorers/cov_matrix.py
@@ -5,6 +5,7 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.statistical_explorer import StatisticalExplorer
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -152,8 +153,9 @@ class CovarianceMatrixExplorer(StatisticalExplorer):
 
     SCHEMA = CovarianceMatrixExplorerSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
+        "numeric_categorical_only": True,
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/ecdf_plot.py
+++ b/DashAI/back/exploration/explorers/ecdf_plot.py
@@ -13,6 +13,7 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.distribution_explorer import DistributionExplorer
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -136,8 +137,9 @@ class ECDFPlotExplorer(DistributionExplorer):
 
     SCHEMA = ECDFPlotSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
+        "numeric_categorical_only": True,
         "input_cardinality": {"min": 1},
     }
 

--- a/DashAI/back/exploration/explorers/multibox_plot.py
+++ b/DashAI/back/exploration/explorers/multibox_plot.py
@@ -13,6 +13,7 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.multidimensional_explorer import MultidimensionalExplorer
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -135,8 +136,9 @@ class MultiColumnBoxPlotExplorer(MultidimensionalExplorer):
 
     SCHEMA = MultiColumnBoxPlotSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
+        "numeric_categorical_only": True,
         "input_cardinality": {"min": 1},
     }
 

--- a/DashAI/back/exploration/explorers/parallel_cordinates.py
+++ b/DashAI/back/exploration/explorers/parallel_cordinates.py
@@ -11,6 +11,7 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.multidimensional_explorer import MultidimensionalExplorer
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -78,8 +79,9 @@ class ParallelCordinatesExplorer(MultidimensionalExplorer):
 
     SCHEMA = ParallelCordinatesSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
+        "numeric_categorical_only": True,
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/scatter_matrix.py
+++ b/DashAI/back/exploration/explorers/scatter_matrix.py
@@ -11,6 +11,7 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.relationship_explorer import RelationshipExplorer
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -102,8 +103,9 @@ class ScatterMatrixExplorer(RelationshipExplorer):
 
     SCHEMA = ScatterMatrixSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
+        "numeric_categorical_only": True,
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/scatter_plot.py
+++ b/DashAI/back/exploration/explorers/scatter_plot.py
@@ -11,6 +11,7 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.relationship_explorer import RelationshipExplorer
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
@@ -103,8 +104,9 @@ class ScatterPlotExplorer(RelationshipExplorer):
 
     SCHEMA = ScatterPlotSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [Float, Integer],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
+        "numeric_categorical_only": True,
         "input_cardinality": {"exact": 2},
     }
 

--- a/tests/back/exploration/test_base_explorer_metadata.py
+++ b/tests/back/exploration/test_base_explorer_metadata.py
@@ -201,3 +201,66 @@ def test_validate_columns_missing_column_in_spec_passes_when_unrestricted():
     explorer_info = _MockExplorerInfo([{"columnName": "missing_col"}])
     column_spec = {}  # no restrictions → passes regardless
     assert cls.validate_columns(explorer_info, column_spec) is True
+
+
+# --- numeric_categorical_only tests ---
+
+
+def test_numeric_categorical_only_passes_int_dtype():
+    cls = _make_explorer(
+        allowed_types=[Float, Integer, Categorical],
+        allowed_dtypes=[],
+        numeric_categorical_only=True,
+        input_cardinality={"min": 1},
+    )
+    explorer_info = _MockExplorerInfo([{"columnName": "cat_num"}])
+    column_spec = {"cat_num": {"type": "Categorical", "dtype": "int64"}}
+    assert cls.validate_columns(explorer_info, column_spec) is True
+
+
+def test_numeric_categorical_only_passes_float_dtype():
+    cls = _make_explorer(
+        allowed_types=[Float, Integer, Categorical],
+        allowed_dtypes=[],
+        numeric_categorical_only=True,
+        input_cardinality={"min": 1},
+    )
+    explorer_info = _MockExplorerInfo([{"columnName": "cat_num"}])
+    column_spec = {"cat_num": {"type": "Categorical", "dtype": "float64"}}
+    assert cls.validate_columns(explorer_info, column_spec) is True
+
+
+def test_numeric_categorical_only_blocks_string_dtype():
+    cls = _make_explorer(
+        allowed_types=[Float, Integer, Categorical],
+        allowed_dtypes=[],
+        numeric_categorical_only=True,
+        input_cardinality={"min": 1},
+    )
+    explorer_info = _MockExplorerInfo([{"columnName": "cat_str"}])
+    column_spec = {"cat_str": {"type": "Categorical", "dtype": "string"}}
+    assert cls.validate_columns(explorer_info, column_spec) is False
+
+
+def test_numeric_categorical_only_blocks_bool_dtype():
+    cls = _make_explorer(
+        allowed_types=[Float, Integer, Categorical],
+        allowed_dtypes=[],
+        numeric_categorical_only=True,
+        input_cardinality={"min": 1},
+    )
+    explorer_info = _MockExplorerInfo([{"columnName": "cat_bool"}])
+    column_spec = {"cat_bool": {"type": "Categorical", "dtype": "bool"}}
+    assert cls.validate_columns(explorer_info, column_spec) is False
+
+
+def test_numeric_categorical_only_false_allows_string_categorical():
+    cls = _make_explorer(
+        allowed_types=[Float, Integer, Categorical],
+        allowed_dtypes=[],
+        numeric_categorical_only=False,
+        input_cardinality={"min": 1},
+    )
+    explorer_info = _MockExplorerInfo([{"columnName": "cat_str"}])
+    column_spec = {"cat_str": {"type": "Categorical", "dtype": "string"}}
+    assert cls.validate_columns(explorer_info, column_spec) is True


### PR DESCRIPTION
This pull request extends support for categorical columns in several data exploration visualizers, while ensuring that only numeric categorical columns (not string or boolean) are accepted where appropriate. The main changes involve updating the allowed types and adding stricter validation logic for categorical data.

**Validation logic updates:**

* The `validate_columns` function in `base_explorer.py` now checks for a new `numeric_categorical_only` flag in explorer metadata. If set, it rejects categorical columns with string or boolean dtypes, ensuring only numeric categorical columns are accepted. [[1]](diffhunk://#diff-4d9acb8839b5fc98d47cbd682775923f7fb78025b509435ffd150230dc09019cL170-R172) [[2]](diffhunk://#diff-4d9acb8839b5fc98d47cbd682775923f7fb78025b509435ffd150230dc09019cR181-R186)

**Explorer metadata and imports:**

* The following explorers now include `Categorical` in their `allowed_types` and set `numeric_categorical_only` to `True`, restricting categorical input to numeric types only:
  - `CorrelationMatrixExplorer` (`corr_matrix.py`) [[1]](diffhunk://#diff-8570f0f799fa9e6f707de8029511d6d3fc7bc5b6a4a0c7ec6dcf4f53d375915dR14) [[2]](diffhunk://#diff-8570f0f799fa9e6f707de8029511d6d3fc7bc5b6a4a0c7ec6dcf4f53d375915dL167-R170)
  - `CovarianceMatrixExplorer` (`cov_matrix.py`) [[1]](diffhunk://#diff-0b4de22cbde5b08e3f7916aabe12cd3c456006a66cba48d4fc588d8976c56d63R8) [[2]](diffhunk://#diff-0b4de22cbde5b08e3f7916aabe12cd3c456006a66cba48d4fc588d8976c56d63L155-R158)
  - `ECDFPlotExplorer` (`ecdf_plot.py`) [[1]](diffhunk://#diff-45f1a839762cb640a5e43ceaa2f54ecb95d006c92bda5a4e5938844b6851af56R16) [[2]](diffhunk://#diff-45f1a839762cb640a5e43ceaa2f54ecb95d006c92bda5a4e5938844b6851af56L139-R142)
  - `MultiColumnBoxPlotExplorer` (`multibox_plot.py`) [[1]](diffhunk://#diff-725046da3c421e9e0a8c1575237f2417f886c8579bfae92f138e0d76be9e7c4dR16) [[2]](diffhunk://#diff-725046da3c421e9e0a8c1575237f2417f886c8579bfae92f138e0d76be9e7c4dL138-R141)
  - `ParallelCordinatesExplorer` (`parallel_cordinates.py`) [[1]](diffhunk://#diff-063d599b04189308e070332bee3af78bedd5f7d7179d2eb07e000e609b55f246R14) [[2]](diffhunk://#diff-063d599b04189308e070332bee3af78bedd5f7d7179d2eb07e000e609b55f246L81-R84)
  - `ScatterMatrixExplorer` (`scatter_matrix.py`) [[1]](diffhunk://#diff-63bcc1f69604f0a0f909d26744d44b82811c7c45d1946310cb2beff2c2672f72R14) [[2]](diffhunk://#diff-63bcc1f69604f0a0f909d26744d44b82811c7c45d1946310cb2beff2c2672f72L105-R108)
  - `ScatterPlotExplorer` (`scatter_plot.py`) [[1]](diffhunk://#diff-824b91103470e84144a2c978d34085a4a75f3e726e63763860fee915c5fe1738R14) [[2]](diffhunk://#diff-824b91103470e84144a2c978d34085a4a75f3e726e63763860fee915c5fe1738L106-R109)

* The `BoxPlotExplorer` now allows all categorical columns, regardless of dtype, by adding `Categorical` to `allowed_types` but not setting the `numeric_categorical_only` flag. [[1]](diffhunk://#diff-5e088fdda668dfba9f9b06537c0b662b70043ce65beaef20d118ffba746e075cR8) [[2]](diffhunk://#diff-5e088fdda668dfba9f9b06537c0b662b70043ce65beaef20d118ffba746e075cL112-R113)