### PR TITLE
Hide home card tags and stack cards on small screens

### DIFF
--- a/DashAI/front/src/components/HomeButton.jsx
+++ b/DashAI/front/src/components/HomeButton.jsx
@@ -26,7 +26,8 @@ function HomeButton({
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: "100%",
+        height: { xs: "auto", lg: "100%" },
+        minHeight: { xs: 200, lg: 0 },
         background: theme.palette.background.paper,
         border: `1px solid ${theme.palette.divider}`,
         borderRadius: "4px",
@@ -85,7 +86,7 @@ function HomeButton({
         >
           <Icon sx={{ fontSize: 25 }} />
         </Box>
-        <Box sx={{ textAlign: "right" }}>
+        <Box sx={{ textAlign: "right", display: { xs: "none", lg: "block" } }}>
           <Box
             sx={{
               ...theme.typography.statusBadge,
@@ -138,7 +139,13 @@ function HomeButton({
           justifyContent: "space-between",
         }}
       >
-        <Box sx={{ display: "flex", gap: "5px", flexWrap: "wrap" }}>
+        <Box
+          sx={{
+            display: { xs: "none", lg: "flex" },
+            gap: "5px",
+            flexWrap: "wrap",
+          }}
+        >
           {chips.map((chip) => (
             <Box
               key={chip}

--- a/DashAI/front/src/pages/home/Home.jsx
+++ b/DashAI/front/src/pages/home/Home.jsx
@@ -287,12 +287,13 @@ function Home() {
           <Box
             sx={{
               p: 4,
-              display: "grid",
-              gridTemplateColumns: "1fr 1fr",
-              gridTemplateRows: "1fr 1fr",
-              gap: 4,
-              height: "70%",
-              width: "80%",
+              display: { xs: "flex", lg: "grid" },
+              flexDirection: { xs: "column", lg: "row" },
+              gridTemplateColumns: { lg: "1fr 1fr" },
+              gridTemplateRows: { lg: "1fr 1fr" },
+              gap: { xs: 2, lg: 4 },
+              height: { xs: "auto", lg: "70%" },
+              width: { xs: "100%", lg: "80%" },
               minHeight: 0,
             }}
           >
@@ -300,7 +301,11 @@ function Home() {
               <Box
                 key={mod.to}
                 data-tour={mod.tourAttr || undefined}
-                sx={{ minHeight: 0, height: "100%" }}
+                sx={{
+                  minHeight: 0,
+                  height: { xs: "auto", lg: "100%" },
+                  flexShrink: { xs: 0, lg: 1 },
+                }}
               >
                 <HomeButton
                   title={mod.title}


### PR DESCRIPTION
## Summary

Updates the home page layout and `HomeButton` component to improve responsiveness across screen sizes. The changes optimize the module grid for mobile devices, make component sizing adaptive, and reduce visual clutter on smaller screens by hiding secondary UI elements.

---

## Type of Change

* [ ] Backend change
* [x] Frontend change
* [ ] CI / Workflow change
* [ ] Build / Packaging change
* [ ] Bug fix
* [ ] Documentation

---

## Changes (by file)

* `DashAI/front/src/pages/home/Home.jsx`

  * Refactored the modules container to use a flex-column layout on mobile (`xs`) and a grid layout on large screens (`lg`).
  * Adjusted spacing, widths, and heights to provide a better responsive experience across devices.
  * Updated module card sizing to use adaptive heights and prevent shrinking on smaller screens.

* `DashAI/front/src/components/HomeButton.jsx`

  * Made the button container height and minimum height responsive for improved display on both mobile and desktop.
  * Hid tags on small screens.

---

## Testing (optional)

* Confirm that module cards maintain consistent sizing and spacing when resizing the browser window.
* Ensure tags are hidden on mobile devices and visible on larger screens.
