### PR TITLE
Fix run tabs spacing and label alignment

### DIFF
--- a/DashAI/front/src/components/models/RunResults.jsx
+++ b/DashAI/front/src/components/models/RunResults.jsx
@@ -134,7 +134,7 @@ export default function RunResults({
   const tabContent = (
     <>
       {activeTab === 0 && (
-        <Box sx={{ py: 4 }}>
+        <Box sx={{ pb: 4 }}>
           <LiveMetricsChart run={run} />
         </Box>
       )}
@@ -175,7 +175,7 @@ export default function RunResults({
       )}
 
       {activeTab === 3 && isFinished && optimizables > 0 && (
-        <Box sx={{ py: 4 }}>
+        <Box sx={{ pb: 4 }}>
           <HyperparameterPlots run={run} />
         </Box>
       )}

--- a/DashAI/front/src/components/models/runResults/PredictionResultsTab.jsx
+++ b/DashAI/front/src/components/models/runResults/PredictionResultsTab.jsx
@@ -73,7 +73,7 @@ export default function PredictionResultsTab({
   return (
     <Box
       sx={{
-        py: 4,
+        pb: 4,
         width: "100%",
         display: "grid",
         gridTemplateColumns: "1fr auto",

--- a/DashAI/front/src/components/models/runResults/ResultsTabsHeader.jsx
+++ b/DashAI/front/src/components/models/runResults/ResultsTabsHeader.jsx
@@ -12,6 +12,16 @@ const groupLabelSx = {
   pt: 1,
 };
 
+// Matches the MUI small Chip's height, so tabs with a count chip don't grow
+// taller than plain-text tabs and push their label off-center.
+const TAB_LABEL_HEIGHT = 24;
+const tabLabelRowSx = {
+  display: "flex",
+  alignItems: "center",
+  gap: 2,
+  height: TAB_LABEL_HEIGHT,
+};
+
 /**
  * The two grouped pill tab bars (Metrics: Live/Hyperparameters, Operations:
  * Explainability/Predictions) shown above a run's results, with a vertical
@@ -49,14 +59,19 @@ export default function ResultsTabsHeader({
           onChange={(e, newValue) => onTabChange(newValue)}
           aria-label="Result characteristics tabs"
         >
-          <Tab value={0} label={t("models:label.liveMetrics")} />
+          <Tab
+            value={0}
+            label={
+              <Box sx={tabLabelRowSx}>{t("models:label.liveMetrics")}</Box>
+            }
+          />
           <Tab
             value={3}
             label={
               <Tooltip title={hyperparametersTooltip}>
-                <span style={{ pointerEvents: "auto" }}>
+                <Box sx={{ ...tabLabelRowSx, pointerEvents: "auto" }}>
                   {t("models:label.hyperparameters")}
-                </span>
+                </Box>
               </Tooltip>
             }
             disabled={!isFinished || optimizables === 0}
@@ -94,14 +109,7 @@ export default function ResultsTabsHeader({
             value={1}
             label={
               <Tooltip title={notFinishedTooltip}>
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 2,
-                    pointerEvents: "auto",
-                  }}
-                >
+                <Box sx={{ ...tabLabelRowSx, pointerEvents: "auto" }}>
                   <span>{t("models:label.explainability")}</span>
                   {isFinished && (
                     <Chip label={explainerCount} size="small" color="primary" />
@@ -115,14 +123,7 @@ export default function ResultsTabsHeader({
             value={2}
             label={
               <Tooltip title={notFinishedTooltip}>
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 2,
-                    pointerEvents: "auto",
-                  }}
-                >
+                <Box sx={{ ...tabLabelRowSx, pointerEvents: "auto" }}>
                   <span>{t("models:label.predictions")}</span>
                   {isFinished && (
                     <Chip


### PR DESCRIPTION
## Summary
The Model Run detail view had two visual inconsistencies in its tab groups: the Predictions and Live Metrics/Hyperparameters panels had extra top padding compared to Explainability, and the Explainability/Predictions tab labels (which include a count chip) sat visually lower than the plain-text Metrics tabs because the chip made their content row taller.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `RunResults.jsx`: changed the Live Metrics and Hyperparameters tab content wrappers from `py: 4` to `pb: 4`, removing the extra top padding so their spacing above the content
matches Explainability (which relies solely on the shared divider's margin)
- `runResults/PredictionResultsTab.jsx`: same `py: 4` → `pb: 4` fix on the Predictions panel's outer wrapper.
- `runResults/ResultsTabsHeader.jsx`: added a shared `tabLabelRowSx` (fixed `height: 24` matching MUI's small Chip) applied to all four tab labels (Live Metrics, Hyperparameters, Explainability, Predictions), so tabs with a count chip no longer grow taller than plain-text tabs and push their label off-center.

---

## Testing (optional)
- Verified in the Models module that the Live Metrics, Hyperparameters, Expns panels now have consistent top spacing, and that all four tab labels sitat the same vertical position regardless of whether they show a count chip.