### PR TITLE
Mark ExplainedVariance metric as maximize so weighted scores compute correctly

### DIFF
--- a/DashAI/back/metrics/regression/explained_variance.py
+++ b/DashAI/back/metrics/regression/explained_variance.py
@@ -67,6 +67,8 @@ class ExplainedVariance(RegressionMetric):
         ),
     )
 
+    MAXIMIZE = True
+
     @staticmethod
     def score(
         true_values: "DashAIDataset",


### PR DESCRIPTION
## Summary
Fixes a scoring bug where a model scoring a perfect 1 on both metrics returned 60/100 instead of 100 when combining R2 (60%) and ExplainedVariance (40%). The `ExplainedVariance` metric was missing the `MAXIMIZE` class attribute, so the framework didn't know higher scores are better. Its 0.4 contribution wasn't counted correctly and only R2's 0.6 came through, giving 60. Added `MAXIMIZE = True` so the weighted combination resolves to 1x0.6 + 1x0.4 = 1.0 --> 100.

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/metrics/regression/explained_variance.py`: added `MAXIMIZE = True` to the `ExplainedVariance` class so scoring and ranking treat higher scores as better.

---

## Testing (optional)

Verify after the fix:
- A perfect model (score = 1 for both R2 and ExplainedVariance individually) shows score 100 for model fit profile.