### PR TITLE
Disable Dataset Hub in Frontend

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
@@ -169,12 +169,6 @@ export default function DatasetsCenterContent() {
             Icon: NotebookIcon,
             "data-tour": "notebook-option",
           },
-          {
-            name: "hub",
-            display_name: t("datasets:label.importFromHub"),
-            description: t("datasets:label.importFromHubDescription"),
-            Icon: HubIcon,
-          },
         ]}
         searchBar={false}
         goToNextStep={goToNextStep}


### PR DESCRIPTION
## Summary
Removes the **"Import from Hub"** dataset import option from the `DatasetsCenterContent` component, effectively disabling access to this import method in the UI for the upcoming release. The option was intentionally excluded from the release scope, so it is no longer presented to users among the available dataset import methods.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DatasetsCenterContent.jsx`: Removed the **"Import from Hub"** option from the dataset import options list, including its name, display name, description, and associated icon.

---

## Notes (optional)
This change disables the "Import from Hub" entry point in the frontend as it was decided not to include this functionality in the upcoming release. The underlying implementation remains in the codebase; only the UI option is removed.