### PR TITLE
Use GPU for translation model inference and compute BLEU/TER locally with torchmetrics

### DIFF
--- a/DashAI/back/metrics/translation/bleu.py
+++ b/DashAI/back/metrics/translation/bleu.py
@@ -3,8 +3,7 @@
 from typing import TYPE_CHECKING
 
 from DashAI.back.core.utils import MultilingualString
-from DashAI.back.metrics.base_metric import prepare_to_metric
-from DashAI.back.metrics.translation_metric import TranslationMetric
+from DashAI.back.metrics.translation_metric import TranslationMetric, prepare_to_metric
 
 if TYPE_CHECKING:
     import numpy as np
@@ -21,6 +20,7 @@ class Bleu(TranslationMetric):
     References
     ----------
     - [1] https://en.wikipedia.org/wiki/BLEU
+    - [2] https://lightning.ai/docs/torchmetrics/stable/text/bleu_score.html
     """
 
     MAXIMIZE: bool = True
@@ -67,12 +67,17 @@ class Bleu(TranslationMetric):
         float
             The calculated BLEU score ranging between 0 and 1.
         """
-        import evaluate
+        from torchmetrics.text.bleu import BLEUScore
 
-        metric = evaluate.load("bleu")
+        bleu_metric = BLEUScore()
         source_sentences, target_sentences = prepare_to_metric(
-            source_sentences, target_sentences, "Bleu"
+            source_sentences, target_sentences
         )
-        return metric.compute(
-            references=source_sentences, predictions=target_sentences
-        )["bleu"]
+        return (
+            bleu_metric(
+                target_sentences,
+                [[reference] for reference in source_sentences],
+            )
+            .numpy()
+            .item()
+        )

--- a/DashAI/back/metrics/translation/ter.py
+++ b/DashAI/back/metrics/translation/ter.py
@@ -3,8 +3,7 @@
 from typing import TYPE_CHECKING
 
 from DashAI.back.core.utils import MultilingualString
-from DashAI.back.metrics.base_metric import prepare_to_metric
-from DashAI.back.metrics.translation_metric import TranslationMetric
+from DashAI.back.metrics.translation_metric import TranslationMetric, prepare_to_metric
 
 if TYPE_CHECKING:
     import numpy as np
@@ -20,7 +19,7 @@ class Ter(TranslationMetric):
 
     References
     ----------
-    - [1] https://huggingface.co/spaces/evaluate-metric/ter
+    - [1] https://lightning.ai/docs/torchmetrics/stable/text/translation_edit_rate.html
     """
 
     MAXIMIZE: bool = False
@@ -66,12 +65,17 @@ class Ter(TranslationMetric):
         float
             The calculated score.
         """
-        import evaluate
+        from torchmetrics.text.ter import TranslationEditRate
 
-        metric = evaluate.load("ter")
+        ter_metric = TranslationEditRate()
         source_sentences, target_sentences = prepare_to_metric(
-            source_sentences, target_sentences, "Ter"
+            source_sentences, target_sentences
         )
-        return metric.compute(
-            references=source_sentences, predictions=target_sentences
-        )["score"]
+        return (
+            ter_metric(
+                target_sentences,
+                source_sentences,
+            )
+            .numpy()
+            .item()
+        )

--- a/DashAI/back/metrics/translation_metric.py
+++ b/DashAI/back/metrics/translation_metric.py
@@ -53,4 +53,11 @@ def prepare_to_metric(
     true = np.array(y[column_name])
     pred = y_pred
 
+    if len(true) != len(pred):
+        raise ValueError(
+            "The length of the true labels and the predicted labels must be equal, "
+            f"given: len(true_labels) = {len(true)} and "
+            f"len(pred_labels) = {len(pred)}."
+        )
+
     return true, pred

--- a/DashAI/back/models/hugging_face/base_opus_mt_transformer.py
+++ b/DashAI/back/models/hugging_face/base_opus_mt_transformer.py
@@ -193,6 +193,12 @@ class OpusMtTransformerMixin(TranslationModel):
                 "Call 'train' with appropriate arguments before using this estimator."
             )
 
+        if self.device.lower() == "gpu":
+            self.model.to("cuda")
+        else:
+            self.model.to("cpu")
+        self.model.eval()
+
         dataset = self.tokenize_data(x_pred)
         dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
 

--- a/DashAI/back/models/hugging_face/m2m100_transformer.py
+++ b/DashAI/back/models/hugging_face/m2m100_transformer.py
@@ -304,6 +304,12 @@ class M2M100Transformer(TranslationModel):
                 "Call 'train' before using this estimator."
             )
 
+        if self.device.lower() == "gpu":
+            self.model.to("cuda")
+        else:
+            self.model.to("cpu")
+        self.model.eval()
+
         dataset = self.tokenize_data(x_pred)
         dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
 

--- a/DashAI/back/models/hugging_face/nllb_transformer.py
+++ b/DashAI/back/models/hugging_face/nllb_transformer.py
@@ -448,6 +448,20 @@ class NllbTransformer(TranslationModel):
                 " with appropriate arguments before using this estimator."
             )
 
+        import torch
+
+        if self.device.lower() == "gpu" and torch.cuda.is_available():
+            self.model.to("cuda")
+        else:
+            self.model.to("cpu")
+        self.model.eval()
+
+        if self.device.lower() == "gpu":
+            self.model.to("cuda")
+        else:
+            self.model.to("cpu")
+        self.model.eval()
+
         dataset = self.tokenize_data(x_pred)
         dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
 

--- a/DashAI/back/models/hugging_face/t5_small_transformer.py
+++ b/DashAI/back/models/hugging_face/t5_small_transformer.py
@@ -275,6 +275,12 @@ class T5SmallTransformer(TranslationModel):
                 "Call 'train' before using this estimator."
             )
 
+        if self.device.lower() == "gpu":
+            self.model.to("cuda")
+        else:
+            self.model.to("cpu")
+        self.model.eval()
+
         dataset = self.tokenize_data(x_pred)
         dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
 


### PR DESCRIPTION
## Summary
Fixes translation models not using the GPU during inference, and replaces the deprecated `evaluate` library with `torchmetrics` for the BLEU and TER translation metrics (CHRF already used torchmetrics). `evaluate.load(...)` fetches the metric script from a remote endpoint (Hugging Face Hub) on every call; switching to `torchmetrics` computes the scores fully locally, with no network dependency.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/models/hugging_face/base_opus_mt_transformer.py`: `predict()` now moves the model to CUDA when `device == "gpu"` (else CPU) and sets `eval()` mode before inference. Previously the model stayed on CPU after init/load, so inputs were copied to a CPU device and inference never used the GPU even when selected.
- `DashAI/back/models/hugging_face/m2m100_transformer.py`: same GPU placement fix in `predict()`.
- `DashAI/back/models/hugging_face/nllb_transformer.py`: same GPU placement fix in `predict()`.
- `DashAI/back/models/hugging_face/t5_small_transformer.py`: same GPU placement fix in `predict()`.
- `DashAI/back/metrics/translation/bleu.py`: replaced `evaluate.load("bleu")` with `torchmetrics.text.bleu.BLEUScore`; references wrapped as list of lists. Import of `prepare_to_metric` switched to `translation_metric`.
- `DashAI/back/metrics/translation/ter.py`: replaced `evaluate.load("ter")` with `torchmetrics.text.ter.TranslationEditRate`. Import of `prepare_to_metric` switched to `translation_metric`.

---

## Testing

1. Train a translation model (e.g. `OpusMtEnEsTransformer`) with **GPU** selected as the device.
2. With the model on GPU, confirm prediction runs on CUDA (e.g. `nvidia-smi` shows utilization / `next(model.model.parameters()).device` is `cuda`) and is faster than CPU.
3. Verify the run's results table shows **BLEU**, **TER**, and **CHRF** values, all in the 0–1 range.