### PR TITLE
Add verified column and badge for dashAI plugins

### DIFF
--- a/DashAI/alembic/versions/e2a9c4f1b8d3_add_verified_column_to_plugin.py
+++ b/DashAI/alembic/versions/e2a9c4f1b8d3_add_verified_column_to_plugin.py
@@ -1,0 +1,35 @@
+"""Add verified column to plugin
+
+Revision ID: e2a9c4f1b8d3
+Revises: 3db684f4090a
+Create Date: 2026-06-08 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e2a9c4f1b8d3"
+down_revision: Union[str, None] = "3db684f4090a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "plugin",
+        sa.Column(
+            "verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("plugin", "verified")

--- a/DashAI/back/api/api_v1/schemas/plugin_params.py
+++ b/DashAI/back/api/api_v1/schemas/plugin_params.py
@@ -13,6 +13,7 @@ class TagParams(BaseModel):
 class PluginParams(BaseModel):
     name: str
     author: str
+    verified: bool = False
     installed_version: str
     lastest_version: str
     tags: List[TagParams]

--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -284,6 +284,9 @@ class Plugin(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     author: Mapped[str] = mapped_column(String, nullable=False)
+    verified: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
     installed_version: Mapped[str] = mapped_column(String, nullable=False)
     lastest_version: Mapped[str] = mapped_column(String, nullable=False)
     tags: Mapped[List["Tag"]] = relationship(

--- a/DashAI/back/dependencies/database/utils.py
+++ b/DashAI/back/dependencies/database/utils.py
@@ -48,6 +48,7 @@ def add_plugin_to_db(
                 logger.debug("Plugin already exists, updating it.")
                 plugin = existing_plugins[0]
                 setattr(plugin, "author", raw_plugin.author)
+                setattr(plugin, "verified", raw_plugin.verified)
                 setattr(plugin, "lastest_version", raw_plugin.lastest_version)
                 setattr(plugin, "summary", raw_plugin.summary)
                 setattr(plugin, "description", raw_plugin.description)
@@ -61,6 +62,7 @@ def add_plugin_to_db(
                 plugin = Plugin(
                     name=raw_plugin.name,
                     author=raw_plugin.author,
+                    verified=raw_plugin.verified,
                     installed_version=raw_plugin.installed_version,
                     lastest_version=raw_plugin.lastest_version,
                     summary=raw_plugin.summary,
@@ -141,6 +143,7 @@ def upgrade_plugin_info_in_db(
                 logger.debug("Plugin found, updating the info.")
                 plugin = existing_plugins[0]
                 setattr(plugin, "installed_version", raw_plugin.lastest_version)
+                setattr(plugin, "verified", raw_plugin.verified)
                 setattr(plugin, "lastest_version", raw_plugin.lastest_version)
                 setattr(plugin, "summary", raw_plugin.summary)
                 setattr(plugin, "description", raw_plugin.description)

--- a/DashAI/back/plugins/utils.py
+++ b/DashAI/back/plugins/utils.py
@@ -19,6 +19,35 @@ _PYPI_SIMPLE_JSON_ACCEPT = "application/vnd.pypi.simple.v1+json"
 _PYPI_SIMPLE_URL = "https://pypi.org/simple/"
 _REQUEST_TIMEOUT_SECONDS = 15
 
+# Author metadata that identifies a plugin as published by the official
+# DashAI account (PyPI user "dashai.nocode"). PyPI does not expose the
+# uploader account through its API, so verification is approximated by
+# matching the package's declared author metadata.
+_VERIFIED_AUTHOR_EMAIL = "dashaisoftware@gmail.com"
+_VERIFIED_AUTHOR_NAME = "dashai team"
+
+
+def _is_verified_author(author: str, author_email: str) -> bool:
+    """Check whether a plugin's author metadata matches the official DashAI
+    account.
+
+    Parameters
+    ----------
+    author : str
+        The author name declared in the package metadata.
+    author_email : str
+        The author email declared in the package metadata. PyPI may format
+        this as a bare address or as "Name <address>".
+
+    Returns
+    -------
+    bool
+        True if the metadata matches the official DashAI author, else False.
+    """
+    email = (author_email or "").lower()
+    name = (author or "").lower()
+    return _VERIFIED_AUTHOR_EMAIL in email or name == _VERIFIED_AUTHOR_NAME
+
 
 def _get_pypi_project_status(plugin_name: str) -> str:
     """
@@ -120,6 +149,10 @@ def get_plugin_by_name_from_pypi(plugin_name: str) -> dict:
     keywords = [keyword for keyword in keywords if keyword in posible_tags]
 
     raw_plugin["tags"] = [{"name": keyword} for keyword in keywords]
+
+    raw_plugin["verified"] = _is_verified_author(
+        raw_plugin.get("author"), raw_plugin.get("author_email")
+    )
 
     if raw_plugin["author"] is None or raw_plugin["author"] == "":
         raw_plugin["author"] = "Unknown author"

--- a/DashAI/front/src/pages/plugins/components/PluginsCard.jsx
+++ b/DashAI/front/src/pages/plugins/components/PluginsCard.jsx
@@ -6,7 +6,10 @@ import usePluginsUpdate from "../hooks/usePluginsUpdate";
 import { PluginStatus } from "../../../types/plugin";
 import CircularProgress from "@mui/material/CircularProgress";
 import { useTranslation } from "react-i18next";
-import { Extension as PluginIcon } from "@mui/icons-material";
+import {
+  Extension as PluginIcon,
+  Verified as VerifiedIcon,
+} from "@mui/icons-material";
 
 const DESCRIPTION_MAX_LINES = 3;
 
@@ -50,6 +53,12 @@ function PluginsCard({
 
   const displayName = plugin.name.replace("dashai-", "");
   const tags = plugin.tags.map((tag) => tag.name);
+
+  const verifiedBadge = plugin.verified ? (
+    <Tooltip title={t("plugins:label.verified")} arrow placement="top">
+      <VerifiedIcon sx={{ fontSize: 16, color: accent, flexShrink: 0 }} />
+    </Tooltip>
+  ) : null;
   const version = plugin.installed_version
     ? `v${plugin.installed_version}`
     : null;
@@ -104,6 +113,8 @@ function PluginsCard({
         >
           {displayName}
         </Typography>
+
+        {verifiedBadge}
 
         {version && (
           <Typography
@@ -272,17 +283,26 @@ function PluginsCard({
       </Box>
 
       {/* Title */}
-      <Typography
-        noWrap
+      <Box
         sx={{
-          ...theme.typography.h5,
-          color: theme.palette.text.primary,
+          display: "flex",
+          alignItems: "center",
+          gap: "6px",
           mb: 6,
           width: "100%",
         }}
       >
-        {displayName}
-      </Typography>
+        <Typography
+          noWrap
+          sx={{
+            ...theme.typography.h5,
+            color: theme.palette.text.primary,
+          }}
+        >
+          {displayName}
+        </Typography>
+        {verifiedBadge}
+      </Box>
 
       {/* Description */}
       <Tooltip
@@ -387,6 +407,7 @@ PluginsCard.propTypes = {
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
     author: PropTypes.string.isRequired,
+    verified: PropTypes.bool,
     tags: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.number.isRequired,

--- a/DashAI/front/src/pages/plugins/components/PluginsDetails.jsx
+++ b/DashAI/front/src/pages/plugins/components/PluginsDetails.jsx
@@ -1,15 +1,18 @@
 import React from "react";
 import CustomLayout from "../../../components/custom/CustomLayout";
 import {
+  Box,
   Button,
   Card,
   Paper,
   CardHeader,
   CardContent,
   Typography,
+  Tooltip,
   Grid,
 } from "@mui/material";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import VerifiedIcon from "@mui/icons-material/Verified";
 import { useParams, useNavigate } from "react-router-dom";
 import PluginsDetailsTab from "./PluginsDetailsTab";
 import PluginTags from "./PluginsTags";
@@ -136,7 +139,27 @@ function PluginsDetails() {
             }}
           >
             <CardHeader
-              title={plugin.name.replace("dashai-", "")}
+              title={
+                <Box
+                  component="span"
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "8px",
+                  }}
+                >
+                  {plugin.name.replace("dashai-", "")}
+                  {plugin.verified && (
+                    <Tooltip
+                      title={t("plugins:label.verified")}
+                      arrow
+                      placement="top"
+                    >
+                      <VerifiedIcon color="primary" sx={{ fontSize: 22 }} />
+                    </Tooltip>
+                  )}
+                </Box>
+              }
               sx={{
                 pb: 0,
                 width: "100%",

--- a/DashAI/front/src/types/plugin.ts
+++ b/DashAI/front/src/types/plugin.ts
@@ -13,6 +13,7 @@ export interface IPlugin {
   id: number;
   name: string;
   author: string;
+  verified: boolean;
   installed_version: string;
   lastest_version: string;
   tags: ITag[];

--- a/DashAI/front/src/utils/i18n/locales/de/plugins.json
+++ b/DashAI/front/src/utils/i18n/locales/de/plugins.json
@@ -22,6 +22,7 @@
     "oldest": "Älteste",
     "plugins": "{{label}} - Plugins",
     "tags": "Schlagwörter",
+    "verified": "Verifiziertes Plugin von dashAI",
     "version": "Version: {{version}}",
     "versionInstalledLatestAvailable": "Installierte Version: <1></1> | Neueste verfügbare Version: <3></3>"
   },

--- a/DashAI/front/src/utils/i18n/locales/en/plugins.json
+++ b/DashAI/front/src/utils/i18n/locales/en/plugins.json
@@ -22,6 +22,7 @@
     "oldest": "Oldest",
     "plugins": "{{label}} - Plugins",
     "tags": "Tags",
+    "verified": "Verified plugin from dashAI",
     "version": "Version: {{version}}",
     "versionInstalledLatestAvailable": "Version installed: <1></1> | Latest version available: <3></3>"
   },

--- a/DashAI/front/src/utils/i18n/locales/es/plugins.json
+++ b/DashAI/front/src/utils/i18n/locales/es/plugins.json
@@ -22,6 +22,7 @@
     "oldest": "Más antiguos",
     "plugins": "Plugins - {{label}}",
     "tags": "Etiquetas",
+    "verified": "Plugin verificado de dashAI",
     "version": "Versión: {{version}}",
     "versionInstalledLatestAvailable": "Versión instalada: <1></1> | Última versión disponible: <3></3>"
   },

--- a/DashAI/front/src/utils/i18n/locales/pt/plugins.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/plugins.json
@@ -22,6 +22,7 @@
     "oldest": "Mais antigos",
     "plugins": "Plugins - {{label}}",
     "tags": "Etiquetas",
+    "verified": "Plugin verificado da dashAI",
     "version": "Versão: {{version}}",
     "versionInstalledLatestAvailable": "Versão instalada: <1></1> | Última versão disponível: <3></3>"
   },

--- a/DashAI/front/src/utils/i18n/locales/zh/plugins.json
+++ b/DashAI/front/src/utils/i18n/locales/zh/plugins.json
@@ -22,6 +22,7 @@
     "oldest": "最旧",
     "plugins": "{{label}} - 插件",
     "tags": "标签",
+    "verified": "来自 dashAI 的已验证插件",
     "version": "版本：{{version}}",
     "versionInstalledLatestAvailable": "已安装版本：<1></1> | 最新可用版本：<3></3>"
   },

--- a/tests/back/plugins/test_plugin_utils.py
+++ b/tests/back/plugins/test_plugin_utils.py
@@ -9,6 +9,7 @@ from DashAI.back.config_object import ConfigObject
 from DashAI.back.dependencies.registry.component_registry import ComponentRegistry
 from DashAI.back.plugins.utils import (
     _get_all_plugins,
+    _is_verified_author,
     execute_pip_command,
     get_plugin_by_name_from_pypi,
     get_plugins_from_pypi,
@@ -73,6 +74,7 @@ def test_get_plugin_by_name_from_pypi():
     print("plugin_data", plugin_data)
     assert plugin_data == {
         "author": "DashAI Team",
+        "verified": True,
         "installed_version": "0.1.0",
         "lastest_version": "0.1.0",
         "tags": [
@@ -108,6 +110,7 @@ def test_get_plugin_by_name_from_pypi_with_other_tags():
 
     assert plugin_data == {
         "author": "DashAI Team",
+        "verified": True,
         "installed_version": "0.1.0",
         "lastest_version": "0.1.0",
         "tags": [
@@ -165,6 +168,7 @@ def test_get_plugins_from_pypi():
     assert plugins == [
         {
             "author": "DashAI Team",
+            "verified": True,
             "installed_version": "0.1.0",
             "lastest_version": "0.1.0",
             "tags": [
@@ -179,6 +183,21 @@ def test_get_plugins_from_pypi():
             "summary": "Tabular Classification Package",
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("author", "author_email", "expected"),
+    [
+        ("DashAI team", "dashaisoftware@gmail.com", True),
+        ("Someone else", "DashAI team <dashaisoftware@gmail.com>", True),
+        ("dashai team", "", True),
+        ("Third party", "other@example.com", False),
+        (None, None, False),
+        ("DashAI", "info@dashai.org", False),
+    ],
+)
+def test_is_verified_author(author, author_email, expected):
+    assert _is_verified_author(author, author_email) is expected
 
 
 def test_execute_pip_install_command():


### PR DESCRIPTION
## Summary
Plugins published by the official dashAI PyPI account (`dashai.nocode`) now show a **Verified** badge in the plugins UI. PyPI exposes no uploader account field through its API, so verification is derived from package author metadata: a plugin is verified when its `author_email` contains `dashaisoftware@gmail.com` **or** its `author` is `DashAI team`. This lets users distinguish official plugins from third party `dashai-*` packages.

<img width="2140" height="1000" alt="image" src="https://github.com/user-attachments/assets/d91fe2af-32db-492b-85cb-dcde892038f1" />

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/dependencies/database/models.py`: add `verified` boolean column to the `Plugin` model (`server_default "0"`).
- `DashAI/alembic/versions/e2a9c4f1b8d3_add_verified_column_to_plugin.py`: migration adding the `verified` column (revises `3db684f4090a`).
- `DashAI/back/plugins/utils.py`: add `_is_verified_author()` helper and compute `verified` from author metadata in `get_plugin_by_name_from_pypi`.
- `DashAI/back/api/api_v1/schemas/plugin_params.py`: add `verified: bool = False` to `PluginParams`.
- `DashAI/back/dependencies/database/utils.py`: persist `verified` on plugin create, update, and upgrade.
- `DashAI/front/src/types/plugin.ts`: add `verified: boolean` to `IPlugin`.
- `DashAI/front/src/pages/plugins/components/PluginsCard.jsx`: render a verified badge (tooltip) in grid and list views.
- `DashAI/front/src/pages/plugins/components/PluginsDetails.jsx`: render a verified badge beside the title.
- `DashAI/front/src/utils/i18n/locales/{en,es,pt,de,zh}/plugins.json`: add `label.verified` string.
- `tests/back/plugins/test_plugin_utils.py`: parametrized test for `_is_verified_author` + updated output assertions.

---

## Testing
- To verify in app: trigger `POST /api/v1/plugins/index` to refresh from PyPI, then confirm official dashAI plugins show the badge.

---

## Notes
- `verified` is recomputed only on the plugins index refresh (`POST /plugins/index`). Existing DB rows default to `false` until refreshed.
- Verification relies on self-declared PyPI metadata (PyPI has no uploader-account API), so it is a best-effort signal, not a cryptographic guarantee. Matching constants live in `DashAI/back/plugins/utils.py` (`_VERIFIED_AUTHOR_EMAIL`, `_VERIFIED_AUTHOR_NAME`).
