### PR TITLE
Encode categorical features in MLP regression

### DIFF
--- a/DashAI/back/models/categorical_encoder_mixin.py
+++ b/DashAI/back/models/categorical_encoder_mixin.py
@@ -1,0 +1,208 @@
+"""Shared categorical-encoding behavior for tabular DashAI models.
+
+Models that feed tabular data into an estimator (scikit-learn wrappers, the
+PyTorch MLP, etc.) need their ``Categorical`` feature columns turned into a
+numeric representation before training/prediction. This mixin centralises that
+logic so each model does not reimplement it.
+
+The mixin provides the ``prepare_dataset`` / ``prepare_output`` hooks expected
+by ``BaseModel`` and the fitted encoder state. Persistence of that state is left
+to each concrete model (``SklearnLikeModel`` pickles the whole instance via
+joblib; the MLP serialises the fields explicitly through ``torch.save``).
+"""
+
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class CategoricalEncoderMixin:
+    """Encode ``Categorical`` feature/target columns into numeric columns.
+
+    When fitting, columns whose ``encoder`` preference is ``"label"`` are label
+    encoded; every other categorical column is one-hot encoded (the safe default,
+    since one hot introduces no false ordinal relationship). When applying (not
+    fitting), the encoders that were actually fitted are applied based on the
+    stored state (``encodings`` / ``one_hot_encoder``) rather than the dataset's
+    current ``encoder`` metadata, which can drift between training and prediction
+    (e.g. a round-trip through Arrow metadata resets the preference to its
+    default).
+    """
+
+    def _setup_categorical_encoders(self) -> None:
+        """Initialise the fitted-encoder state.
+
+        Concrete models must call this from their ``__init__`` (and ensure the
+        fields are persisted by their ``save`` / restored by their ``load``).
+        """
+        self.encodings: dict = {}
+        self.one_hot_encoder: Optional[Any] = None
+        self.categorical_columns: List[str] = []
+        self.output_encodings: dict = {}
+
+    def prepare_dataset(
+        self, dataset: "DashAIDataset", is_fit: bool = False
+    ) -> "DashAIDataset":
+        """Encode categorical feature columns into a numeric representation.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The input dataset to preprocess.
+        is_fit : bool
+            If True, fit the encoders on the data. If False, apply previously
+            fitted encoders. Defaults to False.
+
+        Returns
+        -------
+        DashAIDataset
+            The dataset with categorical columns converted to numeric columns.
+        """
+        from DashAI.back.types.categorical import Categorical
+
+        if not is_fit:
+            # Apply exactly the encoders fitted during training, regardless of
+            # the dataset's (possibly drifted) per column encoder preference.
+            prepared = dataset
+            if self.encodings:
+                prepared = self._prepare_label_encoded(
+                    prepared, is_fit, columns=list(self.encodings.keys())
+                )
+            if self.one_hot_encoder is not None:
+                prepared = self._prepare_one_hot(
+                    prepared, is_fit, columns=self.categorical_columns
+                )
+            return prepared
+
+        types = dataset.types
+        if not any(isinstance(t, Categorical) for t in types.values()):
+            return dataset
+
+        label_cols = [
+            c
+            for c, t in types.items()
+            if isinstance(t, Categorical) and t.encoder == "label"
+        ]
+        # Everything categorical that is not explicitly label-encoded is one-hot
+        # encoded (the safe default: no false ordinal relationship).
+        one_hot_cols = [
+            c
+            for c, t in types.items()
+            if isinstance(t, Categorical) and t.encoder != "label"
+        ]
+
+        prepared = dataset
+        if label_cols:
+            prepared = self._prepare_label_encoded(prepared, is_fit, columns=label_cols)
+        if one_hot_cols:
+            prepared = self._prepare_one_hot(prepared, is_fit, columns=one_hot_cols)
+        return prepared
+
+    def prepare_output(
+        self, dataset: "DashAIDataset", is_fit: bool = False
+    ) -> "DashAIDataset":
+        """Prepare output targets using label encoding.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The output dataset to be transformed.
+        is_fit : bool, optional
+            If True, fit the encoder. If False, use existing encodings.
+
+        Returns
+        -------
+        DashAIDataset
+            Dataset with categorical columns converted to integers.
+        """
+        from DashAI.back.dataloaders.classes.dashai_dataset_utils import (
+            apply_categorical_label_encoder,
+            categorical_label_encoder,
+        )
+
+        prepared = dataset
+        if is_fit:
+            prepared, encodings = categorical_label_encoder(dataset)
+            self.output_encodings.update(encodings)
+        elif self.output_encodings:
+            prepared = apply_categorical_label_encoder(dataset, self.output_encodings)
+        return prepared
+
+    def _prepare_label_encoded(
+        self, dataset: "DashAIDataset", is_fit: bool, columns: list = None
+    ) -> "DashAIDataset":
+        """Prepare dataset using label encoding for categorical columns.
+
+        This is appropriate for tree based models that don't assume
+        ordinal relationships between encoded values.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The dataset to be transformed.
+        is_fit : bool
+            If True, fit the encoder. If False, use existing encodings.
+        columns : list, optional
+            If given, only label-encode the specified columns.
+
+        Returns
+        -------
+        DashAIDataset
+            Dataset with categorical columns converted to integers.
+        """
+        from DashAI.back.dataloaders.classes.dashai_dataset_utils import (
+            apply_categorical_label_encoder,
+            categorical_label_encoder,
+        )
+
+        prepared = dataset
+        if is_fit:
+            prepared, encodings = categorical_label_encoder(dataset, columns=columns)
+            self.encodings.update(encodings)
+        elif self.encodings:
+            relevant_encodings = {
+                k: v
+                for k, v in self.encodings.items()
+                if columns is None or k in columns
+            }
+            prepared = apply_categorical_label_encoder(dataset, relevant_encodings)
+        return prepared
+
+    def _prepare_one_hot(
+        self, dataset: "DashAIDataset", is_fit: bool, columns: list = None
+    ) -> "DashAIDataset":
+        """Prepare dataset using one hot encoding for categorical columns.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The dataset to be transformed.
+        is_fit : bool
+            If True, fit the encoder. If False, use existing encoder.
+        columns : list, optional
+            If given, only one hot encode the specified columns.
+
+        Returns
+        -------
+        DashAIDataset
+            Dataset with categorical columns replaced by one hot columns.
+        """
+        from DashAI.back.dataloaders.classes.dashai_dataset_utils import (
+            apply_categorical_one_hot_encoder,
+            categorical_one_hot_encoder,
+        )
+
+        if is_fit:
+            prepared, encoder, cat_cols = categorical_one_hot_encoder(
+                dataset, columns=columns
+            )
+            self.one_hot_encoder = encoder
+            self.categorical_columns = cat_cols
+        elif self.one_hot_encoder is not None:
+            prepared = apply_categorical_one_hot_encoder(
+                dataset, self.one_hot_encoder, self.categorical_columns
+            )
+        else:
+            prepared = dataset
+        return prepared

--- a/DashAI/back/models/scikit_learn/bayesian_ridge_regression.py
+++ b/DashAI/back/models/scikit_learn/bayesian_ridge_regression.py
@@ -9,9 +9,6 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -219,7 +216,6 @@ class BayesianRidgeRegression(RegressionModel, SklearnLikeRegressor, _BayesianRi
     )
     COLOR: str = "#7E57C2"
     ICON: str = "Psychology"
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/elastic_net_regression.py
+++ b/DashAI/back/models/scikit_learn/elastic_net_regression.py
@@ -10,9 +10,6 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -241,7 +238,6 @@ class ElasticNetRegression(RegressionModel, SklearnLikeRegressor, _ElasticNet):
     )
     COLOR: str = "#26A69A"
     ICON: str = "Hub"
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/k_neighbors_classifier.py
+++ b/DashAI/back/models/scikit_learn/k_neighbors_classifier.py
@@ -10,9 +10,6 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
     SklearnLikeClassifier,
 )
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.tabular_classification_model import TabularClassificationModel
 
 
@@ -144,8 +141,6 @@ class KNeighborsClassifier(
     )
     COLOR: str = "#FFD54F"
     ICON: str = "ScatterPlot"
-
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/k_neighbors_regression.py
+++ b/DashAI/back/models/scikit_learn/k_neighbors_regression.py
@@ -8,9 +8,6 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -197,7 +194,6 @@ class KNeighborsRegression(RegressionModel, SklearnLikeRegressor, _KNeighborsReg
     )
     COLOR: str = "#FFA726"
     ICON: str = "ScatterPlot"
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/lasso_regression.py
+++ b/DashAI/back/models/scikit_learn/lasso_regression.py
@@ -10,9 +10,6 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -206,7 +203,6 @@ class LassoRegression(RegressionModel, SklearnLikeRegressor, _Lasso):
     )
     COLOR: str = "#29B6F6"
     ICON: str = "SelectAll"
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/linearSVR.py
+++ b/DashAI/back/models/scikit_learn/linearSVR.py
@@ -11,9 +11,6 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -347,8 +344,6 @@ class LinearSVR(RegressionModel, SklearnLikeRegressor, _LinearSVR):
     )
     COLOR: str = "#2196F3"
     ICON: str = "Timeline"
-
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/linear_regression.py
+++ b/DashAI/back/models/scikit_learn/linear_regression.py
@@ -9,9 +9,6 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -160,8 +157,6 @@ class LinearRegression(RegressionModel, SklearnLikeRegressor, _LinearRegression)
     )
     COLOR: str = "#3F51B5"
     ICON: str = "ShowChart"
-
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/linear_svc_classifier.py
+++ b/DashAI/back/models/scikit_learn/linear_svc_classifier.py
@@ -13,9 +13,6 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
     SklearnLikeClassifier,
 )
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.tabular_classification_model import TabularClassificationModel
 
 
@@ -242,7 +239,6 @@ class LinearSVCClassifier(
     )
     COLOR: str = "#FF7043"
     ICON: str = "LinearScale"
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/logistic_regression.py
+++ b/DashAI/back/models/scikit_learn/logistic_regression.py
@@ -11,9 +11,6 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
     SklearnLikeClassifier,
 )
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.tabular_classification_model import TabularClassificationModel
 
 
@@ -158,8 +155,6 @@ class LogisticRegression(
     )
     COLOR: str = "#64B5F6"
     ICON: str = "TrendingUp"
-
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/mlp_regression.py
+++ b/DashAI/back/models/scikit_learn/mlp_regression.py
@@ -11,6 +11,7 @@ from DashAI.back.core.schema_fields import (
     schema_field,
 )
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.categorical_encoder_mixin import CategoricalEncoderMixin
 from DashAI.back.models.regression_model import RegressionModel
 from DashAI.back.models.utils import DEVICE_ENUM, DEVICE_PLACEHOLDER, DEVICE_TO_IDX
 
@@ -33,9 +34,9 @@ class MLPRegressorSchema(BaseSchema):
         optimizer_int_field(ge=1),
         placeholder={
             "optimize": False,
-            "fixed_value": 5,
+            "fixed_value": 16,
             "lower_bound": 1,
-            "upper_bound": 15,
+            "upper_bound": 64,
         },
         description=MultilingualString(
             en="Number of neurons in the hidden layer.",
@@ -100,9 +101,9 @@ class MLPRegressorSchema(BaseSchema):
         optimizer_int_field(ge=1),
         placeholder={
             "optimize": False,
-            "fixed_value": 5,
+            "fixed_value": 20,
             "lower_bound": 1,
-            "upper_bound": 15,
+            "upper_bound": 50,
         },
         description=MultilingualString(
             en="Total number of training passes over the dataset.",
@@ -290,7 +291,7 @@ class MLPRegressorSchema(BaseSchema):
     )  # type: ignore
 
 
-class MLPRegression(RegressionModel):
+class MLPRegression(CategoricalEncoderMixin, RegressionModel):
     """Single hidden-layer MLP regressor implemented in PyTorch.
 
     A Multi-layer Perceptron (MLP) is a feedforward neural network composed of an
@@ -403,6 +404,11 @@ class MLPRegression(RegressionModel):
             else "cpu"
         )
         self.model = None
+
+        # Initialise the categorical encoder state inherited from
+        # CategoricalEncoderMixin. These fields are persisted by ``save`` and
+        # restored by ``load`` so ``predict`` reuses the training-time encoders.
+        self._setup_categorical_encoders()
 
     def train(
         self,
@@ -574,6 +580,9 @@ class MLPRegression(RegressionModel):
                 "state": self.model.state_dict(),
                 "params": self.params,
                 "input_dim": self.model.model[0].in_features,
+                "encodings": self.encodings,
+                "one_hot_encoder": self.one_hot_encoder,
+                "categorical_columns": self.categorical_columns,
             },
             filename,
         )
@@ -594,7 +603,10 @@ class MLPRegression(RegressionModel):
         """
         import torch
 
-        data = torch.load(filename)
+        # weights_only=False is required because the checkpoint stores the
+        # fitted categorical encoders (e.g. a scikit-learn OneHotEncoder), which
+        # are not part of torch's safe-globals allowlist.
+        data = torch.load(filename, weights_only=False)
         instance = MLPRegression(**data["params"])
 
         # Rebuild the model architecture using saved input_dim
@@ -606,5 +618,11 @@ class MLPRegression(RegressionModel):
 
         # Load the trained weights
         instance.model.load_state_dict(data["state"])
+
+        # Restore the categorical encoders so predictions match training-time
+        # preprocessing.
+        instance.encodings = data.get("encodings", {})
+        instance.one_hot_encoder = data.get("one_hot_encoder")
+        instance.categorical_columns = data.get("categorical_columns", [])
 
         return instance

--- a/DashAI/back/models/scikit_learn/ridge_regression.py
+++ b/DashAI/back/models/scikit_learn/ridge_regression.py
@@ -11,9 +11,6 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -279,8 +276,6 @@ class RidgeRegression(RegressionModel, SklearnLikeRegressor, _Ridge):
     )
     COLOR: str = "#2196F3"
     ICON: str = "ShowChart"
-
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/sgd_classifier.py
+++ b/DashAI/back/models/scikit_learn/sgd_classifier.py
@@ -12,9 +12,6 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
     SklearnLikeClassifier,
 )
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.tabular_classification_model import TabularClassificationModel
 
 
@@ -272,7 +269,6 @@ class SGDClassifier(TabularClassificationModel, SklearnLikeClassifier, _SGDClass
     )
     COLOR: str = "#78909C"
     ICON: str = "TrendingDown"
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/sklearn_like_model.py
+++ b/DashAI/back/models/scikit_learn/sklearn_like_model.py
@@ -1,49 +1,26 @@
-from enum import Enum
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING
 
 from DashAI.back.models.base_model import BaseModel
-from DashAI.back.types.categorical import Categorical
+from DashAI.back.models.categorical_encoder_mixin import CategoricalEncoderMixin
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
 
-class CategoricalEncodingStrategy(str, Enum):
-    """Strategy for encoding categorical variables.
-
-    LABEL: Use LabelEncoder -
-           Good for models that don't assume linear relationships between features.
-
-    ONE_HOT: Use OneHotEncoder - creates binary columns for each category.
-             Required for linear models (Logistic Regression, SVM, KNN)
-             that would otherwise assume ordinal relationships.
-    """
-
-    LABEL = "label"
-    ONE_HOT = "one_hot"
-
-
-class SklearnLikeModel(BaseModel):
+class SklearnLikeModel(CategoricalEncoderMixin, BaseModel):
     """Abstract base class for scikit-learn-compatible DashAI models.
 
-    Provides ``save`` / ``load`` via joblib, categorical encoding helpers
-    (label or one hot), and the ``prepare_dataset`` / ``prepare_output``
-    pipeline expected by the DashAI training loop. Concrete subclasses
-    (classifiers and regressors) inherit this mixin and supply ``train`` and
-    ``predict`` implementations backed by scikit-learn estimators.
+    Provides ``save`` / ``load`` via joblib and inherits the categorical
+    encoding helpers and ``prepare_dataset`` / ``prepare_output`` pipeline from
+    ``CategoricalEncoderMixin``. Concrete subclasses (classifiers and
+    regressors) supply ``train`` and ``predict`` implementations backed by
+    scikit-learn estimators.
     """
-
-    CATEGORICAL_ENCODING: CategoricalEncodingStrategy = (
-        CategoricalEncodingStrategy.LABEL
-    )
 
     def __init__(self, *args, **kwargs):
         """Initialize the SklearnLikeModel."""
         super().__init__(*args, **kwargs)
-        self.encodings = {}
-        self.one_hot_encoder: Optional[Any] = None
-        self.categorical_columns: List[str] = []
-        self.output_encodings = {}
+        self._setup_categorical_encoders()
 
     def save(self, filename: str) -> None:
         """Serialise the model to disk using joblib.
@@ -122,188 +99,3 @@ class SklearnLikeModel(BaseModel):
         if isinstance(x, DashAIDataset):
             x = self.prepare_dataset(x, is_fit=False).to_pandas()
         return super().predict(x)
-
-    def prepare_output(
-        self, dataset: "DashAIDataset", is_fit: bool = False
-    ) -> "DashAIDataset":
-        """Prepare output targets using Label encoding.
-
-        Parameters
-        ----------
-        dataset : DashAIDataset
-            The output dataset to be transformed.
-        is_fit : bool, optional
-            If True, fit the encoder. If False, use existing encodings.
-
-        Returns
-        -------
-        DashAIDataset
-            Dataset with categorical columns converted to integers.
-        """
-        from DashAI.back.dataloaders.classes.dashai_dataset_utils import (
-            apply_categorical_label_encoder,
-            categorical_label_encoder,
-        )
-
-        prepared = dataset
-
-        if is_fit:
-            prepared, encodings = categorical_label_encoder(dataset)
-            self.output_encodings.update(encodings)
-        else:
-            if self.output_encodings:
-                prepared = apply_categorical_label_encoder(
-                    dataset, self.output_encodings
-                )
-
-        return prepared
-
-    def prepare_dataset(
-        self, dataset: "DashAIDataset", is_fit: bool = False
-    ) -> "DashAIDataset":
-        """Apply the model transformations to the dataset.
-
-        Respects per-column encoder preference stored in each Categorical
-        column's `encoder` field. Falls back to model's CATEGORICAL_ENCODING
-        for columns with unrecognized encoder values.
-
-        Parameters
-        ----------
-        dataset : DashAIDataset
-            The dataset to be transformed.
-        is_fit : bool, optional
-            If True, the method will fit encoders on the data.
-            If False, will apply previously fitted encoders.
-
-        Returns
-        -------
-        DashAIDataset
-            The prepared dataset ready to be converted to
-            an accepted format in the model.
-        """
-        import logging
-
-        _logger = logging.getLogger(__name__)
-
-        types = dataset.types
-        has_categorical = any(isinstance(t, Categorical) for t in types.values())
-
-        if not has_categorical:
-            return dataset
-
-        one_hot_cols = [
-            c
-            for c, t in types.items()
-            if isinstance(t, Categorical) and t.encoder == "one_hot"
-        ]
-        label_cols = [
-            c
-            for c, t in types.items()
-            if isinstance(t, Categorical) and t.encoder == "label"
-        ]
-        default_cols = [
-            c
-            for c, t in types.items()
-            if isinstance(t, Categorical) and t.encoder not in ("one_hot", "label")
-        ]
-        if default_cols:
-            _logger.warning(
-                "Columns %s have unrecognized encoder preference. "
-                "Falling back to model strategy %s.",
-                default_cols,
-                self.CATEGORICAL_ENCODING,
-            )
-            if self.CATEGORICAL_ENCODING == CategoricalEncodingStrategy.ONE_HOT:
-                one_hot_cols.extend(default_cols)
-            else:
-                label_cols.extend(default_cols)
-
-        prepared = dataset
-        if label_cols:
-            prepared = self._prepare_label_encoded(prepared, is_fit, columns=label_cols)
-        if one_hot_cols:
-            prepared = self._prepare_one_hot(prepared, is_fit, columns=one_hot_cols)
-        return prepared
-
-    def _prepare_label_encoded(
-        self, dataset: "DashAIDataset", is_fit: bool, columns: list = None
-    ) -> "DashAIDataset":
-        """Prepare dataset using label encoding for categorical columns.
-
-        This is appropriate for tree based models that don't assume
-        ordinal relationships between encoded values.
-
-        Parameters
-        ----------
-        dataset : DashAIDataset
-            The dataset to be transformed.
-        is_fit : bool
-            If True, fit the encoder. If False, use existing encodings.
-        columns : list, optional
-            If given, only label-encode the specified columns.
-
-        Returns
-        -------
-        DashAIDataset
-            Dataset with categorical columns converted to integers.
-        """
-        from DashAI.back.dataloaders.classes.dashai_dataset_utils import (
-            apply_categorical_label_encoder,
-            categorical_label_encoder,
-        )
-
-        prepared = dataset
-
-        if is_fit:
-            prepared, encodings = categorical_label_encoder(dataset, columns=columns)
-            self.encodings.update(encodings)
-        else:
-            if self.encodings:
-                relevant_encodings = {
-                    k: v
-                    for k, v in self.encodings.items()
-                    if columns is None or k in columns
-                }
-                prepared = apply_categorical_label_encoder(dataset, relevant_encodings)
-
-        return prepared
-
-    def _prepare_one_hot(
-        self, dataset: "DashAIDataset", is_fit: bool, columns: list = None
-    ) -> "DashAIDataset":
-        """Prepare dataset using one hot encoding for categorical columns.
-
-        Parameters
-        ----------
-        dataset : DashAIDataset
-            The dataset to be transformed.
-        is_fit : bool
-            If True, fit the encoder. If False, use existing encoder.
-        columns : list, optional
-            If given, only one hot encode the specified columns.
-
-        Returns
-        -------
-        DashAIDataset
-            Dataset with categorical columns replaced by one hot columns.
-        """
-        from DashAI.back.dataloaders.classes.dashai_dataset_utils import (
-            apply_categorical_one_hot_encoder,
-            categorical_one_hot_encoder,
-        )
-
-        if is_fit:
-            prepared, encoder, cat_cols = categorical_one_hot_encoder(
-                dataset, columns=columns
-            )
-            self.one_hot_encoder = encoder
-            self.categorical_columns = cat_cols
-        else:
-            if self.one_hot_encoder is not None:
-                prepared = apply_categorical_one_hot_encoder(
-                    dataset, self.one_hot_encoder, self.categorical_columns
-                )
-            else:
-                prepared = dataset
-
-        return prepared

--- a/DashAI/back/models/scikit_learn/svc.py
+++ b/DashAI/back/models/scikit_learn/svc.py
@@ -12,9 +12,6 @@ from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.scikit_learn.sklearn_like_classifier import (
     SklearnLikeClassifier,
 )
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.tabular_classification_model import TabularClassificationModel
 
 
@@ -306,8 +303,6 @@ class SVC(TabularClassificationModel, SklearnLikeClassifier, _SVC):
     )
     COLOR: str = "#FF80AB"
     ICON: str = "Timeline"
-
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs):
         """Initialise the model by forwarding all kwargs to the parent class.

--- a/DashAI/back/models/scikit_learn/svr.py
+++ b/DashAI/back/models/scikit_learn/svr.py
@@ -9,9 +9,6 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.models.regression_model import RegressionModel
-from DashAI.back.models.scikit_learn.sklearn_like_model import (
-    CategoricalEncodingStrategy,
-)
 from DashAI.back.models.scikit_learn.sklearn_like_regressor import SklearnLikeRegressor
 
 
@@ -215,7 +212,6 @@ class SVR(RegressionModel, SklearnLikeRegressor, _SVR):
     )
     COLOR: str = "#EF5350"
     ICON: str = "ControlPoint"
-    CATEGORICAL_ENCODING = CategoricalEncodingStrategy.ONE_HOT
 
     def __init__(self, **kwargs) -> None:
         """Initialise the model by forwarding all kwargs to the parent class.


### PR DESCRIPTION
## Summary
MLP regression crashed when given a `Categorical` feature (`can't convert np.ndarray of type numpy.object_`) because, unlike the scikit-learn models, it never encoded categorical columns before feeding them to torch. This adds categorical encoding to the MLP and, along the way, extracts the encoding logic that was living inside `SklearnLikeModel` into a shared mixin so both model families use one implementation. Prediction now applies the encoders that were fitted at training time rather than re reading the dataset's encoder metadata, which can drift between training and prediction.

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/models/categorical_encoder_mixin.py` (new): shared `CategoricalEncoderMixin` providing `prepare_dataset` / `prepare_output`, the label/one-hot helpers, and the fitted-encoder state. Feature columns with `encoder == "label"` are label encoded; every other categorical column is one-hot encoded (safe default). At predict time it applies the stored encoders rather than re-deriving routing from (drift-prone) dataset metadata.
- `DashAI/back/models/scikit_learn/sklearn_like_model.py`: now inherits `CategoricalEncoderMixin`; removed the duplicated encoding methods. Behavior preserved, plus it gains the drift-safe predict path.
- `DashAI/back/models/scikit_learn/mlp_regression.py`: inherits the mixin so categorical features (and any categorical target) are encoded before tensor conversion; persists/restores the fitted encoders in `save`/`load` so prediction matches training preprocessing.
- 13 scikit-learn model files (`linear_regression`, `ridge_regression`, `lasso_regression`, `elastic_net_regression`, `bayesian_ridge_regression`, `linearSVR`, `svr`, `k_neighbors_regression`, `k_neighbors_classifier`, `linear_svc_classifier`, `logistic_regression`, `sgd_classifier`, `svc`): removed the now-unused `CATEGORICAL_ENCODING` attribute and its import. The per-model strategy only affected columns with an unrecognized encoder preference, which does not occur in practice.

---

## Testing (optional)
- Train an MLP regression run on a dataset with a categorical input feature, using both the `label` and `one_hot` encoder preferences; confirm training and prediction succeed (previously crashed).
- Re run an existing scikit-learn tabular regression/classification run to confirm no behavior change.

---

## Notes (optional)
- The drift fix also applies to the scikit-learn models (same shared path), closing the same latent bug there.
- The MLP's categorical target encoding (`output_encodings`) is inert for regression (numeric target) and is not persisted.
- Unrelated MLP defaults (hidden size, epochs) were adjusted.
