### PR TITLE
Remove change_columns_type and encode_labels temporal workarounds from DashAIDataset

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -132,49 +132,6 @@ class DashAIDataset(Dataset):
             return list(self.splits["split_indices"].keys())
         return []
 
-    # This method is still used only because Image dataset load
-    # haven't been implemented to be DashAITypes compatible
-    # So categories can't be labeled as Categorical Datatype
-    # Should be removed ASAP when DashAIImageType and its handlers are implemented
-    @beartype
-    def change_columns_type(self, column_types: Dict[str, str]) -> "DashAIDataset":
-        """Change the type of some columns.
-
-        Note: this is a temporal method, and it will probably will delete in the future.
-
-        Parameters
-        ----------
-        column_types : Dict[str, str]
-            dictionary whose keys are the names of the columns to be changed and the
-            values the new types.
-
-        Returns
-        -------
-        DashAIDataset
-            The dataset after columns type changes.
-        """
-        from datasets import Value as HFValue
-
-        if not isinstance(column_types, dict):
-            raise TypeError(f"types should be a dict, got {type(column_types)}")
-
-        for column in column_types:
-            if column in self.column_names:
-                pass
-            else:
-                raise ValueError(
-                    f"Error while changing column types: column '{column}' does not "
-                    "exist in dataset."
-                )
-        new_features = self.features.copy()
-        for column in column_types:
-            if column_types[column] == "Categorical":
-                new_features[column] = encode_labels(self, column)
-            elif column_types[column] == "Numerical":
-                new_features[column] = HFValue("float32")
-        dataset = self.cast(new_features)
-        return dataset
-
     def compute_base_metadata(self) -> "DashAIDataset":
         """Compute basic metadata for the dataset and store it in self.splits.
 
@@ -970,41 +927,6 @@ def load_dataset(dataset_path: Union[str, os.PathLike]) -> DashAIDataset:
     else:
         splits = {}
     return DashAIDataset(data, splits=splits)
-
-
-# Use it only for Image classification
-# since images are loaded different to tabular data
-# And it's link to DashAIDataTypes is not implemented yet
-# So categorical columns can't be labeled as Categorical Datatype but ClassLabel
-# Should be removed ASAP when DashAIImageType and its handlers are implemented
-@beartype
-def encode_labels(
-    dataset: DashAIDataset,
-    column_name: str,
-) -> object:
-    """Encode a categorical column into numerical labels and
-    return the ClassLabel feature.
-
-    Parameters
-    ----------
-    dataset : DashAIDataset
-        Dataset containing the column to encode.
-    column_name : str
-        Name of the column to encode.
-
-    Returns
-    -------
-    ClassLabel
-        The ClassLabel feature with the mapping of labels to integers.
-    """
-    if column_name not in dataset.column_names:
-        raise ValueError(f"Column '{column_name}' does not exist in the dataset.")
-
-    from datasets import ClassLabel  # local import
-
-    names = list(set(dataset[column_name]))
-    class_label_feature = ClassLabel(names=names)
-    return class_label_feature
 
 
 @beartype

--- a/DashAI/back/tasks/classification_task.py
+++ b/DashAI/back/tasks/classification_task.py
@@ -60,18 +60,13 @@ class ClassificationTask(BaseTask):
         """
         import numpy as np
 
-        from DashAI.back.dataloaders.classes.dashai_dataset import encode_labels
-
         predictions = np.argmax(predictions, axis=1)
 
         output_type = dataset.types.get(output_column)
 
         if isinstance(output_type, Categorical):
             return np.array([output_type.int2str(idx) for idx in predictions])
-        else:
-            # Fallback to old method if not categorical
-            class_labels = encode_labels(dataset, output_column)
-            return np.array(class_labels.int2str(predictions))
+        return np.array(predictions)
 
     def prepare_for_task(
         self,
@@ -127,7 +122,7 @@ class ClassificationTask(BaseTask):
         int | None
             Number of unique labels or None if not applicable
         """
-        from DashAI.back.dataloaders.classes.dashai_dataset import encode_labels
-
-        class_labels = encode_labels(dataset, output_column)
-        return len(class_labels.names)
+        output_type = dataset.types.get(output_column)
+        if isinstance(output_type, Categorical):
+            return output_type.num_categories()
+        return None

--- a/tests/back/dataloaders/test_dashai_dataset.py
+++ b/tests/back/dataloaders/test_dashai_dataset.py
@@ -8,7 +8,6 @@ from typing import List
 import datasets
 import pytest
 from datasets import DatasetDict
-from pyarrow.lib import ArrowInvalid
 from sklearn.datasets import load_iris
 
 from DashAI.back.dataloaders.classes.csv_dataloader import CSVDataLoader
@@ -192,70 +191,6 @@ def test_sample_dashaidataset(dashai_datasetdict: list, method: str, n_samples: 
             for key in one_sample:
                 one_sample[key] = sample[key][index]
             assert any(one_sample == data for data in dataset)
-
-
-# ----------------------------------------------------------------------------
-# test change_columns_type
-
-
-@pytest.mark.parametrize(
-    ("col_types", "expected_exception", "match"),
-    [
-        # test case 1 - try to change the type of an unexistant col.
-        (
-            {"unexistant_col": "Categorical"},
-            ValueError,
-            (
-                r"Error while changing column types: column 'unexistant_col' does not "
-                r"exist in dataset."
-            ),
-        ),
-        # test case 2 - try to change a col to an incompatible type.
-        (
-            {"sepal length (cm)": "Categorical"},
-            ArrowInvalid,
-            r"Float value \d+\.\d+ was truncated converting to int64",
-        ),
-    ],
-    ids=[
-        "test_change_columns_type_raises_error_for_unexistant_col",
-        "test_change_columns_type_raises_error_for_incompatible_type_casting",
-    ],
-)
-def test_change_columns_type_errors(
-    dashai_datasetdict: list, col_types, expected_exception, match
-):
-    with pytest.raises(expected_exception, match=match):
-        dashai_datasetdict.change_columns_type(col_types)
-
-
-def test_dashai_datasetdict_change_columns_type_target_col_as_cat(
-    dashai_datasetdict: DashAIDataset,
-):
-    """Test target column casting to a Categorical (ClassLabel) type."""
-
-    original_features = dashai_datasetdict.features.copy()
-
-    dashai_datasetdict = dashai_datasetdict.change_columns_type(
-        {"target": "Categorical"}
-    )
-    new_features = dashai_datasetdict.features
-
-    assert len(original_features) == len(new_features)
-
-    assert original_features["target"].dtype == "int64"
-    assert new_features["target"].dtype == "int64"
-
-    # check the new types.
-    assert isinstance(original_features["target"], datasets.features.Value)
-    assert isinstance(new_features["target"], datasets.features.ClassLabel)
-
-    # check that the rest of the features remain unmodified.
-    for feature_name in original_features:
-        if feature_name != "target":
-            assert isinstance(original_features[feature_name], datasets.features.Value)
-            assert isinstance(new_features[feature_name], datasets.features.Value)
-            assert original_features[feature_name] == new_features[feature_name]
 
 
 # ----------------------------------------------------------------------------

--- a/tests/back/tasks/test_tasks.py
+++ b/tests/back/tasks/test_tasks.py
@@ -66,7 +66,6 @@ def load_csv_into_datasetdict_iris_extra(file_name):
 def test_validate_tabular_task():
     dataset = to_dashai_dataset(load_csv_into_datasetdict_iris("iris.csv"))
 
-    dataset = dataset.change_columns_type(column_types={"Species": "Categorical"})
     tabular_task = TabularClassificationTask()
     inputs_columns = [
         "SepalLengthCm",


### PR DESCRIPTION
## Summary
  Removes `change_columns_type` and `encode_labels`, two temporal workarounds added when `ImageDataLoader` was integrated. At the time, the image dataloader did not assign DashAI types to its columns, so these functions patched the label column after loading using HuggingFace's `ClassLabel` instead of the proper `Categorical` type. Since `ImageDataLoader` now correctly assigns `DashAIImage` and `Categorical` on load, the workarounds are no longer needed. `classification_task.py` is updated to use the `Categorical` type directly.

  ---

  ## Type of Change

  - [x] Backend change
  - [ ] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [ ] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/back/dataloaders/classes/dashai_dataset.py`: removed `change_columns_type` method and `encode_labels` function
  - `DashAI/back/tasks/classification_task.py`: replaced `encode_labels` usages — `num_labels` now uses `Categorical.num_categories()` directly, `process_predictions` removes the fallback path that relied on `encode_labels`
  - `tests/back/tasks/test_tasks.py`: removed redundant `change_columns_type` call (Species was already `Categorical` via `transform_dataset_with_schema`)
  - `tests/back/dataloaders/test_dashai_dataset.py`: removed 3 tests for `change_columns_type` and orphaned `ArrowInvalid` import

  ---

  ## Notes (optional)

  `encode_labels` used HuggingFace's `ClassLabel` as a substitute for `Categorical`, which was inconsistent with the rest of the DashAI type system. The proper types (`Categorical`, `DashAIImage`, etc.) live in `DashAI/back/types/` and are now used consistently throughout.