### PR TITLE
Update translation handling for language changes in ModelComparisonTable

### DIFF
--- a/DashAI/front/src/components/models/ModelComparisonTable.jsx
+++ b/DashAI/front/src/components/models/ModelComparisonTable.jsx
@@ -44,7 +44,7 @@ function ModelComparisonTable({
   const [runs, setRuns] = useState(initialRuns);
   const [runToDelete, setRunToDelete] = useState(null);
 
-  const { t } = useTranslation(["models", "common"]);
+  const { t, i18n } = useTranslation(["models", "common"]);
   const theme = useTheme();
   const localization = useTableLocalization();
 
@@ -70,7 +70,7 @@ function ModelComparisonTable({
       }
     };
     fetchModels();
-  }, []);
+  }, [i18n.language]);
 
   useEffect(() => {
     const fetchMetrics = async () => {
@@ -82,7 +82,7 @@ function ModelComparisonTable({
       }
     };
     fetchMetrics();
-  }, []);
+  }, [i18n.language]);
 
   // ────────────────────────────────────────────────────────────────────────
   // Fetch scoring profiles for this session's task


### PR DESCRIPTION
  ## Summary
  Component descriptions (metrics, models, etc.) displayed in tooltips and tables are fetched from the backend API, which returns them in the active language. These fetches used an empty dependency array, so descriptions were only loaded once on mount and never refreshed when the user changed the language — requiring a page reload to see the correct translation.

  Fixed by adding `i18n.language` to the `useEffect` dependency arrays of all affected API calls.

  ---
  ## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation
  
  ---
  
  ## Changes (by file)

  - `DashAI/front/src/components/models/ModelComparisonTable.jsx`: added `i18n.language` to the dependency arrays of the `fetchModels` and `fetchMetrics` effects so component descriptions re-fetch on language change.

  ---
  
  ## Testing

  1. Open the Model Comparison table with at least one trained run.
  2. Hover over a metric column header to see the tooltip description.
  3. Switch language from the language selector.
  4. Verify the tooltip description updates immediately without a page reload.