### PR TITLE
Translate dataset processing title across all locales

### DIFF
--- a/DashAI/front/src/components/DatasetVisualization.jsx
+++ b/DashAI/front/src/components/DatasetVisualization.jsx
@@ -457,7 +457,7 @@ export default function DatasetVisualization({
             }}
           >
             <CircularProgress color="primary" />
-            <Typography>Processing your dataset...</Typography>
+            <Typography>{t("datasets:label.processingTitle")}</Typography>
             <Typography
               variant="body2"
               color="text.secondary"

--- a/DashAI/front/src/utils/i18n/locales/de/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/de/datasets.json
@@ -303,6 +303,7 @@
     "position": "Position",
     "possibleIDColumns": "Mögliche ID-Spalten",
     "presetScale": "Voreingestellte Skala",
+    "processingTitle": "Ihr Dataset wird verarbeitet...",
     "processingMessage": "Dies kann je nach Größe Ihrer Daten einige Momente dauern.",
     "proportion": "Anteil",
     "q1": "Q1",

--- a/DashAI/front/src/utils/i18n/locales/en/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/en/datasets.json
@@ -303,6 +303,7 @@
     "position": "Position",
     "possibleIDColumns": "Possible ID Columns",
     "presetScale": "Preset Scale",
+    "processingTitle": "Processing your dataset...",
     "processingMessage": "This may take a few moments depending on the size of your data.",
     "proportion": "Proportion",
     "q1": "Q1",

--- a/DashAI/front/src/utils/i18n/locales/es/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/es/datasets.json
@@ -310,6 +310,7 @@
     "position": "Posición",
     "possibleIDColumns": "Posibles Columnas de ID",
     "presetScale": "Escala Preestablecida",
+    "processingTitle": "Procesando tu dataset...",
     "processingMessage": "Esto puede tardar unos minutos dependiendo del tamaño del dataset.",
     "proportion": "Proporción",
     "q1": "Q1",

--- a/DashAI/front/src/utils/i18n/locales/pt/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/pt/datasets.json
@@ -310,6 +310,7 @@
     "position": "Posição",
     "possibleIDColumns": "Possíveis Colunas de ID",
     "presetScale": "Escala Predefinida",
+    "processingTitle": "Processando seu dataset...",
     "processingMessage": "Isso pode levar alguns minutos dependendo do tamanho do conjunto de dados.",
     "proportion": "Proporção",
     "q1": "Q1",

--- a/DashAI/front/src/utils/i18n/locales/zh/datasets.json
+++ b/DashAI/front/src/utils/i18n/locales/zh/datasets.json
@@ -304,6 +304,7 @@
     "position": "位置",
     "possibleIDColumns": "可能的 ID 列",
     "presetScale": "预设色阶",
+    "processingTitle": "正在处理您的数据集...",
     "processingMessage": "根据数据大小，这可能需要几分钟。",
     "proportion": "比例",
     "q1": "Q1",


### PR DESCRIPTION
## Summary
The "Processing your dataset..." title shown while a dataset is being processed was hardcoded in English directly in the JSX, so it never changed with the app's locale, even though the subtitle right below it was already translated. Added the missing translation key across all supported locales and wired the component to use it.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/DatasetVisualization.jsx`: replaced the hadataset..."` string with `t("datasets:label.processingTitle")`.
- `DashAI/front/src/utils/i18n/locales/{en,es,de,pt,zh}/datasets.json`: added the `label.processingTitle` key with its translation for each locale.

---

## Testing (optional)
- Switched the app language and uploaded a new dataset to confirm the proper locale.