### PR TITLE
fix: update allowed_types for DensityHeatmap and Histogram explorers

### DIFF
--- a/DashAI/back/exploration/explorers/density_heatmap.py
+++ b/DashAI/back/exploration/explorers/density_heatmap.py
@@ -5,6 +5,8 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.relationship_explorer import RelationshipExplorer
+from DashAI.back.types.categorical import Categorical
+from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -99,7 +101,7 @@ class DensityHeatmapExplorer(RelationshipExplorer):
 
     SCHEMA = DensityHeatmapSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
         "input_cardinality": {"exact": 2},
     }

--- a/DashAI/back/exploration/explorers/histogram_plot.py
+++ b/DashAI/back/exploration/explorers/histogram_plot.py
@@ -13,6 +13,8 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.exploration.base_explorer import BaseExplorerSchema
 from DashAI.back.exploration.distribution_explorer import DistributionExplorer
+from DashAI.back.types.categorical import Categorical
+from DashAI.back.types.value_types import Float, Integer
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -183,7 +185,7 @@ class HistogramPlotExplorer(DistributionExplorer):
 
     SCHEMA = HistogramPlotSchema
     metadata: Dict[str, Any] = {
-        "allowed_types": [],
+        "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
         "input_cardinality": {"exact": 1},
     }


### PR DESCRIPTION
This pull request updates the `DensityHeatmapExplorer` and `HistogramPlotExplorer` classes to specify which data types they support. The main change is the addition of `Float`, `Integer`, and `Categorical` to the `allowed_types` metadata for both explorers, improving type validation and documentation.

**Type support improvements:**

* Added `Float`, `Integer`, and `Categorical` to the `allowed_types` metadata in `DensityHeatmapExplorer`, clarifying the types of data supported for density heatmaps. [[1]](diffhunk://#diff-039d9ee7fee8e7fd437ef499b3e85b48712088973c0f200921b6f80cb95d1e37R8-R9) [[2]](diffhunk://#diff-039d9ee7fee8e7fd437ef499b3e85b48712088973c0f200921b6f80cb95d1e37L102-R104)
* Added `Float`, `Integer`, and `Categorical` to the `allowed_types` metadata in `HistogramPlotExplorer`, clarifying the types of data supported for histogram plots. [[1]](diffhunk://#diff-12b87ebaf64ae08f5f0c3c856a50766da2b9d4cd67817aafa44bd0195c31269eR16-R17) [[2]](diffhunk://#diff-12b87ebaf64ae08f5f0c3c856a50766da2b9d4cd67817aafa44bd0195c31269eL186-R188)