### PR TITLE
Resolve lazy imports of DashAIImage and Categorical introduced by ImageDataLoader

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -9,6 +9,7 @@ from datasets import Dataset
 
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.dashai_data_type import DashAIDataType
+from DashAI.back.types.dashai_image import DashAIImage
 from DashAI.back.types.utils import (
     arrow_to_dashai_types,
     comma_float_to_float,
@@ -240,8 +241,6 @@ class DashAIDataset(Dataset):
         dict
             General information including rows, columns, memory usage, and dtypes.
         """
-        from DashAI.back.types.dashai_image import DashAIImage
-
         hashable_cols = [
             c
             for c in dataset_df.columns
@@ -441,8 +440,6 @@ class DashAIDataset(Dataset):
         completeness = 1 - (
             dataset_df.isna().sum().sum() / (len(dataset_df) * len(dataset_df.columns))
         )
-
-        from DashAI.back.types.dashai_image import DashAIImage
 
         hashable_cols = [
             c
@@ -670,8 +667,6 @@ class DashAIDataset(Dataset):
         if not isinstance(result, dict):
             return result
 
-        from DashAI.back.types.dashai_image import DashAIImage
-
         image_cols = [
             c
             for c, t in self._types.items()
@@ -841,8 +836,6 @@ def transform_dataset_with_schema(
                 # Use the dtype from schema for pa_type
                 pa_type = to_arrow_types(dtype)
             elif _type == "Image":
-                from DashAI.back.types.dashai_image import DashAIImage
-
                 dashai_types[column_name] = DashAIImage(dtype=dtype)
                 dai_table[column_name] = table.column(column_name)
                 pa_type = table.schema.field(column_name).type

--- a/DashAI/back/dataloaders/classes/image_dataloader.py
+++ b/DashAI/back/dataloaders/classes/image_dataloader.py
@@ -13,6 +13,8 @@ from DashAI.back.dataloaders.classes.dashai_dataset import (
     to_dashai_dataset,
 )
 from DashAI.back.dataloaders.classes.dataloader import BaseDataLoader
+from DashAI.back.types.categorical import Categorical
+from DashAI.back.types.dashai_image import DashAIImage
 
 
 class ImageDataLoaderSchema(BaseSchema):
@@ -192,9 +194,6 @@ class ImageDataLoader(BaseDataLoader):
         log.debug("Dataset columns: %s", dataset.column_names)
 
         shutil.rmtree(prepared_path[0])
-
-        from DashAI.back.types.categorical import Categorical
-        from DashAI.back.types.dashai_image import DashAIImage
 
         types = {}
         for col in dataset.column_names:


### PR DESCRIPTION
## Summary
  `DashAIImage` and `Categorical` were being imported lazily (inside method bodies) in `dashai_dataset.py` and `image_dataloader.py` as a side effect of the ImageDataLoader integration. No circular import exists between `types/` and `dataloaders/` that would justify this pattern — the other types (`Categorical`, `Float`, `Integer`, `Text`) are already imported at module level. This moves those imports to the top of each file, consistent with the existing convention.

  ---

  ## Type of Change
  Check all that apply like this [x]:

  - [x] Backend change
  - [ ] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [ ] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/back/dataloaders/classes/dashai_dataset.py`: moved `DashAIImage` import to module level; removed 4 lazy imports scattered across methods
  - `DashAI/back/dataloaders/classes/image_dataloader.py`: moved `DashAIImage` and `Categorical` imports to module level; removed lazy imports inside `load_data`
  
  ---

  ## Notes (optional)

  The lazy import of `PIL` inside `_load_images_from_directory` was intentionally left in place — Pillow is an optional heavy dependency and the lazy import there is correct.