### PR TITLE
Fix correct image preview filename for Skewed Chi2 Sampler

### DIFF
--- a/DashAI/back/converters/scikit_learn/skewed_chi_2_sampler.py
+++ b/DashAI/back/converters/scikit_learn/skewed_chi_2_sampler.py
@@ -130,7 +130,7 @@ class SkewedChi2Sampler(
         es="Muestreador Chi²",
         pt="Amostrador Qui-2 Enviesado",
     )
-    IMAGE_PREVIEW = "skewed_chi_2_sampler.png"
+    IMAGE_PREVIEW = "skewed_chi2_sampler.png"
 
     metadata = {"allowed_types": [Float, Integer], "allowed_dtypes": []}
 


### PR DESCRIPTION
 ## Summary
  Fixes a typo in the `IMAGE_PREVIEW` constant of `SkewedChi2Sampler`. The image filename had an extra underscore (`skewed_chi_2_sampler.png`) that didn't match the actual file name (`skewed_chi2_sampler.png`), which would cause the preview image to not load correctly.

  ---
  
  ## Type of Change
  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation


  ---

  ## Changes (by file)
  - `DashAI/back/converters/scikit_learn/skewed_chi_2_sampler.py`: corrected `IMAGE_PREVIEW` value from `"skewed_chi_2_sampler.png"` to `"skewed_chi2_sampler.png"` to match the actual image filename.

  ---

  ## Notes (optional)
  Minimal change — no logic affected, only the image preview reference.