### PR TITLE
Fix missing explorer and converter images in packaged distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-include DashAI/back/dataloaders/description_schemas *
 recursive-include DashAI/back/dataloaders/params_schemas *
 recursive-include DashAI/back/types *
 prune tests/
+recursive-include DashAI/back/static/images/ *


### PR DESCRIPTION
## Summary

This pull request fixes an issue where explorer and converter images were not displayed when installing dashAI from PyPI. The required static image assets were not being included in the packaged distribution, causing missing images in the pip installed application.

The package configuration has been updated to ensure all image files under `DashAI/back/static/images/` are included during package builds and distributed with releases.

---

## Type of Change

Check all that apply like this [x]:

* [ ] Backend change
* [ ] Frontend change
* [ ] CI / Workflow change
* [x] Build / Packaging change
* [x] Bug fix
* [ ] Documentation

---

## Changes (by file)

* `MANIFEST.in`: Added a `recursive-include DashAI/back/static/images *` rule to ensure all image assets are packaged and included in source distributions.

---

## Testing (optional)

* Build and install the package from the generated distribution.
* Verify that explorer and converter images are correctly displayed in the pip installed version of the application.