### PR TITLE
fix: Reduce scope for drag in models and notebooks

### DIFF
--- a/DashAI/front/src/components/models/SessionVisualization.jsx
+++ b/DashAI/front/src/components/models/SessionVisualization.jsx
@@ -65,7 +65,11 @@ export default function SessionVisualization() {
   const [isDragging, setIsDragging] = useState(false);
 
   useEffect(() => {
-    const onStart = () => setIsDragging(true);
+    const onStart = (e) => {
+      if (e.dataTransfer.types.includes("application/x-dashai-model")) {
+        setIsDragging(true);
+      }
+    };
     const onEnd = () => {
       setIsDragging(false);
       setIsDragOver(false);
@@ -256,10 +260,14 @@ export default function SessionVisualization() {
       <Box
         data-session-viz
         onDragOver={(e) => {
+          if (!e.dataTransfer.types.includes("application/x-dashai-model"))
+            return;
           e.preventDefault();
           e.dataTransfer.dropEffect = "copy";
         }}
         onDragEnter={(e) => {
+          if (!e.dataTransfer.types.includes("application/x-dashai-model"))
+            return;
           e.preventDefault();
           setIsDragOver(true);
         }}

--- a/DashAI/front/src/components/models/SessionVisualization.jsx
+++ b/DashAI/front/src/components/models/SessionVisualization.jsx
@@ -260,12 +260,14 @@ export default function SessionVisualization() {
       <Box
         data-session-viz
         onDragOver={(e) => {
+          if (e.dataTransfer.types.includes("Files")) e.preventDefault();
           if (!e.dataTransfer.types.includes("application/x-dashai-model"))
             return;
           e.preventDefault();
           e.dataTransfer.dropEffect = "copy";
         }}
         onDragEnter={(e) => {
+          if (e.dataTransfer.types.includes("Files")) e.preventDefault();
           if (!e.dataTransfer.types.includes("application/x-dashai-model"))
             return;
           e.preventDefault();

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -88,7 +88,11 @@ export default function NotebookView({ notebook }) {
   const [highlightedItemId, setHighlightedItemId] = useState(null);
 
   useEffect(() => {
-    const onStart = () => setIsDragging(true);
+    const onStart = (e) => {
+      if (e.dataTransfer.types.includes("application/x-dashai-tool")) {
+        setIsDragging(true);
+      }
+    };
     const onEnd = () => {
       setIsDragging(false);
       setIsDragOver(false);
@@ -301,11 +305,13 @@ export default function NotebookView({ notebook }) {
   }
 
   const handleDragOver = (e) => {
+    if (!e.dataTransfer.types.includes("application/x-dashai-tool")) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
   };
 
   const handleDragEnter = (e) => {
+    if (!e.dataTransfer.types.includes("application/x-dashai-tool")) return;
     e.preventDefault();
     setIsDragOver(true);
   };

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -305,12 +305,14 @@ export default function NotebookView({ notebook }) {
   }
 
   const handleDragOver = (e) => {
+    if (e.dataTransfer.types.includes("Files")) e.preventDefault();
     if (!e.dataTransfer.types.includes("application/x-dashai-tool")) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
   };
 
   const handleDragEnter = (e) => {
+    if (e.dataTransfer.types.includes("Files")) e.preventDefault();
     if (!e.dataTransfer.types.includes("application/x-dashai-tool")) return;
     e.preventDefault();
     setIsDragOver(true);


### PR DESCRIPTION
This pull request improves the drag-and-drop functionality in both the `SessionVisualization` and `NotebookView` components by ensuring that drag events are only handled for the appropriate custom data types. This helps prevent unintended drag-and-drop interactions and makes the UI more robust.

**Drag-and-drop event handling improvements:**

* In `SessionVisualization.jsx`, drag event handlers (`onStart`, `onDragOver`, and `onDragEnter`) now check that the dragged data includes the `"application/x-dashai-model"` type before responding, preventing unrelated drag events from triggering UI changes. [[1]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061L68-R72) [[2]](diffhunk://#diff-45fa7a89020f52cb25e47f94d3d22216269d23d8177d196a85858456aa38c061R263-R270)
* In `NotebookView.jsx`, drag event handlers (`onStart`, `handleDragOver`, and `handleDragEnter`) now check for the `"application/x-dashai-tool"` type, ensuring that only relevant drag-and-drop actions are processed. [[1]](diffhunk://#diff-324a8940db3cf50e0bf4f7da7dfa79a4434535c4abf4bc584804b6bc619dd9a7L91-R95) [[2]](diffhunk://#diff-324a8940db3cf50e0bf4f7da7dfa79a4434535c4abf4bc584804b6bc619dd9a7R308-R314)