### PR TITLE
Add first and last page buttons to LeanDatasetTable

### DIFF
--- a/DashAI/front/src/components/shared/leanDatasetTable/LeanDatasetTable.jsx
+++ b/DashAI/front/src/components/shared/leanDatasetTable/LeanDatasetTable.jsx
@@ -411,6 +411,8 @@ function LeanDatasetTable({
         count={total}
         page={page}
         rowsPerPage={pageSize}
+        showFirstButton
+        showLastButton
         onPageChange={(_e, p) => setPage(p)}
         onRowsPerPageChange={(e) => {
           setPageSize(parseInt(e.target.value, 10));


### PR DESCRIPTION
## Summary

Adds first and last page navigation controls to the `LeanDatasetTable` pagination component.

---

## Type of Change

Check all that apply like this [x]:

* [ ] Backend change
* [x] Frontend change
* [ ] CI / Workflow change
* [ ] Build / Packaging change
* [ ] Bug fix
* [ ] Documentation

---

## Changes (by file)

* `LeanDatasetTable.jsx`: Added `showFirstButton` and `showLastButton` to the pagination component to enable direct navigation to the first and last pages.

---

## Testing (optional)

* Verify that the pagination controls display first (`<<`) and last (`>>`) page buttons.
* Confirm that clicking the first page button navigates directly to page 1.
* Confirm that clicking the last page button navigates directly to the final available page.
* Ensure existing pagination behavior remains unchanged.