### PR TITLE
Show parameter display names instead of keys across schema forms, run results, and explorer details

### DIFF
--- a/DashAI/front/src/components/models/RunCard.jsx
+++ b/DashAI/front/src/components/models/RunCard.jsx
@@ -490,6 +490,7 @@ function RunCard({
         <Box sx={{ mt: 4 }}>
           <RunResults
             run={run}
+            model={model}
             session={session}
             onRefresh={onOperationsRefresh}
             explainerRefreshTrigger={explainerRefreshTrigger}

--- a/DashAI/front/src/components/models/RunResults.jsx
+++ b/DashAI/front/src/components/models/RunResults.jsx
@@ -48,6 +48,7 @@ import { TIMESTAMP_KEYS } from "../../constants/timestamp";
 
 export default function RunResults({
   run,
+  model,
   session,
   onRefresh,
   explainerRefreshTrigger,
@@ -101,6 +102,11 @@ export default function RunResults({
     canSave: false,
     isSaving: false,
   });
+
+  // Map a parameter key to its display name using the matching model's schema
+  // (the model comes from the right side bar list, so no extra backend fetch).
+  const paramProperties = model?.schema?.properties ?? {};
+  const getParamLabel = (key) => paramProperties[key]?.title ?? key;
 
   const optimizables = checkHowManyOptimazers({ params: run.parameters });
   const isFinished = run.status === 3;
@@ -250,7 +256,7 @@ export default function RunResults({
                       <TableBody>
                         {Object.entries(run.parameters).map(([key, value]) => (
                           <TableRow key={key}>
-                            <TableCell>{key}</TableCell>
+                            <TableCell>{getParamLabel(key)}</TableCell>
                             <TableCell>{renderParamValue(value)}</TableCell>
                           </TableRow>
                         ))}
@@ -879,6 +885,11 @@ RunResults.propTypes = {
     model_session_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     test_metrics: PropTypes.object,
   }).isRequired,
+  model: PropTypes.shape({
+    name: PropTypes.string,
+    display_name: PropTypes.string,
+    schema: PropTypes.object,
+  }),
   session: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,

--- a/DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx
@@ -212,7 +212,10 @@ export default function ExplorerDetailsModal({
                   <TabColumns data={explorer.columns} />
                 </Box>
                 <Box sx={{ flex: "1 1 240px", minWidth: 0 }}>
-                  <TabParameters data={explorer.parameters} />
+                  <TabParameters
+                    data={explorer.parameters}
+                    schema={explorerComponent?.schema}
+                  />
                 </Box>
               </Box>
             </Box>

--- a/DashAI/front/src/components/notebooks/explorer/tabs/Parameters.jsx
+++ b/DashAI/front/src/components/notebooks/explorer/tabs/Parameters.jsx
@@ -20,9 +20,14 @@ function formatValue(value) {
   return String(value);
 }
 
-function Parameters({ data }) {
+function Parameters({ data, schema = null }) {
   const { t } = useTranslation(["common"]);
   const entries = data ? Object.entries(data) : [];
+
+  // Map a parameter key to its display name using the explorer component's
+  // schema (already loaded, so no extra backend fetch); fall back to the key.
+  const properties = schema?.properties ?? {};
+  const getLabel = (key) => properties[key]?.title ?? key;
 
   return (
     <Box>
@@ -47,7 +52,7 @@ function Parameters({ data }) {
                     color: "text.secondary",
                   }}
                 >
-                  {key}
+                  {getLabel(key)}
                 </Typography>
               </TableCell>
               <TableCell
@@ -79,6 +84,7 @@ function Parameters({ data }) {
 
 Parameters.propTypes = {
   data: PropTypes.object.isRequired,
+  schema: PropTypes.object,
 };
 
 export default Parameters;

--- a/DashAI/front/src/components/shared/FormSchemaFieldCard.jsx
+++ b/DashAI/front/src/components/shared/FormSchemaFieldCard.jsx
@@ -169,18 +169,8 @@ function FormSchemaFieldCard({
             fontWeight={600}
             color={errorMessage ? "error.main" : "text.primary"}
           >
-            {label}
+            {label ?? paramKey}
           </Typography>
-          {paramKey && paramKey !== label && (
-            <Typography
-              component="span"
-              variant="caption"
-              color="text.secondary"
-              sx={{ fontFamily: "monospace" }}
-            >
-              {paramKey}
-            </Typography>
-          )}
         </Box>
 
         {headerRight}


### PR DESCRIPTION
## Summary
Parameter labels in the frontend now show a single human readable display name instead of both the display name and the raw key. The schema field card, the run results parameter table, and the explorer details parameters tab all resolve each parameter's display name from schema data that is already loaded, so no extra backend calls are made.

---

## Type of Change

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/shared/FormSchemaFieldCard.jsx`: Header now renders only `label ?? paramKey` (display name, falling back to the key). Removed the separate monospace key line so each schema field shows one label.
- `DashAI/front/src/components/models/RunCard.jsx`: Pass the matched `model` (already resolved from the right side bar list) down to `RunResults`.
- `DashAI/front/src/components/models/RunResults.jsx`: Accept the `model` prop and map each run parameter key to its display name via `model.schema.properties[key].title`, falling back to the key. No extra fetch.
- `DashAI/front/src/components/notebooks/explorer/ExplorerDetailsModal.jsx`: Pass `explorerComponent.schema` into the parameters tab.
- `DashAI/front/src/components/notebooks/explorer/tabs/Parameters.jsx`: Accept a `schema` prop and resolve each parameter's display name from `schema.properties[key].title`, falling back to the key.

---

## Testing

- Open any step that configures a component through a schema form (e.g. adding/configuring a model, converter, or explorer) and confirm each parameter shows a single title, not both the display name and the raw key.
- Open a run's model parameters table and confirm parameter rows show display names, not raw keys.
- Open an explorer's details > parameters tab and confirm the same.
- Confirm fallback to the raw key when a parameter has no display name in the schema.
