### PR TITLE
Fix CUDA/CPU tensor mismatch in image classifier prediction

### DIFF
--- a/DashAI/back/models/base_torchvision_image_classifier.py
+++ b/DashAI/back/models/base_torchvision_image_classifier.py
@@ -456,6 +456,7 @@ class TorchvisionImageClassifier(BaseModel, abc.ABC):
             collate_fn=self._collate_fn_no_labels,
         )
 
+        self.model.to(self.device)
         self.model.eval()
         all_probs = []
         with torch.no_grad():

--- a/DashAI/back/models/cnn_image_classifier.py
+++ b/DashAI/back/models/cnn_image_classifier.py
@@ -531,6 +531,7 @@ class CNNImageClassifier(BaseModel):
             collate_fn=self._collate_fn_no_labels,
         )
 
+        self.model.to(self.device)
         self.model.eval()
         all_probs = []
         with torch.no_grad():

--- a/DashAI/back/models/lenet5_image_classifier.py
+++ b/DashAI/back/models/lenet5_image_classifier.py
@@ -450,6 +450,7 @@ class LeNet5ImageClassifier(BaseModel):
             collate_fn=self._collate_fn_no_labels,
         )
 
+        self.model.to(self.device)
         self.model.eval()
         all_probs = []
         with torch.no_grad():

--- a/DashAI/back/models/mlp_image_classifier.py
+++ b/DashAI/back/models/mlp_image_classifier.py
@@ -499,6 +499,7 @@ class MLPImageClassifier(BaseModel):
             collate_fn=self._collate_fn_no_labels,
         )
 
+        self.model.to(self.device)
         self.model.eval()
         all_probs = []
         with torch.no_grad():


### PR DESCRIPTION
## Summary
Loaded image classifier checkpoints rebuild the backbone on CPU (`torch.load(..., map_location="cpu")`), but `predict` moved only the input images to the device. This caused a `RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same` during prediction. The model is now moved to the device before inference in every image classifier.

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Testing
- On a CUDA machine, train an image classifier, then run a prediction on a saved/loaded model (fresh process) and confirm it completes without the CUDA/CPU tensor type mismatch.
- Verify prediction still works on a CPU-only device.

---

## Changes (by file)
- `DashAI/back/models/base_torchvision_image_classifier.py`: add `self.model.to(self.device)` before the eval loop in `predict` (covers ResNet18, ResNet50, EfficientNet).
- `DashAI/back/models/cnn_image_classifier.py`: same fix in `predict`.
- `DashAI/back/models/lenet5_image_classifier.py`: same fix in `predict`.
- `DashAI/back/models/mlp_image_classifier.py`: same fix in `predict`.
