### PR TITLE
fix: enhance SaveDatasetModal with delete confirmation and scrollable…

### DIFF
--- a/DashAI/front/src/components/notebooks/converter/ConverterHistoryList.jsx
+++ b/DashAI/front/src/components/notebooks/converter/ConverterHistoryList.jsx
@@ -41,14 +41,16 @@ export default function ConverterHistoryList({
                 secondary={scopeText}
               />
               <Chip label={formatDate(converter.created)} size="small" />
-              <IconButton
-                onClick={() => onConverterDelete(converter)}
-                size="small"
-                sx={{ ml: 1 }}
-                color="error"
-              >
-                <Delete />
-              </IconButton>
+              {showDeleteButtons && (
+                <IconButton
+                  onClick={() => onConverterDelete(converter)}
+                  size="small"
+                  sx={{ ml: 1 }}
+                  color="error"
+                >
+                  <Delete />
+                </IconButton>
+              )}
             </Box>
           </ListItem>
         );

--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -1,10 +1,18 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { Modal, TextField, Box, Typography, IconButton } from "@mui/material";
 import { Close } from "@mui/icons-material";
 import { useSnackbar } from "notistack";
 import ConverterHistoryList from "../converter/ConverterHistoryList";
 import StepperNavigationFooter from "../../shared/StepperNavigationFooter";
 import NoteBox from "../NoteBox";
+import DeleteConfirmationModal from "../../threeSectionLayout/DeleteConfirmationModal";
+import ItemsToDeleteList from "../converter/ItemsToDeleteList";
+import { deleteConverterById } from "../../../api/converter";
+import {
+  getConvertersByNotebookId,
+  getExplorersByNotebookId,
+} from "../../../api/notebook";
+import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
 import { generateSequentialName } from "../../../utils/nameGenerator";
 import { useTourContext } from "../../tour/TourProvider";
 import { useTranslation } from "react-i18next";
@@ -15,12 +23,21 @@ export function SaveDatasetModal({
   onSaveDataset,
   appliedConverters,
   existingDatasets = [],
+  notebook,
 }) {
   const [name, setName] = useState("");
   const [frozenDefaultName, setFrozenDefaultName] = useState("");
+  const [localConverters, setLocalConverters] = useState([]);
+  const [openDeleteConfirmation, setOpenDeleteConfirmation] = useState(false);
+  const [converterToDelete, setConverterToDelete] = useState(null);
+  const [deleteModalContent, setDeleteModalContent] = useState("");
+  const [itemsToDelete, setItemsToDelete] = useState([]);
+
   const tourContext = useTourContext();
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation(["datasets", "common"]);
+  const { explorersAndConverters, setExplorersAndConverters } =
+    useExplorersAndConverters();
 
   const { defaultName } = useMemo(() => {
     if (tourContext && tourContext.run) {
@@ -38,6 +55,84 @@ export function SaveDatasetModal({
       setName(defaultName);
     }
   }, [open, defaultName]);
+
+  useEffect(() => {
+    setLocalConverters(appliedConverters);
+  }, [appliedConverters]);
+
+  const fetchExplorersAndConverters = useCallback(async () => {
+    if (!notebook) return;
+    try {
+      const [explorersData, convertersData] = await Promise.all([
+        getExplorersByNotebookId(notebook.id),
+        getConvertersByNotebookId(notebook.id),
+      ]);
+      const explorersWithType = explorersData.map((item) => ({
+        ...item,
+        type: "explorer",
+      }));
+      const convertersWithType = convertersData.map((item) => ({
+        ...item,
+        type: "converter",
+      }));
+      const merged = [...explorersWithType, ...convertersWithType].sort(
+        (a, b) => new Date(a.created) - new Date(b.created),
+      );
+      setExplorersAndConverters(merged);
+    } catch (error) {
+      console.error("Failed to fetch explorers and converters:", error);
+    }
+  }, [notebook, setExplorersAndConverters]);
+
+  const getItemsToDelete = useCallback(
+    (converter) => {
+      const converterIndex = explorersAndConverters.findIndex(
+        (item) => item.id === converter.id && item.type === "converter",
+      );
+      if (converterIndex === -1) return [];
+      return explorersAndConverters.slice(converterIndex);
+    },
+    [explorersAndConverters],
+  );
+
+  const handleConverterDeleteClick = useCallback(
+    (converter) => {
+      setConverterToDelete(converter);
+      const items = getItemsToDelete(converter);
+      setItemsToDelete(items);
+      setDeleteModalContent(
+        t("datasets:label.deleteConverterConfirmation", {
+          converter: converter?.converter,
+        }),
+      );
+      setOpenDeleteConfirmation(true);
+    },
+    [getItemsToDelete, t],
+  );
+
+  const handleConfirmConverterDelete = useCallback(async () => {
+    if (!converterToDelete) return;
+    try {
+      await deleteConverterById(converterToDelete.id);
+      await fetchExplorersAndConverters();
+      setLocalConverters((prev) =>
+        prev.filter((c) => c.id !== converterToDelete.id),
+      );
+      setOpenDeleteConfirmation(false);
+      setConverterToDelete(null);
+      setDeleteModalContent("");
+      setItemsToDelete([]);
+    } catch (error) {
+      console.error("Failed to delete converter:", error);
+    }
+  }, [converterToDelete, fetchExplorersAndConverters]);
+
+  const handleCancelDelete = useCallback(() => {
+    setOpenDeleteConfirmation(false);
+    setConverterToDelete(null);
+    setDeleteModalContent("");
+    setItemsToDelete([]);
+  }, []);
 
   const handleSubmit = () => {
     const datasetName = name.trim();
@@ -76,84 +171,116 @@ export function SaveDatasetModal({
   const nameError = getNameError();
 
   return (
-    <Modal open={open} onClose={() => {}}>
-      <Box
-        sx={{
-          position: "absolute",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-          width: { xs: "90%", sm: 560 },
-          bgcolor: "background.paper",
-          borderRadius: 2,
-          boxShadow: 12,
-          p: 0,
-          outline: "none",
-        }}
-      >
-        {/* Header */}
+    <>
+      <Modal open={open} onClose={() => {}}>
         <Box
           sx={{
-            p: 2,
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: { xs: "90%", sm: 560 },
+            maxHeight: "90vh",
+            bgcolor: "background.paper",
+            borderRadius: 2,
+            boxShadow: 12,
+            p: 0,
+            outline: "none",
             display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            borderBottom: "1px solid rgba(255, 255, 255, 0.1)",
+            flexDirection: "column",
           }}
         >
-          <Typography variant="h6" component="h2">
-            {t("datasets:label.saveProcessedDataset")}
-          </Typography>
-          <IconButton
-            onClick={handleClose}
-            size="small"
-            sx={{ color: "text.secondary" }}
+          {/* Header */}
+          <Box
+            sx={{
+              p: 2,
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              borderBottom: "1px solid rgba(255, 255, 255, 0.1)",
+              flexShrink: 0,
+            }}
           >
-            <Close />
-          </IconButton>
-        </Box>
-
-        {/* Content */}
-        <Box
-          sx={{ p: 3, display: "flex", flexDirection: "column", gap: 3 }}
-          data-tour="save-dataset-modal-notebook"
-        >
-          <NoteBox
-            message={t("datasets:label.newDatasetCreatedWithTransformations")}
-          />
-          <TextField
-            fullWidth
-            label={t("datasets:label.datasetName")}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            variant="outlined"
-            error={Boolean(nameError)}
-            helperText={nameError}
-          />
-
-          <Box>
-            <Typography variant="subtitle2" gutterBottom>
-              {t("datasets:label.appliedTransformations")}
+            <Typography variant="h6" component="h2">
+              {t("datasets:label.saveProcessedDataset")}
             </Typography>
-            {appliedConverters.length === 0 ? (
-              <Typography variant="body2" color="text.secondary">
-                {t("datasets:label.noTransformationsApplied")}
-              </Typography>
-            ) : (
-              <ConverterHistoryList converters={appliedConverters} />
-            )}
+            <IconButton
+              onClick={handleClose}
+              size="small"
+              sx={{ color: "text.secondary" }}
+            >
+              <Close />
+            </IconButton>
           </Box>
 
-          <StepperNavigationFooter
-            onBack={handleClose}
-            onNext={handleSubmit}
-            nextDisabled={Boolean(nameError)}
-            backLabel={t("common:cancel")}
-            nextLabel={t("datasets:button.saveDataset")}
-            variant="save"
-          />
+          {/* Scrollable Content */}
+          <Box
+            sx={{
+              p: 3,
+              display: "flex",
+              flexDirection: "column",
+              gap: 3,
+              overflowY: "auto",
+              flex: 1,
+            }}
+            data-tour="save-dataset-modal-notebook"
+          >
+            <NoteBox
+              message={t("datasets:label.newDatasetCreatedWithTransformations")}
+            />
+            <TextField
+              fullWidth
+              label={t("datasets:label.datasetName")}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              variant="outlined"
+              error={Boolean(nameError)}
+              helperText={nameError}
+            />
+
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                {t("datasets:label.appliedTransformations")}
+              </Typography>
+              {localConverters.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  {t("datasets:label.noTransformationsApplied")}
+                </Typography>
+              ) : (
+                <ConverterHistoryList
+                  converters={localConverters}
+                  onConverterDelete={handleConverterDeleteClick}
+                  showDeleteButtons={true}
+                />
+              )}
+            </Box>
+          </Box>
+
+          {/* Footer - always visible */}
+          <Box sx={{ px: 3, pb: 3, flexShrink: 0 }}>
+            <StepperNavigationFooter
+              onBack={handleClose}
+              onNext={handleSubmit}
+              nextDisabled={Boolean(nameError) || localConverters.length === 0}
+              backLabel={t("common:cancel")}
+              nextLabel={t("datasets:button.saveDataset")}
+              variant="save"
+            />
+          </Box>
         </Box>
-      </Box>
-    </Modal>
+      </Modal>
+
+      <DeleteConfirmationModal
+        open={openDeleteConfirmation}
+        onClose={handleCancelDelete}
+        onConfirm={handleConfirmConverterDelete}
+        content={
+          <Box>
+            <Typography>{deleteModalContent}</Typography>
+            <ItemsToDeleteList items={itemsToDelete} />
+          </Box>
+        }
+      />
+    </>
   );
 }

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -337,6 +337,7 @@ export default function DatasetPreviewNotebook({
           (converter) => converter.status === 3,
         )}
         existingDatasets={existingDatasets}
+        notebook={notebook}
       />
 
       <NotebookHistoryModal


### PR DESCRIPTION
## Summary

The Save Processed Dataset modal in the Notebooks view had three issues: with many applied converters, the modal grew beyond the viewport and the action buttons were lost. The delete buttons inside the converter list crashed with `onConverterDelete is not a function` because `ConverterHistoryList` rendered them unconditionally regardless of whether a handler was passed. Additionally, the Save button had no guard against saving a dataset with no transformations applied.

---

## Type of Change

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx`: Added `maxHeight: 90vh` and flex column layout to the modal container. Separated scrollable content from a pinned footer so action buttons are always visible. Implemented full converter delete flow (confirmation dialog, cascade preview, API call, context refresh) mirroring `NotebookHistoryModal`. Added `localConverters` state to reflect deletions within the modal. Disabled the Save button when no transformations remain.

- `DashAI/front/src/components/notebooks/converter/ConverterHistoryList.jsx`: Wrapped the delete `IconButton` in a `showDeleteButtons` guard — it was defined as a prop but never used to conditionally render the button, causing a crash wherever no `onConverterDelete` handler was passed.

- `DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx`: Passed `notebook` prop to `SaveDatasetModal` so it can fetch and refresh the explorers/converters context after a deletion.

---

## Testing

- Open the Save Processed Dataset modal with several converters applied and verify the list scrolls while the Cancel / Save buttons stay pinned at the bottom.
- Delete a converter from within the modal and confirm the cascade dialog appears, the item is removed from the list, and the parent notebook view reflects the change.
- Delete all converters and verify the Save button becomes disabled.


