### PR TITLE
feat: Solve problem with temp_dir in translation

### DIFF
--- a/DashAI/back/models/hugging_face/base_opus_mt_transformer.py
+++ b/DashAI/back/models/hugging_face/base_opus_mt_transformer.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from sklearn.exceptions import NotFittedError
 
 from DashAI.back.models.translation_model import TranslationModel
-from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
+from DashAI.back.models.utils import (
+    GPU_OR_CPU_PLACEHOLDER,
+    resolve_temp_checkpoint_dir,
+)
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -136,7 +139,7 @@ class OpusMtTransformerMixin(TranslationModel):
 
         has_validation_data = x_validation is not None and y_validation is not None
 
-        output_root = Path(self.TEMP_CHECKPOINT_DIR)
+        output_root = resolve_temp_checkpoint_dir(self.TEMP_CHECKPOINT_DIR)
         output_root.mkdir(parents=True, exist_ok=True)
         run_output_dir = tempfile.mkdtemp(
             prefix=f"{self.__class__.__name__.lower()}_",

--- a/DashAI/back/models/hugging_face/base_text_classification_transformer.py
+++ b/DashAI/back/models/hugging_face/base_text_classification_transformer.py
@@ -12,7 +12,10 @@ from typing import TYPE_CHECKING, Union
 from sklearn.exceptions import NotFittedError
 
 from DashAI.back.models.text_classification_model import TextClassificationModel
-from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
+from DashAI.back.models.utils import (
+    GPU_OR_CPU_PLACEHOLDER,
+    resolve_temp_checkpoint_dir,
+)
 from DashAI.back.types.categorical import Categorical
 
 if TYPE_CHECKING:
@@ -136,7 +139,6 @@ class HuggingFaceTextClassificationTransformer(TextClassificationModel):
         """
         import shutil
         import tempfile
-        from pathlib import Path
 
         import torch
         from transformers import (
@@ -181,7 +183,7 @@ class HuggingFaceTextClassificationTransformer(TextClassificationModel):
         use_gpu = self.device.lower() == "gpu"
         can_use_fp16 = torch.cuda.is_available() and use_gpu
 
-        base_output_dir = Path(self.TEMP_CHECKPOINT_DIR)
+        base_output_dir = resolve_temp_checkpoint_dir(self.TEMP_CHECKPOINT_DIR)
         base_output_dir.mkdir(parents=True, exist_ok=True)
         run_output_dir = tempfile.mkdtemp(
             prefix=f"{self.__class__.__name__.lower()}_",

--- a/DashAI/back/models/hugging_face/m2m100_transformer.py
+++ b/DashAI/back/models/hugging_face/m2m100_transformer.py
@@ -13,7 +13,10 @@ from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
     OpusMtEnESTransformerSchema,
 )
 from DashAI.back.models.translation_model import TranslationModel
-from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
+from DashAI.back.models.utils import (
+    GPU_OR_CPU_PLACEHOLDER,
+    resolve_temp_checkpoint_dir,
+)
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -250,7 +253,9 @@ class M2M100Transformer(TranslationModel):
 
         has_validation_data = x_validation is not None and y_validation is not None
 
-        output_root = Path("DashAI/back/user_models/temp_checkpoints_m2m100")
+        output_root = resolve_temp_checkpoint_dir(
+            "DashAI/back/user_models/temp_checkpoints_m2m100"
+        )
         output_root.mkdir(parents=True, exist_ok=True)
         run_output_dir = tempfile.mkdtemp(prefix="m2m100_", dir=str(output_root))
 

--- a/DashAI/back/models/hugging_face/nllb_transformer.py
+++ b/DashAI/back/models/hugging_face/nllb_transformer.py
@@ -13,7 +13,10 @@ from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
     OpusMtEnESTransformerSchema,
 )
 from DashAI.back.models.translation_model import TranslationModel
-from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
+from DashAI.back.models.utils import (
+    GPU_OR_CPU_PLACEHOLDER,
+    resolve_temp_checkpoint_dir,
+)
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -373,7 +376,9 @@ class NllbTransformer(TranslationModel):
 
         has_validation_data = x_validation is not None and y_validation is not None
 
-        output_root = Path("DashAI/back/user_models/temp_checkpoints_nllb")
+        output_root = resolve_temp_checkpoint_dir(
+            "DashAI/back/user_models/temp_checkpoints_nllb"
+        )
         output_root.mkdir(parents=True, exist_ok=True)
         run_output_dir = tempfile.mkdtemp(prefix="nllb_", dir=str(output_root))
 

--- a/DashAI/back/models/hugging_face/t5_small_transformer.py
+++ b/DashAI/back/models/hugging_face/t5_small_transformer.py
@@ -13,7 +13,10 @@ from DashAI.back.models.hugging_face.opus_mt_en_es_transformer import (
     OpusMtEnESTransformerSchema,
 )
 from DashAI.back.models.translation_model import TranslationModel
-from DashAI.back.models.utils import GPU_OR_CPU_PLACEHOLDER
+from DashAI.back.models.utils import (
+    GPU_OR_CPU_PLACEHOLDER,
+    resolve_temp_checkpoint_dir,
+)
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -221,7 +224,9 @@ class T5SmallTransformer(TranslationModel):
 
         has_validation_data = x_validation is not None and y_validation is not None
 
-        output_root = Path("DashAI/back/user_models/temp_checkpoints_t5_small")
+        output_root = resolve_temp_checkpoint_dir(
+            "DashAI/back/user_models/temp_checkpoints_t5_small"
+        )
         output_root.mkdir(parents=True, exist_ok=True)
         run_output_dir = tempfile.mkdtemp(prefix="t5_small_", dir=str(output_root))
 

--- a/DashAI/back/models/utils.py
+++ b/DashAI/back/models/utils.py
@@ -1,9 +1,43 @@
+import os
+from pathlib import Path
+
 import torch
 
 from DashAI.back.models.hugging_face.llama_utils import (
     get_llama_gpu_devices_formatted,
     is_gpu_available_for_llama_cpp,
 )
+
+
+def resolve_temp_checkpoint_dir(temp_checkpoint_dir: str) -> Path:
+    """Resolve a transformer's temp checkpoint dir to an absolute, writable path.
+
+    Historically ``TEMP_CHECKPOINT_DIR`` was a path relative to the repository
+    root (e.g. ``DashAI/back/user_models/temp_checkpoints_*``). That only works
+    in development mode, where the current working directory is the repo root.
+    In a packaged executable (PyInstaller/AppImage) the working directory is the
+    read-only install location, so creating the directory fails with a
+    permission/not-found error.
+
+    To work in both cases we anchor the checkpoints under the DashAI local data
+    directory (``DASHAI_LOCAL_PATH`` env var, falling back to ``~/.DashAI``) and
+    keep only the final segment of the configured path as the folder name.
+
+    Parameters
+    ----------
+    temp_checkpoint_dir : str
+        The configured (possibly relative) checkpoint directory.
+
+    Returns
+    -------
+    Path
+        An absolute path under the DashAI local data directory.
+    """
+    local_path = os.environ.get("DASHAI_LOCAL_PATH")
+    base = Path(local_path).expanduser() if local_path else Path.home() / ".DashAI"
+    folder_name = Path(temp_checkpoint_dir).name or "temp_checkpoints"
+    return base / "user_models" / folder_name
+
 
 DEVICE_ENUM: list[str] = ["CPU"]
 DEVICE_PLACEHOLDER: str = "CPU"


### PR DESCRIPTION
Training a translation model (or a text-classification model) from the packaged executable fails with PermissionError: [WinError 5] Access is denied: 'DashAI'.

Root cause: every HuggingFace transformer wrote its temporary checkpoints to a relative path:
TEMP_CHECKPOINT_DIR = "DashAI/back/user_models/temp_checkpoints_opus-mt-en-es"

New resolve_temp_checkpoint_dir() helper in models/utils.py that anchors checkpoints to an absolute, writable path under the DashAI local data directory (DASHAI_LOCAL_PATH, falling back to ~/.DashAI) — the same pattern the Huey job queue already uses. It keeps only the final segment of the configured name, so the 24 subclass TEMP_CHECKPOINT_DIR attributes don't need to change.


