### PR TITLE
Show generic dataset creation error message

### DIFF
--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -59,7 +59,7 @@
     "errorCreatingNotebook": "Fehler beim Erstellen des Notizbuchs",
     "errorProcessingExplorer": "Fehler beim Verarbeiten des Explorers: {{error}}",
     "explorerFailed": "Beim Verarbeiten des Explorers ist ein Fehler aufgetreten.",
-    "failedToCreateDataset": "Fehler beim Erstellen des Datensatzes: {{error}}",
+    "failedToCreateDataset": "Der Datensatz konnte nicht erstellt werden. Bitte pruefe deine Datei und Konfiguration und versuche es erneut.",
     "failedToCreateDatasetFromNotebook": "Datensatz konnte nicht aus Notizbuch erstellt werden",
     "failedToCreateExplorer": "Explorer konnte nicht erstellt werden",
     "failedToDeleteDataset": "Datensatz konnte nicht gelöscht werden",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -59,7 +59,7 @@
     "errorCreatingNotebook": "Error creating notebook",
     "errorProcessingExplorer": "Error processing explorer: {{error}}",
     "explorerFailed": "An error occurred during processing the explorer.",
-    "failedToCreateDataset": "Error creating dataset: {{error}}",
+    "failedToCreateDataset": "Could not create the dataset. Please check your file and configuration, then try again.",
     "failedToCreateDatasetFromNotebook": "Failed to create dataset from notebook",
     "failedToCreateExplorer": "Failed to create explorer",
     "failedToDeleteDataset": "Failed to delete dataset",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -59,7 +59,7 @@
     "errorCreatingNotebook": "Error al crear cuaderno",
     "errorProcessingExplorer": "Error al procesar explorador: {{error}}",
     "explorerFailed": "Ocurrió un error durante el procesamiento del explorador.",
-    "failedToCreateDataset": "Error al crear dataset: {{error}}",
+    "failedToCreateDataset": "No se pudo crear el dataset. Revisa tu archivo y la configuracion, y vuelve a intentarlo.",
     "failedToCreateDatasetFromNotebook": "Fallo al crear dataset desde cuaderno",
     "failedToCreateExplorer": "Fallo al crear explorador",
     "failedToDeleteDataset": "Fallo al eliminar dataset",

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -59,7 +59,7 @@
     "errorCreatingNotebook": "Erro ao criar caderno",
     "errorProcessingExplorer": "Erro ao processar explorador: {{error}}",
     "explorerFailed": "Ocorreu um erro durante o processamento do explorador.",
-    "failedToCreateDataset": "Erro ao criar conjunto de dados: {{error}}",
+    "failedToCreateDataset": "Nao foi possivel criar o conjunto de dados. Verifique seu arquivo e a configuracao e tente novamente.",
     "failedToCreateDatasetFromNotebook": "Falha ao criar conjunto de dados a partir do caderno",
     "failedToCreateExplorer": "Falha ao criar explorador",
     "failedToDeleteDataset": "Falha ao excluir conjunto de dados",


### PR DESCRIPTION
## Summary
The dataset creation failure snackbar (`failedToCreateDataset`, a shared key) surfaced the raw backend error via `{{error}}`, which was noisy and not actionable. Reworded to a generic, slightly more helpful message across all locales. Raw errors still go to `console.error` for debugging.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/utils/i18n/locales/en/datasets.json`: reworded `failedToCreateDataset`, removed `{{error}}`.
- `DashAI/front/src/utils/i18n/locales/es/datasets.json`: same, ES.
- `DashAI/front/src/utils/i18n/locales/pt/datasets.json`: same, PT.
- `DashAI/front/src/utils/i18n/locales/de/datasets.json`: same, DE.

