### PR TITLE
Fix pagination reset on column selection

### DIFF
--- a/DashAI/front/src/components/explorations/explorers/EditColumnsDialog.jsx
+++ b/DashAI/front/src/components/explorations/explorers/EditColumnsDialog.jsx
@@ -210,6 +210,7 @@ function EditColumnsDialog({
     enableDensityToggle: false,
     enableFullScreenToggle: false,
     enableHiding: false,
+    autoResetPageIndex: false,
     initialState: {
       density: "compact",
       pagination: { pageIndex: 0, pageSize: 5 },

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -283,6 +283,7 @@ function ColumnSelector({
     enableFullScreenToggle: false,
     enableHiding: false,
     enablePagination: true,
+    autoResetPageIndex: false,
     muiPaginationProps: { rowsPerPageOptions: [10, 15, 20] },
     initialState: {
       pagination: { pageSize: 10, pageIndex: 0 },


### PR DESCRIPTION
## Summary
When a user selected or deselected a column while on any page other than the first, the table would jump back to page 1. This happened because Material React Table resets `pageIndex` to 0 by default whenever its `data` prop changes — and both `ColumnSelector` and `EditColumnsDialog` update `rows` (to refresh the `order` field) on every selection change, inadvertently triggering that reset. Adding `autoResetPageIndex: false` to both tables prevents MRT from resetting the page on data updates.

---

 ## Type of Change
  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation
  
  ---
  
  ## Changes (by file)
  - `DashAI/front/src/components/notebooks/ColumnSelector.jsx`: added
    `autoResetPageIndex: false` to `useMaterialReactTable` config.
  - `DashAI/front/src/components/explorations/explorers/EditColumnsDialog.jsx`:
    added `autoResetPageIndex: false` to `useMaterialReactTable` config.
   
  ---

  ## Testing (optional)
  1. Open a notebook with a dataset that has enough columns to span multiple pages.
  2. Navigate to page 2 (or beyond) in the column selector.
  3. Select or deselect a column — the table should stay on the current page.