### PR TITLE
Fix notebook save empty dataset

### DIFF
--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -264,7 +264,9 @@ class DashAIDataset(Dataset):
         dict
             Dictionary with statistics for each numeric column.
         """
-        numeric_keys = self._get_numeric_columns()
+        numeric_keys = [
+            k for k in self._get_numeric_columns() if k in dataset_df.columns
+        ]
         numeric_cols = dataset_df[numeric_keys]
         numeric_stats = {}
 
@@ -316,7 +318,9 @@ class DashAIDataset(Dataset):
         dict
             Dictionary with statistics for each categorical column.
         """
-        categorical_keys = self._get_categorical_columns()
+        categorical_keys = [
+            k for k in self._get_categorical_columns() if k in dataset_df.columns
+        ]
         categorical_cols = dataset_df[categorical_keys]
         categorical_stats = {}
 
@@ -465,7 +469,9 @@ class DashAIDataset(Dataset):
         dict
             Nested dictionary representing the correlation matrix.
         """
-        numeric_keys = self._get_numeric_columns()
+        numeric_keys = [
+            k for k in self._get_numeric_columns() if k in dataset_df.columns
+        ]
         numeric_cols = dataset_df[numeric_keys]
 
         if numeric_cols.empty:

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -392,6 +392,9 @@ class DashAIDataset(Dataset):
             Dictionary with quality indicators including completeness,
             constant columns, high cardinality columns, and quality score.
         """
+        if dataset_df.empty:
+            return {}
+
         # Count rows with missing values
         rows_with_any_nan = int(dataset_df.isna().any(axis=1).sum())
         rows_with_multiple_nan = int((dataset_df.isna().sum(axis=1) > 1).sum())
@@ -514,6 +517,11 @@ class DashAIDataset(Dataset):
         modified_dataset = super().remove_columns(column_names)
         # Update self with modified dataset attributes
         self.__dict__.update(modified_dataset.__dict__)
+
+        # Keep self.types in sync so Arrow metadata stays consistent
+        if self.types is not None:
+            for col in column_names:
+                self.types.pop(col, None)
 
         return self
 

--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -34,6 +34,7 @@ export function SaveDatasetModal({
   appliedConverters,
   existingDatasets = [],
   notebook,
+  hasNoColumns = false,
 }) {
   const [name, setName] = useState("");
   const [frozenDefaultName, setFrozenDefaultName] = useState("");
@@ -298,10 +299,19 @@ export function SaveDatasetModal({
 
           {/* Footer - always visible */}
           <Box sx={{ px: 3, pb: 3, flexShrink: 0 }}>
+            {hasNoColumns && (
+              <Typography
+                variant="caption"
+                color="error"
+                sx={{ display: "block", mb: 1, textAlign: "center" }}
+              >
+                {t("datasets:error.cannotSaveEmptyDataset")}
+              </Typography>
+            )}
             <StepperNavigationFooter
               onBack={handleClose}
               onNext={handleSubmit}
-              nextDisabled={Boolean(nameError)}
+              nextDisabled={Boolean(nameError) || hasNoColumns}
               backLabel={t("common:cancel")}
               nextLabel={t("common:upload")}
               variant="save"

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -63,6 +63,7 @@ export default function DatasetPreviewNotebook({
   );
 
   const [localColumnTypes, setLocalColumnTypes] = useState({});
+  const [totalRows, setTotalRows] = useState(null);
 
   // Sync types from context — updated by fetchExplorersAndConverters (initial
   // load + delete path) and by handleStatusChange / FormConverterSection
@@ -96,6 +97,14 @@ export default function DatasetPreviewNotebook({
     },
     [notebook?.id],
   );
+
+  // Re-fetch row count whenever converters change
+  useEffect(() => {
+    if (!notebook?.file_path) return;
+    fetchDatasetPage(0, 1, null, null)
+      .then(({ total }) => setTotalRows(total))
+      .catch(() => setTotalRows(null));
+  }, [converterKey, fetchDatasetPage]);
 
   if (!notebook) {
     return (
@@ -248,15 +257,6 @@ export default function DatasetPreviewNotebook({
               endIcon={<Add />}
               onClick={(e) => {
                 e.stopPropagation();
-                if (
-                  convertersLoaded &&
-                  Object.keys(localColumnTypes).length === 0
-                ) {
-                  enqueueSnackbar(t("datasets:error.cannotSaveEmptyDataset"), {
-                    variant: "error",
-                  });
-                  return;
-                }
                 setShowSaveDatasetModal(true);
                 if (tourContext && tourContext.run) {
                   setTimeout(() => {
@@ -316,6 +316,7 @@ export default function DatasetPreviewNotebook({
         )}
         existingDatasets={existingDatasets}
         notebook={notebook}
+        hasNoColumns={convertersLoaded && totalRows === 0}
       />
 
       <NotebookHistoryModal

--- a/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx
@@ -248,6 +248,15 @@ export default function DatasetPreviewNotebook({
               endIcon={<Add />}
               onClick={(e) => {
                 e.stopPropagation();
+                if (
+                  convertersLoaded &&
+                  Object.keys(localColumnTypes).length === 0
+                ) {
+                  enqueueSnackbar(t("datasets:error.cannotSaveEmptyDataset"), {
+                    variant: "error",
+                  });
+                  return;
+                }
                 setShowSaveDatasetModal(true);
                 if (tourContext && tourContext.run) {
                   setTimeout(() => {

--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -94,7 +94,7 @@
     "requiresMinColumns_one": "Erfordert mindestens {{required}} gültige Spalte, aber nur {{available}} verfügbar.",
     "requiresMinColumns_other": "Erfordert mindestens {{required}} gültige Spalten, aber nur {{available}} verfügbar.",
     "zipContentsNotCompatible": "ZIP enthält keine mit dem ausgewählten Datenlader kompatiblen Dateien",
-    "cannotSaveEmptyDataset": "Dataset kann nicht gespeichert werden: Alle Spalten wurden entfernt. Fügen Sie Spalten hinzu, bevor Sie speichern."
+    "cannotSaveEmptyDataset": "Dataset kann nicht gespeichert werden: Alle Spalten wurden entfernt."
   },
   "label": {
     "task": "Aufgabe",

--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -93,7 +93,8 @@
     "requiresExactColumns_other": "Erfordert genau {{required}} gültige Spalten, aber {{available}} verfügbar.",
     "requiresMinColumns_one": "Erfordert mindestens {{required}} gültige Spalte, aber nur {{available}} verfügbar.",
     "requiresMinColumns_other": "Erfordert mindestens {{required}} gültige Spalten, aber nur {{available}} verfügbar.",
-    "zipContentsNotCompatible": "ZIP enthält keine mit dem ausgewählten Datenlader kompatiblen Dateien"
+    "zipContentsNotCompatible": "ZIP enthält keine mit dem ausgewählten Datenlader kompatiblen Dateien",
+    "cannotSaveEmptyDataset": "Dataset kann nicht gespeichert werden: Alle Spalten wurden entfernt. Fügen Sie Spalten hinzu, bevor Sie speichern."
   },
   "label": {
     "task": "Aufgabe",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -92,7 +92,7 @@
     "requiresMinColumns_one": "Requires at least {{required}} valid column, but only {{available}} available.",
     "requiresMinColumns_other": "Requires at least {{required}} valid columns, but only {{available}} available.",
     "zipContentsNotCompatible": "ZIP does not contain files compatible with the selected dataloader",
-    "cannotSaveEmptyDataset": "Cannot save dataset: all columns have been removed. Add columns before saving."
+    "cannotSaveEmptyDataset": "Cannot save dataset: all columns have been removed."
   },
   "label": {
     "task": "Task",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -91,7 +91,8 @@
     "requiresExactColumns_other": "Requires exactly {{required}} valid columns, but {{available}} available.",
     "requiresMinColumns_one": "Requires at least {{required}} valid column, but only {{available}} available.",
     "requiresMinColumns_other": "Requires at least {{required}} valid columns, but only {{available}} available.",
-    "zipContentsNotCompatible": "ZIP does not contain files compatible with the selected dataloader"
+    "zipContentsNotCompatible": "ZIP does not contain files compatible with the selected dataloader",
+    "cannotSaveEmptyDataset": "Cannot save dataset: all columns have been removed. Add columns before saving."
   },
   "label": {
     "task": "Task",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -97,7 +97,7 @@
     "requiresMinColumns_many": "Requiere al menos {{required}} columnas válidas, pero solo {{available}} disponibles.",
     "requiresMinColumns_other": "Requiere al menos {{required}} columnas válidas, pero solo {{available}} disponibles.",
     "zipContentsNotCompatible": "El ZIP no contiene archivos compatibles con el dataloader seleccionado",
-    "cannotSaveEmptyDataset": "No se puede guardar el dataset: se eliminaron todas las columnas. Agrega columnas antes de guardar."
+    "cannotSaveEmptyDataset": "No se puede guardar el dataset: se eliminaron todas las columnas."
   },
   "label": {
     "task": "Tarea",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -96,7 +96,8 @@
     "requiresMinColumns_one": "Requiere al menos {{required}} columna válida, pero solo {{available}} disponible.",
     "requiresMinColumns_many": "Requiere al menos {{required}} columnas válidas, pero solo {{available}} disponibles.",
     "requiresMinColumns_other": "Requiere al menos {{required}} columnas válidas, pero solo {{available}} disponibles.",
-    "zipContentsNotCompatible": "El ZIP no contiene archivos compatibles con el dataloader seleccionado"
+    "zipContentsNotCompatible": "El ZIP no contiene archivos compatibles con el dataloader seleccionado",
+    "cannotSaveEmptyDataset": "No se puede guardar el dataset: se eliminaron todas las columnas. Agrega columnas antes de guardar."
   },
   "label": {
     "task": "Tarea",

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -97,7 +97,7 @@
     "requiresMinColumns_many": "Requer pelo menos {{required}} colunas válidas, mas apenas {{available}} disponíveis.",
     "requiresMinColumns_other": "Requer pelo menos {{required}} colunas válidas, mas apenas {{available}} disponíveis.",
     "zipContentsNotCompatible": "O arquivo ZIP não contém arquivos compatíveis com o dataloader selecionado",
-    "cannotSaveEmptyDataset": "Não é possível salvar o dataset: todas as colunas foram removidas. Adicione colunas antes de salvar."
+    "cannotSaveEmptyDataset": "Não é possível salvar o dataset: todas as colunas foram removidas."
   },
   "label": {
     "task": "Tarefa",

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -96,7 +96,8 @@
     "requiresMinColumns_one": "Requer pelo menos {{required}} coluna válida, mas apenas {{available}} disponível.",
     "requiresMinColumns_many": "Requer pelo menos {{required}} colunas válidas, mas apenas {{available}} disponíveis.",
     "requiresMinColumns_other": "Requer pelo menos {{required}} colunas válidas, mas apenas {{available}} disponíveis.",
-    "zipContentsNotCompatible": "O arquivo ZIP não contém arquivos compatíveis com o dataloader selecionado"
+    "zipContentsNotCompatible": "O arquivo ZIP não contém arquivos compatíveis com o dataloader selecionado",
+    "cannotSaveEmptyDataset": "Não é possível salvar o dataset: todas as colunas foram removidas. Adicione colunas antes de salvar."
   },
   "label": {
     "task": "Tarefa",

--- a/DashAI/front/src/utils/i18n/locales/zh/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/zh/datasets.json
@@ -92,7 +92,8 @@
     "requiresExactColumns_other": "需要恰好 {{required}} 个有效列，但只有 {{available}} 个可用。",
     "requiresMinColumns_one": "至少需要 {{required}} 个有效列，但只有 {{available}} 个可用。",
     "requiresMinColumns_other": "至少需要 {{required}} 个有效列，但只有 {{available}} 个可用。",
-    "zipContentsNotCompatible": "ZIP 文件不包含与所选数据加载器兼容的文件"
+    "zipContentsNotCompatible": "ZIP 文件不包含与所选数据加载器兼容的文件",
+    "cannotSaveEmptyDataset": "无法保存数据集：所有列已被删除，请在保存前添加列。"
   },
   "label": {
     "task": "任务",

--- a/DashAI/front/src/utils/i18n/locales/zh/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/zh/datasets.json
@@ -93,7 +93,7 @@
     "requiresMinColumns_one": "至少需要 {{required}} 个有效列，但只有 {{available}} 个可用。",
     "requiresMinColumns_other": "至少需要 {{required}} 个有效列，但只有 {{available}} 个可用。",
     "zipContentsNotCompatible": "ZIP 文件不包含与所选数据加载器兼容的文件",
-    "cannotSaveEmptyDataset": "无法保存数据集：所有列已被删除，请在保存前添加列。"
+    "cannotSaveEmptyDataset": "无法保存数据集：所有列已被删除。"
   },
   "label": {
     "task": "任务",


### PR DESCRIPTION
## Summary
Saving a dataset from a notebook after removing all columns via converters caused a crash in the backend job (`KeyError`, `ZeroDivisionError`) because `compute_metadata` iterated over stale column type metadata that no longer matched the actual dataframe. The root cause was that `remove_columns` in `DashAIDataset` removed columns from the data but never updated `self.types`, so the Arrow metadata on disk stayed out of sync. Additionally, the frontend offered no feedback — the save button remained active even with an empty result.

---

## Type of Change

  - [x] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

---

## Changes (by file)

- `DashAI/back/dataloaders/classes/dashai_dataset.py`: fixed `remove_columns` to also remove deleted columns from `self.types`, keeping Arrow metadata in sync with the actual data; added early-return guards in `_compute_numeric_metadata`, `_compute_categorical_metadata`, `_compute_correlations`, and `_compute_quality_metadata` to handle dataframes whose columns no longer match the stored type metadata.
- `DashAI/front/src/components/notebooks/notebook/DatasetPreviewNotebook.jsx`: added `totalRows` state that re-fetches the row count after each converter change; passes `hasNoColumns` to `SaveDatasetModal` when the result has 0 rows.
- `DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx`: added `hasNoColumns` prop that disables the submit button and shows an error message when the dataset is empty.
- `DashAI/front/src/utils/i18n/locales/*/datasets.json`: added `error.cannotSaveEmptyDataset` translation key in all five languages.

---

## Testing

- Apply a `ColumnRemover` converter that removes all columns from a notebook, then open "Save as New Dataset". The submit button should be disabled with an error message.
- Apply converters that only remove some columns, save should proceed normally.