### PR TITLE
Fix for the failing workflows due to: Intel old pytorch library and llama-cpp bundle corruption

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,6 +182,9 @@ jobs:
   build-macos-x86_64:
     needs: react-build
     runs-on: macos-15-intel
+    # PyTorch's last macOS Intel wheel is 2.2.2, so `uv sync --locked` can't
+    # resolve here. Kept non-blocking until we decide to drop Intel for good.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Download React build artifact
@@ -298,7 +301,6 @@ jobs:
       - publish-pypi
       - build-windows-executable
       - build-macos-arm64
-      - build-macos-x86_64
       - build-linux-appimage
     runs-on: ubuntu-latest
     permissions:
@@ -325,12 +327,6 @@ jobs:
           name: dashAI-dmg-arm64
           path: artifacts/macos-arm64
 
-      - name: Download macOS x86_64 DMG
-        uses: actions/download-artifact@v4
-        with:
-          name: dashAI-dmg-x86_64
-          path: artifacts/macos-x86_64
-
       - name: Download Linux AppImage
         uses: actions/download-artifact@v4
         with:
@@ -343,7 +339,6 @@ jobs:
           mkdir -p release
           cp "artifacts/windows/dashAI-Installer.exe"         "release/dashAI-${V}-x64-windows.exe"
           cp "artifacts/macos-arm64/dashAI-macos-arm64.dmg"   "release/dashAI-${V}-arm-osx.dmg"
-          cp "artifacts/macos-x86_64/dashAI-macos-x86_64.dmg" "release/dashAI-${V}-x64-osx.dmg"
           cp "artifacts/linux/dashAI-x86_64.AppImage"         "release/dashAI-${V}-x64-linux.AppImage"
 
       - name: Create / update GitHub Release
@@ -356,5 +351,4 @@ jobs:
           files: |
             release/dashAI-${{ steps.version.outputs.version }}-x64-windows.exe
             release/dashAI-${{ steps.version.outputs.version }}-arm-osx.dmg
-            release/dashAI-${{ steps.version.outputs.version }}-x64-osx.dmg
             release/dashAI-${{ steps.version.outputs.version }}-x64-linux.AppImage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dashAI"
-version = "0.9.7"
+version = "0.9.7.post1"
 description = "dashAI: a graphical toolbox for training, evaluating and deploying state-of-the-art AI models."
 readme = "README.rst"
 license = "MIT"
@@ -79,7 +79,14 @@ dependencies = [
 
 [project.optional-dependencies]
 # PyTorch CPU wheels + precompiled CPU llama-cpp (no CUDA SDK / drivers needed)
-cpu = ["torch", "torchvision", "llama-cpp-python"]
+# Upstream's macOS arm64 wheels are malformed zips from 0.3.30 on (0.3.29 is the
+# last good one), so darwin stays pinned until they republish.
+cpu = [
+    "torch",
+    "torchvision",
+    "llama-cpp-python==0.3.29; sys_platform == 'darwin'",
+    "llama-cpp-python; sys_platform != 'darwin'",
+]
 # PyTorch CUDA 12.8 wheels; llama-cpp-python needs CMAKE_ARGS="-DGGML_CUDA=on"
 # at install time to compile with CUDA offload (see Dockerfile.cuda)
 cuda = ["torch", "torchvision", "llama-cpp-python"]

--- a/uv.lock
+++ b/uv.lock
@@ -1401,7 +1401,7 @@ wheels = [
 
 [[package]]
 name = "dashai"
-version = "0.9.7"
+version = "0.9.7.post1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -1472,7 +1472,8 @@ dependencies = [
 
 [package.optional-dependencies]
 cpu = [
-    { name = "llama-cpp-python", version = "0.3.34", source = { registry = "https://abetlen.github.io/llama-cpp-python/whl/cpu" } },
+    { name = "llama-cpp-python", version = "0.3.29", source = { registry = "https://abetlen.github.io/llama-cpp-python/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-dashai-cpu') or (extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
+    { name = "llama-cpp-python", version = "0.3.34", source = { registry = "https://abetlen.github.io/llama-cpp-python/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-dashai-cpu') or (extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
     { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-6-dashai-cpu') or (python_full_version >= '3.15' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda') or (sys_platform != 'darwin' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
     { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.15' and extra == 'extra-6-dashai-cpu') or (python_full_version < '3.15' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda') or (sys_platform != 'darwin' and extra == 'extra-6-dashai-cpu')" },
     { name = "torchvision", version = "0.28.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'extra-6-dashai-cpu') or (python_full_version >= '3.15' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda') or (sys_platform != 'darwin' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
@@ -1522,7 +1523,8 @@ requires-dist = [
     { name = "joblib" },
     { name = "kink" },
     { name = "lime", specifier = ">=0.2.0.1" },
-    { name = "llama-cpp-python", marker = "extra == 'cpu'", index = "https://abetlen.github.io/llama-cpp-python/whl/cpu", conflict = { package = "dashai", extra = "cpu" } },
+    { name = "llama-cpp-python", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = "==0.3.29", index = "https://abetlen.github.io/llama-cpp-python/whl/cpu", conflict = { package = "dashai", extra = "cpu" } },
+    { name = "llama-cpp-python", marker = "sys_platform != 'darwin' and extra == 'cpu'", index = "https://abetlen.github.io/llama-cpp-python/whl/cpu", conflict = { package = "dashai", extra = "cpu" } },
     { name = "llama-cpp-python", marker = "extra == 'cuda'" },
     { name = "llvmlite" },
     { name = "numba" },
@@ -3131,6 +3133,35 @@ sdist = { url = "https://files.pythonhosted.org/packages/f5/86/91a13127d83d793ec
 
 [[package]]
 name = "llama-cpp-python"
+version = "0.3.29"
+source = { registry = "https://abetlen.github.io/llama-cpp-python/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "diskcache", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-6-dashai-cpu') or (python_full_version >= '3.11' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda') or (sys_platform != 'darwin' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'extra-6-dashai-cpu') or (python_full_version < '3.11' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda') or (sys_platform != 'darwin' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.29/llama_cpp_python-0.3.29-py3-none-linux_riscv64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.29/llama_cpp_python-0.3.29-py3-none-macosx_11_0_arm64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.29/llama_cpp_python-0.3.29-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.29/llama_cpp_python-0.3.29-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.29/llama_cpp_python-0.3.29-py3-none-musllinux_1_2_aarch64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.29/llama_cpp_python-0.3.29-py3-none-musllinux_1_2_x86_64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.29/llama_cpp_python-0.3.29-py3-none-win_amd64.whl" },
+]
+
+[[package]]
+name = "llama-cpp-python"
 version = "0.3.34"
 source = { registry = "https://abetlen.github.io/llama-cpp-python/whl/cpu" }
 resolution-markers = [
@@ -3138,21 +3169,15 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
     "python_full_version == '3.13.*' and sys_platform != 'darwin'",
     "python_full_version == '3.12.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
-    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "diskcache" },
-    { name = "jinja2" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-6-dashai-cpu') or (extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-6-dashai-cpu') or (extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
-    { name = "typing-extensions" },
+    { name = "diskcache", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-dashai-cpu') or (python_full_version >= '3.11' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda') or (sys_platform == 'darwin' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'darwin' and extra == 'extra-6-dashai-cpu') or (python_full_version < '3.11' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda') or (sys_platform == 'darwin' and extra == 'extra-6-dashai-cpu' and extra == 'extra-6-dashai-cuda')" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.34/llama_cpp_python-0.3.34-py3-none-linux_riscv64.whl" },


### PR DESCRIPTION
## Summary

The 0.9.7 release run failed both macOS bundle jobs, which left `github-release` skipped and no
installers published. The two failures were unrelated:

- **x86_64:** PyTorch's last macOS Intel wheel is `2.2.2` (2.3+ ships `macosx_*_arm64` only), so
  the universal `uv.lock` pin of `torch==2.13.0` has no candidate on that runner and
  `uv sync --locked` aborts. pip used to hide this by resolving per runner and silently landing
  on 2.2.2.
- **arm64:** the `llama-cpp-python` macOS arm64 wheels published upstream are malformed zips.
  Not a uv problem: 0.3.27, 0.3.28, 0.3.30, 0.3.32, 0.3.33 and 0.3.34 all fail integrity checks,
  and only 0.3.26 and 0.3.29 are clean. PyPI ships sdist only uld
  have failed here too.

This PR fixes arm64, unblocks the GitHub Release, and bumps toted
macOS metadata actually reaches PyPI users. Intel is left non-all on
whether to drop it.

---

## Type of Change

- [ ] Backend change
- [ ] Frontend change
- [x] CI / Workflow change
- [x] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `pyproject.toml`: split the `cpu` extra on `sys_platform` so
  `llama-cpp-python==0.3.29` while every other platform stays unpinned at 0.3.34, which works
  there. Version bumped `0.9.7` to `0.9.7.post1`.
- `uv.lock`: relocked. Only the `dashai` and `llama-cpp-pythonackage
  moved.
- `.github/workflows/publish.yml`: decoupled `build-macos-x86_64` from `github-release`, which was
  coupled in four places (`needs:`, the `download-artifact` stcript,
  and the `files:` list guarded by `fail_on_unmatched_files: ts:`
  alone would still have failed on the other three. Added `conIntel
  job so it stops turning the whole run red.

---

## Testing

The 0.3.29 wheel was checked against the exact path that failed in CI, forcing uv to download and
extract the arm64 artifact:

```
uv pip install --python-platform aarch64-apple-darwin --only-b=0.3.29
  -> Installed 1 package in 12ms
unzip -t  -> No errors detected in compressed data
```

The dylibs land complete in `lib/`. Corruption on the other veee
independent tools (uv, Python `zipfile.testzip()`, `unzip -t`) against a byte-identical double
download, so it is the published file and not a transfer probl

Also worth confirming on review: `uv lock --check` passes, so `uv sync --locked` will not fail on a
stale lockfile after the version bump.

Expected result of the next push to `production`: `publish-pypi`, Windows, arm64 and Linux green,
Intel amber but non-blocking, and `github-release` creating `vllers.

---

## Notes

- **The release ships without a Mac Intel installer, and nothise_notes:
  true` builds the notes from commits, so Intel users will jus.9.6 and
  this one. Worth a line in the release notes or the announcement.
- **`continue-on-error` here is debt, not a fix.** It leaves aat nobody
  will look at. The real decision is still open: either pin to, or
  delete the job. Dropping it is the cleaner option, since a bundle on torch 2.2.2 while every other
  platform is on 2.13 is a support matrix worth avoiding. Appl the
  `macos-15-intel` runner is heading for deprecation too.
- `0.9.7.post1` rather than `0.9.7a`: under PEP 440 the `a` su
  normalizes to `0.9.7a0` and sorts *below* the 0.9.7 already  be
  latest and pip would skip it by default. A post-release sort
  packaging fix", which is exactly what this is.
- The broken wheels have not been reported upstream yet. abetlt macOS
  arm64 zips for six releases and probably does not know.