### PR TITLE
Fix dataset name overridden by auto-generated value after file upload

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
@@ -132,9 +132,11 @@ export default function ConfigureAndUploadDatasetStep({
   }, [
     selectedDataloader,
     datasetFileToUpload,
+    datasetName,
     columnTypes,
     columnRenames,
     formSubmitRef,
+    formValues,
     handleDatasetCreated,
     backHome,
     enqueueSnackbar,


### PR DESCRIPTION
## Summary

  When a user uploaded a file and then manually renamed the dataset, the custom name was silently discarded and the auto-generated name was used instead. The root cause was a stale closure: `submitNewDataset` was memoized with `useCallback` but `datasetName` was missing from its dependency array, so the callback captured the name value from the moment the file was uploaded and never updated when the user typed a new name.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx`: Added `datasetName` and `formValues` to the `useCallback` dependency array of `submitNewDataset` so the callback always closes over the current values when submitted.

  ---

  ## Testing (optional)

  1. Open the dataset creation flow and select a dataloader.
  2. Upload a file — confirm the name field auto-fills.
  3. Manually edit the name to something custom.
  4. Submit — confirm the dataset is created with the custom name, not the
     auto-generated one.
  5. As a regression check, confirm that changing the name *before* uploading
     a file still works correctly.


