### PR TITLE
Preserve generative session folder state when navigating

### DIFF
--- a/DashAI/front/src/components/generative/SessionBar.jsx
+++ b/DashAI/front/src/components/generative/SessionBar.jsx
@@ -47,16 +47,16 @@ export default function SessionBar({ onToggle }) {
         ),
       ),
     ];
-    const initialOpenState = {};
-    uniqueDisplayNames.forEach((displayName) => {
-      initialOpenState[displayName] = false;
-    });
     setOpenSections((prev) => {
-      // Only update if display names have changed
       const prevKeys = Object.keys(prev).sort().join(",");
-      const newKeys = Object.keys(initialOpenState).sort().join(",");
+      const newKeys = uniqueDisplayNames.slice().sort().join(",");
       if (prevKeys === newKeys) return prev;
-      return initialOpenState;
+      // Preserve existing open/close state; initialize new keys as closed
+      const merged = {};
+      uniqueDisplayNames.forEach((displayName) => {
+        merged[displayName] = displayName in prev ? prev[displayName] : false;
+      });
+      return merged;
     });
   }, [sessions, tasks]);
 

--- a/DashAI/front/src/pages/generative/GenerativeContent.jsx
+++ b/DashAI/front/src/pages/generative/GenerativeContent.jsx
@@ -97,23 +97,19 @@ export default function GenerativeContent() {
     return <ParamsBar onToggle={threePanelLayout.handleToggleRight} />;
   };
 
-  const layout = (
-    <ThreePanelLayoutContext.Provider value={threePanelLayout}>
-      <ModuleContainer>
-        <LeftPanel data-tour="sessions-left-panel">
-          <SessionBar onToggle={threePanelLayout.handleToggleLeft} />
-        </LeftPanel>
-        <CenterPanel>{renderCenter()}</CenterPanel>
-        <RightPanel toggleButtonTop="50%" data-tour="parameters-right-panel">
-          {renderRight()}
-        </RightPanel>
-      </ModuleContainer>
-    </ThreePanelLayoutContext.Provider>
-  );
-
-  return isCreating ? (
-    <CreateSessionProvider>{layout}</CreateSessionProvider>
-  ) : (
-    layout
+  return (
+    <CreateSessionProvider>
+      <ThreePanelLayoutContext.Provider value={threePanelLayout}>
+        <ModuleContainer>
+          <LeftPanel data-tour="sessions-left-panel">
+            <SessionBar onToggle={threePanelLayout.handleToggleLeft} />
+          </LeftPanel>
+          <CenterPanel>{renderCenter()}</CenterPanel>
+          <RightPanel toggleButtonTop="50%" data-tour="parameters-right-panel">
+            {renderRight()}
+          </RightPanel>
+        </ModuleContainer>
+      </ThreePanelLayoutContext.Provider>
+    </CreateSessionProvider>
   );
 }


### PR DESCRIPTION
## Summary
Session folders in the generative module sidebar were collapsing whenever the user navigated to the "create session" flow or returned from it. This happened because `GenerativeContent` conditionally wrapped its layout in `CreateSessionProvider`, causing React to unmount and remount the entire tree (including `SessionBar`) on every `isCreating` toggle. A secondary bug also reset all folder states when a session with a new task type was added.

---

## Type of Change

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/pages/generative/GenerativeContent.jsx`: always wrap the layout with `CreateSessionProvider` so the component tree stays stable across route changes, preventing `SessionBar` from remounting.
- `DashAI/front/src/components/generative/SessionBar.jsx`: when the set of task display names changes, preserve existing open/close states and only initialize newly added folders as closed.