### PR TITLE
Update Spanish display names for Additive and Skewed Chi² Samplers

### DIFF
--- a/DashAI/back/converters/scikit_learn/additive_chi_2_sampler.py
+++ b/DashAI/back/converters/scikit_learn/additive_chi_2_sampler.py
@@ -78,7 +78,7 @@ class AdditiveChi2Sampler(
     )
     DISPLAY_NAME = MultilingualString(
         en="Additive Chi² Sampler",
-        es="Muestreador Chi²",
+        es="Muestreador Chi² Aditivo",
         pt="Amostrador Qui-2 Aditivo",
         de="Additiver Chi²-Stichprobennehmer",
         zh="加性卡方采样器",

--- a/DashAI/back/converters/scikit_learn/skewed_chi_2_sampler.py
+++ b/DashAI/back/converters/scikit_learn/skewed_chi_2_sampler.py
@@ -148,7 +148,7 @@ class SkewedChi2Sampler(
     )
     DISPLAY_NAME = MultilingualString(
         en="Skewed Chi² Sampler",
-        es="Muestreador Chi²",
+        es="Muestreador Chi² Sesgado",
         pt="Amostrador Qui-2 Enviesado",
         de="Schiefer Chi²-Stichprobennehmer",
         zh="偏斜卡方采样器",


### PR DESCRIPTION
## Summary
Two converters in the "Polynomial & Kernel Methods" category shared the identical Spanish display name "Muestreador Chi²", making them indistinguishable in the UI when the language is set to Spanish. Added the missing adjective to each name to match the other translations.

---

## Type of Change
  - [x] Backend change
  - [ ] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

---

## Changes (by file)
- `DashAI/back/converters/scikit_learn/additive_chi_2_sampler.py`: changed Spanish `DISPLAY_NAME` from `"Muestreador Chi²"` to `"Muestreador Chi² Aditivo"`
- `DashAI/back/converters/scikit_learn/skewed_chi_2_sampler.py`: changed Spanish `DISPLAY_NAME` from `"Muestreador Chi²"` to `"Muestreador Chi² Sesgado"`

---

## Testing
Switch the UI language to Spanish, open the **Convert** tab, and search for "chi". Both converters should now appear with distinct names.

