### PR TITLE
Fix TorchScript source error for image models in packaged exe

### DIFF
--- a/DashAI/back/models/hugging_face/sd15_depth_controlnet_model.py
+++ b/DashAI/back/models/hugging_face/sd15_depth_controlnet_model.py
@@ -181,8 +181,9 @@ def get_depth_map_sd15(image, device):
     """Convert an input image to a normalised depth map for SD 1.5 ControlNet.
 
     Uses Intel's DPT-Hybrid-MiDaS model to estimate per-pixel depth, then
-    bilinearly interpolates the result to 512x512 and normalises values to the
-    [0, 1] range before returning a three-channel PIL image.
+    interpolates the result back to the source image resolution (rounded down
+    to a multiple of 8) and normalises values to the [0, 1] range before
+    returning a three-channel PIL image.
 
     Parameters
     ----------
@@ -195,8 +196,9 @@ def get_depth_map_sd15(image, device):
     Returns
     -------
     PIL.Image.Image
-        A 512x512 RGB image where each channel encodes the normalised depth
-        value, ready to be used as a ControlNet conditioning signal.
+        An RGB image at the source resolution (each side rounded down to a
+        multiple of 8) where each channel encodes the normalised depth value,
+        ready to be used as a ControlNet conditioning signal.
     """
     import numpy as np
     import torch
@@ -215,9 +217,16 @@ def get_depth_map_sd15(image, device):
     with torch.no_grad(), torch.autocast(device, dtype=torch.float16):
         depth_map = depth_estimator(pixel_values).predicted_depth
 
+    # Preserve the source resolution. SD 1.5's UNet downsamples by 8 in latent
+    # space, so both dimensions must be divisible by 8; round down to the
+    # nearest multiple to avoid a pipeline shape error.
+    width, height = image.size
+    width = max(8, (width // 8) * 8)
+    height = max(8, (height // 8) * 8)
+
     depth_map = torch.nn.functional.interpolate(
         depth_map.unsqueeze(1),
-        size=(512, 512),
+        size=(height, width),
         mode="bicubic",
         align_corners=False,
     )

--- a/DashAI/back/models/hugging_face/sdxl_turbo_model.py
+++ b/DashAI/back/models/hugging_face/sdxl_turbo_model.py
@@ -384,7 +384,7 @@ class SDXLTurboModel(TextToImageGenerationTaskModel):
         """Download and initialise the SDXL Turbo pipeline.
 
         Downloads ``stabilityai/sdxl-turbo`` from HuggingFace Hub via
-        ``AutoPipelineForText2Image.from_pretrained`` and moves the pipeline
+        ``StableDiffusionXLPipeline.from_pretrained`` and moves the pipeline
         to the requested device.  When a GPU is available, the ``fp16``
         variant is loaded to halve memory usage; CPU inference uses
         ``float32``.
@@ -414,7 +414,7 @@ class SDXLTurboModel(TextToImageGenerationTaskModel):
                 Number of images to generate per prompt call.
         """
         import torch
-        from diffusers import AutoPipelineForText2Image
+        from diffusers import StableDiffusionXLPipeline
 
         kwargs = self.validate_and_transform(kwargs)
         use_gpu = DEVICE_TO_IDX.get(kwargs.get("device")) >= 0
@@ -422,7 +422,7 @@ class SDXLTurboModel(TextToImageGenerationTaskModel):
             f"cuda:{DEVICE_TO_IDX.get(kwargs.get('device'))}" if use_gpu else "cpu"
         )
 
-        self.model = AutoPipelineForText2Image.from_pretrained(
+        self.model = StableDiffusionXLPipeline.from_pretrained(
             "stabilityai/sdxl-turbo",
             torch_dtype=torch.float16 if use_gpu else torch.float32,
             variant="fp16" if use_gpu else None,

--- a/dashai.spec
+++ b/dashai.spec
@@ -34,6 +34,11 @@ a = Analysis(
         ),
         ("DashAI/back/seeds", "DashAI/back/seeds"),
         (f"{SITEPKG}/transformers", "transformers"),
+        # Ship source .py for packages that run torch.jit.script at import time.
+        # PyInstaller bundles only .pyc, but TorchScript needs original source
+        # via inspect.getsource, so these must be shipped as data dirs.
+        (f"{SITEPKG}/diffusers", "diffusers"),
+        (f"{SITEPKG}/controlnet_aux", "controlnet_aux"),
     ] + webview_datas,
     hiddenimports=webview_hiddenimports,
     hookspath=["hooks"],


### PR DESCRIPTION
## Summary
The packaged Windows .exe / macOS .dmg are built with PyInstaller, which strips `.py` source and ships only `.pyc`. Several Hugging Face image models trigger `torch.jit.script` at import time (diffusers `kolors`, controlnet_aux `teed/Fsmish`), and TorchScript needs the original source via `inspect.getsource`. In a frozen build this raises `OSError: could not get source code`, so SDXL Turbo and the SD1.5 ControlNet models failed to instantiate. This ships the affected packages' source as data dirs (same approach already used for `transformers`) and switches SDXL Turbo to a concrete pipeline class. The Linux AppImage is unaffected (it pip installs deps with source intact).

This branch also fixes an unrelated SD1.5 depth ControlNet bug where output was forced to 512x512.

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `dashai.spec`: ship `diffusers` and `controlnet_aux` source as data dirs so TorchScript can read source at import time in the frozen build (mirrors the existing `transformers` entry).
- `DashAI/back/models/hugging_face/sdxl_turbo_model.py`: load SDXL Turbo via `StableDiffusionXLPipeline` directly instead of `AutoPipelineForText2Image`. Avoids importing every pipeline class (including the `kolors` jit path) and is faster / lighter; sdxl-turbo resolves to this same pipeline anyway.

---

## Testing

Rebuild the PyInstaller bundle (`pyinstaller --clean --noconfirm dashai.spec`) and run, in the .exe:
- SDXL Turbo image generation
- SD1.5 HED ControlNet and SD1.5 OpenPose ControlNet generation

All three previously crashed with `Can't get source for ...` and should now instantiate and generate.

---

## Notes

- Bundle grows by roughly 20-30 MB (raw `.py` source for the two packages). 
- If other generative models crash on a different library doing import-time `torch.jit.script`, the fix is the same: add that package to the spec `datas`.
