### PR TITLE
Fix mixed image channel sizes in image classifiers

### DIFF
--- a/DashAI/back/models/base_torchvision_image_classifier.py
+++ b/DashAI/back/models/base_torchvision_image_classifier.py
@@ -233,7 +233,11 @@ def _make_image_dataset(x_dataset, y_dataset=None, image_size=224):
             self.label_to_idx = {}
             self.idx_to_label = {}
             if self.label_col_name:
-                unique_labels = sorted(set(self.y_dataset[self.label_col_name]))
+                y_cat = (getattr(y_ds, "types", {}) or {}).get(self.label_col_name)
+                if y_cat is not None and getattr(y_cat, "categories", None):
+                    unique_labels = sorted(y_cat.categories)
+                else:
+                    unique_labels = sorted(set(self.y_dataset[self.label_col_name]))
                 self.label_to_idx = {
                     label: idx for idx, label in enumerate(unique_labels)
                 }
@@ -344,7 +348,7 @@ class TorchvisionImageClassifier(BaseModel, abc.ABC):
             return dataset
 
         col_name = dataset.column_names[0]
-        encoded = [self.label_to_idx.get(lbl, lbl) for lbl in dataset[col_name]]
+        encoded = [self.label_to_idx.get(lbl, -1) for lbl in dataset[col_name]]
         return DashAIDataset(pa.table({col_name: encoded}))
 
     def train(self, x_train, y_train, x_validation=None, y_validation=None):

--- a/DashAI/back/models/cnn_image_classifier.py
+++ b/DashAI/back/models/cnn_image_classifier.py
@@ -216,6 +216,7 @@ def _make_image_dataset(x_dataset, y_dataset=None, image_size=64):
             self.y_dataset = y_ds
             self.transforms = transforms.Compose(
                 [
+                    transforms.Lambda(lambda img: img.convert("RGB")),
                     transforms.Resize((img_size, img_size)),
                     transforms.ToTensor(),
                 ]
@@ -229,7 +230,11 @@ def _make_image_dataset(x_dataset, y_dataset=None, image_size=64):
             self.label_to_idx = {}
             self.idx_to_label = {}
             if self.label_col_name:
-                unique_labels = sorted(set(self.y_dataset[self.label_col_name]))
+                y_cat = (getattr(y_ds, "types", {}) or {}).get(self.label_col_name)
+                if y_cat is not None and getattr(y_cat, "categories", None):
+                    unique_labels = sorted(y_cat.categories)
+                else:
+                    unique_labels = sorted(set(self.y_dataset[self.label_col_name]))
                 self.label_to_idx = {
                     label: idx for idx, label in enumerate(unique_labels)
                 }
@@ -414,7 +419,7 @@ class CNNImageClassifier(BaseModel):
             return dataset
 
         col_name = dataset.column_names[0]
-        encoded = [self.label_to_idx.get(lbl, lbl) for lbl in dataset[col_name]]
+        encoded = [self.label_to_idx.get(lbl, -1) for lbl in dataset[col_name]]
         return DashAIDataset(pa.table({col_name: encoded}))
 
     def train(self, x_train, y_train, x_validation=None, y_validation=None):

--- a/DashAI/back/models/lenet5_image_classifier.py
+++ b/DashAI/back/models/lenet5_image_classifier.py
@@ -167,6 +167,7 @@ def _make_image_dataset(x_dataset, y_dataset=None, image_size=32):
             self.y_dataset = y_ds
             self.transforms = transforms.Compose(
                 [
+                    transforms.Lambda(lambda img: img.convert("RGB")),
                     transforms.Resize((img_size, img_size)),
                     transforms.ToTensor(),
                 ]
@@ -180,7 +181,11 @@ def _make_image_dataset(x_dataset, y_dataset=None, image_size=32):
             self.label_to_idx = {}
             self.idx_to_label = {}
             if self.label_col_name:
-                unique_labels = sorted(set(self.y_dataset[self.label_col_name]))
+                y_cat = (getattr(y_ds, "types", {}) or {}).get(self.label_col_name)
+                if y_cat is not None and getattr(y_cat, "categories", None):
+                    unique_labels = sorted(y_cat.categories)
+                else:
+                    unique_labels = sorted(set(self.y_dataset[self.label_col_name]))
                 self.label_to_idx = {
                     label: idx for idx, label in enumerate(unique_labels)
                 }
@@ -337,7 +342,7 @@ class LeNet5ImageClassifier(BaseModel):
             return dataset
 
         col_name = dataset.column_names[0]
-        encoded = [self.label_to_idx.get(lbl, lbl) for lbl in dataset[col_name]]
+        encoded = [self.label_to_idx.get(lbl, -1) for lbl in dataset[col_name]]
         return DashAIDataset(pa.table({col_name: encoded}))
 
     def train(self, x_train, y_train, x_validation=None, y_validation=None):

--- a/DashAI/back/models/mlp_image_classifier.py
+++ b/DashAI/back/models/mlp_image_classifier.py
@@ -210,6 +210,7 @@ def _make_image_dataset(x_dataset, y_dataset=None, image_size=64):
             self.y_dataset = y_ds
             self.transforms = transforms.Compose(
                 [
+                    transforms.Lambda(lambda img: img.convert("RGB")),
                     transforms.Resize((img_size, img_size)),
                     transforms.ToTensor(),
                 ]
@@ -223,7 +224,11 @@ def _make_image_dataset(x_dataset, y_dataset=None, image_size=64):
             self.label_to_idx = {}
             self.idx_to_label = {}
             if self.label_col_name:
-                unique_labels = sorted(set(self.y_dataset[self.label_col_name]))
+                y_cat = (getattr(y_ds, "types", {}) or {}).get(self.label_col_name)
+                if y_cat is not None and getattr(y_cat, "categories", None):
+                    unique_labels = sorted(y_cat.categories)
+                else:
+                    unique_labels = sorted(set(self.y_dataset[self.label_col_name]))
                 self.label_to_idx = {
                     label: idx for idx, label in enumerate(unique_labels)
                 }
@@ -382,7 +387,7 @@ class MLPImageClassifier(BaseModel):
 
         col_name = dataset.column_names[0]
         labels = dataset[col_name]
-        encoded = [self.label_to_idx.get(label, label) for label in labels]
+        encoded = [self.label_to_idx.get(label, -1) for label in labels]
         table = pa.table({col_name: encoded})
         return DashAIDataset(table)
 


### PR DESCRIPTION
 ## Summary
  Image classifiers (MLP, CNN, LeNet5) failed when training on datasets containing images with mixed channel formats and/or class-imbalanced splits. Two independent bugs were fixed:

  1. The transform pipeline did not normalize image channels before converting to tensors, causing `torch.stack` to fail when a batch mixed grayscale, RGB, and RGBA images.
  2. `label_to_idx` was built only from training split labels, so classes with no training examples (present only in validation) had no index. This caused `prepare_output` to produce a mixed int/string list that PyArrow could not convert.

  ---

  ## Type of Change
  - [x] Backend change
  - [ ] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)
  - `DashAI/back/models/mlp_image_classifier.py`: added `convert("RGB")` to transform pipeline; build `label_to_idx` from `Categorical.categories` (full dataset class list) instead of training split labels; changed `prepare_output` fallback from string to `-1`.
  - `DashAI/back/models/cnn_image_classifier.py`: same fixes.
  - `DashAI/back/models/lenet5_image_classifier.py`: same fixes.
  - `DashAI/back/models/base_torchvision_image_classifier.py`: label index fixes only (`convert("RGB")` was already present).

  ---

  ## Testing
  Train any image classification model on a dataset that:
  - Mixes grayscale, RGB, and/or RGBA images — training should complete without `RuntimeError: stack expects each tensor to be equal size`.
  - Has classes with few examples that may land entirely in the validation split — training should complete without `ArrowInvalid: tried to convert to int64` or `y_true contains values {-1}`.