### PR TITLE
Fix AppImage build "same file" rename error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -274,8 +274,9 @@ jobs:
           PIP_INDEX_URL: https://download.pytorch.org/whl/cpu
           PIP_EXTRA_INDEX_URL: "https://pypi.org/simple https://abetlen.github.io/llama-cpp-python/whl/cpu"
         run: |
+          # python-appimage names the output dashAI-x86_64.AppImage
+          # (.desktop Name + arch), which is the name uploaded below.
           python-appimage build app -p 3.12 appimage/
-          mv ./*.AppImage dashAI-x86_64.AppImage
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
The AppImage build step renamed the produced file onto itself (`mv ./*.AppImage dashAI-x86_64.AppImage`), failing the job with `'./dashAI-x86_64.AppImage' and 'dashAI-x86_64.AppImage' are the same file`. python-appimage already emits exactly that name (from the `.desktop` `Name` + arch), so the rename is removed.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [x] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `.github/workflows/publish.yml`: removed the redundant `mv` in the `build-linux-appimage` job. python-appimage already outputs `dashAI-x86_64.AppImage`, which is the name the upload step references; the self rename was crashing the build.