### PR TITLE
Make optuna CmaEsSampler work and drop incompatible GridSampler

### DIFF
--- a/DashAI/back/optimizers/optuna_optimizer.py
+++ b/DashAI/back/optimizers/optuna_optimizer.py
@@ -38,7 +38,6 @@ class OptunaSchema(BaseSchema):
             enum=[
                 "TPESampler",
                 "CmaEsSampler",
-                "GridSampler",
                 "GPSampler",
                 "NSGAIISampler",
                 "QMCSampler",

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ controlnet_aux
 sacrebleu
 sentencepiece
 optuna
+cmaes
 hyperopt
 nvidia-ml-py
 openpyxl


### PR DESCRIPTION
## Summary
Fixes two Optuna samplers that were selectable in the optimizer UI but always crashed at runtime: `CmaEsSampler` (missing `cmaes` dependency) and `GridSampler` (architecturally incompatible with the bounds based search flow).

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `requirements.txt`: add `cmaes` so `CmaEsSampler` no longer fails with `ModuleNotFoundError: No module named 'cmaes'`.
- `DashAI/back/optimizers/optuna_optimizer.py`: remove `GridSampler` from the sampler enum. The optimizer instantiates samplers with no args (`sampler()`) and drives the search via `suggest_int`/`suggest_float` bounds; `GridSampler` requires an explicit `search_space` dict and cannot run in this flow.

---

## Testing (Optional)
Ran a study with every sampler still offered in the enum. All pass: `TPESampler`, `CmaEsSampler`, `GPSampler`, `NSGAIISampler`, `QMCSampler`, `RandomSampler`.

---

## Notes (Optional)
`GridSampler` removal is intentional, not deferred. It is incompatible by design with the current bounds driven optimization, so wiring `search_space` support would be a separate feature rather than a fix.
