### PR TITLE
Simplify explorer dtype restrictions and fix select all cap

### DIFF
--- a/DashAI/back/exploration/base_explorer.py
+++ b/DashAI/back/exploration/base_explorer.py
@@ -12,6 +12,12 @@ if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
 
+# Dtypes that cannot be plotted on a numeric axis. Shared default for plot
+# explorers that accept the Categorical semantic type but only when it is
+# numerically encoded (an empty dtype means the dtype is unknown).
+NON_NUMERIC_DTYPES: Final[List[str]] = ["string", "bool", ""]
+
+
 class BaseExplorerSchema(BaseSchema):
     """
     Base schema for explorers, it defines the parameters to be used in each explorer.
@@ -103,9 +109,9 @@ class BaseExplorer(ConfigObject, ABC):
         meta.pop("restricted_dtypes", None)
         meta.pop("numeric_categorical_only", None)
 
-        # Ensure type_dtype_restrictions is always present for the frontend
-        if "type_dtype_restrictions" not in meta:
-            meta["type_dtype_restrictions"] = {}
+        # Ensure non_allowed_dtypes is always present for the frontend
+        if "non_allowed_dtypes" not in meta:
+            meta["non_allowed_dtypes"] = []
 
         return meta
 
@@ -172,8 +178,8 @@ class BaseExplorer(ConfigObject, ABC):
         if "max" in input_cardinality and n > input_cardinality["max"]:
             return False
 
-        # Per-type dtype exclusions: maps semantic type name → list of forbidden dtypes.
-        type_dtype_restrictions = metadata.get("type_dtype_restrictions", {})
+        # Global dtype blacklist: dtypes that are never valid for this explorer.
+        non_allowed_dtypes = metadata.get("non_allowed_dtypes", [])
         for column in selected_columns:
             column_name = column["columnName"]
             col_info = column_spec.get(column_name, {})
@@ -182,8 +188,7 @@ class BaseExplorer(ConfigObject, ABC):
 
             if allowed_types and col_type not in allowed_types:
                 return False
-            forbidden_dtypes = type_dtype_restrictions.get(col_type, [])
-            if forbidden_dtypes and col_dtype in forbidden_dtypes:
+            if non_allowed_dtypes and col_dtype in non_allowed_dtypes:
                 return False
             if allowed_dtypes and col_dtype not in allowed_dtypes:
                 return False

--- a/DashAI/back/exploration/explorers/corr_matrix.py
+++ b/DashAI/back/exploration/explorers/corr_matrix.py
@@ -9,7 +9,10 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
-from DashAI.back.exploration.base_explorer import BaseExplorerSchema
+from DashAI.back.exploration.base_explorer import (
+    NON_NUMERIC_DTYPES,
+    BaseExplorerSchema,
+)
 from DashAI.back.exploration.statistical_explorer import StatisticalExplorer
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
@@ -197,7 +200,7 @@ class CorrelationMatrixExplorer(StatisticalExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/cov_matrix.py
+++ b/DashAI/back/exploration/explorers/cov_matrix.py
@@ -3,7 +3,10 @@ from typing import TYPE_CHECKING, Any, Dict
 from DashAI.back.core.schema_fields import bool_field, int_field, schema_field
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
-from DashAI.back.exploration.base_explorer import BaseExplorerSchema
+from DashAI.back.exploration.base_explorer import (
+    NON_NUMERIC_DTYPES,
+    BaseExplorerSchema,
+)
 from DashAI.back.exploration.statistical_explorer import StatisticalExplorer
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
@@ -192,7 +195,7 @@ class CovarianceMatrixExplorer(StatisticalExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/ecdf_plot.py
+++ b/DashAI/back/exploration/explorers/ecdf_plot.py
@@ -11,7 +11,10 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
-from DashAI.back.exploration.base_explorer import BaseExplorerSchema
+from DashAI.back.exploration.base_explorer import (
+    NON_NUMERIC_DTYPES,
+    BaseExplorerSchema,
+)
 from DashAI.back.exploration.distribution_explorer import DistributionExplorer
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
@@ -170,7 +173,7 @@ class ECDFPlotExplorer(DistributionExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
         "input_cardinality": {"min": 1},
     }
 

--- a/DashAI/back/exploration/explorers/multibox_plot.py
+++ b/DashAI/back/exploration/explorers/multibox_plot.py
@@ -11,7 +11,10 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
-from DashAI.back.exploration.base_explorer import BaseExplorerSchema
+from DashAI.back.exploration.base_explorer import (
+    NON_NUMERIC_DTYPES,
+    BaseExplorerSchema,
+)
 from DashAI.back.exploration.multidimensional_explorer import MultidimensionalExplorer
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
@@ -165,7 +168,7 @@ class MultiColumnBoxPlotExplorer(MultidimensionalExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
         "input_cardinality": {"min": 1},
     }
 

--- a/DashAI/back/exploration/explorers/parallel_cordinates.py
+++ b/DashAI/back/exploration/explorers/parallel_cordinates.py
@@ -9,7 +9,10 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
-from DashAI.back.exploration.base_explorer import BaseExplorerSchema
+from DashAI.back.exploration.base_explorer import (
+    NON_NUMERIC_DTYPES,
+    BaseExplorerSchema,
+)
 from DashAI.back.exploration.multidimensional_explorer import MultidimensionalExplorer
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
@@ -94,7 +97,7 @@ class ParallelCordinatesExplorer(MultidimensionalExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/scatter_matrix.py
+++ b/DashAI/back/exploration/explorers/scatter_matrix.py
@@ -9,7 +9,10 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
-from DashAI.back.exploration.base_explorer import BaseExplorerSchema
+from DashAI.back.exploration.base_explorer import (
+    NON_NUMERIC_DTYPES,
+    BaseExplorerSchema,
+)
 from DashAI.back.exploration.relationship_explorer import RelationshipExplorer
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
@@ -123,7 +126,7 @@ class ScatterMatrixExplorer(RelationshipExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
         "input_cardinality": {"min": 2},
     }
 

--- a/DashAI/back/exploration/explorers/scatter_plot.py
+++ b/DashAI/back/exploration/explorers/scatter_plot.py
@@ -9,7 +9,10 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.dependencies.database.models import Explorer, Notebook
-from DashAI.back.exploration.base_explorer import BaseExplorerSchema
+from DashAI.back.exploration.base_explorer import (
+    NON_NUMERIC_DTYPES,
+    BaseExplorerSchema,
+)
 from DashAI.back.exploration.relationship_explorer import RelationshipExplorer
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.value_types import Float, Integer
@@ -129,7 +132,7 @@ class ScatterPlotExplorer(RelationshipExplorer):
     metadata: Dict[str, Any] = {
         "allowed_types": [Float, Integer, Categorical],
         "allowed_dtypes": [],
-        "type_dtype_restrictions": {"Categorical": ["string", "bool", ""]},
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
         "input_cardinality": {"exact": 2},
     }
 

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -206,13 +206,15 @@ function ColumnSelector({
   );
 
   const handleSelectAllRows = useCallback(() => {
+    const limit = inputCardinality.exact || inputCardinality.max;
     const validIds = getValidColumnIds();
-    const allValidSelected =
-      validIds.length > 0 &&
-      validIds.every((id) => rowSelectionModel.includes(id));
+    const selectableIds = limit ? validIds.slice(0, limit) : validIds;
+    const allSelectableSelected =
+      selectableIds.length > 0 &&
+      selectableIds.every((id) => rowSelectionModel.includes(id));
 
-    handleSelection(allValidSelected ? {} : toMRT(validIds));
-  }, [getValidColumnIds, rowSelectionModel]);
+    handleSelection(allSelectableSelected ? {} : toMRT(selectableIds));
+  }, [getValidColumnIds, rowSelectionModel, inputCardinality]);
 
   // Effect to update selection data and validation whenever rowSelectionModel changes
   useEffect(() => {
@@ -313,15 +315,20 @@ function ColumnSelector({
           }
         : {},
     }),
-    muiSelectAllCheckboxProps: () => ({
-      checked:
-        getValidColumnIds().length > 0 &&
-        getValidColumnIds().every((id) => rowSelectionModel.includes(id)),
-      indeterminate:
-        rowSelectionModel.length > 0 &&
-        rowSelectionModel.length < getValidColumnIds().length,
-      onChange: handleSelectAllRows,
-    }),
+    muiSelectAllCheckboxProps: () => {
+      const limit = inputCardinality.exact || inputCardinality.max;
+      const validIds = getValidColumnIds();
+      const selectableIds = limit ? validIds.slice(0, limit) : validIds;
+      return {
+        checked:
+          selectableIds.length > 0 &&
+          selectableIds.every((id) => rowSelectionModel.includes(id)),
+        indeterminate:
+          rowSelectionModel.length > 0 &&
+          rowSelectionModel.length < selectableIds.length,
+        onChange: handleSelectAllRows,
+      };
+    },
     localization,
   });
 

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -29,6 +29,7 @@ import { useTableLocalization } from "../../utils/useTableLocalization";
  * @param {Object} props.inputCardinality - Cardinality requirements {min, max, exact} (optional)
  * @param {Array} props.allowedDtypes - Array of allowed dtype strings (optional)
  * @param {Array} props.allowedTypes - Array of allowed semantic type names (optional)
+ * @param {Array} props.nonAllowedDtypes - Array of forbidden dtype strings (optional)
  * @param {Function} props.onSelectionChange - Callback when selection changes (selectedColumns) (optional)
  * @param {Function} props.onValidationChange - Callback when validation status changes (isValid) (optional)
 
@@ -39,7 +40,7 @@ function ColumnSelector({
   inputCardinality = {},
   allowedDtypes = [],
   allowedTypes = [],
-  typesDtypeRestrictions = {},
+  nonAllowedDtypes = [],
   onSelectionChange = () => {},
   onValidationChange = () => {},
   columnTypes = null,
@@ -161,16 +162,15 @@ function ColumnSelector({
         if (allowedDtypes.length > 0 && !allowedDtypes.includes(row.dataType)) {
           return false;
         }
-        const forbiddenDtypes = typesDtypeRestrictions[row.valueType];
-        if (forbiddenDtypes) {
+        if (nonAllowedDtypes.length > 0) {
           const dtypeKey =
             row.dataType === t("common:unknown") ? "" : row.dataType;
-          if (forbiddenDtypes.includes(dtypeKey)) return false;
+          if (nonAllowedDtypes.includes(dtypeKey)) return false;
         }
         return true;
       })
       .map((row) => row.id);
-  }, [rows, allowedDtypes, allowedTypes, typesDtypeRestrictions]);
+  }, [rows, allowedDtypes, allowedTypes, nonAllowedDtypes]);
 
   // Check if row is selectable - using useCallback for stability
   const isRowSelectable = useCallback(
@@ -413,6 +413,20 @@ function ColumnSelector({
             </Box>
           </Typography>
         )}
+
+        {/* Excluded data types */}
+        {nonAllowedDtypes.length > 0 && (
+          <Typography
+            variant="caption"
+            sx={{ color: "warning.main", mt: 1, display: "block" }}
+          >
+            {t("datasets:label.excludedDataTypes", {
+              dtypes: nonAllowedDtypes
+                .map((d) => (d === "" ? t("common:unknown") : d))
+                .join(", "),
+            })}
+          </Typography>
+        )}
       </Box>
 
       {tool?.metadata?.changes_row_count && (
@@ -455,7 +469,7 @@ ColumnSelector.propTypes = {
   }),
   allowedDtypes: PropTypes.array,
   allowedTypes: PropTypes.array,
-  typesDtypeRestrictions: PropTypes.object,
+  nonAllowedDtypes: PropTypes.array,
   onSelectionChange: PropTypes.func,
   onValidationChange: PropTypes.func,
 };

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -147,8 +147,7 @@ export default function RightBar({ notebook, onToggle }) {
     const allowedTypes = explorer?.metadata?.allowed_types || [];
     const allowedDtypes = explorer?.metadata?.allowed_dtypes || [];
     const inputCardinality = explorer?.metadata?.input_cardinality || {};
-    const typesDtypeRestrictions =
-      explorer?.metadata?.type_dtype_restrictions || {};
+    const nonAllowedDtypes = explorer?.metadata?.non_allowed_dtypes || [];
 
     let validColumns = datasetColumns;
     let disabled = false;
@@ -169,14 +168,12 @@ export default function RightBar({ notebook, onToggle }) {
       );
     }
 
-    // Apply per-type dtype exclusions declared by the backend
-    if (Object.keys(typesDtypeRestrictions).length > 0) {
+    // Apply global dtype blacklist declared by the backend
+    if (nonAllowedDtypes.length > 0) {
       validColumns = validColumns.filter((col) => {
-        const forbidden = typesDtypeRestrictions[col.valueType];
-        if (!forbidden) return true;
         const dtypeKey =
           col.dataType === t("common:unknown") ? "" : col.dataType;
-        return !forbidden.includes(dtypeKey);
+        return !nonAllowedDtypes.includes(dtypeKey);
       });
     }
 

--- a/DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx
+++ b/DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx
@@ -18,7 +18,7 @@ export default function ScopeStepExplorer({
   const allowedTypes = tool?.metadata?.allowed_types || [];
   const allowedDtypes = tool?.metadata?.allowed_dtypes || [];
   const inputCardinality = tool?.metadata?.input_cardinality || {};
-  const typesDtypeRestrictions = tool?.metadata?.type_dtype_restrictions || {};
+  const nonAllowedDtypes = tool?.metadata?.non_allowed_dtypes || [];
   const tourContext = useTourContext();
   const { t } = useTranslation(["datasets", "common"]);
 
@@ -52,7 +52,7 @@ export default function ScopeStepExplorer({
           inputCardinality={inputCardinality}
           allowedTypes={allowedTypes}
           allowedDtypes={allowedDtypes}
-          typesDtypeRestrictions={typesDtypeRestrictions}
+          nonAllowedDtypes={nonAllowedDtypes}
           onSelectionChange={(selected) => setScopeColumns(selected)}
           onValidationChange={(isValid) => setIsSelectionValid(isValid)}
         />

--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -100,6 +100,7 @@
     "all": "alle",
     "allowedDataTypes": "Zulässige Datentypen: <1><0></0></1>",
     "allowedValueTypes": "Zulässige Wertetypen: <1><0></0></1>",
+    "excludedDataTypes": "Ausgeschlossene Datentypen: {{dtypes}}",
     "allTypeChangesValid": "Alle Typänderungen sind gültig und können sicher angewendet werden.",
     "analysisTools": "Analysewerkzeuge",
     "appearance": "Erscheinungsbild",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -98,6 +98,7 @@
     "all": "all",
     "allowedDataTypes": "Allowed data types: <1><0></0></1>",
     "allowedValueTypes": "Allowed value types: <1><0></0></1>",
+    "excludedDataTypes": "Excluded data types: {{dtypes}}",
     "allTypeChangesValid": "All type changes are valid and can be applied safely.",
     "analysisTools": "Analysis Tools",
     "appearance": "Appearance",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -103,6 +103,7 @@
     "all": "todos",
     "allowedDataTypes": "Tipos de datos permitidos: <1><0></0></1>",
     "allowedValueTypes": "Tipos de valores permitidos: <1><0></0></1>",
+    "excludedDataTypes": "Tipos de datos excluidos: {{dtypes}}",
     "allTypeChangesValid": "Todos los cambios de tipo son válidos y pueden aplicarse de forma segura.",
     "analysisTools": "Herramientas de Análisis",
     "appearance": "Apariencia",

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -103,6 +103,7 @@
     "all": "todos",
     "allowedDataTypes": "Tipos de dados permitidos: <1><0></0></1>",
     "allowedValueTypes": "Tipos de valores permitidos: <1><0></0></1>",
+    "excludedDataTypes": "Tipos de dados excluídos: {{dtypes}}",
     "allTypeChangesValid": "Todas as alterações de tipo são válidas e podem ser aplicadas com segurança.",
     "analysisTools": "Ferramentas de Análise",
     "appearance": "Aparência",

--- a/DashAI/front/src/utils/i18n/locales/zh/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/zh/datasets.json
@@ -99,6 +99,7 @@
     "all": "全部",
     "allowedDataTypes": "允许的数据类型：<1><0></0></1>",
     "allowedValueTypes": "允许的值类型：<1><0></0></1>",
+    "excludedDataTypes": "排除的数据类型：{{dtypes}}",
     "allTypeChangesValid": "所有类型更改均有效，可以安全应用。",
     "analysisTools": "分析工具",
     "appearance": "外观",

--- a/tests/back/exploration/test_base_explorer_metadata.py
+++ b/tests/back/exploration/test_base_explorer_metadata.py
@@ -203,14 +203,14 @@ def test_validate_columns_missing_column_in_spec_passes_when_unrestricted():
     assert cls.validate_columns(explorer_info, column_spec) is True
 
 
-# --- type_dtype_restrictions tests ---
+# --- non_allowed_dtypes tests ---
 
 
-def test_type_dtype_restrictions_passes_allowed_dtype():
+def test_non_allowed_dtypes_passes_int_dtype():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
+        non_allowed_dtypes=["string", "bool", ""],
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_num"}])
@@ -218,11 +218,11 @@ def test_type_dtype_restrictions_passes_allowed_dtype():
     assert cls.validate_columns(explorer_info, column_spec) is True
 
 
-def test_type_dtype_restrictions_passes_float_dtype():
+def test_non_allowed_dtypes_passes_float_dtype():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
+        non_allowed_dtypes=["string", "bool", ""],
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_num"}])
@@ -230,11 +230,11 @@ def test_type_dtype_restrictions_passes_float_dtype():
     assert cls.validate_columns(explorer_info, column_spec) is True
 
 
-def test_type_dtype_restrictions_blocks_string_dtype():
+def test_non_allowed_dtypes_blocks_string_dtype():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
+        non_allowed_dtypes=["string", "bool", ""],
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_str"}])
@@ -242,11 +242,11 @@ def test_type_dtype_restrictions_blocks_string_dtype():
     assert cls.validate_columns(explorer_info, column_spec) is False
 
 
-def test_type_dtype_restrictions_blocks_bool_dtype():
+def test_non_allowed_dtypes_blocks_bool_dtype():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
-        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
+        non_allowed_dtypes=["string", "bool", ""],
         input_cardinality={"min": 1},
     )
     explorer_info = _MockExplorerInfo([{"columnName": "cat_bool"}])
@@ -254,7 +254,7 @@ def test_type_dtype_restrictions_blocks_bool_dtype():
     assert cls.validate_columns(explorer_info, column_spec) is False
 
 
-def test_type_dtype_restrictions_absent_allows_string_categorical():
+def test_non_allowed_dtypes_absent_allows_string_categorical():
     cls = _make_explorer(
         allowed_types=[Float, Integer, Categorical],
         allowed_dtypes=[],
@@ -265,20 +265,20 @@ def test_type_dtype_restrictions_absent_allows_string_categorical():
     assert cls.validate_columns(explorer_info, column_spec) is True
 
 
-def test_get_metadata_includes_type_dtype_restrictions():
+def test_get_metadata_includes_non_allowed_dtypes():
     cls = _make_explorer(
         allowed_types=[],
         allowed_dtypes=[],
-        type_dtype_restrictions={"Categorical": ["string", "bool", ""]},
+        non_allowed_dtypes=["string", "bool", ""],
     )
     meta = cls.get_metadata()
-    assert meta["type_dtype_restrictions"] == {"Categorical": ["string", "bool", ""]}
+    assert meta["non_allowed_dtypes"] == ["string", "bool", ""]
 
 
-def test_get_metadata_type_dtype_restrictions_defaults_to_empty():
+def test_get_metadata_non_allowed_dtypes_defaults_to_empty():
     cls = _make_explorer(allowed_types=[], allowed_dtypes=[])
     meta = cls.get_metadata()
-    assert meta["type_dtype_restrictions"] == {}
+    assert meta["non_allowed_dtypes"] == []
 
 
 def test_get_metadata_drops_numeric_categorical_only():


### PR DESCRIPTION
## Summary

Replaces the per type dtype restriction mechanism (`type_dtype_restrictions`, a `{type: [dtypes]}` dict) with a single global dtype blacklist (`non_allowed_dtypes`, a flat list) across all explorers. Every explorer used the exact same value (`{"Categorical": ["string", "bool", ""]}`), so the per type granularity was unused complexity. The blacklist is now displayed to users in the column selector, and a separate fix caps the "select all" action to the explorer's column cardinality limit.

<img width="2545" height="1315" alt="image" src="https://github.com/user-attachments/assets/0608c931-083b-4df1-b763-ff2f2756dff7" />


---

## Type of Change

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

**Select-all cardinality fix**
- `DashAI/front/src/components/notebooks/ColumnSelector.jsx`: cap "select all" and the header checkbox state to `inputCardinality.exact || max`, so explorers requiring exactly N columns no longer select every valid column

**Dtype restriction refactor (backend)**
- `DashAI/back/exploration/base_explorer.py`: add shared `NON_NUMERIC_DTYPES` constant; `validate_columns` now checks a global `non_allowed_dtypes` blacklist; metadata default changed from `type_dtype_restrictions: {}` to `non_allowed_dtypes: []`
- `DashAI/back/exploration/explorers/{scatter_plot,scatter_matrix,parallel_cordinates,multibox_plot,ecdf_plot,cov_matrix,corr_matrix}.py`: use `"non_allowed_dtypes": NON_NUMERIC_DTYPES` instead of the inline dict
- `tests/back/exploration/test_base_explorer_metadata.py`: tests updated to the new mechanism

**Dtype restriction refactor (frontend)**
- `DashAI/front/src/components/notebooks/ColumnSelector.jsx`: rename prop `typesDtypeRestrictions` -> `nonAllowedDtypes`, simplify the filter, add an "Excluded data types" caption so struck through rows have a visible reason
- `DashAI/front/src/components/notebooks/RightBar.jsx`: explorer validation uses the global blacklist
- `DashAI/front/src/components/notebooks/explorerCreation/ScopeStepExplorer.jsx`: read and pass `non_allowed_dtypes`

**Translations**
- `DashAI/front/src/utils/i18n/locales/{en,es,pt,de,zh}/datasets.json`: add `excludedDataTypes` label

---

## Testing

- Verify in the notebook explorer UI that Categorical columns with `string`/`bool` dtype are struck through with the "Excluded data types" note, and that "select all" respects the `exact`/`max` limit (e.g. Scatter Plot, exactly 2)

---

## Notes

- One intentional behavior change: the unknown/empty dtype (`""`) is now blocked for all value types, not just Categorical. Acceptable since an unknown dtype column can't be plotted on a numeric axis anyway.
- Behavior is otherwise unchanged for real data -- Float/Integer never carry `string`/`bool` dtype, so the global blacklist blocks exactly the same columns the per type dict did.
- `non_allowed_dtypes` is strictly less expressive than the per type dict (one rule for all types). No explorer needs per type divergence today; reintroduce the dict if that ever changes.
