### PR TITLE
Add compute_metadata toggle to dataset upload

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/dataset_source.py
+++ b/DashAI/back/api/api_v1/endpoints/dataset_source.py
@@ -317,7 +317,10 @@ async def import_dataset(
     dataset_id : str
         Source-specific dataset identifier (URL-encoded).
     body : ImportRequest
-        Contains the DashAI dataset_id and params.
+        Contains the DashAI dataset_id and params. ``params`` may include
+        ``compute_metadata: bool`` (default True). When False, ``DatasetJob``
+        only computes base metadata (column names, row count, NaN counts) —
+        extended EDA fields (correlations, stats, quality) are omitted.
     registry : ComponentRegistry
         Injected component registry.
     job_queue : BaseJobQueue

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -1842,6 +1842,7 @@ async def preview_with_types(
         ) as tmp_file:
             content = await file.read()
             tmp_file.write(content)
+            previewed_bytes = len(content)
             tmp_file_path = tmp_file.name
 
         try:
@@ -1937,6 +1938,7 @@ async def preview_with_types(
                             "inferred_types": inferred_types,
                             "preview_row_count": total_images,
                             "types_inferred": False,
+                            "previewed_bytes": previewed_bytes,
                         }
 
                     if matched_file is None:
@@ -1999,6 +2001,7 @@ async def preview_with_types(
                 "inferred_types": inferred_types,
                 "preview_row_count": len(loaded_dataset),
                 "types_inferred": True,
+                "previewed_bytes": previewed_bytes,
             }
 
         finally:

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -1248,18 +1248,22 @@ async def rename_dataset_column(
                 # Update nan entries
                 splits_data["nan"][new_name] = splits_data["nan"].pop(old_name)
 
-                # Update general info
-                splits_data["general_info"]["dtypes"][new_name] = splits_data[
-                    "general_info"
-                ]["dtypes"].pop(old_name)
+                # Update general info (absent when compute_metadata=False)
+                if "general_info" in splits_data:
+                    splits_data["general_info"]["dtypes"][new_name] = splits_data[
+                        "general_info"
+                    ]["dtypes"].pop(old_name)
 
                 # Update quality info nan per ratio
-                splits_data["quality_info"]["nan_ratio_per_column"][new_name] = (
-                    splits_data["quality_info"]["nan_ratio_per_column"].pop(old_name)
-                )
+                if "quality_info" in splits_data:
+                    splits_data["quality_info"]["nan_ratio_per_column"][new_name] = (
+                        splits_data["quality_info"]["nan_ratio_per_column"].pop(
+                            old_name
+                        )
+                    )
 
                 # Update numeric_stats if column is numerical
-                if old_name in splits_data["numeric_stats"]:
+                if old_name in splits_data.get("numeric_stats", {}):
                     splits_data["numeric_stats"][new_name] = splits_data[
                         "numeric_stats"
                     ].pop(old_name)

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -6,7 +6,7 @@ from sqlalchemy import exc
 
 from DashAI.back.api.api_v1.schemas.datasets_params import DatasetParams
 from DashAI.back.api.utils import parse_params
-from DashAI.back.dependencies.database.models import Dataset, Notebook
+from DashAI.back.dependencies.database.models import Converter, Dataset, Notebook
 from DashAI.back.job.base_job import BaseJob, JobError
 
 if TYPE_CHECKING:
@@ -141,6 +141,7 @@ class DatasetJob(BaseJob):
                         f"A dataset with the name {random_name} already exists."
                     ) from e
 
+            from_notebook_no_converters = False
             try:
                 if notebook_id is not None:
                     log.debug(f"Copying dataset from notebook id {notebook_id}.")
@@ -157,6 +158,18 @@ class DatasetJob(BaseJob):
                                 " has no associated dataset."
                             )
                             raise JobError(msg)
+                        # Detect whether any converters have been applied to
+                        # this notebook. When none, the saved data is byte-
+                        # identical to the source dataset, so we can reuse
+                        # the source's metadata directly instead of
+                        # recomputing.
+                        has_converters = (
+                            db.query(Converter)
+                            .filter(Converter.notebook_id == notebook_id)
+                            .first()
+                            is not None
+                        )
+                        from_notebook_no_converters = not has_converters
                         new_dataset = load_dataset(
                             os.path.join(notebook_dataset.file_path, "dataset")
                         )
@@ -277,21 +290,40 @@ class DatasetJob(BaseJob):
 
                     new_dataset = transform_dataset_with_schema(new_dataset, schema)
 
-                if params.get("compute_metadata", True):
+                compute_meta = params.get("compute_metadata", True)
+                extended_keys = (
+                    "general_info",
+                    "numeric_stats",
+                    "categorical_stats",
+                    "text_stats",
+                    "quality_info",
+                    "correlations",
+                )
+
+                if from_notebook_no_converters:
+                    # No converters applied - saved data matches the source
+                    # dataset byte-for-byte. Reuse the source's splits.json
+                    # (already loaded into ``new_dataset.splits`` by
+                    # ``load_dataset``) instead of recomputing.
+                    has_extended = any(k in new_dataset.splits for k in extended_keys)
+                    if compute_meta:
+                        # Use source's full metadata if present, else compute.
+                        if not has_extended:
+                            new_dataset.compute_metadata()
+                    else:
+                        # Keep only base metadata; drop any inherited extended.
+                        if "total_rows" not in new_dataset.splits:
+                            new_dataset.compute_base_metadata()
+                        for stale_key in extended_keys:
+                            new_dataset.splits.pop(stale_key, None)
+                elif compute_meta:
                     new_dataset.compute_metadata()
                 else:
                     new_dataset.compute_base_metadata()
-                    # When copying from another dataset (notebook flow), strip
-                    # any extended metadata that was inherited via splits.json
-                    # — the user explicitly opted out.
-                    for stale_key in (
-                        "general_info",
-                        "numeric_stats",
-                        "categorical_stats",
-                        "text_stats",
-                        "quality_info",
-                        "correlations",
-                    ):
+                    # Defensive: strip any extended keys that may have been
+                    # inherited from a source dataset (e.g. notebook flow
+                    # with converters that ran before this rule existed).
+                    for stale_key in extended_keys:
                         new_dataset.splits.pop(stale_key, None)
                 gc.collect()
 

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -281,6 +281,18 @@ class DatasetJob(BaseJob):
                     new_dataset.compute_metadata()
                 else:
                     new_dataset.compute_base_metadata()
+                    # When copying from another dataset (notebook flow), strip
+                    # any extended metadata that was inherited via splits.json
+                    # — the user explicitly opted out.
+                    for stale_key in (
+                        "general_info",
+                        "numeric_stats",
+                        "categorical_stats",
+                        "text_stats",
+                        "quality_info",
+                        "correlations",
+                    ):
+                        new_dataset.splits.pop(stale_key, None)
                 gc.collect()
 
                 dataset_save_path = folder_path / "dataset"

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -277,7 +277,10 @@ class DatasetJob(BaseJob):
 
                     new_dataset = transform_dataset_with_schema(new_dataset, schema)
 
-                new_dataset.compute_metadata()
+                if params.get("compute_metadata", True):
+                    new_dataset.compute_metadata()
+                else:
+                    new_dataset.compute_base_metadata()
                 gc.collect()
 
                 dataset_save_path = folder_path / "dataset"

--- a/DashAI/front/src/api/datasets.ts
+++ b/DashAI/front/src/api/datasets.ts
@@ -13,6 +13,11 @@ export const getDatasets = async (): Promise<IDataset[]> => {
   return response.data;
 };
 
+export const getDataset = async (id: number): Promise<IDataset> => {
+  const response = await api.get<IDataset>(`${datasetEndpoint}/${id}`);
+  return response.data;
+};
+
 export const getDatasetSample = async (id: number): Promise<object> => {
   const response = await api.get<object>(`${datasetEndpoint}/${id}/sample`);
   return response.data;

--- a/DashAI/front/src/components/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/DatasetVisualization.jsx
@@ -333,6 +333,14 @@ export default function DatasetVisualization({
               totalColumns={datasetInfo?.total_columns}
               fileSize={datasetInfo?.general_info?.memory_usage_mb}
             />
+            {/* Compute-metadata missing notice */}
+            {!datasetInfo?.general_info && (
+              <Box>
+                <Alert severity="info" sx={{ mb: 2 }}>
+                  {t("datasets:computeMetadata.missingNotice")}
+                </Alert>
+              </Box>
+            )}
             {/* Data Quality Alerts */}
             <Box>
               <QualityAlerts

--- a/DashAI/front/src/components/datasets/ComputeMetadataConfirmDialog.jsx
+++ b/DashAI/front/src/components/datasets/ComputeMetadataConfirmDialog.jsx
@@ -1,0 +1,57 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+import PropTypes from "prop-types";
+import { useTranslation } from "react-i18next";
+
+function formatRows(n) {
+  if (!n) return "?";
+  if (n >= 1_000_000) return `~${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `~${Math.round(n / 1_000)}k`;
+  return `${n}`;
+}
+
+export default function ComputeMetadataConfirmDialog({
+  open,
+  colCount,
+  estRows,
+  onComputeAnyway,
+  onSkipMetadata,
+}) {
+  const { t } = useTranslation(["datasets", "common"]);
+
+  return (
+    <Dialog open={open} onClose={onSkipMetadata}>
+      <DialogTitle>{t("datasets:computeMetadata.confirmTitle")}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {t("datasets:computeMetadata.confirmBody", {
+            colCount,
+            estRows: formatRows(estRows),
+          })}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onSkipMetadata} color="inherit">
+          {t("datasets:computeMetadata.skipButton")}
+        </Button>
+        <Button onClick={onComputeAnyway} variant="contained">
+          {t("datasets:computeMetadata.computeButton")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+ComputeMetadataConfirmDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  colCount: PropTypes.number,
+  estRows: PropTypes.number,
+  onComputeAnyway: PropTypes.func.isRequired,
+  onSkipMetadata: PropTypes.func.isRequired,
+};

--- a/DashAI/front/src/components/datasets/ComputeMetadataConfirmDialog.jsx
+++ b/DashAI/front/src/components/datasets/ComputeMetadataConfirmDialog.jsx
@@ -20,13 +20,13 @@ export default function ComputeMetadataConfirmDialog({
   open,
   colCount,
   estRows,
-  onComputeAnyway,
-  onSkipMetadata,
+  onConfirm,
+  onCancel,
 }) {
   const { t } = useTranslation(["datasets", "common"]);
 
   return (
-    <Dialog open={open} onClose={onSkipMetadata}>
+    <Dialog open={open} onClose={onCancel}>
       <DialogTitle>{t("datasets:computeMetadata.confirmTitle")}</DialogTitle>
       <DialogContent>
         <DialogContentText>
@@ -37,11 +37,11 @@ export default function ComputeMetadataConfirmDialog({
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onSkipMetadata} color="inherit">
-          {t("datasets:computeMetadata.skipButton")}
+        <Button onClick={onCancel} color="inherit">
+          {t("common:cancel")}
         </Button>
-        <Button onClick={onComputeAnyway} variant="contained">
-          {t("datasets:computeMetadata.computeButton")}
+        <Button onClick={onConfirm} variant="contained">
+          {t("common:upload")}
         </Button>
       </DialogActions>
     </Dialog>
@@ -52,6 +52,6 @@ ComputeMetadataConfirmDialog.propTypes = {
   open: PropTypes.bool.isRequired,
   colCount: PropTypes.number,
   estRows: PropTypes.number,
-  onComputeAnyway: PropTypes.func.isRequired,
-  onSkipMetadata: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
 };

--- a/DashAI/front/src/components/datasets/ComputeMetadataToggle.jsx
+++ b/DashAI/front/src/components/datasets/ComputeMetadataToggle.jsx
@@ -1,0 +1,64 @@
+import { Alert, Box, FormControlLabel, Stack, Switch } from "@mui/material";
+import PropTypes from "prop-types";
+import { useTranslation } from "react-i18next";
+import { shouldRecommendDisableMetadata } from "../../utils/metadataRecommendation";
+
+function formatRows(n) {
+  if (!n) return "?";
+  if (n >= 1_000_000) return `~${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `~${Math.round(n / 1_000)}k`;
+  return `${n}`;
+}
+
+export default function ComputeMetadataToggle({
+  value,
+  onChange,
+  colCount,
+  estRows,
+  disabled = false,
+}) {
+  const { t } = useTranslation(["datasets", "common"]);
+  const recommendDisable = shouldRecommendDisableMetadata({
+    colCount,
+    estRows,
+  });
+
+  return (
+    <Stack spacing={1} sx={{ width: "100%" }}>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={value}
+            onChange={(e) => onChange(e.target.checked)}
+            disabled={disabled}
+            data-testid="compute-metadata-toggle"
+          />
+        }
+        label={t("datasets:computeMetadata.label")}
+      />
+      <Box sx={{ ml: 4, color: "text.secondary", fontSize: 13 }}>
+        {t("datasets:computeMetadata.helper")}
+      </Box>
+      {recommendDisable && (
+        <Alert
+          severity="info"
+          sx={{ ml: 4 }}
+          data-testid="compute-metadata-alert"
+        >
+          {t("datasets:computeMetadata.recommendation", {
+            colCount,
+            estRows: formatRows(estRows),
+          })}
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+ComputeMetadataToggle.propTypes = {
+  value: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+  colCount: PropTypes.number,
+  estRows: PropTypes.number,
+  disabled: PropTypes.bool,
+};

--- a/DashAI/front/src/components/hub/HubImportPanel.jsx
+++ b/DashAI/front/src/components/hub/HubImportPanel.jsx
@@ -42,6 +42,7 @@ export default function HubImportPanel({
   formHasErrors = false,
   onCancel,
   onImported,
+  computeMetadata = true,
 }) {
   const { t } = useTranslation(["hub", "common", "datasets"]);
   const { enqueueSnackbar } = useSnackbar();
@@ -146,13 +147,15 @@ export default function HubImportPanel({
       ? Math.min(Math.max(2, rows), 500)
       : 100;
 
+    // eslint-disable-next-line no-unused-vars
+    const { compute_metadata, ...previewFormValues } = formValues || {};
     previewDebounceRef.current = setTimeout(() => {
       previewHubDataset(
         sourceName,
         dataset.id,
         effectiveRows,
         selectedValue?.name,
-        formValues,
+        previewFormValues,
         datafile?.id,
         selectedFile ?? undefined,
       )
@@ -181,7 +184,15 @@ export default function HubImportPanel({
     selectedValue?.name,
     datafile?.id,
     selectedFile,
-    JSON.stringify(formValues || {}),
+    // Exclude compute_metadata from the dep — it doesn't affect the preview
+    // and toggling it must not re-fetch.
+    JSON.stringify(
+      (() => {
+        // eslint-disable-next-line no-unused-vars
+        const { compute_metadata, ...rest } = formValues || {};
+        return rest;
+      })(),
+    ),
   ]);
 
   const handleColumnRename = useCallback((oldName, newName) => {
@@ -193,11 +204,14 @@ export default function HubImportPanel({
     setImporting(true);
     try {
       const created = await createDataset(name.trim());
+      // eslint-disable-next-line no-unused-vars
+      const { compute_metadata, ...dataloaderParams } = formValues || {};
       const importParams = {
         dataloader: selectedValue.name,
-        dataloader_params: formValues,
+        dataloader_params: dataloaderParams,
         inferred_types: columnTypes,
         column_renames: columnRenames,
+        compute_metadata: computeMetadata,
       };
       if (datafile) {
         importParams.datafile_id = datafile.id;

--- a/DashAI/front/src/components/models/ModelsRightBar.jsx
+++ b/DashAI/front/src/components/models/ModelsRightBar.jsx
@@ -159,6 +159,13 @@ export default function ModelsRightBar({ onToggle }) {
         {!session ? (
           datasetInfo ? (
             <Box sx={{ flex: 1, overflowY: "auto" }}>
+              {!datasetInfo.numeric_stats && !datasetInfo.text_stats && (
+                <Box sx={{ p: 2 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {t("datasets:computeMetadata.missingNotice")}
+                  </Typography>
+                </Box>
+              )}
               <ColumnInsights
                 numericStats={datasetInfo?.numeric_stats}
                 textStats={datasetInfo?.text_stats}

--- a/DashAI/front/src/components/models/ModelsRightBar.jsx
+++ b/DashAI/front/src/components/models/ModelsRightBar.jsx
@@ -159,13 +159,6 @@ export default function ModelsRightBar({ onToggle }) {
         {!session ? (
           datasetInfo ? (
             <Box sx={{ flex: 1, overflowY: "auto" }}>
-              {!datasetInfo.numeric_stats && !datasetInfo.text_stats && (
-                <Box sx={{ p: 2 }}>
-                  <Typography variant="body2" color="text.secondary">
-                    {t("datasets:computeMetadata.missingNotice")}
-                  </Typography>
-                </Box>
-              )}
               <ColumnInsights
                 numericStats={datasetInfo?.numeric_stats}
                 textStats={datasetInfo?.text_stats}

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -79,8 +79,19 @@ function RightBarDatasetView() {
     );
   }
 
+  const hasMetadata = Boolean(
+    datasetInfo?.numeric_stats || datasetInfo?.text_stats,
+  );
+
   return (
     <Box sx={{ flex: 1, overflowY: "auto" }}>
+      {!hasMetadata && (
+        <Box sx={{ p: 2 }}>
+          <Typography variant="body2" color="text.secondary">
+            {t("datasets:computeMetadata.missingNotice")}
+          </Typography>
+        </Box>
+      )}
       <ColumnInsights
         numericStats={datasetInfo?.numeric_stats}
         textStats={datasetInfo?.text_stats}

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -79,19 +79,8 @@ function RightBarDatasetView() {
     );
   }
 
-  const hasMetadata = Boolean(
-    datasetInfo?.numeric_stats || datasetInfo?.text_stats,
-  );
-
   return (
     <Box sx={{ flex: 1, overflowY: "auto" }}>
-      {!hasMetadata && (
-        <Box sx={{ p: 2 }}>
-          <Typography variant="body2" color="text.secondary">
-            {t("datasets:computeMetadata.missingNotice")}
-          </Typography>
-        </Box>
-      )}
       <ColumnInsights
         numericStats={datasetInfo?.numeric_stats}
         textStats={datasetInfo?.text_stats}

--- a/DashAI/front/src/components/notebooks/dataset/QualityAlerts.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/QualityAlerts.jsx
@@ -43,11 +43,13 @@ export const QualityAlerts = ({
     [setDatasetTab, theme],
   );
 
-  if (!qualityInfo) return null;
-
   const { warnings, successes } = useMemo(() => {
     const w = [];
     const s = [];
+
+    if (!qualityInfo) {
+      return { warnings: w, successes: s };
+    }
 
     // Duplicate rows
     if (generalInfo?.duplicate_rows > 0) {
@@ -66,7 +68,10 @@ export const QualityAlerts = ({
     }
 
     // Missing values
-    if (Object.values(missingValues).some((value) => value > 0)) {
+    if (
+      missingValues &&
+      Object.values(missingValues).some((value) => value > 0)
+    ) {
       w.push({
         key: "nan",
         severity: "warning",
@@ -98,6 +103,8 @@ export const QualityAlerts = ({
 
     return { warnings: w, successes: s };
   }, [qualityInfo, generalInfo, missingValues, t]);
+
+  if (!qualityInfo) return null;
 
   const hasIssues = warnings.length > 0;
 

--- a/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
@@ -23,6 +23,11 @@ export default function ConfigureAndUploadDatasetStep({
   onPreviewError,
   formHasErrors,
   existingDatasets = [],
+  computeMetadata = true,
+  computeMetadataTouched = false,
+  onComputeMetadataAutoOff,
+  onComputeMetadataForceOff,
+  onPreviewMetrics,
 }) {
   const { defaultName } = useMemo(
     () => generateSequentialName({ base: "Dataset", items: existingDatasets }),
@@ -37,13 +42,12 @@ export default function ConfigureAndUploadDatasetStep({
   const [datasetFileToUpload, setDatasetFileToUpload] = useState(null);
   const [columnTypes, setColumnTypes] = useState(null);
   const [columnRenames, setColumnRenames] = useState({});
-  const [computeMetadata, setComputeMetadata] = useState(true);
-  const [computeMetadataTouched, setComputeMetadataTouched] = useState(false);
   const [previewMetrics, setPreviewMetrics] = useState({
     colCount: 0,
     estRows: 0,
   });
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingSubmitSkip, setPendingSubmitSkip] = useState(false);
   const tourContext = useTourContext();
 
   const { enqueueSnackbar } = useSnackbar();
@@ -166,20 +170,37 @@ export default function ConfigureAndUploadDatasetStep({
     await doSubmit(computeMetadata);
   }, [computeMetadata, previewMetrics, doSubmit]);
 
-  const handleComputeMetadataChange = useCallback((next) => {
-    setComputeMetadataTouched(true);
-    setComputeMetadata(next);
-  }, []);
-
   const handlePreviewMetrics = useCallback(
     (metrics) => {
       setPreviewMetrics(metrics);
-      if (!computeMetadataTouched && shouldRecommendDisableMetadata(metrics)) {
-        setComputeMetadata(false);
+      if (onPreviewMetrics) {
+        onPreviewMetrics(metrics);
+      }
+      if (
+        computeMetadata &&
+        !computeMetadataTouched &&
+        onComputeMetadataAutoOff &&
+        shouldRecommendDisableMetadata(metrics)
+      ) {
+        onComputeMetadataAutoOff();
       }
     },
-    [computeMetadataTouched],
+    [
+      computeMetadata,
+      computeMetadataTouched,
+      onComputeMetadataAutoOff,
+      onPreviewMetrics,
+    ],
   );
+
+  // After parent flips compute_metadata to false (via auto-off or confirm-skip),
+  // re-trigger pending submit if one is queued.
+  useEffect(() => {
+    if (pendingSubmitSkip && computeMetadata === false) {
+      setPendingSubmitSkip(false);
+      doSubmit(false);
+    }
+  }, [pendingSubmitSkip, computeMetadata, doSubmit]);
 
   const handleFileUpload = (file, url) => {
     setDatasetFileToUpload({ file, url });
@@ -271,8 +292,6 @@ export default function ConfigureAndUploadDatasetStep({
           onPreviewError={setPreviewError}
           onTypesChanged={handleTypesChanged}
           onPreviewLoaded={handlePreviewLoaded}
-          computeMetadata={computeMetadata}
-          onComputeMetadataChange={handleComputeMetadataChange}
           onPreviewMetrics={handlePreviewMetrics}
         />
       </Grid>
@@ -295,11 +314,12 @@ export default function ConfigureAndUploadDatasetStep({
           setConfirmOpen(false);
           await doSubmit(true);
         }}
-        onSkipMetadata={async () => {
+        onSkipMetadata={() => {
           setConfirmOpen(false);
-          setComputeMetadataTouched(true);
-          setComputeMetadata(false);
-          await doSubmit(false);
+          if (onComputeMetadataForceOff) {
+            onComputeMetadataForceOff();
+          }
+          setPendingSubmitSkip(true);
         }}
       />
     </Box>

--- a/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
@@ -24,7 +24,6 @@ export default function ConfigureAndUploadDatasetStep({
   formHasErrors,
   existingDatasets = [],
   computeMetadata = true,
-  onComputeMetadataForceOff,
   onPreviewMetrics,
 }) {
   const { defaultName } = useMemo(
@@ -45,7 +44,6 @@ export default function ConfigureAndUploadDatasetStep({
     estRows: 0,
   });
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [pendingSubmitSkip, setPendingSubmitSkip] = useState(false);
   const tourContext = useTourContext();
 
   const { enqueueSnackbar } = useSnackbar();
@@ -178,15 +176,6 @@ export default function ConfigureAndUploadDatasetStep({
     [onPreviewMetrics],
   );
 
-  // After parent flips compute_metadata to false (via auto-off or confirm-skip),
-  // re-trigger pending submit if one is queued.
-  useEffect(() => {
-    if (pendingSubmitSkip && computeMetadata === false) {
-      setPendingSubmitSkip(false);
-      doSubmit(false);
-    }
-  }, [pendingSubmitSkip, computeMetadata, doSubmit]);
-
   const handleFileUpload = (file, url) => {
     setDatasetFileToUpload({ file, url });
     setPreviewLoaded(false);
@@ -295,17 +284,11 @@ export default function ConfigureAndUploadDatasetStep({
         open={confirmOpen}
         colCount={previewMetrics.colCount}
         estRows={previewMetrics.estRows}
-        onComputeAnyway={async () => {
+        onConfirm={async () => {
           setConfirmOpen(false);
           await doSubmit(true);
         }}
-        onSkipMetadata={() => {
-          setConfirmOpen(false);
-          if (onComputeMetadataForceOff) {
-            onComputeMetadataForceOff();
-          }
-          setPendingSubmitSkip(true);
-        }}
+        onCancel={() => setConfirmOpen(false)}
       />
     </Box>
   );

--- a/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
@@ -24,8 +24,6 @@ export default function ConfigureAndUploadDatasetStep({
   formHasErrors,
   existingDatasets = [],
   computeMetadata = true,
-  computeMetadataTouched = false,
-  onComputeMetadataAutoOff,
   onComputeMetadataForceOff,
   onPreviewMetrics,
 }) {
@@ -176,21 +174,8 @@ export default function ConfigureAndUploadDatasetStep({
       if (onPreviewMetrics) {
         onPreviewMetrics(metrics);
       }
-      if (
-        computeMetadata &&
-        !computeMetadataTouched &&
-        onComputeMetadataAutoOff &&
-        shouldRecommendDisableMetadata(metrics)
-      ) {
-        onComputeMetadataAutoOff();
-      }
     },
-    [
-      computeMetadata,
-      computeMetadataTouched,
-      onComputeMetadataAutoOff,
-      onPreviewMetrics,
-    ],
+    [onPreviewMetrics],
   );
 
   // After parent flips compute_metadata to false (via auto-off or confirm-skip),

--- a/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx
@@ -10,6 +10,8 @@ import { createDataset } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@mui/material/styles";
 import StepperNavigationFooter from "../../shared/StepperNavigationFooter";
+import ComputeMetadataConfirmDialog from "../../datasets/ComputeMetadataConfirmDialog";
+import { shouldRecommendDisableMetadata } from "../../../utils/metadataRecommendation";
 
 export default function ConfigureAndUploadDatasetStep({
   selectedDataloader,
@@ -35,6 +37,13 @@ export default function ConfigureAndUploadDatasetStep({
   const [datasetFileToUpload, setDatasetFileToUpload] = useState(null);
   const [columnTypes, setColumnTypes] = useState(null);
   const [columnRenames, setColumnRenames] = useState({});
+  const [computeMetadata, setComputeMetadata] = useState(true);
+  const [computeMetadataTouched, setComputeMetadataTouched] = useState(false);
+  const [previewMetrics, setPreviewMetrics] = useState({
+    colCount: 0,
+    estRows: 0,
+  });
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const tourContext = useTourContext();
 
   const { enqueueSnackbar } = useSnackbar();
@@ -63,85 +72,114 @@ export default function ConfigureAndUploadDatasetStep({
     }
   }, [previewError, enqueueSnackbar]);
 
-  const submitNewDataset = useCallback(async () => {
-    if (!datasetFileToUpload || !datasetFileToUpload.file) {
-      enqueueSnackbar(t("datasets:error.noDatasetFileAvailable"), {
-        variant: "error",
-      });
-      return;
-    }
-
-    setUploading(true);
-
-    try {
-      // Safely read values from the form ref (may be undefined briefly)
-      const refValues =
-        formSubmitRef && formSubmitRef.current
-          ? formSubmitRef.current.values || {}
-          : {};
-      // Merge values coming from the form schema and the onValuesChange callback
-      const params = { ...refValues, ...(formValues || {}) };
-
-      const name = datasetName.trim() || datasetFileToUpload.file.name;
-      params["name"] = name;
-
-      // Ensure dataloader is passed as a string (backend expects the dataloader name)
-      let dataloaderName = selectedDataloader;
-      if (selectedDataloader && typeof selectedDataloader === "object") {
-        dataloaderName =
-          selectedDataloader.name || selectedDataloader.display_name || null;
-      }
-      params["dataloader"] = dataloaderName;
-
-      if (columnTypes) {
-        params["inferred_types"] = columnTypes;
+  const doSubmit = useCallback(
+    async (effectiveComputeMetadata) => {
+      if (!datasetFileToUpload || !datasetFileToUpload.file) {
+        enqueueSnackbar(t("datasets:error.noDatasetFileAvailable"), {
+          variant: "error",
+        });
+        return;
       }
 
-      if (Object.keys(columnRenames).length > 0) {
-        params["column_renames"] = columnRenames;
-      }
-
-      const { file, url } = datasetFileToUpload;
-
-      const data = await createDataset(name);
+      setUploading(true);
 
       try {
-        const job = await enqueueDatasetRequest(data.id, file, url, params);
-        forceRefreshNow();
-        handleDatasetCreated(data, job);
+        // Safely read values from the form ref (may be undefined briefly)
+        const refValues =
+          formSubmitRef && formSubmitRef.current
+            ? formSubmitRef.current.values || {}
+            : {};
+        // Merge values coming from the form schema and the onValuesChange callback
+        const params = { ...refValues, ...(formValues || {}) };
 
-        if (tourContext?.run) {
-          tourContext.nextStep();
+        const name = datasetName.trim() || datasetFileToUpload.file.name;
+        params["name"] = name;
+
+        // Ensure dataloader is passed as a string (backend expects the dataloader name)
+        let dataloaderName = selectedDataloader;
+        if (selectedDataloader && typeof selectedDataloader === "object") {
+          dataloaderName =
+            selectedDataloader.name || selectedDataloader.display_name || null;
         }
-      } catch (err) {
-        console.error("Error enqueuing dataset job:", err);
-        enqueueSnackbar(t("datasets:error.enqueueDatasetJob"), {
+        params["dataloader"] = dataloaderName;
+
+        if (columnTypes) {
+          params["inferred_types"] = columnTypes;
+        }
+
+        if (Object.keys(columnRenames).length > 0) {
+          params["column_renames"] = columnRenames;
+        }
+
+        params["compute_metadata"] = effectiveComputeMetadata;
+
+        const { file, url } = datasetFileToUpload;
+
+        const data = await createDataset(name);
+
+        try {
+          const job = await enqueueDatasetRequest(data.id, file, url, params);
+          forceRefreshNow();
+          handleDatasetCreated(data, job);
+
+          if (tourContext?.run) {
+            tourContext.nextStep();
+          }
+        } catch (err) {
+          console.error("Error enqueuing dataset job:", err);
+          enqueueSnackbar(t("datasets:error.enqueueDatasetJob"), {
+            variant: "error",
+          });
+          backHome();
+        }
+      } catch (error) {
+        console.error("Error creating dataset:", error);
+        enqueueSnackbar(t("datasets:error.createDatasetError"), {
           variant: "error",
         });
         backHome();
+      } finally {
+        setUploading(false);
       }
-    } catch (error) {
-      console.error("Error creating dataset:", error);
-      enqueueSnackbar(t("datasets:error.createDatasetError"), {
-        variant: "error",
-      });
-      backHome();
-    } finally {
-      setUploading(false);
+    },
+    [
+      selectedDataloader,
+      datasetFileToUpload,
+      datasetName,
+      columnTypes,
+      columnRenames,
+      formSubmitRef,
+      formValues,
+      handleDatasetCreated,
+      backHome,
+      enqueueSnackbar,
+      tourContext,
+      t,
+    ],
+  );
+
+  const submitNewDataset = useCallback(async () => {
+    if (computeMetadata && shouldRecommendDisableMetadata(previewMetrics)) {
+      setConfirmOpen(true);
+      return;
     }
-  }, [
-    selectedDataloader,
-    datasetFileToUpload,
-    datasetName,
-    columnTypes,
-    columnRenames,
-    formSubmitRef,
-    formValues,
-    handleDatasetCreated,
-    backHome,
-    enqueueSnackbar,
-    tourContext,
-  ]);
+    await doSubmit(computeMetadata);
+  }, [computeMetadata, previewMetrics, doSubmit]);
+
+  const handleComputeMetadataChange = useCallback((next) => {
+    setComputeMetadataTouched(true);
+    setComputeMetadata(next);
+  }, []);
+
+  const handlePreviewMetrics = useCallback(
+    (metrics) => {
+      setPreviewMetrics(metrics);
+      if (!computeMetadataTouched && shouldRecommendDisableMetadata(metrics)) {
+        setComputeMetadata(false);
+      }
+    },
+    [computeMetadataTouched],
+  );
 
   const handleFileUpload = (file, url) => {
     setDatasetFileToUpload({ file, url });
@@ -233,6 +271,9 @@ export default function ConfigureAndUploadDatasetStep({
           onPreviewError={setPreviewError}
           onTypesChanged={handleTypesChanged}
           onPreviewLoaded={handlePreviewLoaded}
+          computeMetadata={computeMetadata}
+          onComputeMetadataChange={handleComputeMetadataChange}
+          onPreviewMetrics={handlePreviewMetrics}
         />
       </Grid>
 
@@ -245,6 +286,21 @@ export default function ConfigureAndUploadDatasetStep({
         nextDataTour={
           tourContext?.run ? "dataset-step-upload-button" : undefined
         }
+      />
+      <ComputeMetadataConfirmDialog
+        open={confirmOpen}
+        colCount={previewMetrics.colCount}
+        estRows={previewMetrics.estRows}
+        onComputeAnyway={async () => {
+          setConfirmOpen(false);
+          await doSubmit(true);
+        }}
+        onSkipMetadata={async () => {
+          setConfirmOpen(false);
+          setComputeMetadataTouched(true);
+          setComputeMetadata(false);
+          await doSubmit(false);
+        }}
       />
     </Box>
   );

--- a/DashAI/front/src/components/notebooks/datasetCreation/DataloaderConfigBar.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/DataloaderConfigBar.jsx
@@ -27,6 +27,8 @@ export default function DataloaderConfigBar({
   formSubmitRef,
   setError,
   onValuesChange,
+  computeMetadata = true,
+  onComputeMetadataChange,
 }) {
   const [inferenceRows, setInferenceRows] = useState(1000);
   const [supportsNativeTypes, setSupportsNativeTypes] = useState(false);
@@ -60,6 +62,7 @@ export default function DataloaderConfigBar({
               ...schemaValuesRef.current,
               inference_rows: inferenceRows,
               use_native_types: true,
+              compute_metadata: computeMetadata,
             });
           }
         }
@@ -81,9 +84,16 @@ export default function DataloaderConfigBar({
         ...values,
         inference_rows: inferenceRows,
         use_native_types: useNativeTypes,
+        compute_metadata: computeMetadata,
       });
     }
-  }, [formSubmitRef, inferenceRows, useNativeTypes, onValuesChange]);
+  }, [
+    formSubmitRef,
+    inferenceRows,
+    useNativeTypes,
+    computeMetadata,
+    onValuesChange,
+  ]);
 
   // Handler for when inference_rows changes - merge with schema values
   const handleInferenceRowsChange = useCallback(
@@ -95,10 +105,11 @@ export default function DataloaderConfigBar({
           ...schemaValuesRef.current,
           inference_rows: numeric,
           use_native_types: useNativeTypes,
+          compute_metadata: computeMetadata,
         });
       }
     },
-    [onValuesChange, useNativeTypes],
+    [onValuesChange, useNativeTypes, computeMetadata],
   );
 
   const handleUseNativeTypesChange = useCallback(
@@ -110,11 +121,43 @@ export default function DataloaderConfigBar({
           ...schemaValuesRef.current,
           inference_rows: inferenceRows,
           use_native_types: next,
+          compute_metadata: computeMetadata,
         });
       }
     },
-    [onValuesChange, inferenceRows],
+    [onValuesChange, inferenceRows, computeMetadata],
   );
+
+  const handleComputeMetadataChange = useCallback(
+    (event) => {
+      const next = event.target.checked;
+      if (onComputeMetadataChange) {
+        onComputeMetadataChange(next);
+      }
+      if (onValuesChange) {
+        onValuesChange({
+          ...schemaValuesRef.current,
+          inference_rows: inferenceRows,
+          use_native_types: useNativeTypes,
+          compute_metadata: next,
+        });
+      }
+    },
+    [onValuesChange, onComputeMetadataChange, inferenceRows, useNativeTypes],
+  );
+
+  // Keep formValues in sync when parent changes computeMetadata (e.g. auto-off
+  // from preview metrics, or skip from the confirm dialog).
+  useEffect(() => {
+    if (onValuesChange) {
+      onValuesChange({
+        ...schemaValuesRef.current,
+        inference_rows: inferenceRows,
+        use_native_types: useNativeTypes,
+        compute_metadata: computeMetadata,
+      });
+    }
+  }, [computeMetadata]);
 
   if (!selectedDataloader) {
     return (
@@ -180,6 +223,21 @@ export default function DataloaderConfigBar({
                 </FormSchemaFieldCard>
               </Box>
             )}
+            <Box sx={{ pb: 2 }}>
+              <FormSchemaFieldCard
+                label={t("datasets:computeMetadata.label")}
+                description={t("datasets:computeMetadata.helper")}
+              >
+                <Box sx={{ pt: 2 }}>
+                  <Switch
+                    checked={computeMetadata}
+                    onChange={handleComputeMetadataChange}
+                    size="small"
+                    name="compute_metadata"
+                  />
+                </Box>
+              </FormSchemaFieldCard>
+            </Box>
             <FormSchemaFieldCard
               label={t(
                 useNativeTypes
@@ -228,4 +286,6 @@ DataloaderConfigBar.propTypes = {
   formSubmitRef: PropTypes.shape({ current: PropTypes.any }),
   setError: PropTypes.func,
   onValuesChange: PropTypes.func,
+  computeMetadata: PropTypes.bool,
+  onComputeMetadataChange: PropTypes.func,
 };

--- a/DashAI/front/src/components/notebooks/datasetCreation/DataloaderConfigBar.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/DataloaderConfigBar.jsx
@@ -62,7 +62,6 @@ export default function DataloaderConfigBar({
               ...schemaValuesRef.current,
               inference_rows: inferenceRows,
               use_native_types: true,
-              compute_metadata: computeMetadata,
             });
           }
         }
@@ -84,16 +83,9 @@ export default function DataloaderConfigBar({
         ...values,
         inference_rows: inferenceRows,
         use_native_types: useNativeTypes,
-        compute_metadata: computeMetadata,
       });
     }
-  }, [
-    formSubmitRef,
-    inferenceRows,
-    useNativeTypes,
-    computeMetadata,
-    onValuesChange,
-  ]);
+  }, [formSubmitRef, inferenceRows, useNativeTypes, onValuesChange]);
 
   // Handler for when inference_rows changes - merge with schema values
   const handleInferenceRowsChange = useCallback(
@@ -105,11 +97,10 @@ export default function DataloaderConfigBar({
           ...schemaValuesRef.current,
           inference_rows: numeric,
           use_native_types: useNativeTypes,
-          compute_metadata: computeMetadata,
         });
       }
     },
-    [onValuesChange, useNativeTypes, computeMetadata],
+    [onValuesChange, useNativeTypes],
   );
 
   const handleUseNativeTypesChange = useCallback(
@@ -121,43 +112,24 @@ export default function DataloaderConfigBar({
           ...schemaValuesRef.current,
           inference_rows: inferenceRows,
           use_native_types: next,
-          compute_metadata: computeMetadata,
         });
       }
     },
-    [onValuesChange, inferenceRows, computeMetadata],
+    [onValuesChange, inferenceRows],
   );
 
+  // compute_metadata is intentionally NOT pushed through onValuesChange / formValues —
+  // it flows to the parent through onComputeMetadataChange directly. Avoiding the
+  // formValues round-trip keeps the preview table from re-rendering when the
+  // toggle is clicked, which matters for datasets with many columns.
   const handleComputeMetadataChange = useCallback(
     (event) => {
-      const next = event.target.checked;
       if (onComputeMetadataChange) {
-        onComputeMetadataChange(next);
-      }
-      if (onValuesChange) {
-        onValuesChange({
-          ...schemaValuesRef.current,
-          inference_rows: inferenceRows,
-          use_native_types: useNativeTypes,
-          compute_metadata: next,
-        });
+        onComputeMetadataChange(event.target.checked);
       }
     },
-    [onValuesChange, onComputeMetadataChange, inferenceRows, useNativeTypes],
+    [onComputeMetadataChange],
   );
-
-  // Keep formValues in sync when parent changes computeMetadata (e.g. auto-off
-  // from preview metrics, or skip from the confirm dialog).
-  useEffect(() => {
-    if (onValuesChange) {
-      onValuesChange({
-        ...schemaValuesRef.current,
-        inference_rows: inferenceRows,
-        use_native_types: useNativeTypes,
-        compute_metadata: computeMetadata,
-      });
-    }
-  }, [computeMetadata]);
 
   if (!selectedDataloader) {
     return (

--- a/DashAI/front/src/components/notebooks/datasetCreation/PreviewDataset.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/PreviewDataset.jsx
@@ -15,7 +15,6 @@ import { useSnackbar } from "notistack";
 import { previewWithTypes } from "../../../api/datasets";
 import PreviewDatasetTable from "./PreviewDatasetTable";
 import { useTranslation } from "react-i18next";
-import ComputeMetadataToggle from "../../datasets/ComputeMetadataToggle";
 import { estimateTotalRows } from "../../../utils/metadataRecommendation";
 
 /**
@@ -37,8 +36,6 @@ function PreviewDataset({
   onColumnRename,
   onPreviewLoaded,
   initialData = null,
-  computeMetadata,
-  onComputeMetadataChange,
   onPreviewMetrics,
 }) {
   const theme = useTheme();
@@ -339,17 +336,6 @@ function PreviewDataset({
                 onEncoderChange={handleEncoderChange}
               />
             </Box>
-            {typeof computeMetadata === "boolean" &&
-              onComputeMetadataChange && (
-                <Box sx={{ mt: 4, width: "100%" }}>
-                  <ComputeMetadataToggle
-                    value={computeMetadata}
-                    onChange={onComputeMetadataChange}
-                    colCount={colCount}
-                    estRows={estRows}
-                  />
-                </Box>
-              )}
           </Box>
         )}
       </Grid>
@@ -369,8 +355,6 @@ PreviewDataset.propTypes = {
     inferred_types: PropTypes.object.isRequired,
     preview_row_count: PropTypes.number,
   }),
-  computeMetadata: PropTypes.bool,
-  onComputeMetadataChange: PropTypes.func,
   onPreviewMetrics: PropTypes.func,
 };
 

--- a/DashAI/front/src/components/notebooks/datasetCreation/PreviewDataset.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/PreviewDataset.jsx
@@ -15,6 +15,8 @@ import { useSnackbar } from "notistack";
 import { previewWithTypes } from "../../../api/datasets";
 import PreviewDatasetTable from "./PreviewDatasetTable";
 import { useTranslation } from "react-i18next";
+import ComputeMetadataToggle from "../../datasets/ComputeMetadataToggle";
+import { estimateTotalRows } from "../../../utils/metadataRecommendation";
 
 /**
  * This component shows a preview of the dataset before final upload.
@@ -35,6 +37,9 @@ function PreviewDataset({
   onColumnRename,
   onPreviewLoaded,
   initialData = null,
+  computeMetadata,
+  onComputeMetadataChange,
+  onPreviewMetrics,
 }) {
   const theme = useTheme();
   const { enqueueSnackbar } = useSnackbar();
@@ -183,6 +188,23 @@ function PreviewDataset({
     [onColumnRename],
   );
 
+  const colCount = previewData
+    ? Object.keys(previewData.inferred_types || previewData.schema || {}).length
+    : 0;
+  const estRows = previewData
+    ? estimateTotalRows({
+        previewRowCount: previewData.preview_row_count,
+        previewedBytes: previewData.previewed_bytes,
+        fileSize: datasetData?.file?.size ?? 0,
+      })
+    : 0;
+
+  useEffect(() => {
+    if (previewData && onPreviewMetrics) {
+      onPreviewMetrics({ colCount, estRows });
+    }
+  }, [previewData, colCount, estRows, onPreviewMetrics]);
+
   return (
     <Grid
       sx={{
@@ -317,6 +339,17 @@ function PreviewDataset({
                 onEncoderChange={handleEncoderChange}
               />
             </Box>
+            {typeof computeMetadata === "boolean" &&
+              onComputeMetadataChange && (
+                <Box sx={{ mt: 4, width: "100%" }}>
+                  <ComputeMetadataToggle
+                    value={computeMetadata}
+                    onChange={onComputeMetadataChange}
+                    colCount={colCount}
+                    estRows={estRows}
+                  />
+                </Box>
+              )}
           </Box>
         )}
       </Grid>
@@ -336,6 +369,9 @@ PreviewDataset.propTypes = {
     inferred_types: PropTypes.object.isRequired,
     preview_row_count: PropTypes.number,
   }),
+  computeMetadata: PropTypes.bool,
+  onComputeMetadataChange: PropTypes.func,
+  onPreviewMetrics: PropTypes.func,
 };
 
 export default PreviewDataset;

--- a/DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import {
   Typography,
   Select,
@@ -48,7 +48,7 @@ const ENCODER_OPTIONS = ["one_hot", "label"];
  * @param {Function} onColumnRename - Callback when a column is renamed (oldName, newName) => void
  * @param {Function} onEncoderChange - Callback when encoder changes (columnName, encoder) => void
  */
-export default function PreviewDatasetTable({
+function PreviewDatasetTable({
   rows,
   columnTypes,
   file,
@@ -393,3 +393,5 @@ export default function PreviewDatasetTable({
     </>
   );
 }
+
+export default memo(PreviewDatasetTable);

--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -43,7 +43,6 @@ export function SaveDatasetModal({
   const [deleteModalContent, setDeleteModalContent] = useState("");
   const [itemsToDelete, setItemsToDelete] = useState([]);
   const [computeMetadata, setComputeMetadata] = useState(true);
-  const [computeMetadataTouched, setComputeMetadataTouched] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const notebookColCount = notebook?.total_columns ?? 0;
@@ -52,12 +51,6 @@ export function SaveDatasetModal({
     colCount: notebookColCount,
     estRows: notebookRowCount,
   });
-
-  useEffect(() => {
-    if (open && !computeMetadataTouched && exceedsThreshold) {
-      setComputeMetadata(false);
-    }
-  }, [open, computeMetadataTouched, exceedsThreshold]);
 
   const tourContext = useTourContext();
   const { enqueueSnackbar } = useSnackbar();
@@ -278,10 +271,7 @@ export function SaveDatasetModal({
               <Box sx={{ pt: 2 }}>
                 <Switch
                   checked={computeMetadata}
-                  onChange={(e) => {
-                    setComputeMetadataTouched(true);
-                    setComputeMetadata(e.target.checked);
-                  }}
+                  onChange={(e) => setComputeMetadata(e.target.checked)}
                   size="small"
                   name="compute_metadata"
                 />
@@ -313,7 +303,7 @@ export function SaveDatasetModal({
               onNext={handleSubmit}
               nextDisabled={Boolean(nameError)}
               backLabel={t("common:cancel")}
-              nextLabel={t("datasets:button.saveDataset")}
+              nextLabel={t("common:upload")}
               variant="save"
             />
           </Box>
@@ -342,7 +332,6 @@ export function SaveDatasetModal({
         }}
         onSkipMetadata={() => {
           setConfirmOpen(false);
-          setComputeMetadataTouched(true);
           setComputeMetadata(false);
           doSubmit(false);
         }}

--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -326,15 +326,11 @@ export function SaveDatasetModal({
         open={confirmOpen}
         colCount={notebookColCount}
         estRows={notebookRowCount}
-        onComputeAnyway={() => {
+        onConfirm={() => {
           setConfirmOpen(false);
           doSubmit(true);
         }}
-        onSkipMetadata={() => {
-          setConfirmOpen(false);
-          setComputeMetadata(false);
-          doSubmit(false);
-        }}
+        onCancel={() => setConfirmOpen(false)}
       />
     </>
   );

--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -5,12 +5,12 @@ import {
   Box,
   Typography,
   IconButton,
-  FormControlLabel,
   Switch,
 } from "@mui/material";
 import { Close } from "@mui/icons-material";
 import { shouldRecommendDisableMetadata } from "../../../utils/metadataRecommendation";
 import ComputeMetadataConfirmDialog from "../../datasets/ComputeMetadataConfirmDialog";
+import FormSchemaFieldCard from "../../shared/FormSchemaFieldCard";
 import { useSnackbar } from "notistack";
 import ConverterHistoryList from "../converter/ConverterHistoryList";
 import StepperNavigationFooter from "../../shared/StepperNavigationFooter";
@@ -271,24 +271,22 @@ export function SaveDatasetModal({
               helperText={nameError}
             />
 
-            <Box>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={computeMetadata}
-                    onChange={(e) => {
-                      setComputeMetadataTouched(true);
-                      setComputeMetadata(e.target.checked);
-                    }}
-                    name="compute_metadata"
-                  />
-                }
-                label={t("datasets:computeMetadata.label")}
-              />
-              <Typography variant="caption" color="text.secondary">
-                {t("datasets:computeMetadata.helper")}
-              </Typography>
-            </Box>
+            <FormSchemaFieldCard
+              label={t("datasets:computeMetadata.label")}
+              description={t("datasets:computeMetadata.helper")}
+            >
+              <Box sx={{ pt: 2 }}>
+                <Switch
+                  checked={computeMetadata}
+                  onChange={(e) => {
+                    setComputeMetadataTouched(true);
+                    setComputeMetadata(e.target.checked);
+                  }}
+                  size="small"
+                  name="compute_metadata"
+                />
+              </Box>
+            </FormSchemaFieldCard>
 
             <Box>
               <Typography variant="subtitle2" gutterBottom>

--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -1,6 +1,16 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { Modal, TextField, Box, Typography, IconButton } from "@mui/material";
+import {
+  Modal,
+  TextField,
+  Box,
+  Typography,
+  IconButton,
+  FormControlLabel,
+  Switch,
+} from "@mui/material";
 import { Close } from "@mui/icons-material";
+import { shouldRecommendDisableMetadata } from "../../../utils/metadataRecommendation";
+import ComputeMetadataConfirmDialog from "../../datasets/ComputeMetadataConfirmDialog";
 import { useSnackbar } from "notistack";
 import ConverterHistoryList from "../converter/ConverterHistoryList";
 import StepperNavigationFooter from "../../shared/StepperNavigationFooter";
@@ -32,6 +42,22 @@ export function SaveDatasetModal({
   const [converterToDelete, setConverterToDelete] = useState(null);
   const [deleteModalContent, setDeleteModalContent] = useState("");
   const [itemsToDelete, setItemsToDelete] = useState([]);
+  const [computeMetadata, setComputeMetadata] = useState(true);
+  const [computeMetadataTouched, setComputeMetadataTouched] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const notebookColCount = notebook?.total_columns ?? 0;
+  const notebookRowCount = notebook?.total_rows ?? 0;
+  const exceedsThreshold = shouldRecommendDisableMetadata({
+    colCount: notebookColCount,
+    estRows: notebookRowCount,
+  });
+
+  useEffect(() => {
+    if (open && !computeMetadataTouched && exceedsThreshold) {
+      setComputeMetadata(false);
+    }
+  }, [open, computeMetadataTouched, exceedsThreshold]);
 
   const tourContext = useTourContext();
   const { enqueueSnackbar } = useSnackbar();
@@ -134,20 +160,27 @@ export function SaveDatasetModal({
     setItemsToDelete([]);
   }, []);
 
-  const handleSubmit = () => {
+  const doSubmit = (effectiveComputeMetadata) => {
     const datasetName = name.trim();
-
-    if (datasetName) {
-      if (existingDatasets.some((dataset) => dataset.name === datasetName)) {
-        enqueueSnackbar(t("datasets:error.datasetExists"), {
-          variant: "warning",
-        });
-        return;
-      }
-
-      onSaveDataset(datasetName);
-      handleClose();
+    if (!datasetName) return;
+    if (existingDatasets.some((dataset) => dataset.name === datasetName)) {
+      enqueueSnackbar(t("datasets:error.datasetExists"), {
+        variant: "warning",
+      });
+      return;
     }
+    onSaveDataset(datasetName, {
+      compute_metadata: effectiveComputeMetadata,
+    });
+    handleClose();
+  };
+
+  const handleSubmit = () => {
+    if (computeMetadata && exceedsThreshold) {
+      setConfirmOpen(true);
+      return;
+    }
+    doSubmit(computeMetadata);
   };
 
   const handleClose = () => {
@@ -239,6 +272,25 @@ export function SaveDatasetModal({
             />
 
             <Box>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={computeMetadata}
+                    onChange={(e) => {
+                      setComputeMetadataTouched(true);
+                      setComputeMetadata(e.target.checked);
+                    }}
+                    name="compute_metadata"
+                  />
+                }
+                label={t("datasets:computeMetadata.label")}
+              />
+              <Typography variant="caption" color="text.secondary">
+                {t("datasets:computeMetadata.helper")}
+              </Typography>
+            </Box>
+
+            <Box>
               <Typography variant="subtitle2" gutterBottom>
                 {t("datasets:label.appliedTransformations")}
               </Typography>
@@ -280,6 +332,22 @@ export function SaveDatasetModal({
             <ItemsToDeleteList items={itemsToDelete} />
           </Box>
         }
+      />
+
+      <ComputeMetadataConfirmDialog
+        open={confirmOpen}
+        colCount={notebookColCount}
+        estRows={notebookRowCount}
+        onComputeAnyway={() => {
+          setConfirmOpen(false);
+          doSubmit(true);
+        }}
+        onSkipMetadata={() => {
+          setConfirmOpen(false);
+          setComputeMetadataTouched(true);
+          setComputeMetadata(false);
+          doSubmit(false);
+        }}
       />
     </>
   );

--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -311,7 +311,7 @@ export function SaveDatasetModal({
             <StepperNavigationFooter
               onBack={handleClose}
               onNext={handleSubmit}
-              nextDisabled={Boolean(nameError) || localConverters.length === 0}
+              nextDisabled={Boolean(nameError)}
               backLabel={t("common:cancel")}
               nextLabel={t("datasets:button.saveDataset")}
               variant="save"

--- a/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
@@ -43,8 +43,6 @@ function Upload({
   onTypesChanged,
   onColumnRename,
   onPreviewLoaded,
-  computeMetadata,
-  onComputeMetadataChange,
   onPreviewMetrics,
 }) {
   const [EMPTY, LOADING, LOADED] = [0, 1, 2];
@@ -350,8 +348,6 @@ function Upload({
                 onTypesChanged={onTypesChanged}
                 onColumnRename={onColumnRename}
                 onPreviewLoaded={onPreviewLoaded}
-                computeMetadata={computeMetadata}
-                onComputeMetadataChange={onComputeMetadataChange}
                 onPreviewMetrics={onPreviewMetrics}
               />
             </Box>
@@ -466,8 +462,6 @@ Upload.propTypes = {
   onTypesChanged: PropTypes.func,
   onColumnRename: PropTypes.func,
   onPreviewLoaded: PropTypes.func,
-  computeMetadata: PropTypes.bool,
-  onComputeMetadataChange: PropTypes.func,
   onPreviewMetrics: PropTypes.func,
 };
 

--- a/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
@@ -43,6 +43,9 @@ function Upload({
   onTypesChanged,
   onColumnRename,
   onPreviewLoaded,
+  computeMetadata,
+  onComputeMetadataChange,
+  onPreviewMetrics,
 }) {
   const [EMPTY, LOADING, LOADED] = [0, 1, 2];
   const [datasetState, setDatasetState] = useState(
@@ -347,6 +350,9 @@ function Upload({
                 onTypesChanged={onTypesChanged}
                 onColumnRename={onColumnRename}
                 onPreviewLoaded={onPreviewLoaded}
+                computeMetadata={computeMetadata}
+                onComputeMetadataChange={onComputeMetadataChange}
+                onPreviewMetrics={onPreviewMetrics}
               />
             </Box>
           );
@@ -458,6 +464,11 @@ Upload.propTypes = {
   selectedDataloader: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   onPreviewError: PropTypes.func,
   onTypesChanged: PropTypes.func,
+  onColumnRename: PropTypes.func,
+  onPreviewLoaded: PropTypes.func,
+  computeMetadata: PropTypes.bool,
+  onComputeMetadataChange: PropTypes.func,
+  onPreviewMetrics: PropTypes.func,
 };
 
 export default Upload;

--- a/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/Upload.jsx
@@ -248,7 +248,9 @@ function Upload({
     setFile(null);
   }, [onFileUpload]);
 
-  // memoize datasetData object so its reference stays stable across renders
+  // memoize datasetData object so its reference stays stable across renders.
+  // `compute_metadata` is intentionally stripped: it only affects the upload
+  // job, not the preview, so toggling it must not trigger a preview re-fetch.
   const datasetDataMemo = useMemo(() => {
     let dataloaderName = selectedDataloader;
     if (selectedDataloader && typeof selectedDataloader === "object") {
@@ -256,11 +258,14 @@ function Upload({
         selectedDataloader.name || selectedDataloader.display_name || null;
     }
 
+    // eslint-disable-next-line no-unused-vars
+    const { compute_metadata, ...previewFormValues } = formValues || {};
+
     const params = {
-      ...formValues,
+      ...previewFormValues,
       inference_rows:
-        formValues && formValues.inference_rows != null
-          ? formValues.inference_rows
+        previewFormValues.inference_rows != null
+          ? previewFormValues.inference_rows
           : 1000,
       ...(dataloaderName ? { dataloader_name: dataloaderName } : {}),
     };

--- a/DashAI/front/src/components/notebooks/datasetCreation/UploadDatasetSteps.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/UploadDatasetSteps.jsx
@@ -37,10 +37,6 @@ export default function UploadDatasetSteps({ backHome }) {
   const handleComputeMetadataChange = (next) => {
     setComputeMetadata(next);
   };
-
-  const handleComputeMetadataForceOff = () => {
-    setComputeMetadata(false);
-  };
   const { t } = useTranslation(["datasets"]);
   const { enqueueSnackbar } = useSnackbar();
   const tourContext = useTourContext();
@@ -203,7 +199,6 @@ export default function UploadDatasetSteps({ backHome }) {
           formHasErrors={error}
           existingDatasets={datasets}
           computeMetadata={computeMetadata}
-          onComputeMetadataForceOff={handleComputeMetadataForceOff}
         />
       )}
     </Box>

--- a/DashAI/front/src/components/notebooks/datasetCreation/UploadDatasetSteps.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/UploadDatasetSteps.jsx
@@ -33,21 +33,12 @@ export default function UploadDatasetSteps({ backHome }) {
   const [error, setError] = useState(false);
   const [previewError, setPreviewError] = useState(false);
   const [computeMetadata, setComputeMetadata] = useState(true);
-  const [computeMetadataTouched, setComputeMetadataTouched] = useState(false);
 
   const handleComputeMetadataChange = (next) => {
-    setComputeMetadataTouched(true);
     setComputeMetadata(next);
   };
 
-  const handleComputeMetadataAutoOff = () => {
-    if (!computeMetadataTouched) {
-      setComputeMetadata(false);
-    }
-  };
-
   const handleComputeMetadataForceOff = () => {
-    setComputeMetadataTouched(true);
     setComputeMetadata(false);
   };
   const { t } = useTranslation(["datasets"]);
@@ -212,8 +203,6 @@ export default function UploadDatasetSteps({ backHome }) {
           formHasErrors={error}
           existingDatasets={datasets}
           computeMetadata={computeMetadata}
-          computeMetadataTouched={computeMetadataTouched}
-          onComputeMetadataAutoOff={handleComputeMetadataAutoOff}
           onComputeMetadataForceOff={handleComputeMetadataForceOff}
         />
       )}

--- a/DashAI/front/src/components/notebooks/datasetCreation/UploadDatasetSteps.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/UploadDatasetSteps.jsx
@@ -32,6 +32,24 @@ export default function UploadDatasetSteps({ backHome }) {
   const [formValues, setFormValues] = useState({});
   const [error, setError] = useState(false);
   const [previewError, setPreviewError] = useState(false);
+  const [computeMetadata, setComputeMetadata] = useState(true);
+  const [computeMetadataTouched, setComputeMetadataTouched] = useState(false);
+
+  const handleComputeMetadataChange = (next) => {
+    setComputeMetadataTouched(true);
+    setComputeMetadata(next);
+  };
+
+  const handleComputeMetadataAutoOff = () => {
+    if (!computeMetadataTouched) {
+      setComputeMetadata(false);
+    }
+  };
+
+  const handleComputeMetadataForceOff = () => {
+    setComputeMetadataTouched(true);
+    setComputeMetadata(false);
+  };
   const { t } = useTranslation(["datasets"]);
   const { enqueueSnackbar } = useSnackbar();
   const tourContext = useTourContext();
@@ -133,12 +151,14 @@ export default function UploadDatasetSteps({ backHome }) {
           formSubmitRef={formSubmitRef}
           setError={setError}
           onValuesChange={setFormValues}
+          computeMetadata={computeMetadata}
+          onComputeMetadataChange={handleComputeMetadataChange}
         />,
       );
     } else {
       setRightBarContent(null);
     }
-  }, [step, selectedDataloader, datasets, setRightBarContent]);
+  }, [step, selectedDataloader, datasets, setRightBarContent, computeMetadata]);
 
   const handleDatasetCreated = (newDataset, datasetJob) => {
     addDatasetOptimistically(newDataset);
@@ -191,6 +211,10 @@ export default function UploadDatasetSteps({ backHome }) {
           onPreviewError={setPreviewError}
           formHasErrors={error}
           existingDatasets={datasets}
+          computeMetadata={computeMetadata}
+          computeMetadataTouched={computeMetadataTouched}
+          onComputeMetadataAutoOff={handleComputeMetadataAutoOff}
+          onComputeMetadataForceOff={handleComputeMetadataForceOff}
         />
       )}
     </Box>

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -148,7 +148,11 @@ export default function DatasetPreviewNotebook({
     );
   };
 
-  const handleAddDatasetFromNotebook = async (name, notebookId, options = {}) => {
+  const handleAddDatasetFromNotebook = async (
+    name,
+    notebookId,
+    options = {},
+  ) => {
     try {
       const dataset = await createDataset(name);
 

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -18,7 +18,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Add } from "@mui/icons-material";
 import HistoryIcon from "@mui/icons-material/History";
 import { SaveDatasetModal } from "../datasetCreation/SaveDatasetModal";
-import { getDatasetFileFiltered } from "../../../api/datasets";
+import { getDataset, getDatasetFileFiltered } from "../../../api/datasets";
 import DatasetTable from "../dataset/DatasetTable";
 import { NotebookHistoryModal } from "./NotebookHistoryModal";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
@@ -129,6 +129,22 @@ export default function DatasetPreviewNotebook({
 
       //Failure
       async (result) => {
+        // The poller can fire onError when a job finishes too quickly to be
+        // observed in the changes stream. Confirm the dataset actually failed
+        // before deleting it / surfacing the error.
+        try {
+          const persisted = await getDataset(datasetId);
+          if (persisted && persisted.status === "finished") {
+            enqueueSnackbar(
+              t("datasets:message.datasetCreationSuccess", { datasetName }),
+              { variant: "success" },
+            );
+            return;
+          }
+        } catch (e) {
+          console.error("Failed to verify dataset state after poll error:", e);
+        }
+
         console.error("Dataset job failed:", result);
 
         enqueueSnackbar(

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -148,7 +148,7 @@ export default function DatasetPreviewNotebook({
     );
   };
 
-  const handleAddDatasetFromNotebook = async (name, notebookId) => {
+  const handleAddDatasetFromNotebook = async (name, notebookId, options = {}) => {
     try {
       const dataset = await createDataset(name);
 
@@ -160,7 +160,16 @@ export default function DatasetPreviewNotebook({
       replaceDatasets((prev) => [...prev, dataset]);
       navigate(`/app/data/datasets/${dataset.id}`);
 
-      const job = await enqueueDatasetJob(dataset.id, null, "", {}, notebookId);
+      const params = {
+        compute_metadata: options.compute_metadata ?? true,
+      };
+      const job = await enqueueDatasetJob(
+        dataset.id,
+        null,
+        "",
+        params,
+        notebookId,
+      );
 
       pollForDataset(
         { datasetId: dataset.id, datasetName: name },
@@ -270,8 +279,8 @@ export default function DatasetPreviewNotebook({
       <SaveDatasetModal
         open={showSaveDatasetModal}
         onClose={() => setShowSaveDatasetModal(false)}
-        onSaveDataset={(name) =>
-          handleAddDatasetFromNotebook(name, notebook.id)
+        onSaveDataset={(name, options) =>
+          handleAddDatasetFromNotebook(name, notebook.id, options)
         }
         appliedConverters={converters.filter(
           (converter) => converter.status === 3,

--- a/DashAI/front/src/hooks/datasets/useDatasets.js
+++ b/DashAI/front/src/hooks/datasets/useDatasets.js
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { useSnackbar } from "notistack";
 import {
+  getDataset,
   getDatasets,
   deleteDataset,
   updateDataset,
@@ -111,6 +112,24 @@ export function useDatasets({ t }) {
         setSelectedDatasetId(newDataset.id);
       },
       async () => {
+        // The poller can fire onError when a job finishes too quickly to be
+        // observed in the changes stream. Verify the dataset actually failed
+        // before showing the error / removing the optimistic entry.
+        try {
+          const persisted = await getDataset(newDataset.id);
+          if (persisted && persisted.status === "finished") {
+            enqueueSnackbar(
+              t("datasets:message.datasetCreationSuccess", {
+                datasetName: newDataset.name,
+              }),
+              { variant: "success" },
+            );
+            setSelectedDatasetId(newDataset.id);
+            return;
+          }
+        } catch (e) {
+          console.error("Failed to verify dataset state after poll error:", e);
+        }
         enqueueSnackbar(t("datasets:error.failedToCreateDataset"), {
           variant: "error",
         });

--- a/DashAI/front/src/pages/hub/HubImportPage.jsx
+++ b/DashAI/front/src/pages/hub/HubImportPage.jsx
@@ -54,7 +54,25 @@ export default function HubImportPage() {
   const [dataloaders, setDataloaders] = useState([]);
   const [formValues, setFormValues] = useState({});
   const [formHasErrors, setFormHasErrors] = useState(false);
+  const [computeMetadata, setComputeMetadata] = useState(true);
+  const [computeMetadataTouched, setComputeMetadataTouched] = useState(false);
   const formSubmitRef = useRef(null);
+
+  const handleComputeMetadataChange = (next) => {
+    setComputeMetadataTouched(true);
+    setComputeMetadata(next);
+  };
+
+  const handleComputeMetadataAutoOff = () => {
+    if (!computeMetadataTouched) {
+      setComputeMetadata(false);
+    }
+  };
+
+  const handleComputeMetadataForceOff = () => {
+    setComputeMetadataTouched(true);
+    setComputeMetadata(false);
+  };
 
   useEffect(() => {
     if (!datafileId) return;
@@ -146,6 +164,8 @@ export default function HubImportPage() {
         formSubmitRef={formSubmitRef}
         setError={setFormHasErrors}
         onValuesChange={setFormValues}
+        computeMetadata={computeMetadata}
+        onComputeMetadataChange={handleComputeMetadataChange}
       />
     );
   };
@@ -206,6 +226,7 @@ export default function HubImportPage() {
               formHasErrors={formHasErrors}
               onCancel={handleCancel}
               onImported={handleImported}
+              computeMetadata={computeMetadata}
             />
           )}
         </CenterPanel>

--- a/DashAI/front/src/pages/hub/HubImportPage.jsx
+++ b/DashAI/front/src/pages/hub/HubImportPage.jsx
@@ -61,10 +61,6 @@ export default function HubImportPage() {
     setComputeMetadata(next);
   };
 
-  const handleComputeMetadataForceOff = () => {
-    setComputeMetadata(false);
-  };
-
   useEffect(() => {
     if (!datafileId) return;
     setDatafileLoading(true);

--- a/DashAI/front/src/pages/hub/HubImportPage.jsx
+++ b/DashAI/front/src/pages/hub/HubImportPage.jsx
@@ -55,22 +55,13 @@ export default function HubImportPage() {
   const [formValues, setFormValues] = useState({});
   const [formHasErrors, setFormHasErrors] = useState(false);
   const [computeMetadata, setComputeMetadata] = useState(true);
-  const [computeMetadataTouched, setComputeMetadataTouched] = useState(false);
   const formSubmitRef = useRef(null);
 
   const handleComputeMetadataChange = (next) => {
-    setComputeMetadataTouched(true);
     setComputeMetadata(next);
   };
 
-  const handleComputeMetadataAutoOff = () => {
-    if (!computeMetadataTouched) {
-      setComputeMetadata(false);
-    }
-  };
-
   const handleComputeMetadataForceOff = () => {
-    setComputeMetadataTouched(true);
     setComputeMetadata(false);
   };
 

--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -381,5 +381,15 @@
     "noChangesMade": "Es wurden keine Änderungen vorgenommen",
     "notebookCreated": "Notizbuch erfolgreich erstellt",
     "notebookUpdateSuccess": "Notizbuch erfolgreich aktualisiert"
+  },
+  "computeMetadata": {
+    "label": "Erweiterte Metadaten berechnen (EDA)",
+    "helper": "Bei großen Datensätzen deaktivieren, um den Upload zu beschleunigen. Erweiterte Statistiken (Korrelationen, Qualität usw.) sind dann für diesen Datensatz nicht verfügbar.",
+    "recommendation": "Empfohlen: Deaktivieren. Dieser Datensatz hat {{colCount}} Spalten und {{estRows}} Zeilen. Das Berechnen der Metadaten kann mehrere Minuten dauern.",
+    "confirmTitle": "Metadaten trotzdem berechnen?",
+    "confirmBody": "Dieser Datensatz hat {{colCount}} Spalten und {{estRows}} Zeilen. Das Berechnen der Metadaten kann mehrere Minuten dauern und viel Speicher verbrauchen.",
+    "skipButton": "Metadaten überspringen",
+    "computeButton": "Trotzdem berechnen",
+    "missingNotice": "Für diesen Datensatz wurden keine erweiterten Metadaten berechnet. Lade ihn erneut mit aktivierten Metadaten hoch, um diesen Bereich zu sehen."
   }
 }

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -387,5 +387,15 @@
     "noChangesMade": "No changes were made",
     "notebookCreated": "Notebook created successfully",
     "notebookUpdateSuccess": "Notebook updated successfully"
+  },
+  "computeMetadata": {
+    "label": "Compute extended metadata (EDA)",
+    "helper": "Disable for big datasets to speed up upload. Extended stats (correlations, quality, etc.) won't be available for this dataset.",
+    "recommendation": "Recommended off: this dataset has {{colCount}} columns and {{estRows}} rows. Computing metadata could take several minutes.",
+    "confirmTitle": "Compute metadata anyway?",
+    "confirmBody": "This dataset has {{colCount}} columns and {{estRows}} rows. Computing metadata could take several minutes and use significant memory.",
+    "skipButton": "Skip metadata",
+    "computeButton": "Compute anyway",
+    "missingNotice": "Extended metadata was not computed for this dataset. Re-upload it with metadata enabled to see this section."
   }
 }

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -393,5 +393,15 @@
     "noChangesMade": "No se realizaron cambios",
     "notebookCreated": "Cuaderno creado exitosamente",
     "notebookUpdateSuccess": "Cuaderno actualizado exitosamente"
+  },
+  "computeMetadata": {
+    "label": "Calcular metadatos extendidos (EDA)",
+    "helper": "Desactívalo para conjuntos de datos grandes y acelerar la subida. Las estadísticas extendidas (correlaciones, calidad, etc.) no estarán disponibles para este conjunto.",
+    "recommendation": "Recomendado desactivar: este conjunto tiene {{colCount}} columnas y {{estRows}} filas. Calcular los metadatos podría tardar varios minutos.",
+    "confirmTitle": "¿Calcular metadatos de todas formas?",
+    "confirmBody": "Este conjunto tiene {{colCount}} columnas y {{estRows}} filas. Calcular los metadatos podría tardar varios minutos y consumir mucha memoria.",
+    "skipButton": "Omitir metadatos",
+    "computeButton": "Calcular de todas formas",
+    "missingNotice": "No se calcularon los metadatos extendidos para este conjunto de datos. Vuélvelo a subir con los metadatos habilitados para ver esta sección."
   }
 }

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -390,5 +390,15 @@
     "noChangesMade": "Nenhuma alteração realizada",
     "notebookCreated": "Caderno criado com sucesso",
     "notebookUpdateSuccess": "Caderno atualizado com sucesso"
+  },
+  "computeMetadata": {
+    "label": "Calcular metadados estendidos (EDA)",
+    "helper": "Desative para conjuntos de dados grandes acelerarem o envio. Estatísticas estendidas (correlações, qualidade, etc.) não estarão disponíveis para este conjunto.",
+    "recommendation": "Recomendado desativar: este conjunto tem {{colCount}} colunas e {{estRows}} linhas. Calcular os metadados pode levar vários minutos.",
+    "confirmTitle": "Calcular metadados mesmo assim?",
+    "confirmBody": "Este conjunto tem {{colCount}} colunas e {{estRows}} linhas. Calcular os metadados pode levar vários minutos e consumir muita memória.",
+    "skipButton": "Pular metadados",
+    "computeButton": "Calcular mesmo assim",
+    "missingNotice": "Os metadados estendidos não foram calculados para este conjunto de dados. Envie-o novamente com os metadados ativados para ver esta seção."
   }
 }

--- a/DashAI/front/src/utils/metadataRecommendation.js
+++ b/DashAI/front/src/utils/metadataRecommendation.js
@@ -1,0 +1,20 @@
+export const META_THRESHOLDS = Object.freeze({
+  COLS: 50,
+  ROWS: 100_000,
+});
+
+export function estimateTotalRows({
+  previewRowCount = 0,
+  previewedBytes = 0,
+  fileSize = 0,
+}) {
+  if (!previewRowCount) return 0;
+  if (!fileSize || !previewedBytes) return previewRowCount;
+  return Math.round(previewRowCount * (fileSize / previewedBytes));
+}
+
+export function shouldRecommendDisableMetadata({ colCount = 0, estRows = 0 }) {
+  if (colCount > META_THRESHOLDS.COLS) return true;
+  if (estRows && estRows > META_THRESHOLDS.ROWS) return true;
+  return false;
+}

--- a/DashAI/front/src/utils/metadataRecommendation.test.js
+++ b/DashAI/front/src/utils/metadataRecommendation.test.js
@@ -1,0 +1,70 @@
+import {
+  META_THRESHOLDS,
+  estimateTotalRows,
+  shouldRecommendDisableMetadata,
+} from "./metadataRecommendation";
+
+describe("estimateTotalRows", () => {
+  it("returns 0 when previewRowCount is missing", () => {
+    expect(estimateTotalRows({ previewRowCount: 0 })).toBe(0);
+    expect(estimateTotalRows({})).toBe(0);
+  });
+
+  it("returns previewRowCount when file size is unknown", () => {
+    expect(
+      estimateTotalRows({ previewRowCount: 100, previewedBytes: 1000 }),
+    ).toBe(100);
+  });
+
+  it("scales by fileSize / previewedBytes when both known", () => {
+    expect(
+      estimateTotalRows({
+        previewRowCount: 100,
+        previewedBytes: 1000,
+        fileSize: 10000,
+      }),
+    ).toBe(1000);
+  });
+
+  it("rounds the estimate", () => {
+    expect(
+      estimateTotalRows({
+        previewRowCount: 7,
+        previewedBytes: 1000,
+        fileSize: 1333,
+      }),
+    ).toBe(9);
+  });
+});
+
+describe("shouldRecommendDisableMetadata", () => {
+  it("recommends disable when columns exceed threshold", () => {
+    expect(
+      shouldRecommendDisableMetadata({
+        colCount: META_THRESHOLDS.COLS + 1,
+        estRows: 100,
+      }),
+    ).toBe(true);
+  });
+
+  it("recommends disable when rows exceed threshold", () => {
+    expect(
+      shouldRecommendDisableMetadata({
+        colCount: 5,
+        estRows: META_THRESHOLDS.ROWS + 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not recommend disable below both thresholds", () => {
+    expect(shouldRecommendDisableMetadata({ colCount: 5, estRows: 100 })).toBe(
+      false,
+    );
+  });
+
+  it("ignores estRows when 0 / falsy", () => {
+    expect(shouldRecommendDisableMetadata({ colCount: 5, estRows: 0 })).toBe(
+      false,
+    );
+  });
+});

--- a/tests/back/api/test_dataset_job_compute_metadata_flag.py
+++ b/tests/back/api/test_dataset_job_compute_metadata_flag.py
@@ -1,0 +1,140 @@
+"""Tests for the compute_metadata flag in DatasetJob.run()."""
+
+import json
+import shutil
+from pathlib import Path
+
+from DashAI.back.dependencies.database.models import Dataset
+from DashAI.back.job.dataset_job import DatasetJob
+
+IRIS_SCHEMA = {
+    "SepalLengthCm": {"type": "Float", "dtype": "float64"},
+    "SepalWidthCm": {"type": "Float", "dtype": "float64"},
+    "PetalLengthCm": {"type": "Float", "dtype": "float64"},
+    "PetalWidthCm": {"type": "Float", "dtype": "float64"},
+    "Species": {"type": "Categorical", "dtype": "string"},
+}
+
+
+def _run_dataset_job(client, name: str, compute_metadata: bool) -> Dataset:
+    """Run DatasetJob synchronously with the given compute_metadata flag.
+
+    Parameters
+    ----------
+    client : TestClient
+        Module-scoped FastAPI test client (from ``conftest.py``).
+    name : str
+        Dataset name.
+    compute_metadata : bool
+        Value to pass through ``params["compute_metadata"]``.
+
+    Returns
+    -------
+    Dataset
+        The persisted ``Dataset`` row after the job has finished.
+    """
+    abs_file_path = Path(__file__).parent / "iris.csv"
+    container = client.app.container
+    session_factory = container["session_factory"]
+
+    with session_factory() as db:
+        entry = Dataset(name=name, file_path="")
+        db.add(entry)
+        db.commit()
+        db.refresh(entry)
+
+        kwargs = {
+            "dataset_id": entry.id,
+            "url": "",
+            "params": {
+                "dataloader": "CSVDataLoader",
+                "separator": ",",
+                "name": entry.name,
+                "schema": IRIS_SCHEMA,
+                "compute_metadata": compute_metadata,
+            },
+            "file_path": abs_file_path,
+        }
+        job = DatasetJob(job_type="DatasetJob", kwargs=kwargs, db=db)
+        job.run()
+        db.refresh(entry)
+        return entry
+
+
+def _load_splits(dataset: Dataset) -> dict:
+    splits_path = Path(dataset.file_path) / "dataset" / "splits.json"
+    with open(splits_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_compute_metadata_true_writes_full_metadata(client):
+    entry = _run_dataset_job(client, "iris_full_meta", compute_metadata=True)
+    splits = _load_splits(entry)
+
+    assert "column_names" in splits
+    assert "total_rows" in splits
+    assert splits["total_rows"] == 150
+    for key in (
+        "general_info",
+        "numeric_stats",
+        "categorical_stats",
+        "text_stats",
+        "quality_info",
+        "correlations",
+    ):
+        assert key in splits, f"missing {key} when compute_metadata=True"
+
+    shutil.rmtree(entry.file_path, ignore_errors=True)
+
+
+def test_compute_metadata_false_writes_base_only(client):
+    entry = _run_dataset_job(client, "iris_base_meta", compute_metadata=False)
+    splits = _load_splits(entry)
+
+    assert splits["total_rows"] == 150
+    assert "column_names" in splits
+    assert "nan" in splits
+    assert entry.total_rows == 150
+    assert entry.total_columns == 5
+    for key in (
+        "general_info",
+        "numeric_stats",
+        "categorical_stats",
+        "text_stats",
+        "quality_info",
+        "correlations",
+    ):
+        assert key not in splits, f"unexpected {key} when compute_metadata=False"
+
+    shutil.rmtree(entry.file_path, ignore_errors=True)
+
+
+def test_compute_metadata_default_is_true(client):
+    """Backward compatibility: omitting the flag preserves current behavior."""
+    abs_file_path = Path(__file__).parent / "iris.csv"
+    container = client.app.container
+    session_factory = container["session_factory"]
+
+    with session_factory() as db:
+        entry = Dataset(name="iris_default_meta", file_path="")
+        db.add(entry)
+        db.commit()
+        db.refresh(entry)
+
+        kwargs = {
+            "dataset_id": entry.id,
+            "url": "",
+            "params": {
+                "dataloader": "CSVDataLoader",
+                "separator": ",",
+                "name": entry.name,
+                "schema": IRIS_SCHEMA,
+            },
+            "file_path": abs_file_path,
+        }
+        DatasetJob(job_type="DatasetJob", kwargs=kwargs, db=db).run()
+        db.refresh(entry)
+
+    splits = _load_splits(entry)
+    assert "general_info" in splits
+    shutil.rmtree(entry.file_path, ignore_errors=True)

--- a/tests/back/api/test_preview_with_types_previewed_bytes.py
+++ b/tests/back/api/test_preview_with_types_previewed_bytes.py
@@ -1,0 +1,33 @@
+"""Verify /preview_with_types includes previewed_bytes in the response."""
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_preview_with_types_includes_previewed_bytes(client: TestClient):
+    iris_path = Path(__file__).parent / "iris.csv"
+    file_size = iris_path.stat().st_size
+
+    with open(iris_path, "rb") as fh:
+        files = {"file": ("iris.csv", fh, "text/csv")}
+        data = {
+            "params": json.dumps(
+                {
+                    "dataloader_name": "CSVDataLoader",
+                    "separator": ",",
+                    "inference_rows": 50,
+                }
+            )
+        }
+        response = client.post(
+            "/api/v1/dataset/preview_with_types", files=files, data=data
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert "previewed_bytes" in body
+    assert isinstance(body["previewed_bytes"], int)
+    assert body["previewed_bytes"] > 0
+    assert body["previewed_bytes"] <= file_size


### PR DESCRIPTION
## Summary

Adds a toggle to control whether full EDA metadata (correlations, numeric/categorical/text stats, quality score) is computed when uploading a dataset. Computing metadata on large datasets can take several minutes and use significant memory - users can now skip it and upload faster. The toggle is available in all three upload paths: normal file upload (dataloader config sidebar), save-as-dataset from notebook, and hub import.

When the dataset has many columns or many rows, the toggle auto-shows a recommendation alert. If the user keeps it ON over the threshold and submits, a confirmation dialog asks them to confirm or skip. Datasets uploaded without metadata show a notice in the EDA views.

---

## Type of Change

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

**Backend**
- `DashAI/back/job/dataset_job.py`: branch on `params["compute_metadata"]` (default `True`). When `False`, calls `compute_base_metadata()` instead of `compute_metadata()`. Strips inherited extended metadata when skipping for notebook-copy path. Notebooks with no converters reuse source metadata directly.
- `DashAI/back/api/api_v1/endpoints/datasets.py`: `preview_with_types` response now includes `previewed_bytes` so the frontend can estimate total row count before submit.
- `DashAI/back/api/api_v1/endpoints/dataset_source.py`: docstring notes `compute_metadata` is honored via `body.params` passthrough.
- `tests/back/api/test_dataset_job_compute_metadata_flag.py`: tests for the flag branch (full, base-only, default-true).
- `tests/back/api/test_preview_with_types_previewed_bytes.py`: test for `previewed_bytes` in preview response.

**Frontend**
- `DashAI/front/src/components/notebooks/datasetCreation/DataloaderConfigBar.jsx`: toggle rendered as `FormSchemaFieldCard` + `Switch` in the right sidebar, consistent with "Use Native Types". Does not push through `formValues` (no preview re-render on toggle).
- `DashAI/front/src/components/notebooks/datasetCreation/UploadDatasetSteps.jsx`: holds `computeMetadata` state, passes to `DataloaderConfigBar` and `ConfigureAndUploadDatasetStep`.
- `DashAI/front/src/components/notebooks/datasetCreation/ConfigureAndUploadDatasetStep.jsx`: gates submit on confirm dialog when over threshold with metadata ON.
- `DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx`: toggle + confirm dialog in save-as-dataset modal. Buttons are "Cancel" and "Upload".
- `DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx`: forwards `compute_metadata` through `enqueueDatasetJob`; failure callback verifies dataset state before showing error snackbar.
- `DashAI/front/src/pages/hub/HubImportPage.jsx` + `HubImportPanel.jsx`: toggle in hub import sidebar; `compute_metadata` included in import params; stripped from preview fetch deps so toggling doesn't re-fetch.
- `DashAI/front/src/components/datasets/ComputeMetadataToggle.jsx`: shared toggle + recommendation alert (cols > 50 or est. rows > 100k).
- `DashAI/front/src/components/datasets/ComputeMetadataConfirmDialog.jsx`: confirm dialog with "Cancel" / "Upload" buttons.
- `DashAI/front/src/components/DatasetVisualization.jsx`: info alert when `general_info` missing.
- `DashAI/front/src/components/notebooks/dataset/QualityAlerts.jsx`: fixed hook-order crash when metadata is absent.
- `DashAI/front/src/utils/metadataRecommendation.js` + `.test.js`: threshold helpers + unit tests.
- i18n: `en`, `es`, `de`, `pt` locale files updated with `computeMetadata.*` keys.

---

## Testing

- Upload a narrow dataset (< 50 cols) - toggle ON by default, no alert.
- Upload a wide CSV (> 50 cols) - recommendation alert appears.
- Keep toggle ON and submit over threshold - confirm dialog appears; "Upload" proceeds; "Cancel" closes without submitting.
- Upload with toggle OFF - `splits.json` has only `column_names`, `total_rows`, `nan`. EDA views show the metadata-missing notice.
- Save-as-dataset from a notebook with no converters and toggle OFF - resulting dataset has base metadata only; with toggle ON and an existing metadata-rich source, source metadata is reused.
- Hub import with toggle OFF - base metadata only.

---

## Notes

- `compute_metadata` defaults to `True` - existing clients that don't send the flag keep current behavior.
- The `previewed_bytes` field in preview responses is the size of the uploaded content, not just the rows sampled. This gives a conservative row estimate (may underestimate for sparse files).
- No on-demand recompute endpoint - users who want full metadata after skipping must re-upload with the toggle ON.
