### PR TITLE
Fix type change validation for hub import datasets without local files

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/TypeChangeValidator.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/TypeChangeValidator.jsx
@@ -31,6 +31,10 @@ export const TypeChangeValidator = ({
   const { t } = useTranslation(["datasets", "common"]);
 
   const validateChanges = async () => {
+    if (!file) {
+      setValidationResult({ valid: true, errors: {}, warnings: {} });
+      return;
+    }
     setValidating(true);
     try {
       const formData = new FormData();


### PR DESCRIPTION
## Summary
`TypeChangeValidator` always attempted to POST the dataset file to `/api/v1/dataset/validate_type_changes`, but the hub import flow has no local file (the dataset is already stored on the server). This caused a `422 Unprocessable Entity` and locked the dialog with a failed validation state, making it impossible to change column types during a hub import preview.

When `file` is `null`, the component now skips the API call and immediately marks validation as passed, keeping the dialog open so the user can confirm the change normally.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/notebooks/datasetCreation/TypeChangeValidator.jsx`: Skip `validate_type_changes` API call when `file` is `null`; set result to `{ valid: true }` so the dialog opens in a confirmable state.

---

## Testing (optional)

1. Start a hub import (download a dataset from HuggingFace or OpenML).
2. In the preview step, open the type selector for any column and change its type.
3. Confirm the dialog opens, shows the success state, and "Apply Changes" is enabled.
4. Verify the normal file-upload flow (Datasets → New Dataset) still opens the dialog and calls the validation API as before.