### PR TITLE
Store explorer artifacts at creation

### DIFF
--- a/DashAI/alembic/versions/d5b3c8f2a041_add_artifacts_path_to_explorer.py
+++ b/DashAI/alembic/versions/d5b3c8f2a041_add_artifacts_path_to_explorer.py
@@ -1,0 +1,29 @@
+"""Add artifacts_path to explorer
+
+Revision ID: d5b3c8f2a041
+Revises: c4e8a1d20f3b
+Create Date: 2026-07-31 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d5b3c8f2a041"
+down_revision: Union[str, None] = "c4e8a1d20f3b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "explorer",
+        sa.Column("artifacts_path", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("explorer", "artifacts_path")

--- a/DashAI/back/api/api_v1/endpoints/explorers.py
+++ b/DashAI/back/api/api_v1/endpoints/explorers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from fastapi import APIRouter, Depends, Response, status
 from fastapi.exceptions import HTTPException
@@ -12,7 +12,6 @@ from DashAI.back.api.api_v1.schemas.explorers_params import (
     ExplorerCreate,
     ExplorerResultsOptions,
 )
-from DashAI.back.core.artifacts import normalize_artifacts
 from DashAI.back.core.enums.status import ExplorerStatus
 from DashAI.back.dependencies.database.models import Dataset, Explorer, Notebook
 
@@ -111,14 +110,23 @@ def validate_explorer_params(
 def validate_explorer_finished(explorer: Explorer):
     """
     Function to validate if the explorer is finished.
+
+    The exploration is readable when its stored artifacts are on disk, or,
+    for explorations created before artifacts were persisted, when the raw
+    result file is still there to build them from.
     """
     import pathlib
+
+    from DashAI.back.exploration.artifact_store import has_stored_artifacts
 
     if explorer.status != ExplorerStatus.FINISHED:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Explorer is not finished",
         )
+
+    if has_stored_artifacts(explorer):
+        return True
 
     if (
         explorer.exploration_path is None
@@ -131,6 +139,63 @@ def validate_explorer_finished(explorer: Explorer):
         )
 
     return True
+
+
+def load_explorer_artifacts(
+    explorer: Explorer,
+    component_registry: "ComponentRegistry",
+    session: "Session",
+) -> List[Dict[str, Any]]:
+    """Load the stored artifacts of an explorer, backfilling them if missing.
+
+    Parameters
+    ----------
+    explorer : Explorer
+        The explorer database record.
+    component_registry : ComponentRegistry
+        Registry used only when the artifacts still have to be built.
+    session : Session
+        Session owning ``explorer``, committed when a backfill happened.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        The artifact wire dicts of the exploration.
+
+    Raises
+    ------
+    HTTPException
+        409: the exploration predates stored artifacts and its explorer is no
+        longer registered.
+        400: the artifacts could not be read or built.
+    """
+    from DashAI.back.exploration.artifact_store import (
+        ensure_artifacts_from_registry,
+        has_stored_artifacts,
+    )
+
+    had_artifacts = has_stored_artifacts(explorer)
+    try:
+        artifacts = ensure_artifacts_from_registry(explorer, component_registry)
+    except KeyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Explorer {explorer.exploration_type} is not installed and this "
+                "exploration has no stored results to render"
+            ),
+        ) from e
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Error while getting explorer results",
+        ) from e
+
+    if not had_artifacts:
+        session.commit()
+
+    return artifacts
 
 
 # GET
@@ -292,45 +357,19 @@ async def get_explorer_results(
                 detail="Error while loading the explorer info",
             ) from e
 
-    # validate explorer status and result path
-    validate_explorer_finished(explorer=explorer_info)
+        # validate explorer status and result path
+        validate_explorer_finished(explorer=explorer_info)
 
-    # get explorer class
-    try:
-        explorer_component_class = component_registry[explorer_info.exploration_type][
-            "class"
-        ]
-    except KeyError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"{explorer_info.exploration_type} not found in registry",
-        ) from e
-
-    # instantiate explorer class (it handles returning the results as response object)
-    try:
-        explorer_instance: BaseExplorer = explorer_component_class(
-            **explorer_info.parameters,
+        # The artifacts were built when the exploration ran, so no explorer
+        # class is involved here. Explorations created before artifacts were
+        # persisted are backfilled on this first read.
+        artifacts = load_explorer_artifacts(
+            explorer=explorer_info,
+            component_registry=component_registry,
+            session=db,
         )
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Error while instantiating explorer class",
-        ) from e
 
-    # get results
-    try:
-        results = explorer_instance.get_results(
-            exploration_path=explorer_info.exploration_path,
-            options=params.model_dump().get("options", {}),
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Error while getting explorer results",
-        ) from e
-
-    # Upgrade legacy {"data", "type", "config"} results from plugin explorers
-    return normalize_artifacts(results)
+    return artifacts
 
 
 @router.put("/{explorer_id}/results/")
@@ -339,8 +378,16 @@ async def update_explorer_results(
     params: dict,
     explorer_id: int,
     session_factory: "sessionmaker" = Depends(lambda: di["session_factory"]),
+    component_registry: "ComponentRegistry" = Depends(lambda: di["component_registry"]),
 ):
+    """Store the plot edits (data and layout) made from the frontend.
+
+    The edited figure replaces the payload of the first stored artifact; the
+    raw exploration file is left untouched as the original result.
+    """
     import json
+
+    from DashAI.back.exploration.artifact_store import write_artifacts
 
     db: "Session"
     with session_factory() as db:
@@ -351,15 +398,27 @@ async def update_explorer_results(
                 detail="Explorer not found",
             )
 
-    # update results
-    try:
-        exploration_path = explorer.exploration_path
-        with open(f"{exploration_path}", "w") as f:
-            json.dump(params, f)
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Error while updating explorer results",
-        ) from e
+        artifacts = load_explorer_artifacts(
+            explorer=explorer,
+            component_registry=component_registry,
+            session=db,
+        )
+
+        if not artifacts:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Explorer has no results to update",
+            )
+
+        # update results
+        try:
+            artifacts[0] = {**artifacts[0], "payload": json.dumps(params)}
+            write_artifacts(explorer.artifacts_path, artifacts)
+        except Exception as e:
+            log.exception(e)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Error while updating explorer results",
+            ) from e
 
     return {"message": "Explorer results updated successfully"}

--- a/DashAI/back/app.py
+++ b/DashAI/back/app.py
@@ -12,7 +12,10 @@ from DashAI.back.api.api_v1.api import api_router_v1
 from DashAI.back.api.front_api import router as app_router
 from DashAI.back.container import build_container
 from DashAI.back.dependencies.config_builder import build_config_dict
-from DashAI.back.dependencies.database.backfill import backfill_dataset_counts
+from DashAI.back.dependencies.database.backfill import (
+    backfill_dataset_counts,
+    backfill_explorer_artifacts,
+)
 from DashAI.back.dependencies.database.migrate import migrate_on_startup
 from DashAI.back.seeds import seed_datasets_if_first_run
 
@@ -92,6 +95,11 @@ def create_app(
 
     logger.debug("4b. Backfilling dataset row/column counts.")
     backfill_dataset_counts(di["session_factory"])
+
+    # Runs after the container so the explorer classes are registered: old
+    # explorations can only be upgraded while their explorer is installed.
+    logger.debug("4b-bis. Backfilling explorer render artifacts.")
+    backfill_explorer_artifacts(di["session_factory"])
 
     if enable_seeding:
         logger.debug("4c. Seeding initial datasets if first run.")

--- a/DashAI/back/dependencies/database/backfill.py
+++ b/DashAI/back/dependencies/database/backfill.py
@@ -47,3 +47,63 @@ def backfill_dataset_counts(session_factory: "sessionmaker") -> None:
         if updated:
             db.commit()
             log.debug("Backfilled counts for %d dataset(s).", updated)
+
+
+def backfill_explorer_artifacts(session_factory: "sessionmaker") -> None:
+    """Persist the render artifacts of explorations created before they existed.
+
+    Explorations used to build their artifacts on every read request, which
+    made them unreadable once their explorer class was removed from the
+    registry. This backfill stores the artifacts of every finished exploration
+    that still lacks them, while the explorer classes are installed. Explorers
+    that are already gone are skipped: nothing can be recovered for them.
+
+    Parameters
+    ----------
+    session_factory : sessionmaker
+        SQLAlchemy session factory from the DI container.
+    """
+    from kink import di
+
+    from DashAI.back.core.enums.status import ExplorerStatus
+    from DashAI.back.dependencies.database.models import Explorer
+    from DashAI.back.exploration.artifact_store import (
+        has_stored_artifacts,
+        store_artifacts,
+    )
+
+    component_registry = di["component_registry"]
+
+    with session_factory() as db:
+        pending = (
+            db.query(Explorer)
+            .filter(
+                Explorer.status == ExplorerStatus.FINISHED,
+                Explorer.artifacts_path == None,  # noqa: E711 (SQLAlchemy ORM requires == for column IS NULL)
+                Explorer.exploration_path != None,  # noqa: E711
+            )
+            .all()
+        )
+
+        if not pending:
+            log.debug("No explorers found that require backfilling.")
+            return
+
+        updated = 0
+        for explorer in pending:
+            if has_stored_artifacts(explorer):
+                continue
+            try:
+                explorer_class = component_registry[explorer.exploration_type]["class"]
+                explorer_instance = explorer_class(**explorer.parameters)
+                explorer.artifacts_path = store_artifacts(
+                    explorer_instance, explorer.exploration_path, explorer.id
+                )
+                updated += 1
+            except Exception as e:
+                log.warning(
+                    "Failed to backfill artifacts of explorer %d: %s", explorer.id, e
+                )
+        if updated:
+            db.commit()
+            log.debug("Backfilled artifacts for %d explorer(s).", updated)

--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -699,6 +699,9 @@ class Explorer(Base):
     exploration_type: Mapped[str] = mapped_column(String, nullable=False)
     parameters: Mapped[JSON] = mapped_column(JSON, nullable=False)
     exploration_path: Mapped[str] = mapped_column(String, nullable=True)
+    # Render artifacts built once, when the exploration is created, so results
+    # keep rendering after the explorer class is removed from the registry.
+    artifacts_path: Mapped[str] = mapped_column(String, nullable=True)
     # Metadata
     name: Mapped[str] = mapped_column(String, nullable=True)
 
@@ -732,6 +735,11 @@ class Explorer(Base):
 
     def delete_result(self) -> None:
         """Delete the result of the explorer."""
+        from DashAI.back.exploration.artifact_store import delete_artifacts
+
+        delete_artifacts(self.artifacts_path)
+        self.artifacts_path = None
+
         if self.exploration_path is not None:
             path = pathlib.Path(self.exploration_path)
             if path.exists():

--- a/DashAI/back/exploration/artifact_store.py
+++ b/DashAI/back/exploration/artifact_store.py
@@ -1,0 +1,268 @@
+"""Persistence of the render artifacts produced by an exploration.
+
+An explorer builds its renderable output in
+:meth:`DashAI.back.exploration.base_explorer.BaseExplorer.get_results`. That
+call happens once, when the exploration is created (in the explorer job), and
+its result is normalized into artifact wire dicts and written next to the raw
+exploration file as ``<explorer_id>_artifacts.json``.
+
+Read requests serve that file directly, so a stored exploration keeps
+rendering after its explorer class is removed from the registry (plugin
+uninstalled, component dropped from ``config_builder``): only the
+:class:`DashAI.back.core.artifacts.Artifact` types, which always exist, are
+needed to render it.
+
+Explorations created before the artifacts file existed are upgraded on demand
+by :func:`ensure_artifacts` (called from the read endpoints and from the
+startup backfill) while their explorer class is still installed.
+"""
+
+import json
+import logging
+import pathlib
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+if TYPE_CHECKING:
+    from DashAI.back.dependencies.database.models import Explorer
+    from DashAI.back.dependencies.registry import ComponentRegistry
+    from DashAI.back.exploration.base_explorer import BaseExplorer
+
+log = logging.getLogger(__name__)
+
+ARTIFACTS_SUFFIX = "_artifacts.json"
+
+
+def artifacts_path_for(
+    exploration_path: Union[str, "pathlib.Path"], explorer_id: Any
+) -> pathlib.Path:
+    """Build the artifacts file path that belongs to an exploration result.
+
+    Parameters
+    ----------
+    exploration_path : Union[str, pathlib.Path]
+        Path of the raw result file written by ``save_notebook``.
+    explorer_id : Any
+        Identifier of the explorer record; used as the filename prefix.
+
+    Returns
+    -------
+    pathlib.Path
+        ``<result directory>/<explorer_id>_artifacts.json``.
+    """
+    path = pathlib.Path(exploration_path)
+    directory = path if path.is_dir() else path.parent
+    return directory / f"{explorer_id}{ARTIFACTS_SUFFIX}"
+
+
+def build_artifacts(
+    explorer_instance: "BaseExplorer", exploration_path: Union[str, "pathlib.Path"]
+) -> List[Dict[str, Any]]:
+    """Build the artifact wire dicts of a saved exploration result.
+
+    Parameters
+    ----------
+    explorer_instance : BaseExplorer
+        The instantiated explorer that produced the result.
+    exploration_path : Union[str, pathlib.Path]
+        Path of the raw result file written by ``save_notebook``.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        The normalized artifacts, ready to be serialized as JSON.
+    """
+    from DashAI.back.core.artifacts import normalize_artifacts
+
+    results = explorer_instance.get_results(
+        exploration_path=str(exploration_path), options={}
+    )
+    return normalize_artifacts(results)
+
+
+def write_artifacts(
+    artifacts_path: Union[str, "pathlib.Path"], artifacts: List[Dict[str, Any]]
+) -> str:
+    """Write artifact wire dicts to disk as JSON.
+
+    Parameters
+    ----------
+    artifacts_path : Union[str, pathlib.Path]
+        Destination file, usually from :func:`artifacts_path_for`.
+    artifacts : List[Dict[str, Any]]
+        The artifacts to persist.
+
+    Returns
+    -------
+    str
+        The destination path as a POSIX string.
+    """
+    path = pathlib.Path(artifacts_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as file:
+        json.dump(artifacts, file)
+    return path.as_posix()
+
+
+def read_artifacts(
+    artifacts_path: Union[str, "pathlib.Path"],
+) -> List[Dict[str, Any]]:
+    """Read persisted artifact wire dicts.
+
+    Parameters
+    ----------
+    artifacts_path : Union[str, pathlib.Path]
+        Path of the artifacts file.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        The stored artifacts.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the artifacts file does not exist.
+    """
+    with open(pathlib.Path(artifacts_path), "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def store_artifacts(
+    explorer_instance: "BaseExplorer",
+    exploration_path: Union[str, "pathlib.Path"],
+    explorer_id: Any,
+) -> str:
+    """Build the artifacts of a saved result and persist them next to it.
+
+    Parameters
+    ----------
+    explorer_instance : BaseExplorer
+        The instantiated explorer that produced the result.
+    exploration_path : Union[str, pathlib.Path]
+        Path of the raw result file written by ``save_notebook``.
+    explorer_id : Any
+        Identifier of the explorer record; used as the filename prefix.
+
+    Returns
+    -------
+    str
+        Path of the written artifacts file as a POSIX string.
+    """
+    artifacts = build_artifacts(explorer_instance, exploration_path)
+    return write_artifacts(artifacts_path_for(exploration_path, explorer_id), artifacts)
+
+
+def has_stored_artifacts(explorer: "Explorer") -> bool:
+    """Check whether an explorer record has a readable artifacts file.
+
+    Parameters
+    ----------
+    explorer : Explorer
+        The explorer database record.
+
+    Returns
+    -------
+    bool
+        True when ``artifacts_path`` is set and the file exists.
+    """
+    return (
+        bool(explorer.artifacts_path) and pathlib.Path(explorer.artifacts_path).exists()
+    )
+
+
+def ensure_artifacts(
+    explorer: "Explorer", explorer_instance: Optional["BaseExplorer"] = None
+) -> List[Dict[str, Any]]:
+    """Return the stored artifacts of an explorer, generating them if missing.
+
+    Explorations created before artifacts were persisted are upgraded here:
+    ``explorer_instance`` is asked for its results once, the artifacts are
+    written to disk and ``explorer.artifacts_path`` is set on the record. The
+    caller owns the session and must commit.
+
+    Parameters
+    ----------
+    explorer : Explorer
+        The explorer database record, with ``exploration_path`` set.
+    explorer_instance : Optional[BaseExplorer]
+        Explorer used to build the artifacts. Only needed when the record has
+        no stored artifacts yet.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        The artifacts of the exploration.
+
+    Raises
+    ------
+    ValueError
+        If the artifacts have to be built and no explorer was given.
+    """
+    if has_stored_artifacts(explorer):
+        return read_artifacts(explorer.artifacts_path)
+
+    if explorer_instance is None:
+        raise ValueError(
+            f"Explorer {explorer.id} has no stored artifacts and no explorer "
+            "instance was given to build them."
+        )
+
+    explorer.artifacts_path = store_artifacts(
+        explorer_instance, explorer.exploration_path, explorer.id
+    )
+    log.debug(
+        "Backfilled artifacts of explorer %s at %s.",
+        explorer.id,
+        explorer.artifacts_path,
+    )
+    return read_artifacts(explorer.artifacts_path)
+
+
+def ensure_artifacts_from_registry(
+    explorer: "Explorer", component_registry: "ComponentRegistry"
+) -> List[Dict[str, Any]]:
+    """Return the stored artifacts of an explorer, resolving its class if needed.
+
+    The registry is only consulted when the artifacts still have to be built,
+    so an exploration with stored artifacts is served even when its explorer
+    is no longer registered.
+
+    Parameters
+    ----------
+    explorer : Explorer
+        The explorer database record, with ``exploration_path`` set.
+    component_registry : ComponentRegistry
+        Registry used to resolve the explorer class for a backfill.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        The artifacts of the exploration.
+
+    Raises
+    ------
+    KeyError
+        If a backfill is needed and ``exploration_type`` is not registered,
+        i.e. the exploration predates stored artifacts and its explorer is no
+        longer installed.
+    """
+    if has_stored_artifacts(explorer):
+        return read_artifacts(explorer.artifacts_path)
+
+    explorer_class = component_registry[explorer.exploration_type]["class"]
+    return ensure_artifacts(explorer, explorer_class(**explorer.parameters))
+
+
+def delete_artifacts(artifacts_path: Union[str, "pathlib.Path", None]) -> None:
+    """Delete an artifacts file if it exists.
+
+    Parameters
+    ----------
+    artifacts_path : Union[str, pathlib.Path, None]
+        Path of the artifacts file; ``None`` is a no-op.
+    """
+    if not artifacts_path:
+        return
+    path = pathlib.Path(artifacts_path)
+    if path.exists() and path.is_file():
+        path.unlink()

--- a/DashAI/back/exploration/base_explorer.py
+++ b/DashAI/back/exploration/base_explorer.py
@@ -273,15 +273,25 @@ class BaseExplorer(ConfigObject, ABC):
     def get_results(
         self, exploration_path: str, options: Dict[str, Any]
     ) -> List[Artifact]:
-        """Load a previously saved exploration result and return it for the frontend.
+        """Load a previously saved exploration result and turn it into artifacts.
+
+        This runs once, when the exploration is created: the explorer job (or
+        the pipeline exploration node) calls it right after `save_notebook`,
+        normalizes the returned artifacts and stores them on disk. Read
+        requests serve those stored artifacts, so this method is never called
+        again for an existing exploration and the results keep rendering after
+        the explorer is removed from the registry. Explorations created before
+        artifacts were stored are upgraded by the artifact backfill, which
+        calls this method one last time.
 
         Parameters
         ----------
         exploration_path : str
             Path to the file saved by `save_notebook`.
         options : Dict[str, Any]
-            Optional rendering or filtering options
-            passed from the frontend.
+            Optional rendering or filtering options. Kept for backwards
+            compatibility; artifacts are built once, so no per request option
+            reaches this method.
 
         Returns
         -------
@@ -290,6 +300,6 @@ class BaseExplorer(ConfigObject, ABC):
             :class:`TableArtifact`, :class:`TextArtifact` or
             :class:`ImageArtifact`) describing the exploration result.
             Legacy explorers returning the old ``{"data", "type", "config"}``
-            dict are upgraded by ``normalize_artifacts`` at the API layer.
+            dict are upgraded by ``normalize_artifacts`` before storage.
         """
         raise NotImplementedError

--- a/DashAI/back/job/explorer_job.py
+++ b/DashAI/back/job/explorer_job.py
@@ -91,6 +91,7 @@ class ExplorerJob(BaseJob):
         from kink import di
 
         from DashAI.back.dataloaders.classes.dashai_dataset import load_dataset
+        from DashAI.back.exploration.artifact_store import store_artifacts
 
         component_registry = di["component_registry"]
         session_factory = di["session_factory"]
@@ -220,7 +221,6 @@ class ExplorerJob(BaseJob):
 
                 # Update the explorer info
                 explorer_info.exploration_path = save_path.as_posix()
-                explorer_info.set_status_as_finished()
                 db.commit()
             except Exception as e:
                 log.exception(e)
@@ -229,6 +229,27 @@ class ExplorerJob(BaseJob):
                 raise JobError(
                     (
                         f"Error while saving the exploration "
+                        f"{explorer_info.exploration_type}."
+                    )
+                ) from e
+
+            # Build and persist the render artifacts. This is the only moment
+            # the explorer class is asked for its results: from here on the
+            # stored artifacts are served as is, so the exploration keeps
+            # rendering even if the explorer is removed from the registry.
+            try:
+                explorer_info.artifacts_path = store_artifacts(
+                    explorer_instance, save_path, explorer_info.id
+                )
+                explorer_info.set_status_as_finished()
+                db.commit()
+            except Exception as e:
+                log.exception(e)
+                explorer_info.set_status_as_error()
+                db.commit()
+                raise JobError(
+                    (
+                        f"Error while building the artifacts of the exploration "
                         f"{explorer_info.exploration_type}."
                     )
                 ) from e


### PR DESCRIPTION
## Summary
Explorer results were built on every read request by calling the explorer's `get_results`, so an exploration stopped rendering as soon as its explorer left the component registry (plugin uninstalled, component dropped from `config_builder`). The explorer job now calls `get_results` once, normalizes the output into artifacts and persists them as JSON next to the raw result; read requests serve that file, so only the `Artifact` types, which always exist, are needed to render a stored exploration. Explorations created before this keep working: they are upgraded by a startup backfill while their explorer is still installed, and by a lazy backfill on first read.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/exploration/artifact_store.py`: new module owning artifact persistence: path derivation (`<result dir>/<explorer_id>_artifacts.json`), build (`get_results` + `normalize_artifacts`), read/write, `ensure_artifacts` / `ensure_artifacts_from_registry` for on demand backfill, and deletion.
- `DashAI/back/job/explorer_job.py`: after `save_notebook`, builds and stores the artifacts, sets `artifacts_path`, then marks the explorer as finished. A failure here sets the error status like a save failure.
- `DashAI/back/dependencies/database/models.py`: new nullable `explorer.artifacts_path`; `delete_result` also removes the artifacts file.
- `DashAI/alembic/versions/d5b3c8f2a041_add_artifacts_path_to_explorer.py`: migration adding the column (revises `c4e8a1d20f3b`).
- `DashAI/back/api/api_v1/endpoints/explorers.py`: `POST /{id}/results/` reads the stored artifacts with no registry lookup and no explorer instantiation; falls back to a persisted lazy backfill, and returns 409 when the explorer is uninstalled and nothing was stored. `PUT /{id}/results/` rewrites the stored artifact payload instead of overwriting the raw result file. `validate_explorer_finished` accepts an exploration whose raw file is gone but whose artifacts exist.
- `DashAI/back/dependencies/database/backfill.py`: `backfill_explorer_artifacts` stores the artifacts of every finished exploration that lacks them, skipping (with a warning) explorers that are already gone.
- `DashAI/back/app.py`: runs that backfill after the container is built, so the explorer classes are registered.
- `DashAI/back/exploration/base_explorer.py`: `get_results` docstring states it runs once, at exploration time. Signature unchanged, so the existing explorers and plugin explorers need no edits; legacy `{"data", "type", "config"}` returns are still upgraded before storage.

---

## Testing

- App creation runs the migration, so the schema change is exercised.
- Manual check worth doing: open an exploration created before this branch, confirm it renders (startup backfill), then uninstall or unregister its explorer and confirm it still renders.
- Also worth checking a plot layout edit: save it, reopen, and confirm the edit persists while the raw result file keeps the original figure.

---

## Notes

- Artifacts are stored as JSON wire dicts rather than pickles: no class references, inspectable on disk, and immune to the explorer being removed by construction.
- The raw exploration file is kept as the original result; layout edits only touch the artifacts file.
- Old explorations that were already edited keep their edits, since the backfill reads them back from the raw file the old `PUT` wrote to.
