### PR TITLE
Fix dataset export filename

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -1,4 +1,6 @@
+import asyncio
 import hashlib
+import io
 import logging
 import os
 import time
@@ -1536,11 +1538,88 @@ async def get_dataset_file(
     return JSONResponse(content={"rows": rows, "total": total_rows})
 
 
-def _build_export_response(table: "pa.Table", dataset_name: str) -> StreamingResponse:
+def _build_image_zip(table: "pa.Table") -> io.BytesIO:
+    """Build a ZIP buffer from an image dataset table.
+
+    Uses ZIP_STORED (no compression) because image formats (JPEG, PNG) are
+    already compressed — DEFLATE gains nothing but wastes significant CPU time.
+    """
+    label_col = next(
+        (
+            col
+            for col in table.column_names
+            if not pa.types.is_struct(table.schema.field(col).type)
+            and (
+                pa.types.is_string(table.schema.field(col).type)
+                or pa.types.is_large_string(table.schema.field(col).type)
+                or pa.types.is_dictionary(table.schema.field(col).type)
+            )
+        ),
+        None,
+    )
+
+    image_cols = [
+        col
+        for col in table.column_names
+        if pa.types.is_struct(table.schema.field(col).type)
+    ]
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_STORED) as zf:
+        seen_paths: set = set()
+        for col in image_cols:
+            arr_col = table.column(col)
+            label_arr = table.column(label_col) if label_col else None
+            for i in range(table.num_rows):
+                val = arr_col[i].as_py()
+                if not (isinstance(val, dict) and val.get("bytes")):
+                    continue
+                img_bytes = val["bytes"]
+                raw_path = val.get("path") or ""
+                raw_ext = os.path.splitext(raw_path)[1].lstrip(".").lower()
+                ext = raw_ext if raw_ext else "png"
+                orig_fname = os.path.basename(raw_path) or f"{col}_{i}.{ext}"
+
+                if label_arr is not None:
+                    label_val = str(label_arr[i].as_py())
+                    entry = f"{label_val}/{orig_fname}"
+                else:
+                    entry = f"images/{orig_fname}"
+
+                if entry in seen_paths:
+                    stem, dot_ext = os.path.splitext(orig_fname)
+                    entry_base = (
+                        f"{label_val}/{stem}"
+                        if label_arr is not None
+                        else f"images/{stem}"
+                    )
+                    entry = f"{entry_base}_{i}{dot_ext}"
+                seen_paths.add(entry)
+                zf.writestr(entry, img_bytes)
+
+    zip_buffer.seek(0)
+    return zip_buffer
+
+
+def _iter_buffer(buf: io.BytesIO, chunk_size: int = 65536):
+    """Yield a BytesIO in fixed-size chunks for StreamingResponse."""
+    while True:
+        chunk = buf.read(chunk_size)
+        if not chunk:
+            break
+        yield chunk
+
+
+async def _build_export_response(
+    table: "pa.Table", dataset_name: str
+) -> StreamingResponse:
     """Build a StreamingResponse for dataset export.
 
     For image datasets (struct columns), produces a ZIP in ImageFolder format:
     ``<label>/<original_filename>``. For tabular datasets, produces a plain CSV.
+
+    The CPU-bound work (ZIP/CSV construction) runs in a thread-pool executor so
+    it does not block FastAPI's async event loop.
 
     Parameters
     ----------
@@ -1554,10 +1633,6 @@ def _build_export_response(table: "pa.Table", dataset_name: str) -> StreamingRes
     StreamingResponse
         ZIP (image datasets) or CSV (tabular datasets).
     """
-    import io
-    import os
-    import zipfile
-
     import pyarrow.csv as csv
 
     image_cols = [
@@ -1566,59 +1641,12 @@ def _build_export_response(table: "pa.Table", dataset_name: str) -> StreamingRes
         if pa.types.is_struct(table.schema.field(col).type)
     ]
 
+    loop = asyncio.get_event_loop()
+
     if image_cols:
-        # Find the label column: first non-image string/dictionary column.
-        label_col = next(
-            (
-                col
-                for col in table.column_names
-                if col not in image_cols
-                and (
-                    pa.types.is_string(table.schema.field(col).type)
-                    or pa.types.is_large_string(table.schema.field(col).type)
-                    or pa.types.is_dictionary(table.schema.field(col).type)
-                )
-            ),
-            None,
-        )
-
-        zip_buffer = io.BytesIO()
-        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-            seen_paths: set = set()
-            for col in image_cols:
-                arr_col = table.column(col)
-                label_arr = table.column(label_col) if label_col else None
-                for i in range(table.num_rows):
-                    val = arr_col[i].as_py()
-                    if not (isinstance(val, dict) and val.get("bytes")):
-                        continue
-                    img_bytes = val["bytes"]
-                    raw_path = val.get("path") or ""
-                    raw_ext = os.path.splitext(raw_path)[1].lstrip(".").lower()
-                    ext = raw_ext if raw_ext else "png"
-                    orig_fname = os.path.basename(raw_path) or f"{col}_{i}.{ext}"
-
-                    if label_arr is not None:
-                        label_val = str(label_arr[i].as_py())
-                        entry = f"{label_val}/{orig_fname}"
-                    else:
-                        entry = f"images/{orig_fname}"
-
-                    # Avoid collisions within the same folder.
-                    if entry in seen_paths:
-                        stem, dot_ext = os.path.splitext(orig_fname)
-                        entry_base = (
-                            f"{label_val}/{stem}"
-                            if label_arr is not None
-                            else f"images/{stem}"
-                        )
-                        entry = f"{entry_base}_{i}{dot_ext}"
-                    seen_paths.add(entry)
-                    zf.writestr(entry, img_bytes)
-
-        zip_buffer.seek(0)
+        zip_buffer = await loop.run_in_executor(None, _build_image_zip, table)
         return StreamingResponse(
-            zip_buffer,
+            _iter_buffer(zip_buffer),
             media_type="application/zip",
             headers={"Content-Disposition": f"attachment; filename={dataset_name}.zip"},
         )
@@ -1631,11 +1659,16 @@ def _build_export_response(table: "pa.Table", dataset_name: str) -> StreamingRes
         ]
         if drop_cols:
             table = table.drop(drop_cols)
-        output = io.BytesIO()
-        csv.write_csv(table, output)
-        output.seek(0)
+
+        def _build_csv():
+            output = io.BytesIO()
+            csv.write_csv(table, output)
+            output.seek(0)
+            return output
+
+        csv_buffer = await loop.run_in_executor(None, _build_csv)
         return StreamingResponse(
-            output,
+            _iter_buffer(csv_buffer),
             media_type="text/csv",
             headers={"Content-Disposition": f"attachment; filename={dataset_name}.csv"},
         )
@@ -1676,7 +1709,7 @@ async def export_dataset_as_csv(
             path, filter_model, sort_model
         )
         dataset_name = os.path.basename(path.rstrip("/"))
-        return _build_export_response(table, dataset_name)
+        return await _build_export_response(table, dataset_name)
     except HTTPException:
         raise
     except FileNotFoundError as e:
@@ -1742,7 +1775,7 @@ async def export_dataset_csv_by_id(
                 )
 
             table, _total, _was_filtered = _load_and_filter_table(file_path, None, None)
-            return _build_export_response(table, dataset.name)
+            return await _build_export_response(table, dataset.name)
 
         except HTTPException:
             raise

--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -3,7 +3,13 @@ import {
   MaterialReactTable,
   useMaterialReactTable,
 } from "material-react-table";
-import { Box, Button, Tooltip, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import { useTheme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
@@ -47,6 +53,7 @@ export default function DatasetTable({
   const [data, setData] = useState([]);
   const [rowCount, setRowCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
+  const [isExporting, setIsExporting] = useState(false);
   const [columnOrder, setColumnOrder] = useState([]);
   const [density, setDensity] = useState("compact");
   const [allFilteredData, setAllFilteredData] = useState(null);
@@ -462,6 +469,7 @@ export default function DatasetTable({
 
   const handleExportFilteredRows = useCallback(async () => {
     if (rowCount === 0) return;
+    setIsExporting(true);
     try {
       const hasFilters = columnFilters.length > 0;
       const currentFilterModel = hasFilters ? buildFilterModel() : undefined;
@@ -486,8 +494,17 @@ export default function DatasetTable({
       URL.revokeObjectURL(url);
     } catch (error) {
       console.error("Error exporting data:", error);
+    } finally {
+      setIsExporting(false);
     }
-  }, [rowCount, datasetPath, buildFilterModel, columnFilters, sorting]);
+  }, [
+    rowCount,
+    datasetPath,
+    datasetName,
+    buildFilterModel,
+    columnFilters,
+    sorting,
+  ]);
 
   const table = useMaterialReactTable({
     columns,
@@ -531,8 +548,14 @@ export default function DatasetTable({
             <span>
               <Button
                 onClick={handleExportFilteredRows}
-                disabled={rowCount === 0}
-                startIcon={<FileDownloadIcon />}
+                disabled={rowCount === 0 || isExporting}
+                startIcon={
+                  isExporting ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : (
+                    <FileDownloadIcon />
+                  )
+                }
                 variant="text"
                 size="small"
               >

--- a/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx
@@ -21,6 +21,7 @@ export default function DatasetTable({
   deps = [],
   datasetPath,
   datasetId,
+  datasetName = "dataset",
   columnTypes = {},
   editableColumns = false,
   onEditColumn = null,
@@ -475,8 +476,8 @@ export default function DatasetTable({
         blob.type === "application/octet-stream";
       const ext = isZip ? "zip" : "csv";
       const filename = hasFilters
-        ? `dataset_filtered.${ext}`
-        : `dataset.${ext}`;
+        ? `${datasetName}_filtered.${ext}`
+        : `${datasetName}.${ext}`;
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;

--- a/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx
@@ -84,6 +84,7 @@ const OverviewTab = ({
             initialPageSize={10}
             datasetPath={dataset.file_path}
             datasetId={dataset.id}
+            datasetName={dataset.name}
             onEditColumn={onEditColumnName}
             editableColumns={true}
             columnTypes={

--- a/DashAI/front/src/components/predictions/ResultsTable.jsx
+++ b/DashAI/front/src/components/predictions/ResultsTable.jsx
@@ -115,6 +115,9 @@ function ResultsTable({ selectedPrediction }) {
                 fetchPage={fetchPage}
                 initialPageSize={10}
                 datasetPath={selectedPrediction.results_path}
+                datasetName={
+                  selectedPrediction.dataset?.name ?? "prediction_results"
+                }
                 columnTypes={columnTypes}
               />
             </Paper>


### PR DESCRIPTION
  Summary
  
  Datasets exported from the UI were always saved as dataset.csv / dataset_filtered.csv (or .zip) regardless of the actual dataset name. This PR uses the real dataset name for the downloaded file, adds visual feedback during the export, and reduces the time it takes to build and transfer image dataset ZIPs.

  ---
  Type of Change

  - [x] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---
  Changes (by file)

  - DashAI/back/api/api_v1/endpoints/datasets.py: Extracted _build_image_zip as a standalone function and switched from ZIP_DEFLATED to ZIP_STORED (images are already compressed — DEFLATE adds CPU cost with no size benefit). Both the ZIP and CSV build steps now run in asyncio.run_in_executor so they don't block the FastAPI event loop. Added _iter_buffer to stream the response in 64 KB chunks. _build_export_response is now async.
  - DashAI/front/src/components/notebooks/dataset/DatasetTable.jsx: Added datasetName prop (default: "dataset") used as the base filename on download. Added isExporting state: the export button is disabled and its icon switches to a CircularProgress spinner while the request is in flight, giving immediate feedback to the user.
  - DashAI/front/src/components/notebooks/dataset/tabs/OverviewTab.jsx: Passes datasetName={dataset.name} to DatasetTable.
  - DashAI/front/src/components/predictions/ResultsTable.jsx: Passes datasetName={selectedPrediction.dataset?.name ?? "prediction_results"} to DatasetTable.

  ---
  Testing

  - Export a tabular dataset: downloaded file should be named <dataset_name>.csv.
  - Apply filters and export: file should be named <dataset_name>_filtered.csv.
  - Export an image dataset: file should be named <dataset_name>.zip and the download should start noticeably faster than before.
  - While export is in progress, the export button should show a spinner and be disabled.

  ---
  Notes

  Only the two DatasetTable usages that actually show the export button (OverviewTab and ResultsTable) needed to be updated — the remaining callers either pass showExportButton={false} or enableTopToolbar={false}.