### PR TITLE
Add CUDA Docker image, split CPU/CUDA requirements, and rework README installation docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY . .
 COPY --from=frontend /app/DashAI/front/build DashAI/front/build
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir -r requirements-cpu.txt && \
+    pip install --no-cache-dir --no-deps -e .
 ENV DASHAI_HOST=0.0.0.0
 EXPOSE 8000
 CMD ["python", "-m", "DashAI", "--no-browser"]

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,53 @@
+# =====================================================================
+# DashAI CUDA image (CUDA 12.8)
+# Build with: docker build -t dashai:cuda -f Dockerfile.cuda .
+# Run with: docker run --gpus all -p 8000:8000 dashai:cuda
+# =====================================================================
+
+# -------- Stage 1: build frontend static assets --------
+FROM node:22-alpine AS frontend
+WORKDIR /app/DashAI/front
+COPY DashAI/front/ ./
+RUN corepack enable && yarn install --frozen-lockfile && yarn build
+
+# -------- Stage 2: build Python env (CUDA devel for compilers) --------
+FROM nvidia/cuda:12.8.0-devel-ubuntu22.04 AS builder
+WORKDIR /app
+
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
+
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip python3-dev \
+    build-essential cmake git \
+    && rm -rf /var/lib/apt/lists/*
+
+# CUDA stub so the linker resolves libcuda at build time
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so && \
+    ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1
+
+# requirements-cuda.txt = cu128 torch wheels + CUDA-compiled llama-cpp-python
+# (it -r includes requirements.txt, so copy both)
+COPY requirements.txt requirements-cuda.txt ./
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements-cuda.txt
+
+# -------- Stage 3: runtime (CUDA runtime, no build tools) --------
+FROM nvidia/cuda:12.8.0-runtime-ubuntu22.04
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy installed python env only (not build tools)
+COPY --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# application code
+COPY . .
+# built frontend from stage 1
+COPY --from=frontend /app/DashAI/front/build DashAI/front/build
+
+ENV DASHAI_HOST=0.0.0.0
+EXPOSE 8000
+CMD ["python3", "-m", "DashAI", "--no-browser"]

--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,8 @@ automatically.
 pip installation below.
 
 
-Quick installation (Pypi)
-=========================
+Installation (PyPI)
+===================
 
 dashAI needs Python 3.10 or greater. We strongly recommend installing it inside
 an isolated environment (``venv`` or ``conda``) to avoid clashes with other

--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,38 @@ Then open `http://localhost:8000/ <http://localhost:8000/>`_ in your browser to
 access the dashAI graphical interface.
 
 
+Docker
+======
+
+dashAI can also run inside a container. Two Dockerfiles are provided at the
+repository root.
+
+CPU image
+---------
+
+``Dockerfile`` builds a CPU only image (CPU PyTorch). Build and run it with:
+
+.. code:: bash
+
+    $ docker build -t dashai .
+    $ docker run -p 8000:8000 dashai
+
+NVIDIA GPU image (CUDA)
+-----------------------
+
+``Dockerfile.cuda`` builds a CUDA enabled image (CUDA 12.8 PyTorch and
+``llama-cpp-python`` compiled with CUDA offload). It needs the NVIDIA drivers
+and the `NVIDIA Container Toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>`_
+installed on the host. Build and run it with:
+
+.. code:: bash
+
+    $ docker build -t dashai:cuda -f Dockerfile.cuda .
+    $ docker run --gpus all -p 8000:8000 dashai:cuda
+
+Then open `http://localhost:8000/ <http://localhost:8000/>`_ in your browser.
+
+
 Test datasets
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -195,9 +195,7 @@ NVIDIA GPU image (CUDA)
 -----------------------
 
 ``Dockerfile.cuda`` builds a CUDA enabled image (CUDA 12.8 PyTorch and
-``llama-cpp-python`` compiled with CUDA offload). It needs the NVIDIA drivers
-and the `NVIDIA Container Toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>`_
-installed on the host. Build and run it with:
+``llama-cpp-python`` compiled with CUDA offload). Build and run it with:
 
 .. code:: bash
 
@@ -205,6 +203,21 @@ installed on the host. Build and run it with:
     $ docker run --gpus all -p 8000:8000 dashai:cuda
 
 Then open `http://localhost:8000/ <http://localhost:8000/>`_ in your browser.
+
+To pass the host GPU into the container with ``--gpus all`` you need the NVIDIA
+drivers plus the runtime that wires the GPU into Docker. How you get that
+runtime depends on your setup:
+
+* **Native Linux Docker:** install the
+  `NVIDIA Container Toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>`_
+  on the host.
+* **Docker Desktop (Windows / macOS):** the GPU runtime is bundled with the
+  WSL 2 backend, so you only install the NVIDIA driver on Windows and enable the
+  WSL 2 backend. See the
+  `Docker Desktop GPU docs <https://docs.docker.com/desktop/features/gpu/>`_.
+* **Docker Engine inside a WSL 2 distro (without Docker Desktop):** install the
+  NVIDIA Container Toolkit inside the WSL distro, following the
+  `CUDA on WSL guide <https://docs.nvidia.com/cuda/wsl-user-guide/index.html>`_.
 
 
 Test datasets

--- a/README.rst
+++ b/README.rst
@@ -16,23 +16,163 @@ AI models
 .. image:: ./images/dashai-logo.svg
    :alt: dashAI Logo
 
+Desktop installers (Windows / macOS)
+=====================================
+
+The easiest way to get started. Desktop installers, ready to use, are
+published with every release. They are **CPU only** and bundle everything you
+need, so no Python or extra setup is required.
+
+Download the file for your system from the
+`latest release <https://github.com/DashAISoftware/DashAI/releases/latest>`_:
+
+* **Windows (x64):** ``dashAI-<version>-x64-windows.exe``
+* **macOS (Apple Silicon):** ``dashAI-<version>-arm-osx.dmg``
+* **macOS (Intel):** ``dashAI-<version>-x64-osx.dmg``
+
+Run the installer, launch dashAI, and the graphical interface opens
+automatically.
+
+**Note:** the desktop installers ship with CPU only PyTorch and
+``llama-cpp-python``. For NVIDIA (CUDA) or AMD (ROCm) GPU acceleration, use the
+pip installation below.
+
+
 Quick installation (Pypi)
 =========================
 
+dashAI needs Python 3.10 or greater. We strongly recommend installing it inside
+an isolated environment (``venv`` or ``conda``) to avoid clashes with other
+packages.
 
-dashAI needs Python 3.10 or greater to be installed. Once that requirement is satisfied, you can install dashAI via pip:
+Installing dashAI also installs PyTorch with the default build for your
+platform, which works out of the box on CPU. To enable GPU acceleration (NVIDIA
+CUDA or AMD ROCm), or to force a CPU only build, reinstall PyTorch from the
+matching index as shown in step 3. ``llama-cpp-python`` is required to run LLM
+models (GGUF / Llama, Mistral, Qwen, and similar) inside the app, but it is
+never installed automatically, so install it in step 3 if you need those models.
+
+
+1. Create an environment
+-------------------------
+
+**Linux / macOS (venv)**
+
+.. code:: bash
+
+    $ python3 -m venv .venv
+    $ source .venv/bin/activate
+
+**Windows (venv, PowerShell)**
+
+.. code:: powershell
+
+    > python -m venv .venv
+    > .venv\Scripts\Activate.ps1
+
+**Any OS (conda)**
+
+.. code:: bash
+
+    $ conda create -n dashai python=3.12
+    $ conda activate dashai
+
+
+2. Install dashAI
+-----------------
+
+With the environment active:
 
 .. code:: bash
 
     $ pip install dashai
 
-Then, to initialize the server and the graphical interface, run:
+
+3. Select a PyTorch build and (optional) llama-cpp
+--------------------------------------------------
+
+This step is optional on CPU (step 2 already installed a working PyTorch).
+Run the section below that matches your hardware to pick a specific build.
+
+CPU only (Linux / macOS / Windows)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On Linux the default PyTorch ships the large CUDA build; reinstall from the CPU
+index if you want a smaller CPU only install:
+
+.. code:: bash
+
+    $ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
+    # Optional, for GGUF / Llama models (precompiled CPU wheel, no build tools):
+    $ pip install llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
+
+NVIDIA GPU (CUDA 12.8)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+    # Torch CUDA 12.8 (prebuilt wheels)
+    $ pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
+
+    # Llama compiled with CUDA offload (requires build tools, see below)
+    $ pip install llama-cpp-python -C cmake.args="-DGGML_CUDA=on"
+
+AMD GPU (ROCm 6.4)
+~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+    # Torch ROCm (prebuilt wheels)
+    $ pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm6.4
+
+    # Llama compiled with HIP/ROCm offload (requires build tools, see below)
+    $ pip install llama-cpp-python -C cmake.args="-DGGML_HIP=on"
+
+
+Build tools for GPU llama-cpp
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``-C cmake.args=...`` commands above compile ``llama-cpp-python`` from
+source. They require:
+
+* `CMake <https://cmake.org/>`_ (required to drive the build)
+* A C compiler:
+
+  * **Linux:** ``gcc`` or ``clang``
+  * **Windows:** Visual Studio (C++ build tools / MSVC) or MinGW
+  * **macOS:** Xcode
+
+* **NVIDIA (CUDA):** NVIDIA drivers and the NVIDIA CUDA Toolkit. Use version
+  ``>=12.8`` for RTX 5000 series GPUs to work.
+* **AMD (ROCm):** the ROCm / HIP SDK and AMD drivers.
+
+If you want to skip compilation, precompiled ``llama-cpp-python`` wheels are
+available for CPU and CUDA:
+
+.. code:: bash
+
+    $ pip install llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
+    $ pip install llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/<cuda-version>
+
+Replace ``<cuda-version>`` with your CUDA tag. Prebuilt wheels are published for
+``cu118``, ``cu121``, ``cu122``, ``cu123``, ``cu124``, ``cu125``, ``cu130`` and
+``cu132`` (for example ``cu124``). See the
+`llama-cpp-python installation docs <https://llama-cpp-python.readthedocs.io/en/latest/>`_
+for the available wheels and other backend options.
+
+
+4. Run dashAI
+-------------
+
+Start the server and graphical interface with:
 
 .. code:: bash
 
     $ dashai
 
-Finally, go to `http://localhost:3000/ <http://localhost:3000/>`_ in your browser to access to the dashAI graphical interface.
+Then open `http://localhost:8000/ <http://localhost:8000/>`_ in your browser to
+access the dashAI graphical interface.
 
 
 Test datasets
@@ -112,7 +252,7 @@ First, set the python enviroment, for that you can use
 
 .. code: bash
 
-    $ conda create -n dashai python=3.10
+    $ conda create -n dashai python=3.12
     $ conda activate dashai
 
 Later, install the requirements:

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,68 +1,16 @@
 # ===================================================================
-# DashAI CPU-only environment (PyTorch ≥2.9, torchvision ≥0.24)
+# DashAI CPU-only extras (PyTorch CPU wheels + CPU llama-cpp)
 # ===================================================================
-# No requiere CUDA SDK, cuDNN ni drivers NVIDIA.
-# Compatible con PyInstaller para distribución en Windows sin GPU.
+# Common deps live in requirements.txt; this file only adds the
+# packages that need a special index/build for CPU-only hosts.
+# Install: pip install -r requirements-cpu.txt
 # ===================================================================
 
-# Core web & infra
-fastapi[all]
-SQLAlchemy
-streaming_form_data
-alembic
-kink
+-r requirements.txt
 
-# NumPy & Pandas stack
-numpy
-pandas<3.0.0
-joblib
-
-# Config & validation
-pydantic
-pydantic-settings
-starlette
-
-# ML / AI
-scikit-learn
-datasets
-diffusers
-evaluate
-accelerate
-Pillow
-beartype
-plotly
-shap
-typer
-rich
-torchmetrics
-
-# PyTorch CPU wheels
+# PyTorch CPU wheels (no CUDA SDK / drivers needed)
 torch --index-url https://download.pytorch.org/whl/cpu
 torchvision --index-url https://download.pytorch.org/whl/cpu
 
-# Transformers ecosystem
-transformers
-controlnet_aux
-sacrebleu
-sentencepiece
-
-# Optimization / hyperparam tuning
-optuna
-hyperopt
-
-# Excel / IO / Utils
-openpyxl
-httpx
-wordcloud
-opencv-python
-protobuf
-imblearn
-numba
-llvmlite
-greenery==3.2
-filetype
-huey
-
-# Optional: llama-cpp CPU-only (sin dependencias CUDA)
-# Comentar si no se usa Llama.
+# Llama CPU-only (no CUDA)
 llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,0 +1,17 @@
+# ===================================================================
+# DashAI CUDA extras (CUDA 12.8 PyTorch wheels + CUDA llama-cpp)
+# ===================================================================
+# Common deps live in requirements.txt; this file only adds the
+# packages that need a special index/build for NVIDIA GPU hosts.
+# Requiere drivers NVIDIA + NVIDIA Container Toolkit (Dockerfile.cuda).
+# Install: pip install -r requirements-cuda.txt
+# ===================================================================
+
+-r requirements.txt
+
+# PyTorch CUDA 12.8 wheels (prebuilt)
+torch --index-url https://download.pytorch.org/whl/cu128
+torchvision --index-url https://download.pytorch.org/whl/cu128
+
+# Llama compiled with CUDA offload (needs cmake + CUDA devel headers)
+llama-cpp-python -C cmake.args="-DGGML_CUDA=on"


### PR DESCRIPTION
## Summary
Adds CUDA (NVIDIA GPU) support for running DashAI in Docker and reworks the dependency layout so the heavy, hardware specific packages (PyTorch, llama-cpp-python) are split out from the common requirements. Also rewrites the README installation docs to cover each platform and hardware target (CPU, CUDA, ROCm), the desktop installers, and Docker usage.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [ ] Bug fix
- [x] Documentation

---

## Changes (by file)
- `Dockerfile.cuda`: new multi-stage CUDA 12.8 image (frontend build + CUDA `devel` builder + CUDA `runtime`); installs `requirements-cuda.txt` (cu128 torch wheels and llama-cpp-python compiled with CUDA offload). Run with `--gpus all`.
- `Dockerfile`: CPU image now installs `requirements-cpu.txt` (CPU torch index) then `--no-deps -e .`, so the base image stays CPU-only instead of pulling the large default CUDA torch build on Linux.
- `requirements-cuda.txt`: new. `-r requirements.txt` + cu128 torch/torchvision + CUDA-compiled llama-cpp-python.
- `requirements-cpu.txt`: trimmed to `-r requirements.txt` + CPU torch/torchvision + precompiled CPU llama-cpp-python wheel (no longer duplicates the common deps).
- `README.rst`: new install flow (environment -> install -> per-hardware PyTorch build -> run), desktop installers section, Docker (CPU + CUDA) section, and a breakdown of the GPU runtime requirement per Docker setup (native Linux vs Docker Desktop vs Docker-in-WSL2).

---

## Testing (optional)
- Built and ran `Dockerfile.cuda` with `docker run --gpus all`; confirmed GPU offload via llama-cpp logs

---

## Notes (optional)
- `requirements.txt` is unchanged (torch/torchvision remain declared there), so `pip install dashai` still works; the `-cpu`/`-cuda` files only pin a specific wheel index/build.
- AMD ROCm is documented for pip installs only; there is no ROCm Dockerfile in this PR.
