### PR TITLE
Predict save the cols of the full dataset

### DIFF
--- a/DashAI/back/job/predict_job.py
+++ b/DashAI/back/job/predict_job.py
@@ -422,7 +422,7 @@ class PredictJob(BaseJob):
                         manual_input_data, dataset_trained_path
                     )
 
-                prepared_dataset, y_pred = _run_prediction_pipeline(
+                _, y_pred = _run_prediction_pipeline(
                     task=task,
                     trained_model=trained_model,
                     train_dataset=train_dataset,
@@ -460,9 +460,13 @@ class PredictJob(BaseJob):
                 full_path = Path(path) / folder_name
                 full_path.mkdir(parents=True, exist_ok=True)
 
-                # Add predictions to loaded dataset
+                output_col = model_session.output_columns[0]
+                base_columns = [
+                    col for col in loaded_dataset.column_names if col != output_col
+                ]
+                output_dataset = loaded_dataset.select_columns(base_columns)
                 dataset_with_prediction = to_dashai_dataset(
-                    prepared_dataset.add_column(model_session.output_columns[0], y_pred)
+                    output_dataset.add_column(output_col, y_pred)
                 )
 
                 # Filter schema from trained dataset


### PR DESCRIPTION
Summary of the change PredictJob.run() now builds the saved prediction dataset from the full loaded dataset (all original columns) instead of the input-only prepared_dataset, so columns not used as model input (e.g. id) are preserved alongside the prediction column. The manual-entry prediction flow is unaffected since it has no such extra columns by nature.