### PR TITLE
fix: update file size calculation in dataset info

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -881,6 +881,9 @@ def save_dataset(
         }
     )
 
+    if "general_info" in metadata:
+        metadata["general_info"]["file_size_mb"] = os.path.getsize(data_filepath) / 1e6
+
     with open(metadata_filepath, "w", encoding="utf-8") as f:
         json.dump(metadata, f, indent=2, sort_keys=True, ensure_ascii=False)
 

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -214,7 +214,7 @@ class DashAIDataset(Dataset):
         return {
             "n_rows": len(dataset_df),
             "n_columns": len(dataset_df.columns),
-            "file_size_mb": float(self.arrow_table.nbytes / 1e6),
+            "memory_usage_mb": float(self.arrow_table.nbytes / 1e6),
             "duplicate_rows": duplicate_rows,
             "dtypes": {k: v.to_string().get("type") for k, v in self.types.items()},
         }
@@ -882,7 +882,9 @@ def save_dataset(
     )
 
     if "general_info" in metadata:
-        metadata["general_info"]["file_size_mb"] = os.path.getsize(data_filepath) / 1e6
+        metadata["general_info"]["memory_usage_mb"] = (
+            os.path.getsize(data_filepath) / 1e6
+        )
 
     with open(metadata_filepath, "w", encoding="utf-8") as f:
         json.dump(metadata, f, indent=2, sort_keys=True, ensure_ascii=False)

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -214,7 +214,7 @@ class DashAIDataset(Dataset):
         return {
             "n_rows": len(dataset_df),
             "n_columns": len(dataset_df.columns),
-            "memory_usage_mb": float(dataset_df.memory_usage(deep=True).sum() / 1e6),
+            "file_size_mb": float(self.arrow_table.nbytes / 1e6),
             "duplicate_rows": duplicate_rows,
             "dtypes": {k: v.to_string().get("type") for k, v in self.types.items()},
         }

--- a/DashAI/front/src/components/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/DatasetVisualization.jsx
@@ -337,7 +337,10 @@ export default function DatasetVisualization({
             <Header
               totalRows={datasetInfo?.total_rows}
               totalColumns={datasetInfo?.total_columns}
-              fileSize={datasetInfo?.general_info?.file_size_mb}
+              fileSize={
+                datasetInfo?.general_info?.file_size_mb ??
+                datasetInfo?.general_info?.memory_usage_mb
+              }
             />
             {/* Compute-metadata missing notice */}
             {!datasetInfo?.general_info && (

--- a/DashAI/front/src/components/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/DatasetVisualization.jsx
@@ -337,7 +337,7 @@ export default function DatasetVisualization({
             <Header
               totalRows={datasetInfo?.total_rows}
               totalColumns={datasetInfo?.total_columns}
-              fileSize={datasetInfo?.general_info?.memory_usage_mb}
+              fileSize={datasetInfo?.general_info?.file_size_mb}
             />
             {/* Compute-metadata missing notice */}
             {!datasetInfo?.general_info && (

--- a/DashAI/front/src/components/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/DatasetVisualization.jsx
@@ -337,10 +337,7 @@ export default function DatasetVisualization({
             <Header
               totalRows={datasetInfo?.total_rows}
               totalColumns={datasetInfo?.total_columns}
-              fileSize={
-                datasetInfo?.general_info?.file_size_mb ??
-                datasetInfo?.general_info?.memory_usage_mb
-              }
+              fileSize={datasetInfo?.general_info?.memory_usage_mb}
             />
             {/* Compute-metadata missing notice */}
             {!datasetInfo?.general_info && (


### PR DESCRIPTION
This pull request updates how dataset file size is calculated and displayed in the dataset visualization component. Instead of reporting the in-memory size, the system now reports the actual file size based on the Arrow table, ensuring more accurate information is shown to users.

**Backend: File size calculation update**
- Changed the backend to report `file_size_mb` using the Arrow table's byte size instead of the DataFrame's memory usage, providing a more accurate file size metric. (`DashAI/back/dataloaders/classes/dashai_dataset.py`)

**Frontend: File size display update**
- Updated the frontend to use the new `file_size_mb` field for displaying file size in the dataset visualization header, instead of the previous `memory_usage_mb` field. (`DashAI/front/src/components/DatasetVisualization.jsx`)