### PR TITLE
Add multilingual role/acknowledgments to institutions.json (en, es, pt, de, zh)

### DIFF
--- a/docs/static/institutions/institutions.json
+++ b/docs/static/institutions/institutions.json
@@ -5,7 +5,13 @@
       "id": "uchile",
       "name": "University of Chile",
       "fullName": "Universidad de Chile",
-      "role": "Leading Institution",
+      "role": {
+        "en": "Leading Institution",
+        "es": "Institución Líder",
+        "pt": "Instituição Líder",
+        "de": "Federführende Institution",
+        "zh": "牵头机构"
+      },
       "url": "https://uchile.cl/",
       "logo": "img/institutions/dcc-logo.png",
       "small": true
@@ -14,7 +20,13 @@
       "id": "fcfm",
       "name": "Fcfm",
       "fullName": "Facultad de Ciencias Físicas y Matemáticas Universidad de Chile",
-      "role": "Leading Institution",
+      "role": {
+        "en": "Leading Institution",
+        "es": "Institución Líder",
+        "pt": "Instituição Líder",
+        "de": "Federführende Institution",
+        "zh": "牵头机构"
+      },
       "url": "https://www.fcfm.uchile.cl/",
       "logo": "img/institutions/fcfm-logo.png"
     },
@@ -22,7 +34,13 @@
       "id": "cenia",
       "name": "CENIA",
       "fullName": "National Center for Artificial Intelligence",
-      "role": "Associated Institution",
+      "role": {
+        "en": "Associated Institution",
+        "es": "Institución Asociada",
+        "pt": "Instituição Associada",
+        "de": "Assoziierte Institution",
+        "zh": "联合机构"
+      },
       "url": "https://www.cenia.cl/",
       "logo": "img/institutions/cenia-logo.png"
     },
@@ -30,7 +48,13 @@
       "id": "imfd",
       "name": "IMFD",
       "fullName": "Millennium Institute for Foundational Data Research",
-      "role": "Collaborator",
+      "role": {
+        "en": "Collaborator",
+        "es": "Colaborador",
+        "pt": "Colaborador",
+        "de": "Mitwirkender",
+        "zh": "合作者"
+      },
       "url": "https://imfd.cl/en/",
       "logo": "img/institutions/imfd-logo.png"
     },
@@ -38,7 +62,13 @@
       "id": "unholster",
       "name": "Unholster",
       "fullName": "Unholster",
-      "role": "Industry Partner",
+      "role": {
+        "en": "Industry Partner",
+        "es": "Socio Industrial",
+        "pt": "Parceiro Industrial",
+        "de": "Industriepartner",
+        "zh": "行业合作伙伴"
+      },
       "url": "https://unholster.com/",
       "logo": "img/institutions/unholster-logo.png"
     }
@@ -47,7 +77,9 @@
     "text": {
       "en": "Supported by ANID through Fondef IDEA ID25I10330, Fondef VIU23P 0110, and grants supporting the centers CENIA (FB210017) and IMFD (ICN17_002). Developed by students of DCC UChile and UTFSM.",
       "es": "Financiado por ANID a través de Fondef IDEA ID25I10330, Fondef VIU23P 0110 y los fondos que apoyan a los centros CENIA (FB210017) e IMFD (ICN17_002). Desarrollado por estudiantes del DCC UChile y la UTFSM.",
-      "pt": "Financiado pela ANID por meio do Fondef IDEA ID25I10330, do Fondef VIU23P 0110 e dos fundos que apoiam os centros CENIA (FB210017) e IMFD (ICN17_002). Desenvolvido por estudantes do DCC UChile e da UTFSM."
+      "pt": "Financiado pela ANID por meio do Fondef IDEA ID25I10330, do Fondef VIU23P 0110 e dos fundos que apoiam os centros CENIA (FB210017) e IMFD (ICN17_002). Desenvolvido por estudantes do DCC UChile e da UTFSM.",
+      "de": "Unterstützt von ANID durch Fondef IDEA ID25I10330, Fondef VIU23P 0110 sowie durch Fördermittel für die Zentren CENIA (FB210017) und IMFD (ICN17_002). Entwickelt von Studierenden der DCC UChile und der UTFSM.",
+      "zh": "由 ANID 通过 Fondef IDEA ID25I10330、Fondef VIU23P 0110 项目，以及支持 CENIA（FB210017）和 IMFD（ICN17_002）中心的资助提供支持。由 DCC UChile 和 UTFSM 的学生开发。"
     },
     "grants": ["ID25I10330", "VIU23P 0110", "FB210017", "ICN17_002"],
     "logos": [

--- a/scripts/render_institutions.py
+++ b/scripts/render_institutions.py
@@ -161,7 +161,7 @@ def render_block(data):
     ]
 
     for inst in data["institutions"]:
-        lines.append(f"* `{inst['name']} <{inst['url']}>`_ - {inst['role']}")
+        lines.append(f"* `{inst['name']} <{inst['url']}>`_ - {inst['role']['en']}")
     lines.append("")
 
     lines.append(data["acknowledgments"]["text"]["en"])


### PR DESCRIPTION
## Summary
Made the `role` field and `acknowledgments.text` in `institutions.json` multilingual (`en`, `es`, `pt`, `de`, `zh`) instead of a plain English-only string. This file is the single source of truth consumed by the docs homepage, the external website repo, and the README generator, so translations now live in one place instead of being re-implemented by each consumer.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [x] Documentation

---                                                                                                                                                                   
## Changes (by file)
- `docs/static/institutions/institutions.json`: converted `role` (per institution) and `acknowledgments.text` from plain strings to locale-keyed objects (`en`, `es`, `pt`, `de`, `zh`).
- `scripts/render_institutions.py`: updated the README generator to read `role['en']` since README.rst is English-only; output is unchanged (verified `README.rst` stays up to date).