### PR TITLE
Match GGUF filename case so llama.cpp models load on Linux

### DIFF
--- a/DashAI/back/models/hugging_face/mixtral_model.py
+++ b/DashAI/back/models/hugging_face/mixtral_model.py
@@ -487,7 +487,7 @@ class MixtralModel(TextToTextGenerationTaskModel):
         self.frequency_penalty = kwargs.pop("frequency_penalty", 0.1)
         self.n_ctx = kwargs.pop("context_window", 512)
 
-        self.filename = kwargs.get("filename", "mixtral-8x7b-instruct-v0.1.Q2_K.gguf")
+        self.filename = kwargs.get("filename", "Mixtral-8x7B-Instruct-v0.1.Q2_K.gguf")
         use_gpu = LLAMA_DEVICE_TO_IDX.get(kwargs.get("device")) >= 0
 
         self.model = Llama.from_pretrained(

--- a/DashAI/back/models/hugging_face/smol_lm_model.py
+++ b/DashAI/back/models/hugging_face/smol_lm_model.py
@@ -18,8 +18,8 @@ from DashAI.back.models.utils import (
 )
 
 SMOLLM_FILENAME_MAP = {
-    "HuggingFaceTB/SmolLM2-1.7B-Instruct-GGUF": "*Q4_K_M.gguf",
-    "HuggingFaceTB/SmolLM2-360M-Instruct-GGUF": "*Q8_0.gguf",
+    "HuggingFaceTB/SmolLM2-1.7B-Instruct-GGUF": "*q4_k_m.gguf",
+    "HuggingFaceTB/SmolLM2-360M-Instruct-GGUF": "*q8_0.gguf",
 }
 
 
@@ -417,7 +417,7 @@ class SmolLMModel(TextToTextGenerationTaskModel):
         self.frequency_penalty = kwargs.pop("frequency_penalty", 0.1)
         self.n_ctx = kwargs.pop("context_window", 512)
 
-        self.filename = SMOLLM_FILENAME_MAP.get(self.model_name, "*Q4_K_M.gguf")
+        self.filename = SMOLLM_FILENAME_MAP.get(self.model_name, "*q4_k_m.gguf")
         use_gpu = LLAMA_DEVICE_TO_IDX.get(kwargs.get("device")) >= 0
 
         self.model = Llama.from_pretrained(


### PR DESCRIPTION
## Summary
Fixes llama.cpp (GGUF) models failing to load on the Linux AppImage build. `Llama.from_pretrained` matches the filename pattern with `fnmatch`, which is case insensitive on Windows but case sensitive on Linux, so patterns whose case did not match the real repo filenames worked in dev (Windows) but crashed in the packaged AppImage.

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/models/hugging_face/smol_lm_model.py`: lowercase the GGUF quant patterns in `SMOLLM_FILENAME_MAP` and the default (`*Q4_K_M.gguf` -> `*q4_k_m.gguf`, `*Q8_0.gguf` -> `*q8_0.gguf`). HuggingFaceTB ships lowercase filenames (e.g. `smollm2-1.7b-instruct-q4_k_m.gguf`).
- `DashAI/back/models/hugging_face/mixtral_model.py`: fix the default filename fallback case (`mixtral-8x7b-instruct-v0.1.Q2_K.gguf` -> `Mixtral-8x7B-Instruct-v0.1.Q2_K.gguf`) to match the actual mradermacher repo filename.

---

## Testing (Optional)
Verify Llama and SmolLM work on a Linux OS using any dashAI version (PyPI or AppImage).
