### PR TITLE
Fix model input handling in explainers

### DIFF
--- a/DashAI/back/explainability/explainers/contrastive_shap.py
+++ b/DashAI/back/explainability/explainers/contrastive_shap.py
@@ -238,8 +238,12 @@ class ContrastiveShap(BaseLocalExplainer):
         """
         import shap
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = background_dataset
-        x_train = x["train"]
+        # SHAP calls the model with perturbed frames, which skip the model
+        # preparation, so the background must be in the model feature space.
+        x_train = prepare_model_input(self.model, x["train"])
         y_train = y["train"]
 
         background_data = x_train.to_pandas()
@@ -308,9 +312,10 @@ class ContrastiveShap(BaseLocalExplainer):
         import numpy as np
 
         from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+        from DashAI.back.explainability.model_input import prepare_model_input
 
         dataset = to_dashai_dataset(instances)
-        X = dataset.to_pandas()
+        X = prepare_model_input(self.model, dataset).to_pandas()
 
         predictions = np.asarray(self.model.predict(dataset))
 

--- a/DashAI/back/explainability/explainers/dice_counterfactual.py
+++ b/DashAI/back/explainability/explainers/dice_counterfactual.py
@@ -238,8 +238,12 @@ class DiceCounterfactual(BaseLocalExplainer):
         import dice_ml
         import numpy as np
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = background_dataset
-        x_train = x["train"]
+        # DiCE samples the training frame and queries the model with plain
+        # frames, so both must be in the model feature space.
+        x_train = prepare_model_input(self.model, x["train"])
         y_train = y["train"]
 
         train_frame = x_train.to_pandas()
@@ -323,9 +327,10 @@ class DiceCounterfactual(BaseLocalExplainer):
         import numpy as np
 
         from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+        from DashAI.back.explainability.model_input import prepare_model_input
 
         dataset = to_dashai_dataset(instances)
-        X = dataset.to_pandas()[self.feature_names]
+        X = prepare_model_input(self.model, dataset).to_pandas()[self.feature_names]
 
         predictions = np.asarray(self.model.predict(dataset))
 

--- a/DashAI/back/explainability/explainers/kernel_shap.py
+++ b/DashAI/back/explainability/explainers/kernel_shap.py
@@ -333,9 +333,13 @@ class KernelShap(BaseLocalExplainer):
         """
         sample_background_data = bool(sample_background_data)
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = background_dataset
 
-        x_train = x["train"]
+        # SHAP perturbs the background frame and calls the model with it, so
+        # the background must already be in the model's feature space.
+        x_train = prepare_model_input(self.model, x["train"])
         y_train = y["train"]
 
         background_data = x_train.to_pandas()
@@ -392,13 +396,10 @@ class KernelShap(BaseLocalExplainer):
             dictionary with the shap values for each instance.
         """
         from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+        from DashAI.back.explainability.model_input import prepare_model_input
 
         dataset_dashai = to_dashai_dataset(instances)
-
-        if hasattr(self.model, "prepare_dataset"):
-            dataset_prepared = self.model.prepare_dataset(dataset_dashai, is_fit=False)
-        else:
-            dataset_prepared = dataset_dashai
+        dataset_prepared = prepare_model_input(self.model, dataset_dashai)
 
         X = dataset_prepared.to_pandas()
 

--- a/DashAI/back/explainability/explainers/nearest_counterfactual.py
+++ b/DashAI/back/explainability/explainers/nearest_counterfactual.py
@@ -196,12 +196,18 @@ class NearestCounterfactual(BaseLocalExplainer):
         """
         import numpy as np
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = background_dataset
+        # Candidates and explained instances are compared feature by feature,
+        # so both are kept in the model feature space. predict() keeps taking
+        # the raw split, since it applies that preparation itself.
         x_train = x["train"]
+        x_train_prepared = prepare_model_input(self.model, x_train)
         y_train = y["train"]
 
-        self.background_data = x_train.to_pandas()
-        self.feature_names = list(x_train.column_names)
+        self.background_data = x_train_prepared.to_pandas()
+        self.feature_names = list(x_train_prepared.column_names)
 
         background_probs = self.model.predict(x_train)
         self.background_classes = np.argmax(np.asarray(background_probs), axis=1)
@@ -282,9 +288,10 @@ class NearestCounterfactual(BaseLocalExplainer):
         import numpy as np
 
         from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+        from DashAI.back.explainability.model_input import prepare_model_input
 
         dataset = to_dashai_dataset(instances)
-        X = dataset.to_pandas()
+        X = prepare_model_input(self.model, dataset).to_pandas()
 
         predictions = np.asarray(self.model.predict(dataset))
 

--- a/DashAI/back/explainability/explainers/partial_dependence.py
+++ b/DashAI/back/explainability/explainers/partial_dependence.py
@@ -206,13 +206,19 @@ class PartialDependence(BaseGlobalExplainer):
         import numpy as np
         from sklearn.inspection import partial_dependence
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = dataset
 
-        x_test = x["test"].to_pandas()
+        # scikit-learn's partial_dependence calls the model with plain frames,
+        # bypassing the model preparation, so both splits are moved into the
+        # model feature space here.
+        x_test_dataset = prepare_model_input(self.model, x["test"])
+        x_test = x_test_dataset.to_pandas()
 
-        types = x["train"].types
+        types = prepare_model_input(self.model, x["train"]).types
 
-        features_names = x["test"].column_names
+        features_names = x_test_dataset.column_names
 
         categorical_features = [
             1 if isinstance(types[feature], Categorical) else 0

--- a/DashAI/back/explainability/explainers/permutation_feature_importance.py
+++ b/DashAI/back/explainability/explainers/permutation_feature_importance.py
@@ -442,9 +442,13 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
         from sklearn.metrics import make_scorer
         from sklearn.preprocessing import LabelEncoder
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = dataset
 
-        x_test = x["test"]
+        # permutation_importance permutes the frame and calls the model with
+        # it, bypassing the model preparation.
+        x_test = prepare_model_input(self.model, x["test"])
         y_test = y["test"]
 
         X_df = x_test.to_pandas()

--- a/DashAI/back/explainability/explainers/regression_kernel_shap.py
+++ b/DashAI/back/explainability/explainers/regression_kernel_shap.py
@@ -179,8 +179,12 @@ class RegressionKernelShap(BaseLocalExplainer):
         """
         import shap
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = background_dataset
-        x_train = x["train"]
+        # SHAP calls the model with perturbed frames, which skip the model
+        # preparation, so the background must be in the model feature space.
+        x_train = prepare_model_input(self.model, x["train"])
         y_train = y["train"]
 
         background_data = x_train.to_pandas()
@@ -220,9 +224,10 @@ class RegressionKernelShap(BaseLocalExplainer):
         import numpy as np
 
         from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+        from DashAI.back.explainability.model_input import prepare_model_input
 
         dataset = to_dashai_dataset(instances)
-        X = dataset.to_pandas()
+        X = prepare_model_input(self.model, dataset).to_pandas()
 
         predictions = np.asarray(self.model.predict(dataset)).ravel()
 

--- a/DashAI/back/explainability/explainers/regression_partial_dependence.py
+++ b/DashAI/back/explainability/explainers/regression_partial_dependence.py
@@ -172,8 +172,12 @@ class RegressionPartialDependence(BaseGlobalExplainer):
         """
         import numpy as np
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = dataset
-        x_test = x["test"].to_pandas()
+        # The grid frames are passed straight to the model, bypassing the
+        # model preparation.
+        x_test = prepare_model_input(self.model, x["test"]).to_pandas()
 
         # Cap rows to bound the number of model evaluations.
         max_rows = 200

--- a/DashAI/back/explainability/explainers/regression_permutation_feature_importance.py
+++ b/DashAI/back/explainability/explainers/regression_permutation_feature_importance.py
@@ -245,8 +245,12 @@ class RegressionPermutationFeatureImportance(BaseGlobalExplainer):
         """
         import numpy as np
 
+        from DashAI.back.explainability.model_input import prepare_model_input
+
         x, y = dataset
-        x_test = x["test"].to_pandas()
+        # The permuted frames are passed straight to the model, bypassing the
+        # model preparation.
+        x_test = prepare_model_input(self.model, x["test"]).to_pandas()
         y_test = y["test"].to_pandas().to_numpy().ravel()
 
         rng = np.random.RandomState(self.random_state)

--- a/DashAI/back/explainability/model_input.py
+++ b/DashAI/back/explainability/model_input.py
@@ -1,0 +1,42 @@
+"""Helper to move an explainer's data into the model's feature space.
+
+Explainers receive the model input as the task prepared it, exactly as
+``predict`` receives it in the prediction job: raw columns, before any model
+specific preprocessing. That is what explainers that perturb the input and
+query ``model.predict`` need, since ``predict`` applies the model preparation
+itself.
+
+Explainers that instead build feature matrices (``to_pandas``) and hand them
+to a third party library (SHAP, DiCE, scikit-learn inspection) must work in
+the model's own feature space, because those libraries call the model with
+plain frames that bypass the model preparation. Such explainers call
+:func:`prepare_model_input` on both the background data and the instances so
+that both live in the same space.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+def prepare_model_input(model: Any, dataset: "DashAIDataset") -> "DashAIDataset":
+    """Apply the model's own input preprocessing to a dataset.
+
+    Parameters
+    ----------
+    model : Any
+        The DashAI model being explained.
+    dataset : DashAIDataset
+        Input features as the task prepared them.
+
+    Returns
+    -------
+    DashAIDataset
+        The dataset in the model's feature space, or the dataset unchanged
+        when the model does not define ``prepare_dataset``.
+    """
+    prepare = getattr(model, "prepare_dataset", None)
+    if prepare is None:
+        return dataset
+    return prepare(dataset, is_fit=False)

--- a/DashAI/back/job/explainer_job.py
+++ b/DashAI/back/job/explainer_job.py
@@ -178,7 +178,6 @@ class ExplainerJob(BaseJob):
         splits: Dict[str, Any],
         task: BaseTask,
         same_dataset: bool,
-        trained_model: BaseModel,
     ) -> None:
         import json
         import os
@@ -323,7 +322,10 @@ class ExplainerJob(BaseJob):
                     f"local_explanation_input_{explainer_id}",
                 )
                 save_dataset(input_source, os.path.join(input_dataset_path, "dataset"))
-                X = trained_model.prepare_dataset(X, is_fit=False)
+                # The instances are handed over unprepared, the same way the
+                # prediction job calls model.predict: the model applies its own
+                # preprocessing. Explainers that need the model feature space
+                # ask for it with prepare_model_input.
 
             except Exception as e:
                 log.exception(e)
@@ -512,10 +514,10 @@ class ExplainerJob(BaseJob):
                         test_indexes=splits["test_indexes"],
                         val_indexes=splits["val_indexes"],
                     )
-                    for split_name in data_x:
-                        data_x[split_name] = trained_model.prepare_dataset(
-                            data_x[split_name], is_fit=False
-                        )
+                    # Inputs stay unprepared (see the note in the local
+                    # explanation path); targets are encoded because explainers
+                    # compare them against the model's class indexes.
+                    for split_name in data_y:
                         data_y[split_name] = trained_model.prepare_output(
                             data_y[split_name], is_fit=False
                         )
@@ -551,7 +553,6 @@ class ExplainerJob(BaseJob):
                         splits=splits,
                         task=task,
                         same_dataset=same_dataset,
-                        trained_model=trained_model,
                     )
                 else:
                     raise JobError(f"{explainer_scope} is an invalid explainer type")

--- a/tests/back/api/test_explainer_jobs.py
+++ b/tests/back/api/test_explainer_jobs.py
@@ -122,6 +122,55 @@ class DummyLocalExplainer(BaseLocalExplainer):
         return
 
 
+class MangleModel(DummyModel):
+    """Model whose preparation renames the input columns.
+
+    Mirrors bag-of-words style text models, whose ``prepare_dataset``
+    replaces the raw input column with the vectorized feature columns.
+    """
+
+    COMPATIBLE_COMPONENTS = ["DummyTask"]
+
+    @staticmethod
+    def load(filename):
+        return MangleModel()
+
+    def prepare_dataset(self, dataset, is_fit=False):
+        return dataset.rename_columns(
+            {column: f"{column}_prepared" for column in dataset.column_names}
+        )
+
+
+RAW_INPUT_COLUMNS = []
+
+
+class RawInputLocalExplainer(BaseLocalExplainer):
+    """Local explainer that records the columns the job hands it."""
+
+    COMPATIBLE_COMPONENTS = ["DummyTask"]
+
+    def __init__(self, model: BaseModel) -> None:
+        self.model = model
+        self.explanation = None
+
+    @classmethod
+    def get_schema(cls):
+        return {}
+
+    def fit(self, dataset, **kwargs):
+        return self
+
+    def explain_instance(self, instances):
+        columns = instances.column_names
+        if isinstance(columns, dict):
+            columns = [column for split in columns.values() for column in split]
+        RAW_INPUT_COLUMNS.extend(columns)
+        return {}
+
+    def plot(self, explanation):
+        return
+
+
 @pytest.fixture(autouse=True, name="test_registry")
 def setup_test_registry(client, monkeypatch: pytest.MonkeyPatch):
     """Setup a test registry with test task and explainers components."""
@@ -131,8 +180,10 @@ def setup_test_registry(client, monkeypatch: pytest.MonkeyPatch):
         initial_components=[
             DummyTask,
             DummyModel,
+            MangleModel,
             DummyGlobalExplainer,
             DummyLocalExplainer,
+            RawInputLocalExplainer,
             ExplainerJob,
         ]
     )
@@ -403,6 +454,80 @@ def test_execute_jobs(
     response = client.get(f"/api/v1/job/status/{local_job_id}")
     assert response.json()["status"] == "finished", (
         f"Local job should be finished, got {response.json()['status']}"
+    )
+
+
+def test_local_explainer_receives_unprepared_model_input(
+    client: TestClient, model_session_id: int, dataset_id: int
+):
+    """The job hands over the instances without the model preparation.
+
+    Explainers query ``model.predict``, which prepares its input itself, so
+    preparing beforehand would break models that replace the input column
+    with derived features (bag-of-words counts, for instance). Explainers
+    needing the model feature space ask for it with ``prepare_model_input``.
+    """
+    container = client.app.container
+    session_factory = container["session_factory"]
+    RAW_INPUT_COLUMNS.clear()
+
+    with session_factory() as db:
+        run = Run(
+            model_session_id=model_session_id,
+            optimizer_name="OptunaOptimizer",
+            optimizer_parameters={
+                "n_trials": 1,
+                "sampler": "TPESampler",
+                "pruner": "None",
+            },
+            model_name="MangleModel",
+            parameters={},
+            goal_metric="Accuracy",
+            name="RawInputRun",
+            split_indexes="""{
+                "train_indexes": [0, 1, 2, 3, 4],
+                "test_indexes": [5, 6, 7, 8],
+                "val_indexes": [9, 10, 11, 12]
+            }""",
+        )
+        db.add(run)
+        db.commit()
+        db.refresh(run)
+
+        explainer = LocalExplainer(
+            name="test_raw_local",
+            run_id=run.id,
+            explainer_name="RawInputLocalExplainer",
+            dataset_id=dataset_id,
+            scope={"split": "test", "percentage": 100},
+            parameters={},
+            fit_parameters={},
+        )
+        db.add(explainer)
+        db.commit()
+        db.refresh(explainer)
+        explainer_id = explainer.id
+
+    response = client.post(
+        "/api/v1/job/",
+        data={
+            "job_type": "ExplainerJob",
+            "kwargs": json.dumps(
+                {"explainer_id": explainer_id, "explainer_scope": "local"}
+            ),
+        },
+    )
+    assert response.status_code == 201, response.text
+    job_id = response.json()["id"]
+
+    job_status = client.get(f"/api/v1/job/status/{job_id}").json()
+    assert job_status["status"] == "finished", (
+        f"Job should be finished, got {job_status['status']}"
+    )
+
+    assert RAW_INPUT_COLUMNS, "The explainer never received any instance"
+    assert set(RAW_INPUT_COLUMNS) == set(input_columns), (
+        f"Explainer got prepared columns {sorted(set(RAW_INPUT_COLUMNS))}"
     )
 
 


### PR DESCRIPTION
## Summary
The explainer job prepared the model input (`trained_model.prepare_dataset`) before handing it to the explainer. Text explainers perturb raw text and query `model.predict`, which applies the model preparation itself, so with a bag of words model the raw text column was already replaced by count columns and `predict` re vectorized one of them, raising `ValueError: The feature names should match those that were passed during fit` in sklearn.

The job now passes raw columns straight through, the same contract `predict_job` already uses. Explainers that build plain frames for SHAP, DiCE or the scikit-learn inspection helpers (calls that bypass the model preparation) move their own data into the model feature space via a new `prepare_model_input` helper.

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/explainability/model_input.py`: new helper `prepare_model_input(model, dataset)`; module docstring documents which explainers need the model feature space and why.
- `DashAI/back/job/explainer_job.py`: removed both `prepare_dataset` calls (local instances and `data_x` background splits); targets still go through `prepare_output`; dropped the now unused `trained_model` parameter of `_generate_local_explanation`.
- `DashAI/back/explainability/explainers/kernel_shap.py`: prepares the background in `fit`; its inline `hasattr(model, "prepare_dataset")` block in `explain_instance` replaced by the helper.
- `DashAI/back/explainability/explainers/contrastive_shap.py`, `dice_counterfactual.py`, `regression_kernel_shap.py`: prepare background and instances so both share one feature space.
- `DashAI/back/explainability/explainers/nearest_counterfactual.py`: prepares the candidate frame but keeps the raw split for `model.predict`, which previously prepared it a second time.
- `DashAI/back/explainability/explainers/partial_dependence.py`, `permutation_feature_importance.py`, `regression_partial_dependence.py`, `regression_permutation_feature_importance.py`: prepare the test split (and the train split for the type lookup in `partial_dependence`) before building frames for scikit-learn.
- `tests/back/api/test_explainer_jobs.py`: new `test_local_explainer_receives_unprepared_model_input`, with a model whose preparation renames the input columns and an explainer that records what the job handed it.

Text and image explainers are unchanged: image models define no `prepare_dataset`, so they were never affected.

---

## Testing

- `uv run pytest tests/back` → 735 passed.
- The new job test fails on `develop` (explainer receives `SepalLengthCm_prepared`, ...) and passes here.
- Manual check, bag of words text model with any explainer available
- Manual check with a string categorical feature + DecisionTree, all six tabular/regression explainers run: KernelShap, ContrastiveShap, DiCE, NearestCounterfactual, PartialDependence (over `size`, `color_blue`, `color_red`), PermutationFeatureImportance.

---

## Notes

`prepare_dataset` is not idempotent for one hot models: calling it on already encoded data raises `Missing categorical columns in dataset: ['color']`. That is why `NearestCounterfactual` had to keep the raw split for `predict`. The same double preparation existed on `develop` for KernelShap (the job prepared, then `explain_instance` prepared again), so one hot models plus KernelShap were broken there; this change removes that path.
