### PR TITLE
Fix/hub import dataloader fetch

### DIFF
--- a/DashAI/front/src/components/hub/HubImportPanel.jsx
+++ b/DashAI/front/src/components/hub/HubImportPanel.jsx
@@ -79,8 +79,9 @@ export default function HubImportPanel({
   const [importing, setImporting] = useState(false);
   const previewDebounceRef = useRef(null);
 
-  // Load all DataLoaders once on mount
+  // Load DataLoaders when entering the dataloader-selector step
   useEffect(() => {
+    if (stepValue !== dataloaderStep) return;
     let isMounted = true;
     setLoadingDataloaders(true);
     getComponents({ selectTypes: ["DataLoader"] })
@@ -97,7 +98,7 @@ export default function HubImportPanel({
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [stepValue, dataloaderStep]);
 
   // Reset when dataset/source changes
   useEffect(() => {

--- a/DashAI/front/src/pages/hub/HubImportPage.jsx
+++ b/DashAI/front/src/pages/hub/HubImportPage.jsx
@@ -70,11 +70,13 @@ export default function HubImportPage() {
       .finally(() => setDatafileLoading(false));
   }, [datafileId]);
 
+  // Load DataLoaders once the user reaches the dataloader-selector step
   useEffect(() => {
+    if (step < dataloaderStep) return;
     getComponents({ selectTypes: ["DataLoader"] })
       .then(setDataloaders)
       .catch(() => setDataloaders([]));
-  }, []);
+  }, [step, dataloaderStep]);
 
   // Sync local datafile when context downloads update (e.g. downloading → ready)
   useEffect(() => {


### PR DESCRIPTION
## Summary
The Hub dataset import flow was fetching the full list of available DataLoader components as soon as the user opened a downloaded datafile before they had even reached the dataloader selection step. This fired an unnecessary API call on every datafile click. The fetch is now deferred until the user actually reaches the dataloader selector step.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/pages/hub/HubImportPage.jsx`: gated the `getComponents({ selectTypes: ["DataLoader"] })`
effect behind `step >= dataloaderStep`, sotial mount/datafile click.
- `DashAI/front/src/components/hub/HubImportPanel.jsx`: same fix. The duplicate DataLoader fetch in this
component is now gated behind `stepValue =ing the existing pattern already used forloading the file list at the file-select step.

---

## Testing (optional)
- Open the Hub import flow for a downloadeetwork tab: the `DataLoader` componentsrequest should no longer appear until the "Select Dataloader" step is reached, not on landing on the datafile
info screen.
- Verify navigating back and forth between steps (file select → dataloader → preview → back) still resolves the
previously selected loader correctly from the URL.
                                                                                                               