### PR TITLE
Render AppImage icon from SVG isotype at high resolution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -251,7 +251,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install build python-appimage
           sudo apt-get update
-          sudo apt-get install -y libfuse2 imagemagick
+          sudo apt-get install -y libfuse2 imagemagick librsvg2-bin
       - name: Build wheel (frontend bundled)
         run: python -m build --wheel
       - name: Verify frontend is included in wheel
@@ -262,8 +262,11 @@ jobs:
           fi
       - name: Prepare AppImage recipe
         run: |
-          # Icon referenced by dashai.desktop (Icon=dashai); take the first frame of the .ico
-          convert installer/dashAI.ico[0] appimage/dashai.png
+          # Icon referenced by dashai.desktop (Icon=dashai). Rasterize the
+          # scalable SVG isotype to a large square PNG so desktops have a
+          # high-resolution icon (the .ico only carried small frames).
+          rsvg-convert -h 512 DashAI/front/public/dashai-isotype.svg -o /tmp/dashai-isotype.png
+          convert /tmp/dashai-isotype.png -background none -gravity center -extent 512x512 appimage/dashai.png
           # Append the freshly built wheel (with bundled frontend) to the recipe requirements
           WHEEL=$(ls "$PWD"/dist/*.whl | head -n1)
           echo "$WHEEL" >> appimage/requirements.txt


### PR DESCRIPTION
## Summary
The Linux AppImage shipped a broken icon. The build extracted frame 0 of `dashAI.ico`, which is the 16x16 entry (ICO frames are ordered smallest first), so python-appimage installed it under `hicolor/16x16` and desktops fell back to a generic icon. Rasterize the scalable `dashai-isotype.svg` to a 512x512 PNG instead so the embedded icon is high resolution and usable by desktop integration.

---

## Type of Change

- [ ] Backend change
- [ ] Frontend change
- [x] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `.github/workflows/publish.yml`: in the AppImage build, install `librsvg2-bin` and replace `convert installer/dashAI.ico[0]` (16x16 frame) with `rsvg-convert` of `DashAI/front/public/dashai-isotype.svg` at height 512, then pad to a 512x512 square PNG via `convert -extent`.

---

## Notes
**IMPORTANT**: This fixes the resolution of the embedded icon only. **AppImages do not self register their icon**, so on a stock distro without integration tooling the downloaded file still shows a generic icon until it is integrated. That is inherent to the format and out of scope here.
