### PR TITLE
Clear stale localStorage state when deleting or recreating a run

### DIFF
--- a/DashAI/front/src/components/models/RunCard.jsx
+++ b/DashAI/front/src/components/models/RunCard.jsx
@@ -72,6 +72,7 @@ function RunCard({
   const { t } = useTranslation(["models", "common"]);
   const { enqueueSnackbar } = useSnackbar();
   const [resultsVisible, setResultsVisible] = useState(() => {
+    if (run.status === 0) return false;
     const saved = localStorage.getItem(`run-${run.id}-results-visible`);
     return saved ? JSON.parse(saved) : false;
   });
@@ -510,6 +511,8 @@ function RunCard({
           onClose={() => setDeleteConfirmOpen(false)}
           onConfirm={() => {
             setDeleteConfirmOpen(false);
+            localStorage.removeItem(`run-${run.id}-results-visible`);
+            localStorage.removeItem(`run-${run.id}-active-tab`);
             onDelete(run);
           }}
           content={t("models:message.confirmDeleteRun")}

--- a/DashAI/front/src/components/models/RunResults.jsx
+++ b/DashAI/front/src/components/models/RunResults.jsx
@@ -61,6 +61,7 @@ export default function RunResults({
   const [localExplainers, setLocalExplainers] = useState([]);
   const [predictions, setPredictions] = useState([]);
   const [internalVisible, setInternalVisible] = useState(() => {
+    if (run.status === 0) return false;
     const saved = localStorage.getItem(`run-${run.id}-results-visible`);
     return saved ? JSON.parse(saved) : false;
   });
@@ -73,7 +74,13 @@ export default function RunResults({
 
   const [activeTab, setActiveTab] = useState(() => {
     const saved = localStorage.getItem(`run-${run.id}-active-tab`);
-    return saved ? JSON.parse(saved) : 0;
+    if (saved !== null) {
+      const savedTab = JSON.parse(saved);
+      // Tabs 1+ (Explainability, Predictions, Hyperparameters) require a finished run
+      if (savedTab > 0 && run.status !== 3) return 0;
+      return savedTab;
+    }
+    return 0;
   });
 
   const [globalCreatorOpen, setGlobalCreatorOpen] = useState(false);

--- a/DashAI/front/src/components/models/modelSession/runButtons/DeleteRun.jsx
+++ b/DashAI/front/src/components/models/modelSession/runButtons/DeleteRun.jsx
@@ -37,6 +37,8 @@ export default function DeleteRun({ run, onRunDelete }) {
           onConfirm={async () => {
             try {
               await deleteRun(run.id);
+              localStorage.removeItem(`run-${run.id}-active-tab`);
+              localStorage.removeItem(`run-${run.id}-results-visible`);
               onRunDelete(run.id);
               enqueueSnackbar(t("message.runDeletedSuccessfully"), {
                 variant: "success",


### PR DESCRIPTION
## Summary
 SQLite reuses primary key IDs when records are deleted. Combined with localStorage persisting tab selection and card visibility per `run.id`, a newly created run could inherit the UI state of a previously deleted run with the same ID — opening expanded or showing the Explainability/Predictions tab instead of Live Metrics.

Fixed by cleaning up localStorage on delete and ignoring saved state for runs that haven't started yet (`status === 0`) or haven't finished (`status !== 3`).

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/front/src/components/models/RunCard.jsx`: clear `results-visible` and `active-tab` localStorage keys on delete confirmation; default card to closed when `run.status === 0`.
  - `DashAI/front/src/components/models/RunResults.jsx`: ignore saved visible state when `run.status === 0`; ignore saved tab index > 0 when `run.status !== 3` (tabs requiring a finished run).
  - `DashAI/front/src/components/models/modelSession/runButtons/DeleteRun.jsx`: clean up localStorage keys after a successful delete API call.

  ---

  ## Testing

  1. Create a run, train it, open the results card and switch to the Explainability tab.
  2. Delete the run.
  3. Add the same model again — the new run card should be collapsed and default to the Live Metrics tab.

  Repeat with Predictions tab and with the card closed before deleting.