### PR TITLE
Fix lazy imports for pyarrow and datasets

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/dataset_source.py
+++ b/DashAI/back/api/api_v1/endpoints/dataset_source.py
@@ -10,8 +10,6 @@ from fastapi.exceptions import HTTPException
 from kink import di
 from pydantic import BaseModel
 
-from DashAI.back.types.inf.type_inference import infer_types
-
 if TYPE_CHECKING:
     from DashAI.back.dependencies.registry import ComponentRegistry
 
@@ -186,6 +184,8 @@ async def preview_dataset_with_params(
     dict
         ``{"sample": [...], "inferred_types": {...}, "preview_row_count": int}``.
     """
+    from DashAI.back.types.inf.type_inference import infer_types
+
     _get_source(source_name, registry)  # validate source exists
     decoded_id = unquote(dataset_id)
     n_rows = max(1, min(body.n_rows, 500))

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -9,7 +9,6 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-import pyarrow as pa
 from fastapi import APIRouter, Depends, File, Form, Query, Response, UploadFile, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import HTTPException
@@ -27,6 +26,7 @@ from DashAI.back.api.api_v1.schemas.datasets_params import (
 from DashAI.back.dependencies.database.models import Dataset, ModelSession
 
 if TYPE_CHECKING:
+    import pyarrow as pa
     from sqlalchemy.orm.session import sessionmaker
 
     from DashAI.back.dependencies.registry import ComponentRegistry
@@ -131,7 +131,7 @@ class _FilteredTableCache:
     """LRU cache for filtered/sorted PyArrow tables with TTL eviction."""
 
     def __init__(self, max_size: int = _CACHE_MAX_SIZE, ttl: int = _CACHE_TTL_SECONDS):
-        self._store: OrderedDict[str, tuple[float, pa.Table, int]] = OrderedDict()
+        self._store: OrderedDict[str, tuple[float, "pa.Table", int]] = OrderedDict()
         self._max_size = max_size
         self._ttl = ttl
 
@@ -164,7 +164,7 @@ class _FilteredTableCache:
         path: str,
         filter_model: str | None,
         sort_model: str | None,
-        table: pa.Table,
+        table: "pa.Table",
         total: int,
     ):
         key = self._make_key(path, filter_model, sort_model)
@@ -185,7 +185,7 @@ def _load_and_filter_table(
     path: str,
     filter_model: str | None,
     sort_model: str | None,
-) -> tuple[pa.Table, int, bool]:
+) -> tuple["pa.Table", int, bool]:
     """Load arrow file, apply filters and sorting.
 
     Returns (table, total, was_filtered).

--- a/DashAI/back/dataloaders/classes/image_dataloader.py
+++ b/DashAI/back/dataloaders/classes/image_dataloader.py
@@ -1,24 +1,24 @@
 """DashAI Image Dataloader."""
 
 import shutil
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 from beartype import beartype
-from datasets import Dataset
 
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
-from DashAI.back.dataloaders.classes.dashai_dataset import (
-    DashAIDataset,
-    to_dashai_dataset,
-)
 from DashAI.back.dataloaders.classes.dataloader import BaseDataLoader
 from DashAI.back.types.categorical import Categorical
-from DashAI.back.types.dashai_image import DashAIImage
 
 
 class ImageDataLoaderSchema(BaseSchema):
     pass
+
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import (
+        DashAIDataset,
+    )
 
 
 IMAGE_EXTENSIONS = {
@@ -149,7 +149,7 @@ class ImageDataLoader(BaseDataLoader):
         temp_path: str,
         params: Dict[str, Any],  # noqa: ARG002
         n_sample: int | None = None,
-    ) -> DashAIDataset:
+    ) -> "DashAIDataset":
         """Load an image dataset.
 
         Parameters
@@ -172,6 +172,13 @@ class ImageDataLoader(BaseDataLoader):
         """
         import logging
         import os
+
+        from datasets import Dataset
+
+        from DashAI.back.dataloaders.classes.dashai_dataset import (
+            to_dashai_dataset,
+        )
+        from DashAI.back.types.dashai_image import DashAIImage
 
         log = logging.getLogger(__name__)
 

--- a/DashAI/back/dataloaders/classes/image_dataloader.py
+++ b/DashAI/back/dataloaders/classes/image_dataloader.py
@@ -3,8 +3,6 @@
 import shutil
 from typing import TYPE_CHECKING, Any, Dict
 
-from beartype import beartype
-
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dataloaders.classes.dataloader import BaseDataLoader
@@ -16,9 +14,7 @@ class ImageDataLoaderSchema(BaseSchema):
 
 
 if TYPE_CHECKING:
-    from DashAI.back.dataloaders.classes.dashai_dataset import (
-        DashAIDataset,
-    )
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
 
 IMAGE_EXTENSIONS = {
@@ -142,7 +138,6 @@ class ImageDataLoader(BaseDataLoader):
         zh="图像数据加载器",
     )
 
-    @beartype
     def load_data(
         self,
         filepath_or_buffer: str,

--- a/DashAI/back/models/hugging_face/metrics_callback.py
+++ b/DashAI/back/models/hugging_face/metrics_callback.py
@@ -1,7 +1,6 @@
 from transformers import TrainerCallback
 
 from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
-from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
 
 
 class MetricsCallback(TrainerCallback):
@@ -51,6 +50,8 @@ class MetricsCallback(TrainerCallback):
         log_val_every_n_steps : int, optional
             Log validation metrics every N optimizer steps. Defaults to 50.
         """
+        from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+
         self.model_instance = model_instance
         self.x_train = to_dashai_dataset(x_train)
         self.y_train = to_dashai_dataset(y_train)

--- a/DashAI/back/types/dashai_image.py
+++ b/DashAI/back/types/dashai_image.py
@@ -6,13 +6,23 @@ import io
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar, Optional
 
-import pyarrow as pa
-
 from DashAI.back.types.dashai_data_type import DashAIDataType
 
 if TYPE_CHECKING:
     import numpy as np
+    import pyarrow as pa
     from PIL import Image as PILImage
+
+
+class _LazyPAType:
+    _value = None
+
+    def __get__(self, _obj, _objtype=None):
+        if _LazyPAType._value is None:
+            import pyarrow as pa
+
+            _LazyPAType._value = pa.struct({"bytes": pa.binary(), "path": pa.string()})
+        return _LazyPAType._value
 
 
 @dataclass
@@ -25,9 +35,7 @@ class DashAIImage(DashAIDataType):
       ``DashAIImage(bytes=b"...", path="cat.jpg")``.
     """
 
-    pa_type: ClassVar[pa.DataType] = pa.struct(
-        {"bytes": pa.binary(), "path": pa.string()}
-    )
+    pa_type: ClassVar["pa.DataType"] = _LazyPAType()
 
     dtype: str = "struct"
     bytes: Optional[bytes] = field(default=None, repr=False)


### PR DESCRIPTION
## Summary
Deferred dependencies (`pyarrow`, `datasets`) to lazy imports so they are only loaded when actually used, not at app startup.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/types/dashai_image.py`: replaced eagerly-evaluated `pa_type` class variable with a lazy descriptor that imports `pyarrow` on first access
- `DashAI/back/api/api_v1/endpoints/dataset_source.py`: moved `infer_types` import inside the function body, breaking the `dataset_source -> type_inference -> dashai_dataset -> datasets` startup import chain
- `DashAI/back/api/api_v1/endpoints/datasets.py`: moved `pyarrow` import inside function/method bodies where it is used
- `DashAI/back/dataloaders/classes/image_dataloader.py`: moved `datasets`, `DashAIDataset`, `to_dashai_dataset`, and `DashAIImage` imports inside the `load` method
- `DashAI/back/models/hugging_face/metrics_callback.py`: moved `to_dashai_dataset` import inside `__init__`