### PR TITLE
Fix missing import for pyarrow in datasets.py

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -1557,6 +1557,8 @@ def _build_image_zip(table: "pa.Table") -> io.BytesIO:
     Uses ZIP_STORED (no compression) because image formats (JPEG, PNG) are
     already compressed — DEFLATE gains nothing but wastes significant CPU time.
     """
+    import pyarrow as pa
+
     label_col = next(
         (
             col
@@ -1646,6 +1648,7 @@ async def _build_export_response(
     StreamingResponse
         ZIP (image datasets) or CSV (tabular datasets).
     """
+    import pyarrow as pa
     import pyarrow.csv as csv
 
     image_cols = [


### PR DESCRIPTION
## Summary

This pull request fixes an issue that occurred when exporting datasets containing images. The error was caused by the `pyarrow` dependency not being available in the required scope during dataset export operations.

---

## Type of Change

Check all that apply like this [x]:

* [x] Backend change
* [ ] Frontend change
* [ ] CI / Workflow change
* [ ] Build / Packaging change
* [x] Bug fix
* [ ] Documentation

---

## Changes (by file)

* `DashAI/back/api/api_v1/endpoints/datasets.py`

  * Moved the `pyarrow` import inside the `_build_image_zip` function to load the dependency only when image exports are performed.
  * Added the `pyarrow` import inside the `_build_export_response` function for consistency and proper dependency scoping.

---

## Testing (optional)

* Verify that exporting a dataset containing images completes successfully without raising import-related errors.