### PR TITLE
Prevent docs search bar overlapping logo on mobile

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1813,6 +1813,20 @@ tbody tr:hover {
     display: flex !important;
   }
 
+  /* Let search shrink instead of overlapping the logo on narrow screens */
+  [class*="navbarSearchContainer"] {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto !important;
+    max-width: 180px !important;
+    margin-left: 8px !important;
+  }
+
+  [class*="searchBar_"],
+  .navbar__search {
+    max-width: 100% !important;
+  }
+
 
   /* Ensure inner items don't overflow */
   .navbar__inner {


### PR DESCRIPTION
## Summary
On mobile, the documentation navbar's search bar had a fixed 250px width that never shrank, causing it to overlap the DashAI logo on narrow screens. This lets the search container shrink to fit so the logo stays clear.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [x] Documentation

---

## Changes (by file)
- `docs/src/css/custom.css`: In the `max-width: 996px` media query, override the fixed search container width so it shrinks (`flex: 1 1 auto`, `min-width: 0`, `width: auto`, `max-width: 180px`) instead of forcing 250px and overlapping the logo.

---

## Testing (optional)
Open the docs site at a phone width viewport (or DevTools device mode) and confirm the search bar and logo no longer overlap. To check on a real phone:
`cd docs && yarn start --host 0.0.0.0`, then open `http://<LAN-IP>:3000`.
