### PR TITLE
fix: change flag in explorers to accept numerical categorical

### DIFF
--- a/DashAI/back/exploration/base_explorer.py
+++ b/DashAI/back/exploration/base_explorer.py
@@ -99,8 +99,13 @@ class BaseExplorer(ConfigObject, ABC):
         if not meta.get("allowed_dtypes") or meta["allowed_dtypes"] == ["*"]:
             meta["allowed_dtypes"] = []
 
-        # Drop restricted_dtypes — always [] in all explorers
+        # Drop internal-only flags that are not consumed by the frontend directly
         meta.pop("restricted_dtypes", None)
+        meta.pop("numeric_categorical_only", None)
+
+        # Ensure type_dtype_restrictions is always present for the frontend
+        if "type_dtype_restrictions" not in meta:
+            meta["type_dtype_restrictions"] = {}
 
         return meta
 
@@ -167,9 +172,8 @@ class BaseExplorer(ConfigObject, ABC):
         if "max" in input_cardinality and n > input_cardinality["max"]:
             return False
 
-        # When an explorer sets "numeric_categorical_only" in its metadata, Categorical
-        # columns are only accepted if their dtype is numeric (not string/bool).
-        reject_string_categorical = bool(metadata.get("numeric_categorical_only"))
+        # Per-type dtype exclusions: maps semantic type name → list of forbidden dtypes.
+        type_dtype_restrictions = metadata.get("type_dtype_restrictions", {})
         for column in selected_columns:
             column_name = column["columnName"]
             col_info = column_spec.get(column_name, {})
@@ -178,11 +182,8 @@ class BaseExplorer(ConfigObject, ABC):
 
             if allowed_types and col_type not in allowed_types:
                 return False
-            if (
-                reject_string_categorical
-                and col_type == "Categorical"
-                and col_dtype in ("string", "bool", "")
-            ):
+            forbidden_dtypes = type_dtype_restrictions.get(col_type, [])
+            if forbidden_dtypes and col_dtype in forbidden_dtypes:
                 return False
             if allowed_dtypes and col_dtype not in allowed_dtypes:
                 return False

--- a/DashAI/back/exploration/explorers/corr_matrix.py
+++ b/DashAI/back/exploration/explorers/corr_matrix.py
@@ -187,7 +187,7 @@ class CorrelationMatrixExplorer(StatisticalExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "numeric_categorical_only": True,
+        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/cov_matrix.py
+++ b/DashAI/back/exploration/explorers/cov_matrix.py
@@ -182,7 +182,7 @@ class CovarianceMatrixExplorer(StatisticalExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "numeric_categorical_only": True,
+        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/ecdf_plot.py
+++ b/DashAI/back/exploration/explorers/ecdf_plot.py
@@ -160,7 +160,7 @@ class ECDFPlotExplorer(DistributionExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "numeric_categorical_only": True,
+        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
         "input_cardinality": {"min": 1},
     }
 

--- a/DashAI/back/exploration/explorers/multibox_plot.py
+++ b/DashAI/back/exploration/explorers/multibox_plot.py
@@ -138,7 +138,7 @@ class MultiColumnBoxPlotExplorer(MultidimensionalExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "numeric_categorical_only": True,
+        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
         "input_cardinality": {"min": 1},
     }
 

--- a/DashAI/back/exploration/explorers/parallel_cordinates.py
+++ b/DashAI/back/exploration/explorers/parallel_cordinates.py
@@ -90,7 +90,7 @@ class ParallelCordinatesExplorer(MultidimensionalExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "numeric_categorical_only": True,
+        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/scatter_matrix.py
+++ b/DashAI/back/exploration/explorers/scatter_matrix.py
@@ -116,7 +116,7 @@ class ScatterMatrixExplorer(RelationshipExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "numeric_categorical_only": True,
+        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/scatter_plot.py
+++ b/DashAI/back/exploration/explorers/scatter_plot.py
@@ -121,7 +121,7 @@ class ScatterPlotExplorer(RelationshipExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "numeric_categorical_only": True,
+        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
         "input_cardinality": {"exact": 2},
     }
 

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -162,8 +162,10 @@ function ColumnSelector({
           return false;
         }
         const forbiddenDtypes = typesDtypeRestrictions[row.valueType];
-        if (forbiddenDtypes && forbiddenDtypes.includes(row.dataType)) {
-          return false;
+        if (forbiddenDtypes) {
+          const dtypeKey =
+            row.dataType === t("common:unknown") ? "" : row.dataType;
+          if (forbiddenDtypes.includes(dtypeKey)) return false;
         }
         return true;
       })

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -39,6 +39,7 @@ function ColumnSelector({
   inputCardinality = {},
   allowedDtypes = [],
   allowedTypes = [],
+  typesDtypeRestrictions = {},
   onSelectionChange = () => {},
   onValidationChange = () => {},
   columnTypes = null,
@@ -160,10 +161,14 @@ function ColumnSelector({
         if (allowedDtypes.length > 0 && !allowedDtypes.includes(row.dataType)) {
           return false;
         }
+        const forbiddenDtypes = typesDtypeRestrictions[row.valueType];
+        if (forbiddenDtypes && forbiddenDtypes.includes(row.dataType)) {
+          return false;
+        }
         return true;
       })
       .map((row) => row.id);
-  }, [rows, allowedDtypes, allowedTypes]);
+  }, [rows, allowedDtypes, allowedTypes, typesDtypeRestrictions]);
 
   // Check if row is selectable - using useCallback for stability
   const isRowSelectable = useCallback(
@@ -441,6 +446,7 @@ ColumnSelector.propTypes = {
   }),
   allowedDtypes: PropTypes.array,
   allowedTypes: PropTypes.array,
+  typesDtypeRestrictions: PropTypes.object,
   onSelectionChange: PropTypes.func,
   onValidationChange: PropTypes.func,
 };

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -147,6 +147,8 @@ export default function RightBar({ notebook, onToggle }) {
     const allowedTypes = explorer?.metadata?.allowed_types || [];
     const allowedDtypes = explorer?.metadata?.allowed_dtypes || [];
     const inputCardinality = explorer?.metadata?.input_cardinality || {};
+    const typesDtypeRestrictions =
+      explorer?.metadata?.type_dtype_restrictions || {};
 
     let validColumns = datasetColumns;
     let disabled = false;
@@ -165,6 +167,14 @@ export default function RightBar({ notebook, onToggle }) {
       validColumns = validColumns.filter((col) =>
         allowedDtypes.includes(col.dataType),
       );
+    }
+
+    // Apply per-type dtype exclusions declared by the backend
+    if (Object.keys(typesDtypeRestrictions).length > 0) {
+      validColumns = validColumns.filter((col) => {
+        const forbidden = typesDtypeRestrictions[col.valueType];
+        return !forbidden || !forbidden.includes(col.dataType);
+      });
     }
 
     // Check cardinality requirements

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -173,7 +173,10 @@ export default function RightBar({ notebook, onToggle }) {
     if (Object.keys(typesDtypeRestrictions).length > 0) {
       validColumns = validColumns.filter((col) => {
         const forbidden = typesDtypeRestrictions[col.valueType];
-        return !forbidden || !forbidden.includes(col.dataType);
+        if (!forbidden) return true;
+        const dtypeKey =
+          col.dataType === t("common:unknown") ? "" : col.dataType;
+        return !forbidden.includes(dtypeKey);
       });
     }
 

--- a/DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx
+++ b/DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx
@@ -18,6 +18,7 @@ export default function ScopeStepExplorer({
   const allowedTypes = tool?.metadata?.allowed_types || [];
   const allowedDtypes = tool?.metadata?.allowed_dtypes || [];
   const inputCardinality = tool?.metadata?.input_cardinality || {};
+  const typesDtypeRestrictions = tool?.metadata?.type_dtype_restrictions || {};
   const tourContext = useTourContext();
   const { t } = useTranslation(["datasets", "common"]);
 
@@ -51,6 +52,7 @@ export default function ScopeStepExplorer({
           inputCardinality={inputCardinality}
           allowedTypes={allowedTypes}
           allowedDtypes={allowedDtypes}
+          typesDtypeRestrictions={typesDtypeRestrictions}
           onSelectionChange={(selected) => setScopeColumns(selected)}
           onValidationChange={(isValid) => setIsSelectionValid(isValid)}
         />

--- a/tests/back/exploration/test_base_explorer_metadata.py
+++ b/tests/back/exploration/test_base_explorer_metadata.py
@@ -203,14 +203,14 @@ def test_validate_columns_missing_column_in_spec_passes_when_unrestricted():
     assert cls.validate_columns(explorer_info, column_spec) is True
 
 
-# --- numeric_categorical_only tests ---
+# --- type_dtype_restrictions tests ---
 
 
-def test_numeric_categorical_only_passes_int_dtype():
+def test_type_dtype_restrictions_passes_allowed_dtype():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        numeric_categorical_only=True,
+        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_num"}])
@@ -218,11 +218,11 @@ def test_numeric_categorical_only_passes_int_dtype():
     assert cls.validate_columns(explorer_info, column_spec) is True
 
 
-def test_numeric_categorical_only_passes_float_dtype():
+def test_type_dtype_restrictions_passes_float_dtype():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        numeric_categorical_only=True,
+        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_num"}])
@@ -230,11 +230,11 @@ def test_numeric_categorical_only_passes_float_dtype():
     assert cls.validate_columns(explorer_info, column_spec) is True
 
 
-def test_numeric_categorical_only_blocks_string_dtype():
+def test_type_dtype_restrictions_blocks_string_dtype():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        numeric_categorical_only=True,
+        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_str"}])
@@ -242,11 +242,11 @@ def test_numeric_categorical_only_blocks_string_dtype():
     assert cls.validate_columns(explorer_info, column_spec) is False
 
 
-def test_numeric_categorical_only_blocks_bool_dtype():
+def test_type_dtype_restrictions_blocks_bool_dtype():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        numeric_categorical_only=True,
+        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_bool"}])
@@ -254,13 +254,38 @@ def test_numeric_categorical_only_blocks_bool_dtype():
     assert cls.validate_columns(explorer_info, column_spec) is False
 
 
-def test_numeric_categorical_only_false_allows_string_categorical():
+def test_type_dtype_restrictions_absent_allows_string_categorical():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        numeric_categorical_only=False,
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_str"}])
     column_spec = {"cat_str": {"type": "Categorical", "dtype": "string"}}
     assert cls.validate_columns(explorer_info, column_spec) is True
+
+
+def test_get_metadata_includes_type_dtype_restrictions():
+    cls = _make_explorer(
+        allowed_types=[],
+        allowed_dtypes=[],
+        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
+    )
+    meta = cls.get_metadata()
+    assert meta["type_dtype_restrictions"] == {"Categorical": ["string", "bool", ""]}
+
+
+def test_get_metadata_type_dtype_restrictions_defaults_to_empty():
+    cls = _make_explorer(allowed_types=[], allowed_dtypes=[])
+    meta = cls.get_metadata()
+    assert meta["type_dtype_restrictions"] == {}
+
+
+def test_get_metadata_drops_numeric_categorical_only():
+    cls = _make_explorer(
+        allowed_types=[],
+        allowed_dtypes=[],
+        numeric_categorical_only=True,
+    )
+    meta = cls.get_metadata()
+    assert "numeric_categorical_only" not in meta


### PR DESCRIPTION

This pull request refactors how per-type dtype restrictions are handled in both the backend and frontend, replacing the old `numeric_categorical_only` flag with a more flexible `type_dtype_restrictions` mapping. This change improves clarity, extensibility, and consistency across the codebase. It also updates relevant validation logic and tests, and ensures the frontend properly respects these backend restrictions when selecting columns.

**Backend changes:**

* Replaced the `numeric_categorical_only` flag in explorer metadata with a new `type_dtype_restrictions` dictionary, allowing explicit per-type dtype exclusions (e.g., for `Categorical`, exclude `string`, `bool`, and empty dtypes). This is reflected in all relevant explorer classes. [[1]](diffhunk://#diff-8570f0f799fa9e6f707de8029511d6d3fc7bc5b6a4a0c7ec6dcf4f53d375915dL190-R190) [[2]](diffhunk://#diff-0b4de22cbde5b08e3f7916aabe12cd3c456006a66cba48d4fc588d8976c56d63L185-R185) [[3]](diffhunk://#diff-45f1a839762cb640a5e43ceaa2f54ecb95d006c92bda5a4e5938844b6851af56L163-R163) [[4]](diffhunk://#diff-725046da3c421e9e0a8c1575237f2417f886c8579bfae92f138e0d76be9e7c4dL141-R141) [[5]](diffhunk://#diff-063d599b04189308e070332bee3af78bedd5f7d7179d2eb07e000e609b55f246L93-R93) [[6]](diffhunk://#diff-63bcc1f69604f0a0f909d26744d44b82811c7c45d1946310cb2beff2c2672f72L119-R119) [[7]](diffhunk://#diff-824b91103470e84144a2c978d34085a4a75f3e726e63763860fee915c5fe1738L124-R124)
* Updated `get_metadata` in `base_explorer.py` to remove internal-only flags (`numeric_categorical_only`), always include `type_dtype_restrictions`, and ensure the frontend receives the correct metadata.
* Refactored the `validate_columns` logic to use `type_dtype_restrictions` for per-type dtype validation instead of the old flag. [[1]](diffhunk://#diff-4d9acb8839b5fc98d47cbd682775923f7fb78025b509435ffd150230dc09019cL170-R176) [[2]](diffhunk://#diff-4d9acb8839b5fc98d47cbd682775923f7fb78025b509435ffd150230dc09019cL181-R186)

**Frontend changes:**

* Updated the `ColumnSelector` component and its consumers to accept and enforce `typesDtypeRestrictions` when determining valid/invalid columns for selection. [[1]](diffhunk://#diff-e7481b802e414d0101281c678d736b1ed1f0b7b4fcfaabead90913d0de9a5ce9R42) [[2]](diffhunk://#diff-e7481b802e414d0101281c678d736b1ed1f0b7b4fcfaabead90913d0de9a5ce9R164-R171) [[3]](diffhunk://#diff-e7481b802e414d0101281c678d736b1ed1f0b7b4fcfaabead90913d0de9a5ce9R449) [[4]](diffhunk://#diff-711647abd9237f7984867e4544ede07fcf00a688129ce0f7ae4dd2c752781c81R150-R151) [[5]](diffhunk://#diff-711647abd9237f7984867e4544ede07fcf00a688129ce0f7ae4dd2c752781c81R172-R179) [[6]](diffhunk://#diff-8e8147f65b67fee062d470d6e9a0b1af118e88b358de8744c5b6c4201a485e93R21) [[7]](diffhunk://#diff-8e8147f65b67fee062d470d6e9a0b1af118e88b358de8744c5b6c4201a485e93R55)
* Ensured that column validation in the right sidebar and explorer creation step respects these backend-provided dtype restrictions. [[1]](diffhunk://#diff-711647abd9237f7984867e4544ede07fcf00a688129ce0f7ae4dd2c752781c81R150-R151) [[2]](diffhunk://#diff-711647abd9237f7984867e4544ede07fcf00a688129ce0f7ae4dd2c752781c81R172-R179) [[3]](diffhunk://#diff-8e8147f65b67fee062d470d6e9a0b1af118e88b358de8744c5b6c4201a485e93R21) [[4]](diffhunk://#diff-8e8147f65b67fee062d470d6e9a0b1af118e88b358de8744c5b6c4201a485e93R55)

**Testing improvements:**

* Updated and expanded tests to cover the new `type_dtype_restrictions` logic, including positive and negative cases, and checks for correct metadata emission and legacy flag removal.

These changes collectively make dtype restrictions more explicit and maintainable, and ensure consistent enforcement across the backend and frontend.