### PR TITLE
Add n_components validation and warnings for dimensionality reduction converters

### DIFF
--- a/DashAI/back/converters/base_converter.py
+++ b/DashAI/back/converters/base_converter.py
@@ -72,6 +72,9 @@ class BaseConverter(ConfigObject, ABC):
         meta["color"] = cls.COLOR if cls.COLOR else "rgb(255, 255, 255)"
         meta["supervised"] = cls.SUPERVISED
         meta["changes_row_count"] = cls.CHANGES_ROW_COUNT
+        meta["n_components_features_bounded"] = getattr(
+            cls, "N_COMPONENTS_FEATURES_BOUNDED", False
+        )
 
         # Serialize allowed_types class references → class name strings for the frontend
         raw_types = meta.get("allowed_types", [])

--- a/DashAI/back/converters/category/dimensionality_reduction.py
+++ b/DashAI/back/converters/category/dimensionality_reduction.py
@@ -26,3 +26,4 @@ class DimensionalityReductionConverter(BaseConverter):
     )
     ICON: Final[str] = Icon.Layers.value
     COLOR: Final[str] = "rgb(255, 99, 132)"
+    N_COMPONENTS_FEATURES_BOUNDED: bool = True

--- a/DashAI/back/converters/scikit_learn/fast_ica.py
+++ b/DashAI/back/converters/scikit_learn/fast_ica.py
@@ -208,6 +208,7 @@ class FastICA(DimensionalityReductionConverter, SklearnWrapper, FastICAOperation
     """
 
     SCHEMA = FastICASchema
+    N_COMPONENTS_FEATURES_BOUNDED: bool = False
     DESCRIPTION = MultilingualString(
         en="FastICA: a fast algorithm for Independent Component Analysis.",
         es=(

--- a/DashAI/back/converters/scikit_learn/nystroem.py
+++ b/DashAI/back/converters/scikit_learn/nystroem.py
@@ -170,6 +170,7 @@ class Nystroem(DimensionalityReductionConverter, SklearnWrapper, NystroemOperati
     """
 
     SCHEMA = NystroemSchema
+    N_COMPONENTS_FEATURES_BOUNDED: bool = False
     DESCRIPTION = MultilingualString(
         en=(
             "Approximate a kernel map using a subset of the training data. "

--- a/DashAI/back/converters/scikit_learn/pca.py
+++ b/DashAI/back/converters/scikit_learn/pca.py
@@ -306,6 +306,19 @@ class PCA(DimensionalityReductionConverter, SklearnWrapper, PCAOPERATION):
 
         super().__init__(**kwargs)
 
+    def fit(self, x, y=None):
+        x_pandas = x.to_pandas() if hasattr(x, "to_pandas") else x
+        n_samples, n_features = x_pandas.shape
+        max_components = min(n_samples, n_features)
+        if isinstance(self.n_components, int) and self.n_components > max_components:
+            raise ValueError(
+                f"n_components={self.n_components} exceeds "
+                f"min(n_samples, n_features)={max_components}. "
+                f"Reduce n_components to at most {max_components}, "
+                "or select more columns in the converter scope."
+            )
+        return super().fit(x, y)
+
     def get_output_type(self, column_name: str = None) -> DashAIDataType:
         """Return the DashAI data type produced by this converter for a column.
 

--- a/DashAI/back/converters/scikit_learn/truncated_svd.py
+++ b/DashAI/back/converters/scikit_learn/truncated_svd.py
@@ -211,6 +211,7 @@ class TruncatedSVD(
     metadata = {
         "allowed_types": [Float, Integer],
         "allowed_dtypes": [],
+        "input_cardinality": {"min": 2},
     }
 
     def __init__(self, **kwargs):

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -227,6 +227,7 @@ export default function RightBar({ notebook, onToggle }) {
 
     const allowedTypes = converter?.metadata?.allowed_types || [];
     const allowedDtypes = converter?.metadata?.allowed_dtypes || [];
+    const inputCardinality = converter?.metadata?.input_cardinality || {};
 
     let validColumns = datasetColumns;
     let disabled = false;
@@ -245,6 +246,27 @@ export default function RightBar({ notebook, onToggle }) {
       validColumns = validColumns.filter((col) =>
         allowedDtypes.includes(col.dataType),
       );
+    }
+
+    // Check cardinality requirements
+    if (inputCardinality.exact != null) {
+      if (validColumns.length < inputCardinality.exact) {
+        disabled = true;
+        tooltip += `\n\n${t("datasets:error.requiresExactColumns", {
+          required: inputCardinality.exact,
+          available: validColumns.length,
+          count: inputCardinality.exact,
+        })}`;
+      }
+    } else if (inputCardinality.min != null) {
+      if (validColumns.length < inputCardinality.min) {
+        disabled = true;
+        tooltip += `\n\n${t("datasets:error.requiresMinColumns", {
+          required: inputCardinality.min,
+          available: validColumns.length,
+          count: inputCardinality.min,
+        })}`;
+      }
     }
 
     // Check if there are no valid columns at all (some restriction was applied)

--- a/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/FormConverterSection.jsx
@@ -160,6 +160,8 @@ export default function FormConverterSection({
       {step === 1 && (
         <ParameterStepConverter
           converter={tool.name}
+          tool={tool}
+          selectedColumns={columns}
           initialParams={{}}
           handleSaveConverter={handleSaveConverter}
           setStep={setStep}

--- a/DashAI/front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx
@@ -91,7 +91,7 @@ export default function ParameterStepConverter({
       {showNComponentsWarning && (
         <Alert severity="warning" sx={{ mb: 2 }}>
           {t("datasets:label.nComponentsColumnInfo", {
-            count: nColumnsSelected,
+            n: nColumnsSelected,
           })}
         </Alert>
       )}

--- a/DashAI/front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from "react";
-import { Box, Typography } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { Alert, Box, Typography } from "@mui/material";
 import FormSchemaWithSelectedModel from "../../shared/FormSchemaWithSelectedModel";
 import FormSchemaContainer from "../../shared/FormSchemaContainer";
 import { useTourContext } from "../../tour/TourProvider";
@@ -7,6 +7,8 @@ import { useTranslation } from "react-i18next";
 
 export default function ParameterStepConverter({
   converter,
+  tool,
+  selectedColumns = [],
   initialParams,
   handleSaveConverter,
   setStep,
@@ -55,6 +57,21 @@ export default function ParameterStepConverter({
     }
   }, [tourContext?.stepIndex, tourContext?.run]);
 
+  const nColumnsSelected = selectedColumns.length;
+  const defaultNComponents =
+    tool?.schema?.properties?.n_components?.default ?? null;
+  const [currentNComponents, setCurrentNComponents] =
+    useState(defaultNComponents);
+
+  const isDimensionalityReduction =
+    tool?.metadata?.n_components_features_bounded === true;
+
+  const showNComponentsWarning =
+    isDimensionalityReduction &&
+    typeof currentNComponents === "number" &&
+    nColumnsSelected > 0 &&
+    currentNComponents > nColumnsSelected;
+
   return (
     <Box
       sx={{
@@ -71,6 +88,13 @@ export default function ParameterStepConverter({
       >
         {t("datasets:label.configureParameters")}
       </Typography>
+      {showNComponentsWarning && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {t("datasets:label.nComponentsColumnInfo", {
+            count: nColumnsSelected,
+          })}
+        </Alert>
+      )}
       <FormSchemaContainer>
         <FormSchemaWithSelectedModel
           onFormSubmit={handleSave}
@@ -79,6 +103,11 @@ export default function ParameterStepConverter({
           onCancel={() => setStep(0)}
           saveButtonText={t("datasets:button.createConverter")}
           hideButtons={hideButtons}
+          onValuesChange={(values) => {
+            if (values?.n_components !== undefined) {
+              setCurrentNComponents(values.n_components);
+            }
+          }}
         />
       </FormSchemaContainer>
     </Box>

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -29,6 +29,7 @@ export default function ScopeStepConverter({
   const tourContext = useTourContext();
   const allowedTypes = tool?.metadata?.allowed_types || [];
   const allowedDtypes = tool?.metadata?.allowed_dtypes || [];
+  const inputCardinality = tool?.metadata?.input_cardinality || {};
   const { t } = useTranslation(["common", "datasets"]);
   const { columnTypes } = useExplorersAndConverters();
 
@@ -97,6 +98,7 @@ export default function ScopeStepConverter({
           tool={tool}
           allowedTypes={allowedTypes}
           allowedDtypes={allowedDtypes}
+          inputCardinality={inputCardinality}
           columnTypes={columnTypes}
           onSelectionChange={(columnsInfo) => {
             const processedColumns = columnsInfo.map((col) => ({

--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -267,7 +267,7 @@
     "missingValuesOverview": "Übersicht fehlender Werte",
     "mostFrequent": "Am häufigsten",
     "nameYourNotebook": "Notizbuch benennen",
-    "nComponentsColumnInfo": "Sie haben {{count}} Spalte(n) ausgewählt. n_components muss kleiner oder gleich {{count}} sein. Reduzieren Sie n_components oder wählen Sie mehr Spalten aus, um Fehler zu vermeiden.",
+    "nComponentsColumnInfo": "Sie haben {{n}} Spalte(n) ausgewählt. n_components muss kleiner oder gleich {{n}} sein. Reduzieren Sie n_components oder wählen Sie mehr Spalten aus, um Fehler zu vermeiden.",
     "newDatasetCreatedWithTransformations": "Ein neuer Datensatz wird mit diesen Transformationen erstellt. Er kann mit anderen Modulen verwendet werden, ohne das Original zu beeinflussen.",
     "noDataQualityIssuesDetected": "Keine Datenqualitätsprobleme erkannt",
     "noDuplicateRows": "Keine doppelten Zeilen im Datensatz gefunden.",

--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -267,6 +267,7 @@
     "missingValuesOverview": "Übersicht fehlender Werte",
     "mostFrequent": "Am häufigsten",
     "nameYourNotebook": "Notizbuch benennen",
+    "nComponentsColumnInfo": "Sie haben {{count}} Spalte(n) ausgewählt. n_components muss kleiner oder gleich {{count}} sein. Reduzieren Sie n_components oder wählen Sie mehr Spalten aus, um Fehler zu vermeiden.",
     "newDatasetCreatedWithTransformations": "Ein neuer Datensatz wird mit diesen Transformationen erstellt. Er kann mit anderen Modulen verwendet werden, ohne das Original zu beeinflussen.",
     "noDataQualityIssuesDetected": "Keine Datenqualitätsprobleme erkannt",
     "noDuplicateRows": "Keine doppelten Zeilen im Datensatz gefunden.",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -267,6 +267,7 @@
     "missingValuesOverview": "Missing Values Overview",
     "mostFrequent": "Most Frequent",
     "nameYourNotebook": "Name your Notebook",
+    "nComponentsColumnInfo": "You selected {{count}} column(s). n_components must be less than or equal to {{count}}. Reduce n_components or add more columns to avoid errors.",
     "newDatasetCreatedWithTransformations": "A new dataset will be created with these transformations. It can be used with other modules without affecting the original.",
     "noDataQualityIssuesDetected": "No data quality issues detected",
     "noDuplicateRows": "No duplicate rows detected in the dataset.",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -267,7 +267,7 @@
     "missingValuesOverview": "Missing Values Overview",
     "mostFrequent": "Most Frequent",
     "nameYourNotebook": "Name your Notebook",
-    "nComponentsColumnInfo": "You selected {{count}} column(s). n_components must be less than or equal to {{count}}. Reduce n_components or add more columns to avoid errors.",
+    "nComponentsColumnInfo": "You selected {{n}} column(s). n_components must be less than or equal to {{n}}. Reduce n_components or add more columns to avoid errors.",
     "newDatasetCreatedWithTransformations": "A new dataset will be created with these transformations. It can be used with other modules without affecting the original.",
     "noDataQualityIssuesDetected": "No data quality issues detected",
     "noDuplicateRows": "No duplicate rows detected in the dataset.",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -273,6 +273,7 @@
     "missingValuesOverview": "Resumen de Valores Faltantes",
     "mostFrequent": "Más Frecuente",
     "nameYourNotebook": "Nombre su Cuaderno",
+    "nComponentsColumnInfo": "Seleccionaste {{count}} columna(s). n_components debe ser menor o igual a {{count}}. Reduce n_components o agrega más columnas para evitar errores.",
     "newDatasetCreatedWithTransformations": "Se creará un nuevo dataset con estas transformaciones. Puede usarse con otros módulos sin afectar el original.",
     "noDataQualityIssuesDetected": "No se detectaron problemas de calidad de datos",
     "noDuplicateRows": "No se detectaron filas duplicadas en el dataset.",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -273,7 +273,7 @@
     "missingValuesOverview": "Resumen de Valores Faltantes",
     "mostFrequent": "Más Frecuente",
     "nameYourNotebook": "Nombre su Cuaderno",
-    "nComponentsColumnInfo": "Seleccionaste {{count}} columna(s). n_components debe ser menor o igual a {{count}}. Reduce n_components o agrega más columnas para evitar errores.",
+    "nComponentsColumnInfo": "Seleccionaste {{n}} columna(s). n_components debe ser menor o igual a {{n}}. Reduce n_components o agrega más columnas para evitar errores.",
     "newDatasetCreatedWithTransformations": "Se creará un nuevo dataset con estas transformaciones. Puede usarse con otros módulos sin afectar el original.",
     "noDataQualityIssuesDetected": "No se detectaron problemas de calidad de datos",
     "noDuplicateRows": "No se detectaron filas duplicadas en el dataset.",

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -273,6 +273,7 @@
     "missingValuesOverview": "Resumo de Valores Ausentes",
     "mostFrequent": "Mais Frequente",
     "nameYourNotebook": "Nomeie seu Caderno",
+    "nComponentsColumnInfo": "Você selecionou {{count}} coluna(s). n_components deve ser menor ou igual a {{count}}. Reduza n_components ou adicione mais colunas para evitar erros.",
     "newDatasetCreatedWithTransformations": "Um novo conjunto de dados será criado com estas transformações. Pode ser usado com outros módulos sem afetar o original.",
     "noDataQualityIssuesDetected": "Nenhum problema de qualidade de dados detectado",
     "noDuplicateRows": "Nenhuma linha duplicada detectada no conjunto de dados.",

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -273,7 +273,7 @@
     "missingValuesOverview": "Resumo de Valores Ausentes",
     "mostFrequent": "Mais Frequente",
     "nameYourNotebook": "Nomeie seu Caderno",
-    "nComponentsColumnInfo": "Você selecionou {{count}} coluna(s). n_components deve ser menor ou igual a {{count}}. Reduza n_components ou adicione mais colunas para evitar erros.",
+    "nComponentsColumnInfo": "Você selecionou {{n}} coluna(s). n_components deve ser menor ou igual a {{n}}. Reduza n_components ou adicione mais colunas para evitar erros.",
     "newDatasetCreatedWithTransformations": "Um novo conjunto de dados será criado com estas transformações. Pode ser usado com outros módulos sem afetar o original.",
     "noDataQualityIssuesDetected": "Nenhum problema de qualidade de dados detectado",
     "noDuplicateRows": "Nenhuma linha duplicada detectada no conjunto de dados.",

--- a/DashAI/front/src/utils/i18n/locales/zh/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/zh/datasets.json
@@ -268,6 +268,7 @@
     "missingValuesOverview": "缺失值概览",
     "mostFrequent": "最频繁",
     "nameYourNotebook": "为笔记本命名",
+    "nComponentsColumnInfo": "您选择了 {{count}} 列。n_components 必须小于或等于 {{count}}。请减少 n_components 或选择更多列以避免错误。",
     "newDatasetCreatedWithTransformations": "将使用这些变换创建新数据集。可在其他模块中使用，不影响原始数据。",
     "noDataQualityIssuesDetected": "未检测到数据质量问题",
     "noDuplicateRows": "数据集中未检测到重复行。",

--- a/DashAI/front/src/utils/i18n/locales/zh/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/zh/datasets.json
@@ -268,7 +268,7 @@
     "missingValuesOverview": "缺失值概览",
     "mostFrequent": "最频繁",
     "nameYourNotebook": "为笔记本命名",
-    "nComponentsColumnInfo": "您选择了 {{count}} 列。n_components 必须小于或等于 {{count}}。请减少 n_components 或选择更多列以避免错误。",
+    "nComponentsColumnInfo": "您选择了 {{n}} 列。n_components 必须小于或等于 {{n}}。请减少 n_components 或选择更多列以避免错误。",
     "newDatasetCreatedWithTransformations": "将使用这些变换创建新数据集。可在其他模块中使用，不影响原始数据。",
     "noDataQualityIssuesDetected": "未检测到数据质量问题",
     "noDuplicateRows": "数据集中未检测到重复行。",


### PR DESCRIPTION
## Summary

Dimensionality reduction converters (PCA, IncrementalPCA, TruncatedSVD) would silently fail at job execution time when `n_components` exceeded the number of selected columns, showing a cryptic sklearn error with no guidance. This PR adds two layers of prevention: a real-time warning in the parameter configuration step, and proper column-count enforcement for TruncatedSVD (which requires at least 2 input features) using the existing `input_cardinality` mechanism already in place for explorers.

---

## Type of Change

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

**Backend**
- `back/converters/scikit_learn/pca.py`: Added `fit()` override with a user-friendly `ValueError` when `n_components` exceeds `min(n_samples, n_features)`
- `back/converters/category/dimensionality_reduction.py`: Added `N_COMPONENTS_FEATURES_BOUNDED = True` class attribute to flag converters where `n_components` is bounded by the number of input features
- `back/converters/scikit_learn/nystroem.py`: Override `N_COMPONENTS_FEATURES_BOUNDED = False` (its `n_components` is bounded by `n_samples`, not features)
- `back/converters/scikit_learn/fast_ica.py`: Override `N_COMPONENTS_FEATURES_BOUNDED = False` (does not enforce the same constraint)
- `back/converters/scikit_learn/truncated_svd.py`: Added `"input_cardinality": {"min": 2}` to metadata — TruncatedSVD always requires at least 2 input features
- `back/converters/base_converter.py`: Exposes `n_components_features_bounded` in `get_metadata()` so the frontend can read it

**Frontend**
- `front/src/components/notebooks/converterCreation/FormConverterSection.jsx`: Passes `tool` and `selectedColumns` down to `ParameterStepConverter`
- `front/src/components/notebooks/converterCreation/ParameterStepConverter.jsx`: Shows a real-time warning `Alert` when `n_components > number of selected columns`, only for converters with `n_components_features_bounded = true`. Tracks the live form value via the existing `onValuesChange` callback
- `front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx`: Reads `input_cardinality` from converter metadata and passes it to `ColumnSelector`, enabling cardinality enforcement at column selection time
- `front/src/components/notebooks/RightBar.jsx`: Extended `validateConverter` to check `input_cardinality` (min/exact) — same logic already used by `validateExplorer` — so converters like TruncatedSVD are disabled in the list when the dataset doesn't have enough valid columns
- `front/src/utils/i18n/locales/{en,es,pt,de,zh}/datasets.json`: Added `nComponentsColumnInfo` translation key for the warning message

---

## Testing

- Dimensionality reduction converters (PCA, IncrementalPCA, TruncatedSVD) show a warning in the parameter step when `n_components` exceeds the number of selected columns, and that the warning disappears when the value is corrected.
- TruncatedSVD is disabled in the converter list when the dataset does not have at least 2 valid numeric columns.
- Converters that do not have this constraint (Nystroem, RBFSampler, SkewedChi2Sampler, FastICA) do not show the warning regardless of the column count.

 