### PR TITLE
Fix target column typing in TF-IDF model output preparation

### DIFF
--- a/DashAI/back/models/scikit_learn/tfidf_logreg_text_classification_model.py
+++ b/DashAI/back/models/scikit_learn/tfidf_logreg_text_classification_model.py
@@ -242,16 +242,46 @@ class TfIdfLogRegTextClassificationModel(TextClassificationModel):
         return self.classifier.predict_proba(X_tfidf)
 
     def prepare_output(self, dataset: "DashAIDataset", is_fit: bool = False):
-        from datasets import Dataset as HFDataset
+        """Label encode the target column, keeping it typed.
 
-        from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The output dataset containing the target labels.
+        is_fit : bool, optional
+            If ``True``, fit the label encoder before transforming. If
+            ``False``, apply the existing encoding. Default is ``False``.
+
+        Returns
+        -------
+        DashAIDataset
+            The dataset with the target column encoded as integers and typed
+            as ``Categorical``, its categories in label encoder order (the
+            class index order of the model predictions).
+        """
+        import pyarrow as pa
+
+        from DashAI.back.dataloaders.classes.dashai_dataset import modify_table
+        from DashAI.back.types.categorical import Categorical
 
         col = dataset.column_names[0]
         if is_fit:
             encoded = self.label_encoder.fit_transform(dataset[col]).tolist()
         else:
             encoded = self.label_encoder.transform(dataset[col]).tolist()
-        return to_dashai_dataset(HFDataset.from_dict({col: encoded}))
+
+        # Rebuilding the dataset from the encoded values alone would drop the
+        # column type, and explainers read the class names from it.
+        types = dict(dataset.types)
+        types[col] = Categorical(
+            values=[str(label) for label in self.label_encoder.classes_],
+            converted=True,
+        )
+        return modify_table(
+            dataset,
+            columns={col: pa.array(encoded, type=pa.int64())},
+            types=types,
+        )
 
     def save(self, filename: Union[str, "Path"]) -> None:
         import joblib


### PR DESCRIPTION
## Summary

Fixes target label encoding in the TF-IDF logistic regression text classification model so that the encoded target column preserves its `Categorical` type and class names. This ensures downstream explainers receive the expected metadata and produce consistent outputs.

---

## Type of Change

Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `tfidf_logreg_text_classification_model.py`:

  - Refactored `prepare_output` to update the target column using `modify_table` instead of rebuilding the dataset.
  - Preserved the target column as a `Categorical` type after label encoding, including the class names in the correct order.
  - Added a comprehensive docstring describing the method's parameters, return value, and behavior.
  - Removed unused imports (`HFDataset` and `to_dashai_dataset`) and added `modify_table` and `Categorical` to support the new implementation.

---

## Testing (optional)

Verify that:

- The TF-IDF logistic regression model returns predictions with the target column typed as `Categorical`.
- Explainers using the model output work correctly.
