### PR TITLE
fix: add missing German translations to backend components

### DIFF
--- a/DashAI/back/explainability/explainers/kernel_shap.py
+++ b/DashAI/back/explainability/explainers/kernel_shap.py
@@ -39,11 +39,17 @@ class KernelShapSchema(BaseSchema):
                 "características às saídas do modelo. Opções: 'identity' "
                 "(identidade) ou 'logit' (log-odds)."
             ),
+            de=(
+                "Verknüpfungsfunktion, um Merkmalswichtigkeitswerte mit den "
+                "Modellausgaben zu verbinden. Optionen: 'identity' "
+                "(Identitätsfunktion) oder 'logit' (Log-Odds)."
+            ),
         ),
         alias=MultilingualString(
             en="Link function",
             es="Función de enlace",
             pt="Função de ligação",
+            de="Verknüpfungsfunktion",
         ),
     )  # type: ignore
 
@@ -68,11 +74,17 @@ class KernelShapSchema(BaseSchema):
                 "de treinamento completo. Conjuntos menores reduzem o tempo de "
                 "execução."
             ),
+            de=(
+                "Parameter zum Anpassen des Erklärers. 'true', wenn Hintergrunddaten "
+                "gesamplet werden müssen; sonst wird der gesamte Trainingssatz "
+                "verwendet. Kleinere Datensätze beschleunigen die Laufzeit."
+            ),
         ),
         alias=MultilingualString(
             en="Sample background data",
             es="Muestrear datos de fondo",
             pt="Amostrar dados de fundo",
+            de="Hintergrunddaten samplen",
         ),
     )  # type: ignore
 
@@ -94,11 +106,16 @@ class KernelShapSchema(BaseSchema):
                 "à fração de amostras de fundo a extrair do conjunto de "
                 "treinamento."
             ),
+            de=(
+                "Wenn 'Hintergrunddaten samplen' ausgewählt ist, entspricht dies dem "
+                "Anteil der Hintergrundproben aus dem Trainingssatz."
+            ),
         ),
         alias=MultilingualString(
             en="Background fraction",
             es="Fracción de fondo",
             pt="Fração de fundo",
+            de="Hintergrundfraktion",
         ),
     )  # type: ignore
 
@@ -124,11 +141,17 @@ class KernelShapSchema(BaseSchema):
                 "houver características categóricas, 'shuffle' é usado por "
                 "padrão."
             ),
+            de=(
+                "Wenn 'true', werden zufällige Instanzen mit 'shuffle' gesamplet "
+                "oder der Datensatz mit 'kmeans' zusammengefasst. Bei kategorialen "
+                "Merkmalen wird standardmäßig 'shuffle' verwendet."
+            ),
         ),
         alias=MultilingualString(
             en="Sampling method",
             es="Método de muestreo",
             pt="Método de amostragem",
+            de="Samplingmethode",
         ),
     )  # type: ignore
 
@@ -157,7 +180,7 @@ class KernelShap(BaseLocalExplainer):
 
     COMPATIBLE_COMPONENTS = ["TabularClassificationTask"]
     DISPLAY_NAME = MultilingualString(
-        en="Kernel SHAP", es="Kernel SHAP", pt="Kernel SHAP"
+        en="Kernel SHAP", es="Kernel SHAP", pt="Kernel SHAP", de="Kernel SHAP"
     )
     DESCRIPTION = MultilingualString(
         en=(
@@ -172,6 +195,10 @@ class KernelShap(BaseLocalExplainer):
         pt=(
             "Kernel SHAP aproxima os valores de Shapley para explicar a saída do "
             "modelo atribuindo a contribuição de cada característica à previsão."
+        ),
+        de=(
+            "Kernel SHAP approximiert SHAP-Werte, um die Modellausgabe zu erklären, "
+            "indem die Beiträge jedes Merkmals zur Vorhersage zugeordnet werden."
         ),
     )
     COLOR = "#008000"

--- a/DashAI/back/exploration/explorers/describe_explorer.py
+++ b/DashAI/back/exploration/explorers/describe_explorer.py
@@ -48,8 +48,14 @@ class DescribeExplorerSchema(BaseExplorerSchema):
                 "Percentis a incluir na exploração. Use inteiros entre 0 e "
                 "100. Exemplo: '25, 50, 75'"
             ),
+            de=(
+                "Perzentile für die Exploration. Ganzzahlen zwischen 0 und 100. "
+                "Beispiel: '25, 50, 75'"
+            ),
         ),
-        alias=MultilingualString(en="Percentiles", es="Percentiles", pt="Percentis"),
+        alias=MultilingualString(
+            en="Percentiles", es="Percentiles", pt="Percentis", de="Perzentile"
+        ),
     )  # type: ignore
     include: schema_field(
         none_type(enum_field(["all", "number", "object", "category", "datetime"])),
@@ -58,9 +64,13 @@ class DescribeExplorerSchema(BaseExplorerSchema):
             en=("Data types to include in the exploration."),
             es=("Tipos de datos a incluir en la exploración."),
             pt=("Tipos de dados a incluir na exploração."),
+            de="Datentypen, die in die Exploration einbezogen werden.",
         ),
         alias=MultilingualString(
-            en="Include dtypes", es="Incluir tipos", pt="Incluir tipos"
+            en="Include dtypes",
+            es="Incluir tipos",
+            pt="Incluir tipos",
+            de="Typen einschließen",
         ),
     )  # type: ignore
     exclude: schema_field(
@@ -70,9 +80,13 @@ class DescribeExplorerSchema(BaseExplorerSchema):
             en=("Data types to exclude from the exploration."),
             es=("Tipos de datos a excluir de la exploración."),
             pt=("Tipos de dados a excluir da exploração."),
+            de="Datentypen, die von der Exploration ausgeschlossen werden.",
         ),
         alias=MultilingualString(
-            en="Exclude dtypes", es="Excluir tipos", pt="Excluir tipos"
+            en="Exclude dtypes",
+            es="Excluir tipos",
+            pt="Excluir tipos",
+            de="Typen ausschließen",
         ),
     )  # type: ignore
 
@@ -102,6 +116,7 @@ class DescribeExplorer(PreviewInspectionExplorer):
         en="Describe Dataset",
         es="Describir Dataset",
         pt="Explorador de Descrição Estatística",
+        de="Datensatz beschreiben",
     )
     DESCRIPTION = MultilingualString(
         en=(
@@ -122,12 +137,20 @@ class DescribeExplorer(PreviewInspectionExplorer):
             "colunas de objeto: count, unique, top e freq. Você pode escolher "
             "percentis e quais tipos incluir ou excluir."
         ),
+        de=(
+            "Erzeugt eine statistische Zusammenfassung des Datensatzes. Für "
+            "numerische Spalten: Anzahl, Mittelwert, Standardabweichung, Min, "
+            "25%, 50%, 75% und Max. Für Objektspalten: Anzahl, eindeutige Werte, "
+            "häufigster Wert und Häufigkeit. Perzentile und Datentypen können "
+            "ein- oder ausgeschlossen werden."
+        ),
     )
 
     SHORT_DESCRIPTION = MultilingualString(
         en="Generate a statistical summary of the dataset.",
         es="Genera un resumen estadístico del dataset.",
         pt="Gera um resumo estatístico do conjunto de dados.",
+        de="Erstellt eine statistische Zusammenfassung des Datensatzes.",
     )
     IMAGE_PREVIEW = "describe_explorer.png"
 

--- a/DashAI/back/exploration/explorers/multibox_plot.py
+++ b/DashAI/back/exploration/explorers/multibox_plot.py
@@ -48,11 +48,16 @@ class MultiColumnBoxPlotSchema(BaseExplorerSchema):
                 "Se True, o diagrama de caixa será horizontal; caso "
                 "contrário, vertical."
             ),
+            de=(
+                "Wenn True, wird das Boxplot horizontal dargestellt; "
+                "andernfalls vertikal."
+            ),
         ),
         alias=MultilingualString(
             en="Horizontal plot",
             es="Gráfico horizontal",
             pt="Gráfico horizontal",
+            de="Horizontales Diagramm",
         ),
     )  # type: ignore
     points: schema_field(
@@ -70,11 +75,16 @@ class MultiColumnBoxPlotSchema(BaseExplorerSchema):
                 "Um de 'all', 'outliers' ou 'False'. Determina quais pontos "
                 "são exibidos."
             ),
+            de=(
+                "Eines von 'all', 'outliers' oder 'False'. Bestimmt, welche "
+                "Punkte angezeigt werden."
+            ),
         ),
         alias=MultilingualString(
             en="Points shown",
             es="Puntos mostrados",
             pt="Pontos exibidos",
+            de="Angezeigte Punkte",
         ),
     )  # type: ignore
     opposite_axis: schema_field(
@@ -84,9 +94,13 @@ class MultiColumnBoxPlotSchema(BaseExplorerSchema):
             en=("Column name or index to use for the opposite axis."),
             es=("Nombre o índice de columna para el eje opuesto."),
             pt=("Nome ou índice de coluna para usar no eixo oposto."),
+            de="Spaltenname oder -index für die gegenüberliegende Achse.",
         ),
         alias=MultilingualString(
-            en="Opposite axis", es="Eje opuesto", pt="Eixo oposto"
+            en="Opposite axis",
+            es="Eje opuesto",
+            pt="Eixo oposto",
+            de="Gegenüberliegende Achse",
         ),
     )  # type: ignore
 
@@ -117,6 +131,7 @@ class MultiColumnBoxPlotExplorer(MultidimensionalExplorer):
         en="Multiple Column Box Plot",
         es="Diagrama de Caja Multicolumna",
         pt="Diagrama de Caixa Múltiplo",
+        de="Mehrspaltiges Boxplot",
     )
     DESCRIPTION = MultilingualString(
         en=(
@@ -130,6 +145,10 @@ class MultiColumnBoxPlotExplorer(MultidimensionalExplorer):
         pt=(
             "Exibe um diagrama de caixa para múltiplas colunas em um eixo, "
             "usando outra coluna como eixo oposto (se fornecida)."
+        ),
+        de=(
+            "Zeigt ein Boxplot für mehrere Spalten auf einer Achse, "
+            "optional mit einer weiteren Spalte als gegenüberliegende Achse."
         ),
     )
     IMAGE_PREVIEW = "multi_column_box_plot.png"

--- a/DashAI/back/exploration/explorers/wordcloud.py
+++ b/DashAI/back/exploration/explorers/wordcloud.py
@@ -33,9 +33,13 @@ class WordcloudSchema(BaseExplorerSchema):
             en="Maximum number of words to display in the word cloud.",
             es="Número máximo de palabras a mostrar en la nube de palabras.",
             pt="Número máximo de palavras a exibir na nuvem de palavras.",
+            de="Maximale Anzahl der anzuzeigenden Wörter in der Wortwolke.",
         ),
         alias=MultilingualString(
-            en="Max words", es="Máximo de palabras", pt="Máximo de palavras"
+            en="Max words",
+            es="Máximo de palabras",
+            pt="Máximo de palavras",
+            de="Max. Wörter",
         ),
     )  # type: ignore
     background_color: schema_field(
@@ -51,11 +55,16 @@ class WordcloudSchema(BaseExplorerSchema):
                 "transparente."
             ),
             pt=("Cor de fundo da nuvem de palavras. Se None, o fundo é transparente."),
+            de=(
+                "Hintergrundfarbe der Wortwolke. Bei None ist der Hintergrund "
+                "transparent."
+            ),
         ),
         alias=MultilingualString(
             en="Background color",
             es="Color de fondo",
             pt="Cor de fundo",
+            de="Hintergrundfarbe",
         ),
     )  # type: ignore
 
@@ -75,7 +84,10 @@ class WordcloudExplorer(DistributionExplorer):
     """
 
     DISPLAY_NAME = MultilingualString(
-        en="Word Cloud", es="Nube de Palabras", pt="Nuvem de Palavras"
+        en="Word Cloud",
+        es="Nube de Palabras",
+        pt="Nuvem de Palavras",
+        de="Wortwolke",
     )
     DESCRIPTION = MultilingualString(
         en=(
@@ -91,6 +103,11 @@ class WordcloudExplorer(DistributionExplorer):
             "Representação visual do texto onde o tamanho da palavra "
             "reflete sua frequência. Gera uma nuvem de palavras concatenando "
             "colunas de texto selecionadas."
+        ),
+        de=(
+            "Visuelle Darstellung von Text, bei der die Wortgröße die Häufigkeit "
+            "widerspiegelt. Erzeugt eine Wortwolke durch Verkettung ausgewählter "
+            "Textspalten."
         ),
     )
     IMAGE_PREVIEW = "wordcloud.png"

--- a/DashAI/back/models/hugging_face/sd15_depth_controlnet_model.py
+++ b/DashAI/back/models/hugging_face/sd15_depth_controlnet_model.py
@@ -43,11 +43,17 @@ class SD15DepthControlNetSchema(BaseSchema):
                 "mas aumentam o tempo de geração. Intervalo típico: 20-30 para "
                 "resultados rápidos, 40-50 para maior qualidade."
             ),
+            de=(
+                "Anzahl der Entrauschungsschritte. Mehr Schritte verfeinern das Bild, "
+                "erhöhen aber die Generierungszeit. Typischer Bereich: 20-30 für "
+                "schnelle Ergebnisse, 40-50 für höhere Qualität."
+            ),
         ),
         alias=MultilingualString(
             en="Num inference steps",
             es="Número de pasos de inferencia",
             pt="Número de passos de inferência",
+            de="Anzahl Inferenzschritte",
         ),
     )  # type: ignore
 
@@ -73,11 +79,18 @@ class SD15DepthControlNetSchema(BaseSchema):
                 "saída segue de perto a estrutura da entrada; acima de 1.5 a "
                 "profundidade domina e pode produzir resultados rígidos."
             ),
+            de=(
+                "Gewichtung des ControlNet-Tiefenkonditionierens (Bereich 0.0-2.0). "
+                "Bei 0.0 hat die Tiefenkarte keinen Effekt; bei 1.0 folgt die Ausgabe "
+                "eng der Eingangsstruktur; über 1.5 dominiert die Tiefe und kann zu "
+                "starren Ergebnissen führen."
+            ),
         ),
         alias=MultilingualString(
             en="ControlNet conditioning scale",
             es="Escala de condicionamiento ControlNet",
             pt="Escala de condicionamento ControlNet",
+            de="ControlNet-Konditionierungsskala",
         ),
     )  # type: ignore
 
@@ -98,11 +111,16 @@ class SD15DepthControlNetSchema(BaseSchema):
                 "Escala de Orientação Livre de Classificador (CFG). Controla com que "
                 "rigor a imagem segue o prompt. Valores 7-9 são típicos para SD 1.5."
             ),
+            de=(
+                "Classifier-Free Guidance (CFG)-Skala. Steuert, wie streng das Bild "
+                "dem Text-Prompt folgt. Werte 7-9 sind typisch für SD 1.5."
+            ),
         ),
         alias=MultilingualString(
             en="Guidance scale",
             es="Escala de guía",
             pt="Escala de orientação",
+            de="Führungsskala",
         ),
     )  # type: ignore
 
@@ -123,11 +141,17 @@ class SD15DepthControlNetSchema(BaseSchema):
                 "recomendada para modelos de difusão. A inferência em CPU é "
                 "possível, mas muito lenta."
             ),
+            de=(
+                "Hardware-Gerät für die Inferenz. GPU wird dringend für "
+                "Diffusionsmodelle empfohlen. CPU-Inferenz ist möglich, "
+                "aber sehr langsam."
+            ),
         ),
         alias=MultilingualString(
             en="Device",
             es="Dispositivo",
             pt="Dispositivo",
+            de="Gerät",
         ),
     )  # type: ignore
 
@@ -208,6 +232,7 @@ class SD15DepthControlNetModel(BaseControlNetModel):
         en="SD 1.5 Depth ControlNet",
         es="SD 1.5 ControlNet de Profundidad",
         pt="SD 1.5 ControlNet de Profundidade",
+        de="SD 1.5 Tiefen-ControlNet",
     )
     DESCRIPTION: str = MultilingualString(
         en=(
@@ -239,6 +264,17 @@ class SD15DepthControlNetModel(BaseControlNetModel):
             "512x512 px. Utiliza "
             "lllyasviel/sd-controlnet-depth "
             "(https://huggingface.co/lllyasviel/sd-controlnet-depth) e "
+            "runwayml/stable-diffusion-v1-5 "
+            "(https://huggingface.co/runwayml/stable-diffusion-v1-5)."
+        ),
+        de=(
+            "Kombiniert die ControlNet-Tiefenkonditionierung mit Stable Diffusion 1.5 "
+            "für strukturbewusste Bildgenerierung. Nimmt ein Eingabebild und einen "
+            "Text-Prompt: Eine Tiefenkarte wird mit dem DPT-Hybrid-MiDaS-Modell von "
+            "Intel extrahiert und als räumliche Bedingung zur Steuerung der "
+            "Bildsynthese bei 512x512 px verwendet. Verwendet "
+            "lllyasviel/sd-controlnet-depth "
+            "(https://huggingface.co/lllyasviel/sd-controlnet-depth) und "
             "runwayml/stable-diffusion-v1-5 "
             "(https://huggingface.co/runwayml/stable-diffusion-v1-5)."
         ),

--- a/DashAI/back/models/hugging_face/stable_diffusion_v1_depth_controlnet.py
+++ b/DashAI/back/models/hugging_face/stable_diffusion_v1_depth_controlnet.py
@@ -42,11 +42,18 @@ class StableDiffusionXLV1ControlNetSchema(BaseSchema):
                 "20-30 para resultados rápidos, 40-50 para maior qualidade. "
                 "Valores acima de 100 raramente melhoram o resultado."
             ),
+            de=(
+                "Anzahl der Entrauschungsschritte. Mehr Schritte verfeinern das Bild, "
+                "erhöhen aber die Generierungszeit. Typischer Bereich: 20-30 für "
+                "schnelle Ergebnisse, 40-50 für höhere Qualität. Werte über 100 "
+                "verbessern das Ergebnis kaum."
+            ),
         ),
         alias=MultilingualString(
             en="Num inference steps",
             es="Número de pasos de inferencia",
             pt="Número de passos de inferência",
+            de="Anzahl Inferenzschritte",
         ),
     )  # type: ignore
 
@@ -76,11 +83,18 @@ class StableDiffusionXLV1ControlNetSchema(BaseSchema):
                 "perto a estrutura da imagem de entrada; acima de 1.5 a restrição de "
                 "profundidade domina e pode produzir resultados excessivamente rígidos."
             ),
+            de=(
+                "Gewichtung des ControlNet-Tiefenkonditionierens (Bereich 0.0-2.0). "
+                "Bei 0.0 hat die Tiefenkarte keinen Effekt; bei 1.0 (Standard) folgt "
+                "die Ausgabe eng der Eingangsbildstruktur; über 1.5 dominiert die "
+                "Tiefenbeschränkung und kann zu übermäßig starren Ergebnissen führen."
+            ),
         ),
         alias=MultilingualString(
             en="ControlNet conditioning scale",
             es="Escala de condicionamiento ControlNet",
             pt="Escala de condicionamento ControlNet",
+            de="ControlNet-Konditionierungsskala",
         ),
     )  # type: ignore
 
@@ -106,11 +120,18 @@ class StableDiffusionXLV1ControlNetSchema(BaseSchema):
                 "difusão. Selecione 'CPU' em sistemas sem GPU compatível, mas espere "
                 "tempos de geração significativamente mais longos."
             ),
+            de=(
+                "Hardware-Gerät für die Inferenz. Wählen Sie eine GPU-Option für "
+                "Hardware-Beschleunigung, die für Diffusionsmodelle dringend empfohlen "
+                "wird. Wählen Sie 'CPU' auf Systemen ohne kompatible GPU, aber rechnen "
+                "Sie mit deutlich längeren Generierungszeiten."
+            ),
         ),
         alias=MultilingualString(
             en="Device",
             es="Dispositivo",
             pt="Dispositivo",
+            de="Gerät",
         ),
     )  # type: ignore
 
@@ -177,6 +198,7 @@ class StableDiffusionXLV1ControlNet(BaseControlNetModel):
         en="Stable Diffusion XL V1 ControlNet",
         es="Stable Diffusion XL V1 ControlNet",
         pt="Stable Diffusion XL V1 ControlNet",
+        de="Stable Diffusion XL V1 ControlNet",
     )
     DESCRIPTION: str = MultilingualString(
         en=(
@@ -214,6 +236,19 @@ class StableDiffusionXLV1ControlNet(BaseControlNetModel):
             "(https://huggingface.co/diffusers/controlnet-depth-sdxl-1.0-small), "
             "madebyollin/sdxl-vae-fp16-fix "
             "(https://huggingface.co/madebyollin/sdxl-vae-fp16-fix) e "
+            "stabilityai/stable-diffusion-xl-base-1.0 "
+            "(https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0)."
+        ),
+        de=(
+            "Kombiniert die ControlNet-Tiefenkonditionierung mit der Stable "
+            "Diffusion XL 1.0-Pipeline für strukturbewusste Bildgenerierung. "
+            "Nimmt ein Eingabebild und einen Text-Prompt: Eine Tiefenkarte wird "
+            "mit dem DPT-Hybrid-MiDaS-Modell von Intel extrahiert und als "
+            "räumliche Bedingung zur Steuerung der Bildsynthese verwendet. "
+            "Verwendet diffusers/controlnet-depth-sdxl-1.0-small "
+            "(https://huggingface.co/diffusers/controlnet-depth-sdxl-1.0-small), "
+            "madebyollin/sdxl-vae-fp16-fix "
+            "(https://huggingface.co/madebyollin/sdxl-vae-fp16-fix) und "
             "stabilityai/stable-diffusion-xl-base-1.0 "
             "(https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0)."
         ),

--- a/DashAI/back/models/hugging_face/tongyi_z_image_model.py
+++ b/DashAI/back/models/hugging_face/tongyi_z_image_model.py
@@ -294,11 +294,17 @@ class TongyiZImageSchema(BaseSchema):
                 "Quantas imagens gerar a partir de um único prompt em um lote. "
                 "Requer proporcionalmente mais memória GPU por imagem adicional."
             ),
+            de=(
+                "Anzahl der Bilder, die aus einem einzelnen Prompt in einem Batch "
+                "generiert werden. Erfordert proportional mehr GPU-Speicher pro "
+                "zusätzlichem Bild."
+            ),
         ),
         alias=MultilingualString(
             en="Num images per prompt",
             es="Número de imágenes por prompt",
             pt="Número de imagens por prompt",
+            de="Bilder pro Prompt",
         ),
     )  # type: ignore
 
@@ -324,6 +330,7 @@ class TongyiZImageModel(TextToImageGenerationTaskModel):
         en="Tongyi Z-Image",
         es="Tongyi Z-Image",
         pt="Tongyi Z-Image",
+        de="Tongyi Z-Image",
     )
     DESCRIPTION: str = MultilingualString(
         en=(
@@ -354,6 +361,16 @@ class TongyiZImageModel(TextToImageGenerationTaskModel):
             "de última geração com uma fração do seu tamanho. Destaca-se em "
             "geração fotorrealista de imagens, estilos diversos e renderização "
             "precisa de texto. Modelo disponível em "
+            "https://huggingface.co/Tongyi-AI/Tongyi-Z-Image."
+        ),
+        de=(
+            "Tongyi Z-Image ist Alibabas 6B-Parameter-Text-zu-Bild-Modell mit "
+            "einer neuartigen S3-DiT-Architektur (Sparse Spatial-Spectral "
+            "Diffusion Transformer). Es ist derzeit eines der am häufigsten "
+            "heruntergeladenen Modelle auf Hugging Face und übertrifft frühere "
+            "Open-Source-Modelle auf dem neuesten Stand bei einem Bruchteil ihrer "
+            "Größe. Hervorragend für fotorealistische Bildgenerierung, diverse "
+            "Stile und genaues Text-Rendering. Modell verfügbar unter "
             "https://huggingface.co/Tongyi-AI/Tongyi-Z-Image."
         ),
     )

--- a/DashAI/back/models/scikit_learn/svc.py
+++ b/DashAI/back/models/scikit_learn/svc.py
@@ -178,8 +178,14 @@ class SVCSchema(BaseSchema):
                 "O parâmetro 'redução' determina se "
                 "uma heurística de redução é utilizada."
             ),
+            de=(
+                "Der Parameter 'shrinking' bestimmt, ob "
+                "eine Schrumpfungsheuristik verwendet wird."
+            ),
         ),
-        alias=MultilingualString(en="shrinking", es="reducción", pt="redução"),
+        alias=MultilingualString(
+            en="shrinking", es="reducción", pt="redução", de="Schrumpfung"
+        ),
     )  # type: ignore
     tol: schema_field(
         optimizer_float_field(gt=0.0),
@@ -196,8 +202,11 @@ class SVCSchema(BaseSchema):
                 " la tolerancia para el criterio de detención."
             ),
             pt=("O parâmetro 'tol' determina a tolerância para o critério de parada."),
+            de="Der Parameter 'tol' bestimmt die Toleranz für das Stoppkriterium.",
         ),
-        alias=MultilingualString(en="tolerance", es="tolerancia", pt="tolerância"),
+        alias=MultilingualString(
+            en="tolerance", es="tolerancia", pt="tolerância", de="Toleranz"
+        ),
     )  # type: ignore
 
 
@@ -227,6 +236,7 @@ class SVC(TabularClassificationModel, SklearnLikeClassifier, _SVC):
         en="Support Vector Machine (SVM)",
         es="Máquina de Vectores de Soporte (SVM)",
         pt="Máquina de Vetores de Suporte (SVM)",
+        de="Support-Vektor-Maschine (SVM)",
     )
     DESCRIPTION: str = MultilingualString(
         en=(
@@ -259,6 +269,17 @@ class SVC(TabularClassificationModel, SklearnLikeClassifier, _SVC):
             "número de características é grande em relação ao número de amostras e "
             "podem modelar fronteiras de decisão complexas e não lineares mediante "
             "o uso de funções kernel como linear, polinomial e de base radial (RBF)."
+        ),
+        de=(
+            "Die Support-Vektor-Maschine (SVM) ist ein überwachter "
+            "Machine-Learning-Algorithmus für Klassifikations- und "
+            "Regressionsaufgaben. Sie findet die optimale Hyperebene, die die "
+            "Margin zwischen verschiedenen Klassen in einem hochdimensionalen "
+            "Merkmalsraum maximiert. SVMs sind besonders effektiv, wenn die Anzahl "
+            "der Merkmale im Verhältnis zur Anzahl der Stichproben groß ist, und "
+            "können komplexe, nichtlineare Entscheidungsgrenzen durch den Einsatz "
+            "von Kernelfunktionen wie linear, polynomial und radialer Basisfunktion "
+            "(RBF) modellieren."
         ),
     )
     COLOR: str = "#FF80AB"


### PR DESCRIPTION
## Summary

- Complete `de=` fields in `MultilingualString` for 8 backend components that were missing German translations
- Fixes: KernelShap explainer, DescribeExplorer, MultiColumnBoxPlotExplorer, WordcloudExplorer, SD15DepthControlNet, StableDiffusionXLV1ControlNet, TongyiZImage model, and SVC classifier
- All `DESCRIPTION`, `DISPLAY_NAME`, parameter `description`, and `alias` fields now have German translations

## Test plan

- [ ] Verify the app renders German labels correctly when language is set to `de`
- [ ] Check that the component registry loads without errors
- [ ] Confirm no ruff linting errors (`ruff check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)