### PR TITLE
feat: enhance search functionality to support substring matching and smote exclude target column

### DIFF
--- a/DashAI/back/converters/base_converter.py
+++ b/DashAI/back/converters/base_converter.py
@@ -84,6 +84,10 @@ class BaseConverter(ConfigObject, ABC):
         if not meta.get("allowed_dtypes") or meta["allowed_dtypes"] == ["*"]:
             meta["allowed_dtypes"] = []
 
+        # Ensure non_allowed_dtypes is always present for the frontend
+        if "non_allowed_dtypes" not in meta:
+            meta["non_allowed_dtypes"] = []
+
         # Drop restricted_dtypes (no converter uses it; it is always [])
         meta.pop("restricted_dtypes", None)
 

--- a/DashAI/back/converters/imbalanced_learn/smote_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smote_converter.py
@@ -14,22 +14,8 @@ from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.dashai_data_type import DashAIDataType
+from DashAI.back.types.utils import NON_NUMERIC_DTYPES
 from DashAI.back.types.value_types import Float, Integer
-
-NUMERIC_DTYPES = [
-    "int8",
-    "int16",
-    "int32",
-    "int64",
-    "uint8",
-    "uint16",
-    "uint32",
-    "uint64",
-    "float16",
-    "float32",
-    "float64",
-    "bool",
-]
 
 
 class SMOTESchema(BaseSchema):
@@ -126,7 +112,8 @@ class SMOTEConverter(SamplingConverter, ImbalancedLearnWrapper, SMOTE):
 
     metadata = {
         "allowed_types": [Float, Integer, Categorical],
-        "allowed_dtypes": NUMERIC_DTYPES,
+        "allowed_dtypes": [],
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
     }
 
     def __init__(self, **kwargs):

--- a/DashAI/back/converters/imbalanced_learn/smote_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smote_converter.py
@@ -12,8 +12,24 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.dashai_data_type import DashAIDataType
 from DashAI.back.types.value_types import Float, Integer
+
+NUMERIC_DTYPES = [
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float16",
+    "float32",
+    "float64",
+    "bool",
+]
 
 
 class SMOTESchema(BaseSchema):
@@ -109,8 +125,8 @@ class SMOTEConverter(SamplingConverter, ImbalancedLearnWrapper, SMOTE):
     IMAGE_PREVIEW = "smote.png"
 
     metadata = {
-        "allowed_types": [Float, Integer],
-        "allowed_dtypes": [],
+        "allowed_types": [Float, Integer, Categorical],
+        "allowed_dtypes": NUMERIC_DTYPES,
     }
 
     def __init__(self, **kwargs):

--- a/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
@@ -14,22 +14,8 @@ from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.dashai_data_type import DashAIDataType
+from DashAI.back.types.utils import NON_NUMERIC_DTYPES
 from DashAI.back.types.value_types import Float, Integer
-
-NUMERIC_DTYPES = [
-    "int8",
-    "int16",
-    "int32",
-    "int64",
-    "uint8",
-    "uint16",
-    "uint32",
-    "uint64",
-    "float16",
-    "float32",
-    "float64",
-    "bool",
-]
 
 
 class SMOTEENNSchema(BaseSchema):
@@ -135,7 +121,8 @@ class SMOTEENNConverter(SamplingConverter, ImbalancedLearnWrapper, SMOTEENN):
 
     metadata = {
         "allowed_types": [Float, Integer, Categorical],
-        "allowed_dtypes": NUMERIC_DTYPES,
+        "allowed_dtypes": [],
+        "non_allowed_dtypes": NON_NUMERIC_DTYPES,
     }
 
     def __init__(self, **kwargs):

--- a/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
+++ b/DashAI/back/converters/imbalanced_learn/smoteenn_converter.py
@@ -12,8 +12,24 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.schema_fields.base_schema import BaseSchema
 from DashAI.back.core.utils import MultilingualString
+from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.dashai_data_type import DashAIDataType
 from DashAI.back.types.value_types import Float, Integer
+
+NUMERIC_DTYPES = [
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float16",
+    "float32",
+    "float64",
+    "bool",
+]
 
 
 class SMOTEENNSchema(BaseSchema):
@@ -118,8 +134,8 @@ class SMOTEENNConverter(SamplingConverter, ImbalancedLearnWrapper, SMOTEENN):
     IMAGE_PREVIEW = "smoteenn.png"
 
     metadata = {
-        "allowed_types": [Float, Integer],
-        "allowed_dtypes": [],
+        "allowed_types": [Float, Integer, Categorical],
+        "allowed_dtypes": NUMERIC_DTYPES,
     }
 
     def __init__(self, **kwargs):

--- a/DashAI/back/exploration/base_explorer.py
+++ b/DashAI/back/exploration/base_explorer.py
@@ -6,17 +6,12 @@ from DashAI.back.core.artifacts import Artifact
 from DashAI.back.core.schema_fields import BaseSchema
 from DashAI.back.dependencies.database.models import Explorer, Notebook
 from DashAI.back.static.icons import Icon
+from DashAI.back.types.utils import NON_NUMERIC_DTYPES  # noqa: F401
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
-
-
-# Dtypes that cannot be plotted on a numeric axis. Shared default for plot
-# explorers that accept the Categorical semantic type but only when it is
-# numerically encoded (an empty dtype means the dtype is unknown).
-NON_NUMERIC_DTYPES: Final[List[str]] = ["string", "bool", ""]
 
 
 class BaseExplorerSchema(BaseSchema):

--- a/DashAI/back/types/utils.py
+++ b/DashAI/back/types/utils.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Final, List
 
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.dashai_data_type import DashAIDataType
@@ -16,6 +16,11 @@ from DashAI.back.types.value_types import (
     Time,
     Timestamp,
 )
+
+# Dtypes that cannot be treated as numeric. Shared default for components
+# (explorers, converters) that accept the Categorical semantic type but only
+# when it is numerically encoded (an empty dtype means the dtype is unknown).
+NON_NUMERIC_DTYPES: Final[List[str]] = ["string", "bool", ""]
 
 
 def _get_dtype_arrow_map() -> Dict[str, Any]:

--- a/DashAI/front/src/components/notebooks/ColumnSelector.jsx
+++ b/DashAI/front/src/components/notebooks/ColumnSelector.jsx
@@ -30,6 +30,7 @@ import { useTableLocalization } from "../../utils/useTableLocalization";
  * @param {Array} props.allowedDtypes - Array of allowed dtype strings (optional)
  * @param {Array} props.allowedTypes - Array of allowed semantic type names (optional)
  * @param {Array} props.nonAllowedDtypes - Array of forbidden dtype strings (optional)
+ * @param {Array} props.excludedColumnIds - Array of row ids that cannot be selected regardless of type (optional)
  * @param {Function} props.onSelectionChange - Callback when selection changes (selectedColumns) (optional)
  * @param {Function} props.onValidationChange - Callback when validation status changes (isValid) (optional)
 
@@ -41,6 +42,7 @@ function ColumnSelector({
   allowedDtypes = [],
   allowedTypes = [],
   nonAllowedDtypes = [],
+  excludedColumnIds = [],
   onSelectionChange = () => {},
   onValidationChange = () => {},
   columnTypes = null,
@@ -156,6 +158,9 @@ function ColumnSelector({
   const getValidColumnIds = useCallback(() => {
     return rows
       .filter((row) => {
+        if (excludedColumnIds.includes(row.id)) {
+          return false;
+        }
         if (allowedTypes.length > 0 && !allowedTypes.includes(row.valueType)) {
           return false;
         }
@@ -170,7 +175,25 @@ function ColumnSelector({
         return true;
       })
       .map((row) => row.id);
-  }, [rows, allowedDtypes, allowedTypes, nonAllowedDtypes]);
+  }, [rows, allowedDtypes, allowedTypes, nonAllowedDtypes, excludedColumnIds]);
+
+  // Deselect any already-selected column that becomes excluded (e.g. it was
+  // picked as scope and then also set as the target column)
+  useEffect(() => {
+    if (excludedColumnIds.length === 0) return;
+    const filtered = rowSelectionModel.filter(
+      (id) => !excludedColumnIds.includes(id),
+    );
+    if (filtered.length === rowSelectionModel.length) return;
+    setRowSelectionModel(filtered);
+    setRows((prevRows) =>
+      prevRows.map((row) => ({
+        ...row,
+        order: filtered.indexOf(row.id) + 1,
+      })),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [excludedColumnIds, rowSelectionModel]);
 
   // Check if row is selectable - using useCallback for stability
   const isRowSelectable = useCallback(
@@ -470,6 +493,7 @@ ColumnSelector.propTypes = {
   allowedDtypes: PropTypes.array,
   allowedTypes: PropTypes.array,
   nonAllowedDtypes: PropTypes.array,
+  excludedColumnIds: PropTypes.array,
   onSelectionChange: PropTypes.func,
   onValidationChange: PropTypes.func,
 };

--- a/DashAI/front/src/components/notebooks/RightBar.jsx
+++ b/DashAI/front/src/components/notebooks/RightBar.jsx
@@ -312,6 +312,7 @@ export default function RightBar({ notebook, onToggle }) {
 
   const { filteredExplorers, filteredConverters } = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
+    const tokens = query.split(/\s+/).filter(Boolean);
 
     const rankMatch = (item) => {
       const displayName = (
@@ -324,13 +325,14 @@ export default function RightBar({ notebook, onToggle }) {
         item.description ||
         ""
       ).toLowerCase();
-      if (displayName.includes(query)) return 1;
-      if (description.includes(query)) return 2;
+      if (tokens.every((token) => displayName.includes(token))) return 1;
+      const combined = `${displayName} ${description}`;
+      if (tokens.every((token) => combined.includes(token))) return 2;
       return 0;
     };
 
     const filterAndRank = (items) => {
-      if (!query) return items;
+      if (!tokens.length) return items;
       return items
         .map((item) => ({ item, rank: rankMatch(item) }))
         .filter(({ rank }) => rank > 0)

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -29,6 +29,7 @@ export default function ScopeStepConverter({
   const tourContext = useTourContext();
   const allowedTypes = tool?.metadata?.allowed_types || [];
   const allowedDtypes = tool?.metadata?.allowed_dtypes || [];
+  const nonAllowedDtypes = tool?.metadata?.non_allowed_dtypes || [];
   const inputCardinality = tool?.metadata?.input_cardinality || {};
   const { t } = useTranslation(["common", "datasets"]);
   const { columnTypes } = useExplorersAndConverters();
@@ -102,6 +103,7 @@ export default function ScopeStepConverter({
           tool={tool}
           allowedTypes={allowedTypes}
           allowedDtypes={allowedDtypes}
+          nonAllowedDtypes={nonAllowedDtypes}
           excludedColumnIds={excludedColumnIds}
           inputCardinality={inputCardinality}
           columnTypes={columnTypes}

--- a/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
+++ b/DashAI/front/src/components/notebooks/converterCreation/ScopeStepConverter.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Box, Typography, Tooltip, IconButton } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import ConverterClassColumnModal from "./ConverterTargetColumnModal";
@@ -32,6 +32,10 @@ export default function ScopeStepConverter({
   const inputCardinality = tool?.metadata?.input_cardinality || {};
   const { t } = useTranslation(["common", "datasets"]);
   const { columnTypes } = useExplorersAndConverters();
+  const excludedColumnIds = useMemo(
+    () => (targetColumn ? [targetColumn.idx - 1] : []),
+    [targetColumn],
+  );
 
   const handleSubmit = () => {
     nextStep();
@@ -98,6 +102,7 @@ export default function ScopeStepConverter({
           tool={tool}
           allowedTypes={allowedTypes}
           allowedDtypes={allowedDtypes}
+          excludedColumnIds={excludedColumnIds}
           inputCardinality={inputCardinality}
           columnTypes={columnTypes}
           onSelectionChange={(columnsInfo) => {


### PR DESCRIPTION
This pull request improves the search functionality in the `RightBar` component by making the search more flexible and accurate. Instead of matching the entire search query as a single string, the search now splits the query into individual tokens and checks if all tokens are present in the item's display name or description.

**Search improvements:**

* The search query is now split into tokens, and the filtering logic checks that all tokens are present in the display name or description, allowing for more flexible multi-word searches. [[1]](diffhunk://#diff-711647abd9237f7984867e4544ede07fcf00a688129ce0f7ae4dd2c752781c81R315) [[2]](diffhunk://#diff-711647abd9237f7984867e4544ede07fcf00a688129ce0f7ae4dd2c752781c81L327-R335)
* The filter logic now returns all items if there are no tokens (i.e., the search box is empty), maintaining previous behavior for empty queries.