### PR TITLE
Preserve column types after Embedding and Tokenizer conversion

### DIFF
--- a/DashAI/back/converters/hugging_face/embedding.py
+++ b/DashAI/back/converters/hugging_face/embedding.py
@@ -247,4 +247,9 @@ class Embedding(AdvancedPreprocessingConverter, HuggingFaceWrapper):
                     pa.array(embeddings_np[:, i].tolist(), type=pa.float32()),
                 )
 
+        # Remove original text columns — they are replaced by their emb_* counterparts
+        for column in batch.column_names:
+            col_idx = result_table.column_names.index(column)
+            result_table = result_table.remove_column(col_idx)
+
         return DashAIDataset(result_table)

--- a/DashAI/back/converters/hugging_face/tokenizer.py
+++ b/DashAI/back/converters/hugging_face/tokenizer.py
@@ -185,6 +185,11 @@ class TokenizerConverter(AdvancedPreprocessingConverter, HuggingFaceWrapper):
                     pa.array(input_ids[:, i].tolist(), type=pa.int64()),
                 )
 
+        # Remove original text columns — they are replaced by their tok_* counterparts
+        for column in batch.column_names:
+            col_idx = result_table.column_names.index(column)
+            result_table = result_table.remove_column(col_idx)
+
         return DashAIDataset(result_table)
 
     def get_output_type(self, column_name: Optional[str] = None) -> DashAIDataType:


### PR DESCRIPTION
## Summary
The `Embedding` and `TokenizerConverter` converters were leaving the original text columns in the transformed dataset output. Since `get_output_type()` applies to all columns in the result, the original `text` column was being assigned
`Float` (Embedding) or `Integer` (Tokenizer) instead of keeping its `Text` type.

The fix removes the original input columns from `result_table` inside `_process_batch` after the derived columns are appended, so only the new `emb_*` / `tok_*` columns are returned and the rebuild step correctly treats the source column as replaced.

---

## Type of Change

  - [x] Backend change
  - [ ] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

---

## Changes (by file)

- `DashAI/back/converters/hugging_face/embedding.py`: remove original text columns from `result_table` in `_process_batchumns.
- `DashAI/back/converters/hugging_face/tokenizer.py`: remove original text columns from `result_table` in `_process_batch` after appending `tok_*` columns.

---

## Testing

Apply the `Embedding` or `TokenizerConverter` converter to a Text column in a notebook and verify that:
1. The original `text` column is no longer prese
2. The new `emb_*` / `tok_*` columns appear with `Float` / `Integer` types.
3. Other columns (e.g. `label`) retain their ori

---

## Notes

Both converters share the same root cause. Any ft appends derived columns in `_process_batch` should also remove the originals to avoid the same type-overwrite issue.