### PR TITLE
Fix option box responsive cards

### DIFF
--- a/DashAI/back/tasks/image_classification_task.py
+++ b/DashAI/back/tasks/image_classification_task.py
@@ -21,29 +21,20 @@ class ImageClassificationTask(ClassificationTask):
 
     DESCRIPTION: str = MultilingualString(
         en=(
-            "Image classification in machine learning involves predicting "
-            "categorical labels for image data. Models are trained to learn "
-            "visual patterns and features in images, enabling accurate "
-            "classification of new instances."
+            "Predict categorical labels from image data by learning visual "
+            "patterns and features."
         ),
         es=(
-            "La clasificación de imágenes en el aprendizaje automático implica "
-            "predecir etiquetas categóricas para datos de imágenes. Los modelos "
-            "se entrenan para aprender patrones visuales y características en "
-            "las imágenes, lo que permite una clasificación precisa de nuevas "
-            "instancias."
+            "Predice etiquetas categóricas para imágenes aprendiendo patrones "
+            "y características visuales."
         ),
         pt=(
-            "A classificação de imagens no aprendizado de máquina envolve a "
-            "previsão de rótulos categóricos para dados de imagem. Os modelos "
-            "são treinados para aprender padrões visuais e características nas "
-            "imagens, permitindo uma classificação precisa de novas instâncias."
+            "Prevê rótulos categóricos para imagens aprendendo padrões "
+            "e características visuais."
         ),
         de=(
-            "Bildklassifikation im maschinellen Lernen umfasst die Vorhersage "
-            "kategorialer Zielgrößen für Bilddaten. Modelle werden trainiert, um "
-            "visuelle Muster und Merkmale in Bildern zu erlernen, was eine genaue "
-            "Klassifikation neuer Instanzen ermöglicht."
+            "Sagt kategoriale Zielgrößen für Bilddaten vorher, indem visuelle "
+            "Muster erlernt werden."
         ),
     )
     DISPLAY_NAME: str = MultilingualString(

--- a/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/OptionBox.jsx
@@ -33,7 +33,7 @@ export default function OptionBox({
       onClick={onClick}
       sx={{
         width: "100%",
-        height: 250,
+        height: { xs: 290, sm: 290, md: 260, lg: 250, xl: 250 },
         textAlign: "left",
         display: "flex",
         flexDirection: "column",
@@ -111,24 +111,24 @@ export default function OptionBox({
         enterDelay={300}
         placement="bottom"
       >
-        <Typography
-          ref={descRef}
-          variant="body1"
-          sx={{
-            fontWeight: 300,
-            color: theme.palette.text.secondary,
-            lineHeight: 1.65,
-            flexGrow: 1,
-            width: "100%",
-            display: "-webkit-box",
-            WebkitLineClamp: DESCRIPTION_MAX_LINES,
-            WebkitBoxOrient: "vertical",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-          }}
-        >
-          {description}
-        </Typography>
+        <Box sx={{ flexGrow: 1, overflow: "hidden", width: "100%" }}>
+          <Typography
+            ref={descRef}
+            variant="body1"
+            sx={{
+              fontWeight: 300,
+              color: theme.palette.text.secondary,
+              lineHeight: 1.65,
+              display: "-webkit-box",
+              WebkitLineClamp: DESCRIPTION_MAX_LINES,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {description}
+          </Typography>
+        </Box>
       </Tooltip>
 
       {/* Footer: chips + arrow */}

--- a/DashAI/front/src/components/threeSectionLayout/SelectOptionMenu.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/SelectOptionMenu.jsx
@@ -1,5 +1,21 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Box, Grid, Button, Alert, AlertTitle, Skeleton } from "@mui/material";
+
+function useContainerColumns(ref) {
+  const [size, setSize] = useState(4);
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new ResizeObserver(([entry]) => {
+      const w = entry.contentRect.width;
+      if (w >= 800) setSize(4);
+      else if (w >= 500) setSize(6);
+      else setSize(12);
+    });
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref]);
+  return size;
+}
 import SearchBar from "./SearchBar";
 import CustomLayout from "../custom/CustomLayout";
 import OptionBox from "./OptionBox";
@@ -23,6 +39,8 @@ export default function SelectOptionMenu({
     option.name.toLowerCase().includes(search.toLowerCase()),
   );
   const { t } = useTranslation(["common", "datasets"]);
+  const gridRef = useRef(null);
+  const colSize = useContainerColumns(gridRef);
 
   return (
     <CustomLayout title={title} subtitle={subtitle} padding={0}>
@@ -62,6 +80,7 @@ export default function SelectOptionMenu({
         )}
 
         <Grid
+          ref={gridRef}
           container
           direction="row"
           alignItems="stretch"
@@ -70,10 +89,7 @@ export default function SelectOptionMenu({
         >
           {loading
             ? Array.from({ length: 6 }).map((_, index) => (
-                <Grid
-                  size={{ xl: 4, lg: 4, md: 6, sm: 12, xs: 12 }}
-                  key={index}
-                >
+                <Grid size={colSize} key={index}>
                   <Skeleton variant="rounded" height={100} />
                 </Grid>
               ))
@@ -84,10 +100,7 @@ export default function SelectOptionMenu({
                 option;
 
               return (
-                <Grid
-                  size={{ xl: 4, lg: 4, md: 6, sm: 12, xs: 12 }}
-                  key={index}
-                >
+                <Grid size={colSize} key={index}>
                   <OptionBox
                     optionName={display_name}
                     description={description}


### PR DESCRIPTION
## Summary

  Improved the responsiveness of the option card grid shown on module home pages (Models, Datasets, Generative). Cards now adapt their column count based on the actual content area width rather than the viewport, so opening/closing sidebars correctly reflows the layout. Card height is fixed per viewport breakpoint to keep all cards the same size. Also shortened the `ImageClassificationTask` description to be consistent in length with other tasks.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/back/tasks/image_classification_task.py`: Shortened `DESCRIPTION` to a single concise sentence per language, consistent with other tasks.
  - `DashAI/front/src/components/threeSectionLayout/OptionBox.jsx`: Replaced fixed `height: 250` with responsive breakpoint values; fixed description truncation bug caused by `flexGrow` conflicting with `-webkit-line-clamp` by wrapping the text in a container `Box`.
  - `DashAI/front/src/components/threeSectionLayout/SelectOptionMenu.jsx`: Added `useContainerColumns` hook using `ResizeObserver` to compute column count from the actual container width instead of the viewport, so the grid reflows correctly when sidebars are toggled.

  ---

  ## Testing

  - Open the Models module and toggle the left/right sidebars — the card grid should reflow between 1, 2, and 3 columns based on available space.
  - Verify that description text is never clipped mid-word and the `...` only appears at the end of the last visible line.