### PR TITLE
fix: enhance StatBox to handle text overflow with tooltip

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/StatBox.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/StatBox.jsx
@@ -1,9 +1,18 @@
-import React from "react";
-import { Paper, Typography } from "@mui/material";
+import React, { useRef, useState } from "react";
+import { Paper, Typography, Tooltip } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 
 export const StatBox = ({ label, value }) => {
   const theme = useTheme();
+  const textRef = useRef(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const handleMouseEnter = () => {
+    if (textRef.current) {
+      setIsTruncated(textRef.current.scrollWidth > textRef.current.clientWidth);
+    }
+  };
+
   return (
     <Paper
       elevation={1}
@@ -13,15 +22,25 @@ export const StatBox = ({ label, value }) => {
         borderRadius: 2,
         bgcolor: theme.palette.ui.panelMedium,
         width: "200px",
+        overflow: "hidden",
       }}
     >
-      <Typography
-        variant="h5"
-        fontWeight="bold"
-        sx={{ color: theme.palette.text.primary }}
-      >
-        {value}
-      </Typography>
+      <Tooltip title={isTruncated ? String(value) : ""} placement="top">
+        <Typography
+          ref={textRef}
+          variant="h5"
+          fontWeight="bold"
+          onMouseEnter={handleMouseEnter}
+          sx={{
+            color: theme.palette.text.primary,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {value}
+        </Typography>
+      </Tooltip>
       <Typography variant="body2" color="text.secondary">
         {label}
       </Typography>


### PR DESCRIPTION
## Summary
  Fixed stat cards in the dataset visualization overflowing when a value is too long (e.g. `template+human_variation` in `ai-vs-human` dataset ). Text is now truncated with an ellipsis, and a tooltip showing the full value appears on hover — but only when the text is actually truncated.

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `DashAI/front/src/components/notebooks/dataset/StatBox.jsx`: Added text truncation with ellipsis, conditional MUI `Tooltip` that only shows when the text overflows, and a ref-based truncation check on mouse enter.

  ---

  ## Testing (optional)
  Open the dataset visualization on a column whose most frequent value is a long string. Verify that:
  1. The stat card does not overflow.
  2. Hovering over the truncated text shows the full value in a tooltip.
  3. Cards with short values show no tooltip.