### PR TITLE
Add a Linux AppImage to the release builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -230,7 +230,61 @@ jobs:
           retention-days: 1
 
   # ============================================================
-  # 6. Publish installers to GitHub Release
+  # 6. Build Linux AppImage
+  # ============================================================
+  build-linux-appimage:
+    needs: react-build
+    # ubuntu-22.04 sets the minimum glibc (2.35) for the AppImage.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download React build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: react-build
+          path: DashAI/front/build
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build python-appimage
+          sudo apt-get update
+          sudo apt-get install -y libfuse2 imagemagick
+      - name: Build wheel (frontend bundled)
+        run: python -m build --wheel
+      - name: Verify frontend is included in wheel
+        run: |
+          if ! unzip -l dist/*.whl | grep -q 'DashAI/front/build'; then
+            echo "Frontend files not found in the wheel package!"
+            exit 1
+          fi
+      - name: Prepare AppImage recipe
+        run: |
+          # Icon referenced by dashai.desktop (Icon=dashai); take the first frame of the .ico
+          convert installer/dashAI.ico[0] appimage/dashai.png
+          # Append the freshly built wheel (with bundled frontend) to the recipe requirements
+          WHEEL=$(ls "$PWD"/dist/*.whl | head -n1)
+          echo "$WHEEL" >> appimage/requirements.txt
+      - name: Build AppImage
+        # CPU torch as the primary index; PyPI + the precompiled CPU llama-cpp
+        # wheel index as extras. python-appimage's pip honors these env vars.
+        env:
+          PIP_INDEX_URL: https://download.pytorch.org/whl/cpu
+          PIP_EXTRA_INDEX_URL: "https://pypi.org/simple https://abetlen.github.io/llama-cpp-python/whl/cpu"
+        run: |
+          python-appimage build app -p 3.12 appimage/
+          mv ./*.AppImage dashAI-x86_64.AppImage
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashAI-appimage
+          path: dashAI-x86_64.AppImage
+          retention-days: 1
+
+  # ============================================================
+  # 7. Publish installers to GitHub Release
   # ============================================================
   github-release:
     needs:
@@ -238,6 +292,7 @@ jobs:
       - build-windows-executable
       - build-macos-arm64
       - build-macos-x86_64
+      - build-linux-appimage
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -269,6 +324,12 @@ jobs:
           name: dashAI-dmg-x86_64
           path: artifacts/macos-x86_64
 
+      - name: Download Linux AppImage
+        uses: actions/download-artifact@v4
+        with:
+          name: dashAI-appimage
+          path: artifacts/linux
+
       - name: Stage release files with OS/arch tags
         run: |
           V="${{ steps.version.outputs.version }}"
@@ -276,6 +337,7 @@ jobs:
           cp "artifacts/windows/dashAI-Installer.exe"         "release/dashAI-${V}-x64-windows.exe"
           cp "artifacts/macos-arm64/dashAI-macos-arm64.dmg"   "release/dashAI-${V}-arm-osx.dmg"
           cp "artifacts/macos-x86_64/dashAI-macos-x86_64.dmg" "release/dashAI-${V}-x64-osx.dmg"
+          cp "artifacts/linux/dashAI-x86_64.AppImage"         "release/dashAI-${V}-x64-linux.AppImage"
 
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2
@@ -288,3 +350,4 @@ jobs:
             release/dashAI-${{ steps.version.outputs.version }}-x64-windows.exe
             release/dashAI-${{ steps.version.outputs.version }}-arm-osx.dmg
             release/dashAI-${{ steps.version.outputs.version }}-x64-osx.dmg
+            release/dashAI-${{ steps.version.outputs.version }}-x64-linux.AppImage

--- a/DashAI/__main__.py
+++ b/DashAI/__main__.py
@@ -277,8 +277,13 @@ def main(
 
     logger.info("Starting Huey consumer.")
 
-    if getattr(sys, "frozen", False):
-        logger.info("Running inside PyInstaller bundle.")
+    # In a PyInstaller bundle or an AppImage, sys.executable is the bundled
+    # launcher (not a bare Python), so spawning the Huey consumer as
+    # "sys.executable -m huey..." re-enters the app instead of running Python.
+    # Run it in a thread in those cases.
+    in_appimage = bool(os.environ.get("APPIMAGE") or os.environ.get("APPDIR"))
+    if getattr(sys, "frozen", False) or in_appimage:
+        logger.info("Running inside a bundled launcher (PyInstaller/AppImage).")
         _start_huey_thread()
         logger.info("Started embedded Huey consumer (thread).")
     else:

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,12 @@ requires glibc 2.35 or newer (Ubuntu 22.04+, Debian 12+, Fedora 36+, and most
 distributions from 2022 on) and FUSE 2 to mount. If FUSE is missing, run it
 with ``./dashAI-<version>-x64-linux.AppImage --appimage-extract-and-run``.
 
+When double clicked, the AppImage opens a terminal window to show the server
+logs. This needs a terminal emulator, which every standard desktop (GNOME, KDE,
+XFCE, and others) already provides, so no setup is required. On a minimal system
+with no terminal emulator the log window is skipped, but the app still starts
+and opens the browser as usual.
+
 **Note:** the desktop installers ship with CPU only PyTorch and
 ``llama-cpp-python``. For NVIDIA (CUDA) or AMD (ROCm) GPU acceleration, use the
 pip installation below.

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ AI models
 .. image:: ./images/dashai-logo.svg
    :alt: dashAI Logo
 
-Desktop installers (Windows / macOS)
-=====================================
+Desktop installers (Windows / macOS / Linux)
+=============================================
 
 The easiest way to get started. Desktop installers, ready to use, are
 published with every release. They are **CPU only** and bundle everything you
@@ -29,9 +29,22 @@ Download the file for your system from the
 * **Windows (x64):** ``dashAI-<version>-x64-windows.exe``
 * **macOS (Apple Silicon):** ``dashAI-<version>-arm-osx.dmg``
 * **macOS (Intel):** ``dashAI-<version>-x64-osx.dmg``
+* **Linux (x64):** ``dashAI-<version>-x64-linux.AppImage``
 
-Run the installer, launch dashAI, and the graphical interface opens
-automatically.
+On Windows and macOS, run the installer, launch dashAI, and the graphical
+interface opens automatically.
+
+On Linux, make the AppImage executable and run it:
+
+.. code:: bash
+
+    $ chmod +x dashAI-<version>-x64-linux.AppImage
+    $ ./dashAI-<version>-x64-linux.AppImage
+
+The AppImage bundles its own Python, so nothing needs to be installed. It
+requires glibc 2.35 or newer (Ubuntu 22.04+, Debian 12+, Fedora 36+, and most
+distributions from 2022 on) and FUSE 2 to mount. If FUSE is missing, run it
+with ``./dashAI-<version>-x64-linux.AppImage --appimage-extract-and-run``.
 
 **Note:** the desktop installers ship with CPU only PyTorch and
 ``llama-cpp-python``. For NVIDIA (CUDA) or AMD (ROCm) GPU acceleration, use the

--- a/appimage/.gitattributes
+++ b/appimage/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.sh text eol=lf
+*.desktop text eol=lf
+requirements.txt text eol=lf

--- a/appimage/dashai.appdata.xml
+++ b/appimage/dashai.appdata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.dashai.app</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <name>dashAI</name>
+  <summary>Graphical toolbox for training, evaluating and deploying AI models</summary>
+  <description>
+    <p>
+      DashAI is a graphical toolbox for training, evaluating and deploying
+      state-of-the-art AI models.
+    </p>
+  </description>
+  <launchable type="desktop-id">dashai.desktop</launchable>
+  <url type="homepage">https://dash-ai.com/</url>
+</component>

--- a/appimage/dashai.desktop
+++ b/appimage/dashai.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=dashAI
+GenericName=AI Toolbox
+Comment=Graphical toolbox for training, evaluating and deploying AI models
+Exec=dashai
+Icon=dashai
+Categories=Science;Education;Development;
+Terminal=true

--- a/appimage/entrypoint.sh
+++ b/appimage/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run the dashAI app via the installed package. Starts the FastAPI server,
+# the Huey consumer, and opens the browser at http://localhost:8000/.
+{{ python-executable }} -m DashAI "$@"

--- a/appimage/entrypoint.sh
+++ b/appimage/entrypoint.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
 # Run the dashai console script installed by pip into the embedded Python.
 # Starts the FastAPI server, the Huey consumer, and opens the browser.
-{{ python-executable }} "${APPDIR}/opt/python{{ python-version }}/bin/dashai" "$@"
+
+# When launched from a file manager (double-click) there is no terminal, so
+# the server logs would be invisible. Relaunch inside a terminal emulator in
+# that case. If none is available, fall through and run headless (the browser
+# still opens). DASHAI_IN_TERMINAL guards against an infinite relaunch loop.
+if [ ! -t 1 ] && [ -z "${DASHAI_IN_TERMINAL}" ]; then
+    export DASHAI_IN_TERMINAL=1
+    if command -v x-terminal-emulator >/dev/null 2>&1; then
+        exec x-terminal-emulator -e "$0" "$@"
+    elif command -v gnome-terminal >/dev/null 2>&1; then
+        exec gnome-terminal -- "$0" "$@"
+    elif command -v konsole >/dev/null 2>&1; then
+        exec konsole -e "$0" "$@"
+    elif command -v xfce4-terminal >/dev/null 2>&1; then
+        exec xfce4-terminal -e "$0" "$@"
+    elif command -v xterm >/dev/null 2>&1; then
+        exec xterm -e "$0" "$@"
+    fi
+fi
+
+exec "{{ python-executable }}" "${APPDIR}/opt/python{{ python-version }}/bin/dashai" "$@"

--- a/appimage/entrypoint.sh
+++ b/appimage/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Run the dashAI app via the installed package. Starts the FastAPI server,
-# the Huey consumer, and opens the browser at http://localhost:8000/.
-{{ python-executable }} -m DashAI "$@"
+# Run the dashai console script installed by pip into the embedded Python.
+# Starts the FastAPI server, the Huey consumer, and opens the browser.
+{{ python-executable }} "${APPDIR}/opt/python{{ python-version }}/bin/dashai" "$@"

--- a/appimage/requirements.txt
+++ b/appimage/requirements.txt
@@ -1,0 +1,3 @@
+torch
+torchvision
+llama-cpp-python


### PR DESCRIPTION
## Summary
Adds a Linux AppImage build to the release workflow so every release ships a self contained, CPU only Linux executable alongside the existing Windows/macOS installers. The AppImage is built with `python-appimage` (embeds a manylinux CPython + the app and its deps), so end users need no Python installed. Includes small launcher fixes required to make the app run correctly inside an AppImage.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [x] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `.github/workflows/publish.yml`: new `build-linux-appimage` job (runs on `ubuntu-22.04` for glibc 2.35). Builds the wheel (frontend bundled), generates the icon, builds the AppImage via `python-appimage`, and uploads it. The `github-release` job now depends on it and publishes `dashAI-<version>-x64-linux.AppImage`. CPU torch/llama-cpp wheels are selected via `PIP_INDEX_URL`/`PIP_EXTRA_INDEX_URL`.
- `appimage/requirements.txt`: recipe deps (bare names only — `torch`, `torchvision`, `llama-cpp-python`); the locally built wheel path is appended at build time.
- `appimage/entrypoint.sh`: runs the `dashai` console script via the embedded Python; relaunches inside a terminal emulator when double-clicked (headless fallback if none).
- `appimage/dashai.desktop`, `appimage/dashai.appdata.xml`: desktop + AppStream metadata required by the recipe.
- `appimage/.gitattributes`: forces LF endings on the shell/desktop files.
- `DashAI/__main__.py`: run the Huey consumer in a thread when running inside an AppImage (detected via `APPDIR`/`APPIMAGE`), matching the existing PyInstaller `sys.frozen` path.

---

## Testing (optional)
- Built and ran the AppImage on a Debian VM with no system Python: server starts, Huey queue processes jobs, browser opens at `localhost:8000`, and CPU llama-cpp LLM inference works.

---

## Notes (optional)
- AppImage is CPU only, consistent with the Windows/macOS installers. GPU stays on the CUDA Docker image.
- Host requirements: glibc >= 2.35 and FUSE2 (or run with `--appimage-extract-and-run`). No Python needed.
- The double click terminal popup needs a terminal emulator installed; otherwise it runs headless and still opens the browser.
