### PR TITLE
Keep job queue widget anchored to viewport edges across browser zoom

### DIFF
--- a/DashAI/front/src/components/jobs/JobQueueWidget.jsx
+++ b/DashAI/front/src/components/jobs/JobQueueWidget.jsx
@@ -147,6 +147,43 @@ const JobQueueWidget = () => {
     }
   }, [position]);
 
+  // A saved drag position is an absolute pixel offset from a past viewport
+  // size. Browser zoom changes window.innerWidth/innerHeight (fewer CSS
+  // pixels fit as you zoom in), so a position that was on-screen before can
+  // end up beyond the new viewport edge — the widget silently goes offscreen.
+  // Re-clamp on mount (covers loading the app while already zoomed) and on
+  // every resize (covers zooming while the app is open).
+  useEffect(() => {
+    const clampToViewport = () => {
+      setPosition((prev) => {
+        if (!prev) return prev;
+        const rect = dragRef.current?.getBoundingClientRect();
+        const width = rect?.width ?? 320;
+        const height = rect?.height ?? 56;
+        const maxLeft = Math.max(0, window.innerWidth - width);
+        const clampedLeft = Math.min(Math.max(prev.left, 0), maxLeft);
+
+        if (prev.top !== undefined) {
+          const maxTop = Math.max(0, window.innerHeight - height);
+          const clampedTop = Math.min(Math.max(prev.top, 0), maxTop);
+          if (clampedLeft === prev.left && clampedTop === prev.top) return prev;
+          return { left: clampedLeft, top: clampedTop };
+        }
+
+        const maxBottom = Math.max(0, window.innerHeight - height);
+        const clampedBottom = Math.min(Math.max(prev.bottom, 0), maxBottom);
+        if (clampedLeft === prev.left && clampedBottom === prev.bottom) {
+          return prev;
+        }
+        return { left: clampedLeft, bottom: clampedBottom };
+      });
+    };
+
+    clampToViewport();
+    window.addEventListener("resize", clampToViewport);
+    return () => window.removeEventListener("resize", clampToViewport);
+  }, []);
+
   const handleClearAllJobs = () => {
     setConfirmClearAll(true);
   };

--- a/DashAI/front/src/components/jobs/JobQueueWidget.jsx
+++ b/DashAI/front/src/components/jobs/JobQueueWidget.jsx
@@ -79,11 +79,24 @@ const JobQueueWidget = () => {
   const [forceUpdate, setForceUpdate] = useState(0);
   const [isHovered, setIsHovered] = useState(false);
 
-  // Drag state
+  // Drag state — anchored to whichever edge (left/right, top/bottom) is
+  // nearest, as a distance in px from that edge. This is what lets the
+  // default (never-dragged) position sit at a fixed spot regardless of
+  // browser zoom: `right`/`bottom` distances don't change when the viewport
+  // shrinks or grows. Storing dragged positions as left/top instead (an
+  // older version of this code did) broke that: the widget would visibly
+  // slide as zoom changed, since its true offset was measured from the
+  // opposite (far) edge.
   const [position, setPosition] = useState(() => {
     try {
       const saved = localStorage.getItem("jobQueueWidgetPosition");
-      return saved ? JSON.parse(saved) : null;
+      if (!saved) return null;
+      const parsed = JSON.parse(saved);
+      // Discard positions saved by the old left/top-based format.
+      if (parsed && "horizontal" in parsed && "vertical" in parsed) {
+        return parsed;
+      }
+      return null;
     } catch {
       return null;
     }
@@ -114,14 +127,18 @@ const JobQueueWidget = () => {
         Math.min(moveEvent.clientY - offsetY, window.innerHeight - rect.height),
       );
 
-      // If in lower half of screen, use bottom instead of top
-      // so widget expands upward when opened
-      const isLowerHalf = newTop > window.innerHeight / 2;
-      const positionData = isLowerHalf
-        ? { left: newLeft, bottom: window.innerHeight - newTop - rect.height }
-        : { left: newLeft, top: newTop };
+      // Anchor to whichever half of the screen the widget is closer to, so
+      // its distance from that edge (not from the opposite one) is what
+      // gets persisted and re-rendered.
+      const isRightHalf = newLeft + rect.width / 2 > window.innerWidth / 2;
+      const isLowerHalf = newTop + rect.height / 2 > window.innerHeight / 2;
 
-      setPosition(positionData);
+      setPosition({
+        horizontal: isRightHalf ? "right" : "left",
+        h: isRightHalf ? window.innerWidth - newLeft - rect.width : newLeft,
+        vertical: isLowerHalf ? "bottom" : "top",
+        v: isLowerHalf ? window.innerHeight - newTop - rect.height : newTop,
+      });
     };
 
     const handleMouseUp = () => {
@@ -147,12 +164,10 @@ const JobQueueWidget = () => {
     }
   }, [position]);
 
-  // A saved drag position is an absolute pixel offset from a past viewport
-  // size. Browser zoom changes window.innerWidth/innerHeight (fewer CSS
-  // pixels fit as you zoom in), so a position that was on-screen before can
-  // end up beyond the new viewport edge — the widget silently goes offscreen.
-  // Re-clamp on mount (covers loading the app while already zoomed) and on
-  // every resize (covers zooming while the app is open).
+  // Safety net only: an edge-anchored offset stays valid across zoom by
+  // design, but an extreme window resize (viewport now narrower/shorter
+  // than the widget itself) could still push it out of bounds, so re-clamp
+  // on mount and on resize.
   useEffect(() => {
     const clampToViewport = () => {
       setPosition((prev) => {
@@ -160,22 +175,12 @@ const JobQueueWidget = () => {
         const rect = dragRef.current?.getBoundingClientRect();
         const width = rect?.width ?? 320;
         const height = rect?.height ?? 56;
-        const maxLeft = Math.max(0, window.innerWidth - width);
-        const clampedLeft = Math.min(Math.max(prev.left, 0), maxLeft);
-
-        if (prev.top !== undefined) {
-          const maxTop = Math.max(0, window.innerHeight - height);
-          const clampedTop = Math.min(Math.max(prev.top, 0), maxTop);
-          if (clampedLeft === prev.left && clampedTop === prev.top) return prev;
-          return { left: clampedLeft, top: clampedTop };
-        }
-
-        const maxBottom = Math.max(0, window.innerHeight - height);
-        const clampedBottom = Math.min(Math.max(prev.bottom, 0), maxBottom);
-        if (clampedLeft === prev.left && clampedBottom === prev.bottom) {
-          return prev;
-        }
-        return { left: clampedLeft, bottom: clampedBottom };
+        const maxH = Math.max(0, window.innerWidth - width);
+        const maxV = Math.max(0, window.innerHeight - height);
+        const clampedH = Math.min(Math.max(prev.h, 0), maxH);
+        const clampedV = Math.min(Math.max(prev.v, 0), maxV);
+        if (clampedH === prev.h && clampedV === prev.v) return prev;
+        return { ...prev, h: clampedH, v: clampedV };
       });
     };
 
@@ -385,10 +390,8 @@ const JobQueueWidget = () => {
             position: "fixed",
             ...(position
               ? {
-                  left: position.left,
-                  ...(position.top !== undefined
-                    ? { top: position.top }
-                    : { bottom: position.bottom }),
+                  [position.horizontal]: position.h,
+                  [position.vertical]: position.v,
                 }
               : {
                   bottom: { xs: 16, sm: (theme) => theme.spacing(3) },


### PR DESCRIPTION
## Summary
Fixes the job queue widget going offscreen (or appearing to slide) when the browser's zoom level changes. Dragged positions are now anchored to the nearest edge (distance from left/right and top/bottom) instead of an absolute left/top offset, so they stay fixed regardless of zoom, the same approach the widget's default position already used.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/front/src/components/jobs/JobQueueWidget.jsx`:
  - Drag end now computes which edge (left/right) and which edge (top/bottom) the widget is closest to, and persists the offset from those edges instead of a left/top pixel pair. This makes a dragged position zoom-invariant, matching how the default position already behaves.
  - Added a `resize` listener (also run once on mount) that re-clamps the stored offset against the current viewport size, a safety net for extreme window resizes, not the primary fix.
  - Positions saved by the old left/top-based format are discarded on load and fall back to the default corner, since there's no reliable way to migrate them and it's a low-stakes UI preference.

---

## Testing (optional)
- Drag the widget near a corner, then zoom the browser in and out repeatedly, it should stay visually anchored in place instead of sliding or disappearing.
- Reload the page while the browser is already zoomed in/out. The widget should be visible immediately.
- Drag the widget to each of the four corners/edges and confirm it still expands/collapses in the expected direction (upward when near the bottom, etc.).