### PR TITLE
Move pyarrow to runtime import in datasets endpoint

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+import pyarrow as pa
 from fastapi import APIRouter, Depends, File, Form, Query, Response, UploadFile, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import HTTPException
@@ -26,7 +27,6 @@ from DashAI.back.api.api_v1.schemas.datasets_params import (
 from DashAI.back.dependencies.database.models import Dataset, Folder, ModelSession
 
 if TYPE_CHECKING:
-    import pyarrow as pa
     from sqlalchemy.orm.session import sessionmaker
 
     from DashAI.back.dependencies.registry import ComponentRegistry

--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -9,7 +9,6 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-import pyarrow as pa
 from fastapi import APIRouter, Depends, File, Form, Query, Response, UploadFile, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import HTTPException
@@ -27,6 +26,7 @@ from DashAI.back.api.api_v1.schemas.datasets_params import (
 from DashAI.back.dependencies.database.models import Dataset, Folder, ModelSession
 
 if TYPE_CHECKING:
+    import pyarrow as pa
     from sqlalchemy.orm.session import sessionmaker
 
     from DashAI.back.dependencies.registry import ComponentRegistry
@@ -362,6 +362,8 @@ async def filter_dataset_file(
     pagination over the same filter+sort combination avoids re-reading
     and re-filtering the Arrow file.
     """
+    import pyarrow as pa
+
     cached = _filtered_table_cache.get(path, filter_model, sort_model)
     if cached is not None:
         table, total = cached


### PR DESCRIPTION
## Summary
  `pyarrow` was imported inside the `TYPE_CHECKING` block, which is only evaluated by static analysis tools (e.g., mypy), not at runtime. This caused a `NameError` when creating a new notebook, since the `filter_dataset_file` endpoint references `pa` at runtime.

  ---

  ## Type of Change

  - [x] Backend change
  - [ ] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/back/api/api_v1/endpoints/datasets.py`: moved `import pyarrow as pa` out of the `TYPE_CHECKING` block into the top-level runtime imports.

  ---

  ## Testing (optional)

  Create a new notebook — the endpoint should no longer raise `NameError: name 'pa' is not defined`.