### PR TITLE
Replace sidebar action buttons with hub buttons across modules

### DIFF
--- a/DashAI/front/src/components/generative/SessionBar.jsx
+++ b/DashAI/front/src/components/generative/SessionBar.jsx
@@ -2,6 +2,7 @@ import { Box, Typography, Divider } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useNavigate } from "react-router-dom";
 import FolderIcon from "@mui/icons-material/Folder";
+import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import SearchBar from "../threeSectionLayout/SearchBar";
 import { useEffect, useState } from "react";
 import InfoSessionModal from "./InfoSessionModal";
@@ -145,7 +146,8 @@ export default function SessionBar({ onToggle }) {
           {selectedSessionId ? (
             <NewItemButton
               onClick={handleNewSessionButton}
-              title={t("generative:button.createSession")}
+              title={t("generative:button.generativeHub")}
+              EndIcon={ViewModuleIcon}
             />
           ) : (
             <Typography variant="body1" color="textSecondary">

--- a/DashAI/front/src/components/models/ModelsLeftBar.jsx
+++ b/DashAI/front/src/components/models/ModelsLeftBar.jsx
@@ -4,6 +4,7 @@ import { Box, Divider, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import StorageIcon from "@mui/icons-material/Storage";
 import Biotech from "@mui/icons-material/Biotech";
+import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import Footer from "../threeSectionLayout/Footer";
 import SideBar from "../threeSectionLayout/panelContainers/SideBar";
 import CollapsibleList from "../threeSectionLayout/CollapsibleList";
@@ -229,7 +230,8 @@ export default function ModelsLeftBar({ onToggle }) {
         {selectedDatasetId || selectedSessionId ? (
           <NewItemButton
             onClick={handleNewSessionButton}
-            title={t("models:button.newSession")}
+            title={t("models:button.modelsHub")}
+            EndIcon={ViewModuleIcon}
           />
         ) : (
           <Typography variant="body1" color="textSecondary">

--- a/DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx
+++ b/DashAI/front/src/components/notebooks/DatasetNotebookLeftBar.jsx
@@ -4,6 +4,7 @@ import { Box, Divider, Typography } from "@mui/material";
 import StorageIcon from "@mui/icons-material/Storage";
 import DescriptionIcon from "@mui/icons-material/Description";
 import CloudDownloadIcon from "@mui/icons-material/CloudDownload";
+import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import Footer from "../threeSectionLayout/Footer";
 import CollapsibleList from "../threeSectionLayout/CollapsibleList";
 import SearchBar from "../threeSectionLayout/SearchBar";
@@ -163,7 +164,8 @@ export default function DatasetsNotebooksLeftBar({
         {selectedDatasetId || selectedNotebookId ? (
           <NewItemButton
             onClick={handleNewSessionButton}
-            title={t("datasets:button.newDatasetNotebook")}
+            title={t("datasets:button.datasetHub")}
+            EndIcon={ViewModuleIcon}
           />
         ) : (
           <Typography variant="body1" color="textSecondary">

--- a/DashAI/front/src/components/threeSectionLayout/NewItemButton.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/NewItemButton.jsx
@@ -5,6 +5,7 @@ import { t } from "i18next";
 export default function NewItemButton({
   onClick,
   title = t("common:newItem", "New Item"),
+  EndIcon = AddIcon,
 }) {
   return (
     <Button
@@ -24,7 +25,7 @@ export default function NewItemButton({
         "&:hover": { bgcolor: "primary.light" },
       }}
       onClick={onClick}
-      endIcon={<AddIcon />}
+      endIcon={<EndIcon />}
     >
       {title}
     </Button>

--- a/DashAI/front/src/components/threeSectionLayout/NewItemButton.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/NewItemButton.jsx
@@ -27,7 +27,16 @@ export default function NewItemButton({
       onClick={onClick}
       endIcon={<EndIcon />}
     >
-      {title}
+      <Box
+        component="span"
+        sx={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {title}
+      </Box>
     </Button>
   );
 }

--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -38,6 +38,7 @@
     "createExplorer": "Explorer erstellen",
     "createNotebook": "Notizbuch erstellen",
     "goToDatasets": "Zu Datensätzen",
+    "datasetHub": "Datensatz-Zentrale",
     "newDatasetNotebook": "Neuer Datensatz/Notizbuch",
     "newNotebook": "Neues Notizbuch",
     "reUploadDataset": "Datensatz erneut hochladen",

--- a/DashAI/front/src/utils/i18n/locales/de/generative.json
+++ b/DashAI/front/src/utils/i18n/locales/de/generative.json
@@ -1,7 +1,8 @@
 {
   "button": {
     "backToTaskSelection": "Zurück zur Aufgabenauswahl",
-    "createSession": "Sitzung erstellen"
+    "createSession": "Sitzung erstellen",
+    "generativeHub": "Generative Zentrale"
   },
   "error": {
     "failedToCreateSession": "Sitzung konnte nicht erstellt werden",

--- a/DashAI/front/src/utils/i18n/locales/de/models.json
+++ b/DashAI/front/src/utils/i18n/locales/de/models.json
@@ -13,6 +13,7 @@
     "newPrediction": "Neue Vorhersage",
     "newDatasetPrediction": "Neue Datensatz-Vorhersage",
     "newManualPrediction": "Neue manuelle Vorhersage",
+    "modelsHub": "Modell-Zentrale",
     "newSession": "Neue Sitzung",
     "retrain": "Neu trainieren",
     "runAll": "Alle ausführen",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -38,6 +38,7 @@
     "createExplorer": "Create Explorer",
     "createNotebook": "Create Notebook",
     "goToDatasets": "Go to Datasets",
+    "datasetHub": "Dataset Hub",
     "newDatasetNotebook": "New Dataset/Notebook",
     "newNotebook": "New Notebook",
     "reUploadDataset": "Re-upload Dataset",

--- a/DashAI/front/src/utils/i18n/locales/en/generative.json
+++ b/DashAI/front/src/utils/i18n/locales/en/generative.json
@@ -1,7 +1,8 @@
 {
   "button": {
     "backToTaskSelection": "Back to Task Selection",
-    "createSession": "Create a session"
+    "createSession": "Create a session",
+    "generativeHub": "Generative Hub"
   },
   "error": {
     "failedToCreateSession": "Failed to create session",

--- a/DashAI/front/src/utils/i18n/locales/en/models.json
+++ b/DashAI/front/src/utils/i18n/locales/en/models.json
@@ -13,6 +13,7 @@
     "newPrediction": "New Prediction",
     "newDatasetPrediction": "New Dataset Prediction",
     "newManualPrediction": "New Manual Prediction",
+    "modelsHub": "Models Hub",
     "newSession": "New Session",
     "retrain": "Re-train",
     "runAll": "Run All",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -38,6 +38,7 @@
     "createExplorer": "Crear Explorador",
     "createNotebook": "Crear Cuaderno",
     "goToDatasets": "Ir a Datasets",
+    "datasetHub": "Centro de Datasets",
     "newDatasetNotebook": "Nuevo Dataset/Cuaderno",
     "newNotebook": "Nuevo Cuaderno",
     "reUploadDataset": "Volver a Subir Dataset",

--- a/DashAI/front/src/utils/i18n/locales/es/generative.json
+++ b/DashAI/front/src/utils/i18n/locales/es/generative.json
@@ -1,7 +1,8 @@
 {
   "button": {
     "backToTaskSelection": "Volver a Selección de Tarea",
-    "createSession": "Crear una sesión"
+    "createSession": "Crear una sesión",
+    "generativeHub": "Centro Generativo"
   },
   "error": {
     "failedToCreateSession": "Error al crear la sesión",

--- a/DashAI/front/src/utils/i18n/locales/es/models.json
+++ b/DashAI/front/src/utils/i18n/locales/es/models.json
@@ -13,6 +13,7 @@
     "newPrediction": "Nueva Predicción",
     "newDatasetPrediction": "Nueva Predicción de Dataset",
     "newManualPrediction": "Nueva Predicción Manual",
+    "modelsHub": "Centro de Modelos",
     "newSession": "Nueva Sesión",
     "retrain": "Re-entrenar",
     "runAll": "Ejecutar Todo",

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -38,6 +38,7 @@
     "createExplorer": "Criar Explorador",
     "createNotebook": "Criar Caderno",
     "goToDatasets": "Ir para Conjuntos de Dados",
+    "datasetHub": "Central de Dados",
     "newDatasetNotebook": "Novo Conjunto de Dados/Caderno",
     "newNotebook": "Novo Caderno",
     "reUploadDataset": "Reenviar Conjunto de Dados",

--- a/DashAI/front/src/utils/i18n/locales/pt/generative.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/generative.json
@@ -1,7 +1,8 @@
 {
   "button": {
     "backToTaskSelection": "Voltar para Seleção de Tarefa",
-    "createSession": "Criar uma sessão"
+    "createSession": "Criar uma sessão",
+    "generativeHub": "Central Generativa"
   },
   "error": {
     "failedToCreateSession": "Erro ao criar a sessão",

--- a/DashAI/front/src/utils/i18n/locales/pt/models.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/models.json
@@ -13,6 +13,7 @@
     "newPrediction": "Nova Previsão",
     "newDatasetPrediction": "Nova Previsão de Conjunto de Dados",
     "newManualPrediction": "Nova Previsão Manual",
+    "modelsHub": "Central de Modelos",
     "newSession": "Nova Sessão",
     "retrain": "Retreinar",
     "runAll": "Executar Tudo",


### PR DESCRIPTION
## Summary
  Replaced the "New Dataset/Notebook", "New Session", and "Create a session" buttons in the Datasets, Models, and Generative sidebars with hub-style buttons ("Dataset Hub", "Models Hub", "Generative Hub"). The buttons now use the `ViewModule` icon to signal navigation to a central resource hub. Also improved `NewItemButton` to support custom icons and prevent text overflow with ellipsis truncation.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [ ] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `components/threeSectionLayout/NewItemButton.jsx`: added `EndIcon` prop for custom icons (defaults to `AddIcon`); added ellipsis truncation for long labels button with "Dataset Hub" using `ViewModuleIcon`
  - `components/models/ModelsLeftBar.jsx`: replaced "New Session" button with "Models Hub" using `ViewModuleIcon`
  - `components/generative/SessionBar.jsx`: replaced "Create a session" button with "Generative Hub" using `ViewModuleIcon`
  - `locales/{en,es,pt,de}/datasets.json`: added `datasetHub` translation key
  - `locales/{en,es,pt,de}/models.json`: added `modelsHub` translation key
  - `locales/{en,es,pt,de}/generative.json`: added `generativeHub` translation key