### PR TITLE
Handle sklearn version difference in ROCAUC scoring

### DIFF
--- a/DashAI/back/metrics/classification/roc_auc.py
+++ b/DashAI/back/metrics/classification/roc_auc.py
@@ -110,12 +110,15 @@ class ROCAUC(ClassificationMetric):
 
         if multiclass is None:
             multiclass = n_classes > 2
-        if multiclass:
-            return roc_auc_score(
-                true_labels,
-                probs_pred_labels,
-                multi_class="ovr",
-                labels=list(range(n_classes)),
-            )
-        else:
-            return roc_auc_score(true_labels, probs_pred_labels[:, 1])
+        try:
+            if multiclass:
+                return roc_auc_score(
+                    true_labels,
+                    probs_pred_labels,
+                    multi_class="ovr",
+                    labels=list(range(n_classes)),
+                )
+            else:
+                return roc_auc_score(true_labels, probs_pred_labels[:, 1])
+        except ValueError:
+            return float("nan")


### PR DESCRIPTION
## Summary
   Older sklearn versions raise `ValueError` in `roc_auc_score` when a class is absent from a split during One-vs Rest (OvR) evaluation, while newer versions (e.g. 1.7.2) return `NaN` with a warning instead. This caused training jobs to crash on machines with older sklearn while working fine on machines with newer sklearn. The fix wraps the `roc_auc_score` call in a `try/except ValueError` so both behaviors normalize to `float("nan")`, which `base_model.calculate_metrics` already filters out via `math.isfinite`.

   ---

   ## Type of Change
  - [x] Backend change
  - [ ] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

   ---

   ## Changes (by file)
   - `DashAI/back/metrics/classification/roc_auc.py`: wrap `roc_auc_score` call in `try/except ValueError` to return `float("nan")` instead of propagating the exception when a class is absent from a split in OvR mode.

   ---

   ## Testing (optional)
   Train a classification model with an imbalanced dataset (no stratified split) so at least one class is absent from validation/test. Confirm training completes and ROCAUC is omitted from those splits instead of crashing the job.

   ---

   ## Notes (optional)
   This bug only manifests when: (1) the task is multiclass, (2) the dataset is split without stratification, and (3) at least one class has no samples in the validation or test split. The `calculate_metrics` call happens inside the training loop (per epoch/step), so the crash occurs early during training rather than at the end.