### PR TITLE
feat: add Matthews correlation coefficient classification metric

### DIFF
--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -119,6 +119,7 @@ from DashAI.back.metrics.classification.cohen_kappa import CohenKappa
 from DashAI.back.metrics.classification.f1 import F1
 from DashAI.back.metrics.classification.hamming_distance import HammingDistance
 from DashAI.back.metrics.classification.log_loss import LogLoss
+from DashAI.back.metrics.classification.matthews_corrcoef import MatthewsCorrCoef
 from DashAI.back.metrics.classification.precision import Precision
 from DashAI.back.metrics.classification.recall import Recall
 from DashAI.back.metrics.classification.roc_auc import ROCAUC
@@ -420,6 +421,7 @@ def get_initial_components():
         LogLoss,
         HammingDistance,
         CohenKappa,
+        MatthewsCorrCoef,
         # Optimizers
         OptunaOptimizer,
         HyperOptOptimizer,

--- a/DashAI/back/metrics/classification/matthews_corrcoef.py
+++ b/DashAI/back/metrics/classification/matthews_corrcoef.py
@@ -1,0 +1,106 @@
+"""DashAI Matthews Correlation Coefficient classification metric implementation."""
+
+from typing import TYPE_CHECKING, Optional
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.metrics.classification_metric import (
+    ClassificationMetric,
+    prepare_to_metric,
+)
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class MatthewsCorrCoef(ClassificationMetric):
+    """Correlation between predicted and true labels, robust to class imbalance.
+
+    The Matthews Correlation Coefficient (MCC) is a balanced measure of the
+    quality of a classification that can be used even when the classes are of
+    very different sizes. In essence it is the correlation coefficient between
+    the observed and predicted classifications, computed from the confusion
+    matrix.
+
+    ::
+
+        MCC = (TP·TN − FP·FN) /
+              sqrt((TP+FP)(TP+FN)(TN+FP)(TN+FN))
+
+    Range: [-1, 1]. Interpretation: +1 a perfect prediction; 0 no better than
+    random guessing; -1 total disagreement between prediction and observation.
+    Because a high score requires the classifier to do well on every class
+    (all four confusion-matrix quadrants), MCC is regarded as more informative
+    than accuracy or F1 on imbalanced problems. It generalises to the
+    multiclass setting via scikit-learn's implementation.
+
+    References
+    ----------
+    - [1] Matthews, B.W. (1975). "Comparison of the predicted and observed
+           secondary structure of T4 phage lysozyme." Biochimica et Biophysica
+           Acta (BBA) - Protein Structure, 405(2), 442-451.
+    - [2] Chicco, D. & Jurman, G. (2020). "The advantages of the Matthews
+           correlation coefficient (MCC) over F1 score and accuracy in binary
+           classification evaluation." BMC Genomics, 21(6).
+    - [3] https://scikit-learn.org/stable/modules/generated/
+           sklearn.metrics.matthews_corrcoef.html
+    """
+
+    DESCRIPTION = MultilingualString(
+        en=(
+            "The Matthews Correlation Coefficient measures the correlation "
+            "between predicted and true labels, returning a value in [-1, 1] "
+            "that stays reliable even when the classes are imbalanced."
+        ),
+        es=(
+            "El Coeficiente de Correlación de Matthews mide la correlación "
+            "entre las etiquetas predichas y verdaderas, devolviendo un valor "
+            "en [-1, 1] que sigue siendo confiable incluso con clases "
+            "desbalanceadas."
+        ),
+        pt=(
+            "O Coeficiente de Correlação de Matthews mede a correlação entre "
+            "os rótulos previstos e verdadeiros, retornando um valor em "
+            "[-1, 1] que permanece confiável mesmo com classes desbalanceadas."
+        ),
+        de=(
+            "Der Matthews-Korrelationskoeffizient misst die Korrelation "
+            "zwischen vorhergesagten und wahren Labels und liefert einen Wert "
+            "in [-1, 1], der auch bei unausgewogenen Klassen zuverlässig bleibt."
+        ),
+        zh="马修斯相关系数衡量预测标签与真实标签之间的相关性，返回 [-1, 1] "
+        "范围内的值，即使在类别不平衡时也保持可靠。",
+    )
+
+    @staticmethod
+    def score(
+        true_labels: "DashAIDataset",
+        probs_pred_labels: "np.ndarray",
+        multiclass: Optional[bool] = None,
+    ) -> float:
+        """Calculate the Matthews Correlation Coefficient.
+
+        Parameters
+        ----------
+        true_labels : DashAIDataset
+            A DashAI dataset with labels.
+        probs_pred_labels : np.ndarray
+            A two-dimensional matrix in which each column represents a class
+            and the row values represent the probability that an example belongs
+            to the class associated with the column.
+        multiclass : bool, optional
+            Whether the task is a multiclass classification. If None, it will be
+            determined automatically from the number of unique labels.
+
+        Returns
+        -------
+        float
+            Matthews Correlation Coefficient between true labels and predicted
+            labels.
+        """
+        from sklearn.metrics import matthews_corrcoef
+
+        true_labels, pred_labels = prepare_to_metric(true_labels, probs_pred_labels)
+
+        return matthews_corrcoef(true_labels, pred_labels)

--- a/tests/back/metrics/test_classification_metrics.py
+++ b/tests/back/metrics/test_classification_metrics.py
@@ -6,6 +6,7 @@ from datasets import Dataset
 
 from DashAI.back.metrics.classification.accuracy import Accuracy
 from DashAI.back.metrics.classification.f1 import F1
+from DashAI.back.metrics.classification.matthews_corrcoef import MatthewsCorrCoef
 from DashAI.back.metrics.classification.precision import Precision
 from DashAI.back.metrics.classification.recall import Recall
 
@@ -51,6 +52,32 @@ def test_f1_score(metric_input: Dict[str, List[int]]):
     assert score <= 1.0
 
 
+def test_matthews_corrcoef(metric_input: Dict[str, List[int]]):
+    score = MatthewsCorrCoef.score(
+        metric_input["true_labels"], metric_input["pred_labels"]
+    )
+
+    assert isinstance(score, float)
+    assert score >= -1.0
+    assert score <= 1.0
+
+
+def test_matthews_corrcoef_matches_sklearn_reference(
+    metric_input: Dict[str, List[int]],
+):
+    from sklearn.metrics import matthews_corrcoef
+
+    true = np.array(metric_input["true_labels"]["foo"])
+    pred = np.argmax(metric_input["pred_labels"], axis=1)
+    expected = matthews_corrcoef(true, pred)
+
+    score = MatthewsCorrCoef.score(
+        metric_input["true_labels"], metric_input["pred_labels"]
+    )
+
+    assert score == pytest.approx(expected)
+
+
 def test_metrics_different_input_sizes(metric_input: Dict[str, List[int]]):
     error_pattern = (
         r"The length of the true labels and the predicted labels must be equal, "
@@ -80,3 +107,11 @@ def test_metrics_different_input_sizes(metric_input: Dict[str, List[int]]):
         match=error_pattern,
     ):
         F1.score(metric_input["true_labels"], metric_input["wrong_size_labels"])
+
+    with pytest.raises(
+        ValueError,
+        match=error_pattern,
+    ):
+        MatthewsCorrCoef.score(
+            metric_input["true_labels"], metric_input["wrong_size_labels"]
+        )


### PR DESCRIPTION
## What
Adds the Matthews Correlation Coefficient (MCC) as a new classification metric
(`MatthewsCorrCoef`), wrapping `sklearn.metrics.matthews_corrcoef`.

## Why
MCC is a balanced measure that stays reliable under class imbalance, where
accuracy and F1 can be misleading. It complements the existing
Accuracy / F1 / Precision / Recall / Cohen Kappa metrics and handles binary
and multiclass natively.

## Changes
- New metric `DashAI/back/metrics/classification/matthews_corrcoef.py`
  (follows the `CohenKappa` pattern, multilingual descriptions).
- Registered in `initial_components.py`.
- Tests in `tests/back/metrics/test_classification_metrics.py` covering the
  value range and comparing against the sklearn reference.

## Verification
- `pytest tests/back/metrics/test_classification_metrics.py` - all pass.
- Cross-checked against `sklearn.matthews_corrcoef` on synthetic binary,
  multiclass and imbalanced data (exact match; +1 on perfect prediction,
  -1 on total disagreement).
- `ruff check` / `ruff format` clean.

No new dependencies (scikit-learn is already a core dependency).
