### PR TITLE
demo: adjust input field width for manual prediction

### DIFF
--- a/DashAI/front/src/components/predictions/InputField.jsx
+++ b/DashAI/front/src/components/predictions/InputField.jsx
@@ -1,14 +1,18 @@
 import React from "react";
-import { TextField, Select, MenuItem, FormControl } from "@mui/material";
+import { Box, TextField, Select, MenuItem, FormControl } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
+import {
+  MIN_INPUT_WIDTH,
+  CHAR_WIDTH_PX,
+  INPUT_PADDING_PX,
+} from "./inputFieldConstants";
 
-const MIN_INPUT_WIDTH = 120;
-const CHAR_WIDTH_PX = 8;
-const INPUT_PADDING_PX = 28;
-
-function computeWidth(val) {
-  const len = String(val ?? "").length;
+function computeWidth(val, placeholder) {
+  const len = Math.max(
+    String(val ?? "").length,
+    String(placeholder ?? "").length,
+  );
   return Math.max(MIN_INPUT_WIDTH, len * CHAR_WIDTH_PX + INPUT_PADDING_PX);
 }
 
@@ -116,7 +120,7 @@ function InputField({
                 : parseFloat(e.target.value);
           handleChange(rowIndex, col, val);
         }}
-        sx={{ width: computeWidth(value), ...commonStyles }}
+        sx={{ width: computeWidth(value, placeholder), ...commonStyles }}
       />
     );
   }
@@ -132,7 +136,7 @@ function InputField({
         value={value}
         placeholder={placeholder}
         onChange={(e) => handleChange(rowIndex, col, e.target.value)}
-        sx={{ width: computeWidth(value), ...commonStyles }}
+        sx={{ width: computeWidth(value, placeholder), ...commonStyles }}
       />
     );
   }
@@ -166,7 +170,7 @@ function InputField({
       value={value}
       placeholder={placeholder}
       onChange={(e) => handleChange(rowIndex, col, e.target.value)}
-      sx={{ width: computeWidth(value), ...commonStyles }}
+      sx={{ width: computeWidth(value, placeholder), ...commonStyles }}
     />
   );
 }

--- a/DashAI/front/src/components/predictions/InputField.jsx
+++ b/DashAI/front/src/components/predictions/InputField.jsx
@@ -3,6 +3,15 @@ import { TextField, Select, MenuItem, FormControl } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
 
+const MIN_INPUT_WIDTH = 120;
+const CHAR_WIDTH_PX = 8;
+const INPUT_PADDING_PX = 28;
+
+function computeWidth(val) {
+  const len = String(val ?? "").length;
+  return Math.max(MIN_INPUT_WIDTH, len * CHAR_WIDTH_PX + INPUT_PADDING_PX);
+}
+
 function InputField({
   handleChange,
   rowIndex,
@@ -40,7 +49,7 @@ function InputField({
 
   if (effectiveType === "Categorical" && categories && categories.length > 0) {
     return (
-      <FormControl fullWidth size="small">
+      <FormControl size="small" sx={{ minWidth: MIN_INPUT_WIDTH }}>
         <Select
           value={value || ""}
           onChange={(e) => handleChange(rowIndex, col, e.target.value)}
@@ -91,7 +100,6 @@ function InputField({
 
     return (
       <TextField
-        fullWidth
         size="small"
         type="number"
         value={value}
@@ -108,7 +116,7 @@ function InputField({
                 : parseFloat(e.target.value);
           handleChange(rowIndex, col, val);
         }}
-        sx={commonStyles}
+        sx={{ width: computeWidth(value), ...commonStyles }}
       />
     );
   }
@@ -120,12 +128,11 @@ function InputField({
   ) {
     return (
       <TextField
-        fullWidth
         size="small"
         value={value}
         placeholder={placeholder}
         onChange={(e) => handleChange(rowIndex, col, e.target.value)}
-        sx={commonStyles}
+        sx={{ width: computeWidth(value), ...commonStyles }}
       />
     );
   }
@@ -155,12 +162,11 @@ function InputField({
 
   return (
     <TextField
-      fullWidth
       size="small"
       value={value}
       placeholder={placeholder}
       onChange={(e) => handleChange(rowIndex, col, e.target.value)}
-      sx={commonStyles}
+      sx={{ width: computeWidth(value), ...commonStyles }}
     />
   );
 }

--- a/DashAI/front/src/components/predictions/ManualInputForm.jsx
+++ b/DashAI/front/src/components/predictions/ManualInputForm.jsx
@@ -124,7 +124,7 @@ export default function ManualInputForm({
         sx={{
           border: `1px solid ${theme.palette.divider}`,
           borderRadius: 1,
-          overflow: "hidden",
+          overflow: "auto",
           boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
         }}
       >
@@ -155,6 +155,7 @@ export default function ManualInputForm({
                     color: theme.palette.text.primary,
                     textTransform: "none",
                     whiteSpace: "nowrap",
+                    minWidth: 120,
                   }}
                 >
                   {col}

--- a/DashAI/front/src/components/predictions/ManualInputForm.jsx
+++ b/DashAI/front/src/components/predictions/ManualInputForm.jsx
@@ -15,6 +15,7 @@ import {
 import { useTheme } from "@mui/material/styles";
 import { AddCircleOutline, DeleteOutline } from "@mui/icons-material";
 import InputField from "./InputField";
+import { MIN_INPUT_WIDTH } from "./inputFieldConstants";
 import { useTranslation } from "react-i18next";
 
 export default function ManualInputForm({
@@ -155,7 +156,7 @@ export default function ManualInputForm({
                     color: theme.palette.text.primary,
                     textTransform: "none",
                     whiteSpace: "nowrap",
-                    minWidth: 120,
+                    minWidth: MIN_INPUT_WIDTH,
                   }}
                 >
                   {col}

--- a/DashAI/front/src/components/predictions/inputFieldConstants.js
+++ b/DashAI/front/src/components/predictions/inputFieldConstants.js
@@ -1,0 +1,3 @@
+export const MIN_INPUT_WIDTH = 120;
+export const CHAR_WIDTH_PX = 8;
+export const INPUT_PADDING_PX = 28;


### PR DESCRIPTION
This pull request improves the usability of input fields in the prediction UI by making their widths dynamically adjust to the content and ensuring a minimum width for better readability. It also tweaks some layout styles for improved appearance and usability.

**Dynamic input sizing and layout improvements:**

* Added logic in `InputField.jsx` to compute the width of input fields dynamically based on their content, with a minimum width enforced, enhancing the user experience for both text and numeric inputs. [[1]](diffhunk://#diff-7e386b54c744eb6622842bf11289e49104420b3fa5bd81e5643c39c2f8be4f46R6-R14) [[2]](diffhunk://#diff-7e386b54c744eb6622842bf11289e49104420b3fa5bd81e5643c39c2f8be4f46L111-R119) [[3]](diffhunk://#diff-7e386b54c744eb6622842bf11289e49104420b3fa5bd81e5643c39c2f8be4f46L123-R135) [[4]](diffhunk://#diff-7e386b54c744eb6622842bf11289e49104420b3fa5bd81e5643c39c2f8be4f46L158-R169)
* Updated categorical input fields (`Select` components) to use a minimum width instead of full width, ensuring consistency with other input types.
* Removed the `fullWidth` prop from `TextField` components to allow dynamic sizing. [[1]](diffhunk://#diff-7e386b54c744eb6622842bf11289e49104420b3fa5bd81e5643c39c2f8be4f46L94) [[2]](diffhunk://#diff-7e386b54c744eb6622842bf11289e49104420b3fa5bd81e5643c39c2f8be4f46L123-R135) [[3]](diffhunk://#diff-7e386b54c744eb6622842bf11289e49104420b3fa5bd81e5643c39c2f8be4f46L158-R169)

**Styling and layout tweaks:**

* Changed the container in `ManualInputForm.jsx` to use `overflow: auto` instead of `hidden`, improving scrollability for overflowing content.
* Added a `minWidth` style for column headers in `ManualInputForm.jsx` to maintain consistent sizing with input fields.