### PR TITLE
Fix format regression prediction outputs using training data precision

### DIFF
--- a/DashAI/front/src/components/models/PredictionCard.jsx
+++ b/DashAI/front/src/components/models/PredictionCard.jsx
@@ -33,12 +33,23 @@ import {
 import { useTheme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
 
+import {
+  getTargetDecimals,
+  formatPredictionRows,
+} from "../../utils/predictionFormat";
+
 const RUNNING_STATUSES = [1, 2]; // Delivered or Started
 
 /**
  * PredictionCard - Displays a single prediction with results table
  */
-export default function PredictionCard({ prediction, onDelete, onUpdate }) {
+export default function PredictionCard({
+  prediction,
+  onDelete,
+  onUpdate,
+  targetColumn = null,
+  datasetSample = null,
+}) {
   const [expanded, setExpanded] = useState(() => {
     const saved = localStorage.getItem(`prediction-${prediction.id}-expanded`);
     return saved !== null ? JSON.parse(saved) : true;
@@ -151,9 +162,17 @@ export default function PredictionCard({ prediction, onDelete, onUpdate }) {
             sortModel,
           )
         : await getDatasetFile(prediction.results_path, page, pageSize);
-      return { rows: data.rows ?? [], total: data.total ?? 0 };
+      const targetDecimals = getTargetDecimals(datasetSample, targetColumn);
+      return {
+        rows: formatPredictionRows(
+          data.rows ?? [],
+          targetColumn,
+          targetDecimals,
+        ),
+        total: data.total ?? 0,
+      };
     },
-    [prediction.results_path],
+    [prediction.results_path, datasetSample, targetColumn],
   );
 
   return (

--- a/DashAI/front/src/components/models/RunResults.jsx
+++ b/DashAI/front/src/components/models/RunResults.jsx
@@ -41,6 +41,8 @@ import LiveMetricsChart from "./LiveMetricsChart";
 import HyperparameterPlots from "./HyperparameterPlots";
 import { getExplainers } from "../../api/explainer";
 import { getPredictions } from "../../api/predict";
+import { getModelSessionById } from "../../api/modelSession";
+import { getDatasetSample } from "../../api/datasets";
 import { checkHowManyOptimazers } from "../../utils/schema";
 import { useTranslation } from "react-i18next";
 import TimestampWrapper from "../shared/TimestampWrapper";
@@ -83,6 +85,9 @@ export default function RunResults({
     }
     return 0;
   });
+
+  const [trainingDatasetSample, setTrainingDatasetSample] = useState(null);
+  const [outputColumn, setOutputColumn] = useState(null);
 
   const [globalCreatorOpen, setGlobalCreatorOpen] = useState(false);
   const [localCreatorOpen, setLocalCreatorOpen] = useState(false);
@@ -135,6 +140,25 @@ export default function RunResults({
   useEffect(() => {
     fetchOperations();
   }, [fetchOperations, explainerRefreshTrigger]);
+
+  useEffect(() => {
+    const sessionId = run.model_session_id || session?.id;
+    if (!sessionId) return;
+    let cancelled = false;
+    getModelSessionById(sessionId)
+      .then((sessionData) => {
+        if (cancelled) return null;
+        setOutputColumn(sessionData.output_columns?.[0] ?? null);
+        return getDatasetSample(sessionData.dataset_id);
+      })
+      .then((sample) => {
+        if (!cancelled && sample) setTrainingDatasetSample(sample);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [run.model_session_id, session?.id]);
 
   // Refetch when run parameters change (after editing)
   useEffect(() => {
@@ -782,6 +806,8 @@ export default function RunResults({
                             prediction={prediction}
                             onDelete={handlePredictionDeleted}
                             onUpdate={fetchOperations}
+                            targetColumn={outputColumn}
+                            datasetSample={trainingDatasetSample}
                           />
                         ))}
                     </Box>
@@ -854,6 +880,8 @@ export default function RunResults({
                             prediction={prediction}
                             onDelete={handlePredictionDeleted}
                             onUpdate={fetchOperations}
+                            targetColumn={outputColumn}
+                            datasetSample={trainingDatasetSample}
                           />
                         ))}
                     </Box>

--- a/DashAI/front/src/components/predictions/ManualInputForm.jsx
+++ b/DashAI/front/src/components/predictions/ManualInputForm.jsx
@@ -10,6 +10,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 import InputField from "./InputField";
+import { getTargetDecimals } from "../../utils/predictionFormat";
 
 const HEADER_HEIGHT = 40;
 const ROW_HEIGHT = 52;
@@ -29,6 +30,7 @@ export default function ManualInputForm({
 }) {
   const theme = useTheme();
   const [rows, setRows] = useState(createInitialRows);
+  const targetDecimals = getTargetDecimals(sample, targetColumn);
   const { t } = useTranslation(["prediction", "common"]);
 
   function createInitialRows() {
@@ -287,7 +289,13 @@ export default function ManualInputForm({
                             : `1px solid ${divider}`,
                       }}
                     >
-                      {predVal != null ? String(predVal) : ""}
+                      {predVal != null
+                        ? typeof predVal === "number"
+                          ? targetDecimals !== null
+                            ? predVal.toFixed(targetDecimals)
+                            : String(parseFloat(predVal.toPrecision(12)))
+                          : String(predVal)
+                        : ""}
                     </td>
                     <td
                       style={{

--- a/DashAI/front/src/components/predictions/PredictionModal.jsx
+++ b/DashAI/front/src/components/predictions/PredictionModal.jsx
@@ -388,7 +388,11 @@ export default function PredictionModal({ isOpen, onClose, run }) {
                 )}
               </Box>
             ) : (
-              <ResultsTable selectedPrediction={selectedPrediction} />
+              <ResultsTable
+                selectedPrediction={selectedPrediction}
+                datasetSample={sample}
+                targetColumn={experiment?.output_columns?.[0]}
+              />
             )}
           </>
         )}
@@ -397,7 +401,11 @@ export default function PredictionModal({ isOpen, onClose, run }) {
           <>
             {selectedPrediction ? (
               <Box>
-                <ResultsTable selectedPrediction={selectedPrediction} />
+                <ResultsTable
+                  selectedPrediction={selectedPrediction}
+                  datasetSample={sample}
+                  targetColumn={experiment?.output_columns?.[0]}
+                />
               </Box>
             ) : (
               <PredictionsTable

--- a/DashAI/front/src/components/predictions/ResultsTable.jsx
+++ b/DashAI/front/src/components/predictions/ResultsTable.jsx
@@ -20,15 +20,27 @@ import {
   getDatasetTypesByFilePath,
 } from "../../api/datasets";
 import { useTranslation } from "react-i18next";
+import {
+  getTargetDecimals,
+  formatPredictionRows,
+} from "../../utils/predictionFormat";
 
 const RUNNING_STATUSES = [1, 2]; // Delivered or Started
 
-function ResultsTable({ selectedPrediction }) {
+function ResultsTable({
+  selectedPrediction,
+  datasetSample = null,
+  targetColumn = null,
+}) {
   const theme = useTheme();
   const [loadingExecution, setLoadingExecution] = useState(
     RUNNING_STATUSES.includes(getPredictionStatus(selectedPrediction?.status)),
   );
   const [columnTypes, setColumnTypes] = useState({});
+  const targetDecimals = React.useMemo(
+    () => getTargetDecimals(datasetSample, targetColumn),
+    [datasetSample, targetColumn],
+  );
   const { t } = useTranslation(["prediction"]);
 
   useEffect(() => {
@@ -51,9 +63,16 @@ function ResultsTable({ selectedPrediction }) {
             sortModel,
           )
         : await getDatasetFile(selectedPrediction.results_path, page, pageSize);
-      return { rows: data.rows ?? [], total: data.total ?? 0 };
+      return {
+        rows: formatPredictionRows(
+          data.rows ?? [],
+          targetColumn,
+          targetDecimals,
+        ),
+        total: data.total ?? 0,
+      };
     },
-    [selectedPrediction],
+    [selectedPrediction, targetColumn, targetDecimals],
   );
 
   useEffect(() => {

--- a/DashAI/front/src/utils/predictionFormat.js
+++ b/DashAI/front/src/utils/predictionFormat.js
@@ -1,0 +1,27 @@
+export function getTargetDecimals(sample, targetColumn) {
+  if (!sample || !targetColumn || !sample[targetColumn]) return null;
+  const values = sample[targetColumn];
+  let maxDecimals = 0;
+  for (const val of values) {
+    if (val == null || typeof val !== "number") continue;
+    const str = String(val);
+    const dot = str.indexOf(".");
+    if (dot !== -1) maxDecimals = Math.max(maxDecimals, str.length - dot - 1);
+  }
+  return maxDecimals;
+}
+
+export function formatPredictionRows(rows, targetColumn, targetDecimals) {
+  if (!rows.length || targetColumn == null) return rows;
+  return rows.map((row) => {
+    const val = row[targetColumn];
+    if (typeof val !== "number") return row;
+    return {
+      ...row,
+      [targetColumn]:
+        targetDecimals !== null
+          ? val.toFixed(targetDecimals)
+          : String(parseFloat(val.toPrecision(12))),
+    };
+  });
+}


### PR DESCRIPTION
  ## Summary

  Regression prediction results were displaying raw floating-point artifacts (e.g. `4724.554999999999` instead of `4724.55`). The fix detects the target column's decimal precision from the training dataset sample and applies it consistently across all prediction surfaces — manual input, dataset predictions, and the results table. Falls back to `toPrecision(12)` when the training sample is unavailable (e.g. dataset uploaded without the label column).

  ---

  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `front/src/utils/predictionFormat.js`: new shared utility — `getTargetDecimals(sample, targetColumn)` detects max decimal
  places from training sample values; `formatPredictionRows(rows, targetColumn, targetDecimals)` applies `toFixed(n)` to the output column.
  - `front/src/components/predictions/ManualInputForm.jsx`: imports shared utility; formats predicted value using detected precision instead of raw `String()`.
  - `front/src/components/models/PredictionCard.jsx`: accepts new `targetColumn` and `datasetSample` props (training dataset); formats output column in `fetchPage` callback.
  - `front/src/components/predictions/ResultsTable.jsx`: same props as `PredictionCard`; formats output column via shared utility.
  - `front/src/components/predictions/PredictionModal.jsx`: passes `sample` (already fetched from training dataset) and
  `experiment.output_columns[0]` to `ResultsTable`.
  - `front/src/components/models/RunResults.jsx`: fetches model session on mount to obtain training dataset sample and output column name; passes both to each `PredictionCard`.

  ---

  ## Testing

  - Run a regression model and verify the predicted value in the **Manual Prediction** dialog matches the decimal format of the target column in the training data.
  - Run a **dataset prediction** and open the results table — output column should show the same precision.