### PR TITLE
Fix tour styles

### DIFF
--- a/DashAI/front/src/components/tour/TourProvider.jsx
+++ b/DashAI/front/src/components/tour/TourProvider.jsx
@@ -16,40 +16,53 @@ import { useTheme } from "@mui/material/styles";
 import { CustomTooltip } from "./CustomTooltip";
 import { useTourRegistry } from "../../contexts/TourRegistryContext";
 
-// hard-light blend: result = 1 - 2*(1-src)*(1-dst) when src > 0.5
-// Inverse: src = 1 - (1-target) / (2*(1-dst))
-// For near-black dst ≈ 0, simplifies to src ≈ (1 + target) / 2
-function hardLightInverse(hexColor) {
+// The overlay (not the spotlight) has mix-blend-mode: hard-light.
+// Everything inside the overlay (including spotlight box-shadow) blends
+// with the PAGE CONTENT behind, so we must pre-invert colors differently
+// depending on whether the page is dark (≈black) or light (≈white).
+//
+// Dark (dst≈0): hard-light(src,0) = 2*src-1 for src>0.5  → inverse: (target+1)/2
+// Light (dst≈1): hard-light(src,1) = 2*src   for src≤0.5 → inverse: target/2
+function hlInverse(hexColor, isDark) {
   const r = parseInt(hexColor.slice(1, 3), 16);
   const g = parseInt(hexColor.slice(3, 5), 16);
   const b = parseInt(hexColor.slice(5, 7), 16);
-  const ri = Math.min(255, Math.round((255 + r) / 2));
-  const gi = Math.min(255, Math.round((255 + g) / 2));
-  const bi = Math.min(255, Math.round((255 + b) / 2));
-  return `rgb(${ri},${gi},${bi})`;
+  if (isDark) {
+    return `rgb(${Math.min(255, Math.round((255 + r) / 2))},${Math.min(255, Math.round((255 + g) / 2))},${Math.min(255, Math.round((255 + b) / 2))})`;
+  }
+  return `rgb(${Math.round(r / 2)},${Math.round(g / 2)},${Math.round(b / 2)})`;
 }
 
 const SpotlightHighlight = ({ isInteractive }) => (
   <GlobalStyles
     styles={(theme) => {
-      const c = hardLightInverse(theme.palette.primary.main);
+      const isDark = theme.palette.mode === "dark";
+      const c = hlInverse(theme.palette.primary.main, isDark);
+      const baseShadow = isDark
+        ? `0 0 0 2px ${c}, 0 0 8px ${c}`
+        : `0 0 0 2px ${c}`;
+      const interactiveShadow = isDark
+        ? `0 0 0 2px ${c}, 0 0 8px ${c}`
+        : `0 0 0 2px ${c}, 0 0 2px ${c}`;
       const base = {
         ".react-joyride__spotlight": {
-          boxShadow: `0 0 0 2px ${c}, 0 0 14px ${c} !important`,
+          boxShadow: `${baseShadow} !important`,
         },
       };
       if (!isInteractive) return base;
       return {
         "@keyframes tourSpotlightGlow": {
-          "0%": { filter: `drop-shadow(0 0 3px ${c})` },
+          "0%": { filter: `drop-shadow(0 0 1px ${c})` },
           "50%": {
-            filter: `drop-shadow(0 0 10px ${c}) drop-shadow(0 0 20px ${c})`,
+            filter: isDark
+              ? `drop-shadow(0 0 5px ${c}) drop-shadow(0 0 8px ${c})`
+              : `drop-shadow(0 0 2px ${c}) drop-shadow(0 0 3px ${c})`,
           },
-          "100%": { filter: `drop-shadow(0 0 3px ${c})` },
+          "100%": { filter: `drop-shadow(0 0 1px ${c})` },
         },
         ".react-joyride__spotlight": {
-          boxShadow: `0 0 0 2px ${c}, 0 0 14px ${c} !important`,
-          animation: "tourSpotlightGlow 1.8s ease-in-out infinite !important",
+          boxShadow: `${interactiveShadow} !important`,
+          animation: "tourSpotlightGlow 2.2s ease-in-out infinite !important",
         },
       };
     }}

--- a/DashAI/front/src/constants/tours/datasetsTour.js
+++ b/DashAI/front/src/constants/tours/datasetsTour.js
@@ -53,26 +53,26 @@ export const datasetsTourSteps = [
               download="personality_dataset.csv"
               style={{
                 display: "inline-block",
-                backgroundColor: "#ef9f27",
-                color: "#0c0c0a",
+                backgroundColor: "#2C7AFF",
+                color: "#FEFEFF",
                 padding: "10px 20px",
                 textDecoration: "none",
                 borderRadius: "4px",
                 fontWeight: "bold",
                 marginTop: "10px",
               }}
-              onMouseOver={(e) => (e.target.style.backgroundColor = "#c47d0e")}
-              onMouseOut={(e) => (e.target.style.backgroundColor = "#ef9f27")}
+              onMouseOver={(e) => (e.target.style.backgroundColor = "#A7C7FF")}
+              onMouseOut={(e) => (e.target.style.backgroundColor = "#2C7AFF")}
             ></a>
           </p>
           <p
             style={{
-              backgroundColor: "#1b2f26",
-              color: "white",
+              backgroundColor: "rgba(76, 175, 80, 0.12)",
+              color: "inherit",
               padding: "8px",
               borderRadius: "4px",
               marginTop: "10px",
-              borderLeft: "3px solid #4caf50",
+              borderLeft: "3px solid #43A047",
             }}
           >
             <strong></strong>
@@ -159,12 +159,12 @@ export const datasetsTourSteps = [
           </ul>
           <p
             style={{
-              backgroundColor: "#1b2f26",
-              color: "white",
+              backgroundColor: "rgba(76, 175, 80, 0.12)",
+              color: "inherit",
               padding: "8px",
               borderRadius: "4px",
               marginTop: "10px",
-              borderLeft: "3px solid #4caf50",
+              borderLeft: "3px solid #43A047",
             }}
           ></p>
         </div>
@@ -196,12 +196,12 @@ export const datasetsTourSteps = [
           </ul>
           <p
             style={{
-              backgroundColor: "#1b2f26",
-              color: "white",
+              backgroundColor: "rgba(76, 175, 80, 0.12)",
+              color: "inherit",
               padding: "8px",
               borderRadius: "4px",
               marginTop: "10px",
-              borderLeft: "3px solid #4caf50",
+              borderLeft: "3px solid #43A047",
             }}
           >
             <strong></strong>

--- a/DashAI/front/src/constants/tours/experimentsTour.js
+++ b/DashAI/front/src/constants/tours/experimentsTour.js
@@ -150,7 +150,8 @@ export const experimentsTourSteps = [
         </p>
         <p
           style={{
-            backgroundColor: "#e3f2fd",
+            backgroundColor: "rgba(44, 122, 255, 0.10)",
+            borderLeft: "3px solid #2C7AFF",
             padding: "8px",
             borderRadius: "4px",
             marginTop: "10px",
@@ -179,7 +180,8 @@ export const experimentsTourSteps = [
         </p>
         <p
           style={{
-            backgroundColor: "#e3f2fd",
+            backgroundColor: "rgba(44, 122, 255, 0.10)",
+            borderLeft: "3px solid #2C7AFF",
             padding: "8px",
             borderRadius: "4px",
             marginTop: "10px",
@@ -433,7 +435,8 @@ export const experimentsTourSteps = [
         </p>
         <p
           style={{
-            backgroundColor: "#fff3e0",
+            backgroundColor: "rgba(251, 192, 45, 0.12)",
+            borderLeft: "3px solid #fbc02d",
             padding: "8px",
             borderRadius: "4px",
             marginTop: "10px",
@@ -519,7 +522,8 @@ export const experimentsTourSteps = [
         </p>
         <p
           style={{
-            backgroundColor: "#fff3e0",
+            backgroundColor: "rgba(251, 192, 45, 0.12)",
+            borderLeft: "3px solid #fbc02d",
             padding: "8px",
             borderRadius: "4px",
             marginTop: "10px",
@@ -633,8 +637,8 @@ export const experimentsTourSteps = [
         </ul>
         <div
           style={{
-            backgroundColor: "#f0f9ff",
-            border: "1px solid #bae6fd",
+            backgroundColor: "rgba(44, 122, 255, 0.08)",
+            border: "1px solid rgba(44, 122, 255, 0.25)",
             borderRadius: "4px",
             padding: "12px",
             marginTop: "15px",

--- a/DashAI/front/src/constants/tours/modelsTour.js
+++ b/DashAI/front/src/constants/tours/modelsTour.js
@@ -118,10 +118,10 @@ export const modelsTourSteps = [
           <h3></h3>
           <p></p>
           <p>
-            <strong style={{ color: "#2e7d32" }}></strong>
+            <strong style={{ color: "#43A047" }}></strong>
           </p>
           <p>
-            <strong style={{ color: "#d32f2f" }}></strong>
+            <strong style={{ color: "#e53935" }}></strong>
           </p>
           <p></p>
         </div>
@@ -221,7 +221,9 @@ export const modelsTourSteps = [
           <p>
             <strong></strong>
           </p>
-          <p style={{ marginTop: "10px", fontSize: "14px", color: "#666" }}></p>
+          <p
+            style={{ marginTop: "10px", fontSize: "14px", color: "inherit" }}
+          ></p>
         </div>
       </Trans>
     ),

--- a/DashAI/front/src/constants/tours/notebookTour.js
+++ b/DashAI/front/src/constants/tours/notebookTour.js
@@ -253,12 +253,12 @@ export const notebookTourSteps = [
           </ul>
           <p
             style={{
-              backgroundColor: "#1b2f26",
-              color: "white",
+              backgroundColor: "rgba(76, 175, 80, 0.12)",
+              color: "inherit",
               padding: "8px",
               borderRadius: "4px",
               marginTop: "10px",
-              borderLeft: "3px solid #4caf50",
+              borderLeft: "3px solid #43A047",
             }}
           >
             <strong></strong>


### PR DESCRIPTION
## Summary

  Fixed several visual inconsistencies in the tour/tutorial system that appeared in light mode and across both themes. The main issues were: hardcoded dark backgrounds in tip boxes that broke in light mode, a spotlight border that was invisible or the wrong color in light mode due to incorrect handling of Joyride's `mix-blend-mode: hard-light` overlay, and an overly intense interactive step pulse animation.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `front/src/components/tour/TourProvider.jsx`: Replaced `hardLightInverse` (computed only for dark backgrounds) with a mode-aware `hlInverse(color, isDark)` that correctly inverts the primary color through Joyride's `mix-blend-mode: hard-light` overlay — `(255+x)/2` for dark pages, `x/2` for light pages. Reduced pulse animation intensity and speed, and added a subtle glow to distinguish interactive steps from non-interactive ones in light mode.

  - `front/src/constants/tours/datasetsTour.js`: Updated download button color from legacy orange (`#ef9f27`) to primary blue (`#2C7AFF`). Replaced hardcoded dark green tip boxes (`#1b2f26`, `color: white`) with semi-transparent green (`rgba(76, 175, 80, 0.12)`, `color: inherit`) so they render correctly in both themes.

  - `front/src/constants/tours/notebookTour.js`: Same tip box fix as `datasetsTour.js`.

  - `front/src/constants/tours/experimentsTour.js`: Replaced light-only hardcoded backgrounds (`#e3f2fd`, `#fff3e0`, `#f0f9ff`) with semi-transparent equivalents. Added left border accents to match the tip box style used in other tours.

  - `front/src/constants/tours/modelsTour.js`: Replaced dark-only text colors (`#2e7d32`, `#d32f2f`) with mid-brightness alternatives (`#43A047`, `#e53935`) readable on both light and dark dialog backgrounds. Changed `color: #666` to `color: inherit`.

  ---

  ## Testing

  - Verify the spotlight border appears in the correct primary blue in both light and dark mode.
  - Check that tip boxes are readable across the datasets, notebook, experiments, and models tours in both themes.
  - Confirm interactive steps have a subtle pulsing glow that distinguishes them from non-interactive steps in both modes.