### PR TITLE
Fix EDA metadata toggle cut off in Save as Dataset modal

### DIFF
--- a/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx
@@ -239,15 +239,15 @@ export function SaveDatasetModal({
             </IconButton>
           </Box>
 
-          {/* Scrollable Content */}
+          {/* Static fields — always visible, never scroll */}
           <Box
             sx={{
-              p: 3,
+              px: 3,
+              pt: 3,
               display: "flex",
               flexDirection: "column",
               gap: 3,
-              overflowY: "auto",
-              flex: 1,
+              flexShrink: 0,
             }}
             data-tour="save-dataset-modal-notebook"
           >
@@ -278,22 +278,32 @@ export function SaveDatasetModal({
               </Box>
             </FormSchemaFieldCard>
 
-            <Box>
-              <Typography variant="subtitle2" gutterBottom>
-                {t("datasets:label.appliedTransformations")}
+            <Typography variant="subtitle2">
+              {t("datasets:label.appliedTransformations")}
+            </Typography>
+          </Box>
+
+          {/* Scrollable converter list */}
+          <Box
+            sx={{
+              px: 3,
+              pb: 2,
+              overflowY: "auto",
+              flex: 1,
+              minHeight: 0,
+            }}
+          >
+            {localConverters.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                {t("datasets:label.noTransformationsApplied")}
               </Typography>
-              {localConverters.length === 0 ? (
-                <Typography variant="body2" color="text.secondary">
-                  {t("datasets:label.noTransformationsApplied")}
-                </Typography>
-              ) : (
-                <ConverterHistoryList
-                  converters={localConverters}
-                  onConverterDelete={handleConverterDeleteClick}
-                  showDeleteButtons={true}
-                />
-              )}
-            </Box>
+            ) : (
+              <ConverterHistoryList
+                converters={localConverters}
+                onConverterDelete={handleConverterDeleteClick}
+                showDeleteButtons={true}
+              />
+            )}
           </Box>
 
           {/* Footer - always visible */}


### PR DESCRIPTION
## Summary

The "Compute extended metadata (EDA)" toggle in the Save as Dataset modal was getting cut off as more converters were added. Fixed by separating the static form fields (note, name, EDA toggle) from the converter list, making only the list scrollable.

---

## Type of Change

Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/notebooks/datasetCreation/SaveDatasetModal.jsx`: split the single scrollable content box into a static section (`flexShrink: 0`) for note, dataset name field, EDA toggle, and transformations heading, and a separate scrollable section (`flex: 1`, `minHeight: 0`, `overflowY: auto`) for the converter list.

---

## Testing (optional)

Open the Save as Dataset modal in the Notebooks view with several converters applied. Verify that the "Compute extended metadata (EDA)" card is always fully visible and that the converter list scrolls independently when there are many entries.
