### PR TITLE
Add auto-clear for selected run ID after highlighting run card

### DIFF
--- a/DashAI/front/src/components/models/SessionVisualization.jsx
+++ b/DashAI/front/src/components/models/SessionVisualization.jsx
@@ -162,6 +162,7 @@ export default function SessionVisualization() {
     if (element) {
       element.scrollIntoView({ behavior: "smooth", block: "center" });
     }
+    setTimeout(() => setSelectedRunId(null), 2000);
   }, []);
 
   const handleViewDetails = React.useCallback((run) => {


### PR DESCRIPTION
## Summary
Clicking a row in the model comparison table highlighted the corresponding run card (scale + shadow) with no way to dismiss it — the effect persisted until the page was refreshed or the user navigated away. The highlight now
automatically clears after 2 seconds, matching the existing auto-clear pattern already used for newly added run cards.

---

## Type of Change

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/models/SessionVisualization.jsx`: added a `setTimeout` in `handleRowClick` to reset `selectedRunId` to `null` after 2000 ms.