### PR TITLE
Refactor datasetjob with units

### DIFF
--- a/DashAI/back/dependencies/database/models.py
+++ b/DashAI/back/dependencies/database/models.py
@@ -106,10 +106,14 @@ class Dataset(Base):
     def set_status_as_started(self) -> None:
         """
         Update the status of the dataset to started and set created to now.
+
+        Unlike ``Run`` or ``Explorer``, this table has no ``start_time`` /
+        ``end_time`` columns, so there is nothing to stamp beyond the timestamps
+        it does declare. Assigning them anyway only set an attribute on the
+        instance that was dropped at commit and read back as missing.
         """
         self.status = DatasetStatus.STARTED
         self.created = datetime.now()
-        self.start_time = datetime.now()
 
     def set_status_as_finished(self) -> None:
         """
@@ -117,7 +121,6 @@ class Dataset(Base):
         """
         self.status = DatasetStatus.FINISHED
         self.last_modified = datetime.now()
-        self.end_time = datetime.now()
 
     def set_status_as_error(self) -> None:
         """

--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -352,10 +352,12 @@ from DashAI.back.tasks.translation_task import TranslationTask
 
 # Units
 from DashAI.back.units.apply_converter_unit import ApplyConverterUnit
+from DashAI.back.units.apply_dataset_schema_unit import ApplyDatasetSchemaUnit
 from DashAI.back.units.build_global_explainer_unit import BuildGlobalExplainerUnit
 from DashAI.back.units.build_local_explainer_unit import BuildLocalExplainerUnit
 from DashAI.back.units.build_manual_input_unit import BuildManualInputUnit
 from DashAI.back.units.build_model_unit import BuildModelUnit
+from DashAI.back.units.compute_dataset_metadata_unit import ComputeDatasetMetadataUnit
 from DashAI.back.units.evaluate_model_unit import EvaluateModelUnit
 from DashAI.back.units.fit_converter_unit import FitConverterUnit
 from DashAI.back.units.fit_model_unit import FitModelUnit
@@ -365,14 +367,18 @@ from DashAI.back.units.generate_global_explanation_unit import (
 from DashAI.back.units.generate_local_explanation_unit import (
     GenerateLocalExplanationUnit,
 )
+from DashAI.back.units.infer_dataset_types_unit import InferDatasetTypesUnit
+from DashAI.back.units.load_datafile_dataset_unit import LoadDatafileDatasetUnit
 from DashAI.back.units.load_dataset_unit import LoadDatasetUnit
 from DashAI.back.units.load_run_model_unit import LoadRunModelUnit
 from DashAI.back.units.load_trained_model_unit import LoadTrainedModelUnit
 from DashAI.back.units.load_training_dataset_unit import LoadTrainingDatasetUnit
+from DashAI.back.units.load_uploaded_dataset_unit import LoadUploadedDatasetUnit
 from DashAI.back.units.predict_unit import PredictUnit
 from DashAI.back.units.prepare_and_split_unit import PrepareAndSplitUnit
 from DashAI.back.units.prepare_explanation_data_unit import PrepareExplanationDataUnit
 from DashAI.back.units.run_exploration_unit import RunExplorationUnit
+from DashAI.back.units.save_dataset_to_path_unit import SaveDatasetToPathUnit
 from DashAI.back.units.save_dataset_unit import SaveDatasetUnit
 from DashAI.back.units.save_exploration_unit import SaveExplorationUnit
 from DashAI.back.units.save_model_unit import SaveModelUnit
@@ -568,6 +574,12 @@ def get_initial_components():
         PrepareExplanationDataUnit,
         GenerateGlobalExplanationUnit,
         GenerateLocalExplanationUnit,
+        LoadUploadedDatasetUnit,
+        LoadDatafileDatasetUnit,
+        InferDatasetTypesUnit,
+        ApplyDatasetSchemaUnit,
+        ComputeDatasetMetadataUnit,
+        SaveDatasetToPathUnit,
         # Explainers
         ContrastiveShap,
         DiceCounterfactual,

--- a/DashAI/back/job/dataset_job.py
+++ b/DashAI/back/job/dataset_job.py
@@ -8,6 +8,14 @@ from DashAI.back.api.api_v1.schemas.datasets_params import DatasetParams
 from DashAI.back.api.utils import parse_params
 from DashAI.back.dependencies.database.models import Converter, Dataset, Notebook
 from DashAI.back.job.base_job import BaseJob, JobError
+from DashAI.back.units.apply_dataset_schema_unit import ApplyDatasetSchemaUnit
+from DashAI.back.units.compute_dataset_metadata_unit import ComputeDatasetMetadataUnit
+from DashAI.back.units.context import ExecutionContext
+from DashAI.back.units.infer_dataset_types_unit import InferDatasetTypesUnit
+from DashAI.back.units.load_datafile_dataset_unit import LoadDatafileDatasetUnit
+from DashAI.back.units.load_dataset_unit import LoadDatasetUnit
+from DashAI.back.units.load_uploaded_dataset_unit import LoadUploadedDatasetUnit
+from DashAI.back.units.save_dataset_to_path_unit import SaveDatasetToPathUnit
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import sessionmaker
@@ -98,14 +106,6 @@ class DatasetJob(BaseJob):
         import uuid
         from pathlib import Path
 
-        from DashAI.back.dataloaders.classes.dashai_dataset import (
-            load_dataset,
-            save_dataset,
-            transform_dataset_with_schema,
-        )
-        from DashAI.back.types.inf.type_inference import infer_types
-
-        component_registry = di["component_registry"]
         session_factory = di["session_factory"]
         config = di["config"]
 
@@ -122,6 +122,8 @@ class DatasetJob(BaseJob):
             temp_dir = tempfile.mkdtemp(prefix="dashai-dataset-")
         url = self.kwargs.get("url", "")
 
+        ctx = ExecutionContext()
+
         try:
             with session_factory() as db:
                 dataset = db.get(Dataset, dataset_id)
@@ -133,6 +135,13 @@ class DatasetJob(BaseJob):
                 db.refresh(dataset)
 
             self.report_progress(0.1, "Loading data")
+
+            # Whether the destination folder is this job's to delete. Re-importing
+            # into an existing dataset writes over its current folder, and the
+            # failure paths below clean up by removing it — which would destroy
+            # data the surviving row still points at. Only a folder this run
+            # created may be removed.
+            folder_is_ours = False
 
             if n_sample and dataset.file_path != "":
                 folder_path = Path(dataset.file_path)
@@ -148,6 +157,7 @@ class DatasetJob(BaseJob):
                     raise JobError(
                         f"A dataset with the name {random_name} already exists."
                     ) from e
+                folder_is_ours = True
 
             from_notebook_no_converters = False
             try:
@@ -159,6 +169,9 @@ class DatasetJob(BaseJob):
                             .filter(Notebook.id == notebook_id)
                             .first()
                         )
+                        # Checked here rather than left to the load unit, whose
+                        # own wording for a missing notebook differs from this
+                        # one. The message reaches the UI, so it is preserved.
                         if not notebook_dataset:
                             msg = (
                                 "Notebook with ID "
@@ -178,208 +191,156 @@ class DatasetJob(BaseJob):
                             is not None
                         )
                         from_notebook_no_converters = not has_converters
-                        new_dataset = load_dataset(
-                            os.path.join(notebook_dataset.file_path, "dataset")
-                        )
+
+                    # ``LoadDatasetUnit`` also publishes ``dataset_path`` (the
+                    # notebook's own copy) and ``dataset_id`` (the *source*
+                    # dataset). Neither describes what is being created here: the
+                    # save goes to a new folder, and this job's ``dataset_id`` is
+                    # the destination row, read from kwargs. Nothing below reads
+                    # them from the context, and nothing should start to.
+                    LoadDatasetUnit(notebook_id=notebook_id)(ctx)
+
+                    # No schema is applied to a notebook copy: it is already a
+                    # stored dataset, with its types settled when it was created.
 
                 else:
                     source_name = self.kwargs.get("source_name")
 
                     if source_name:
                         # --- Hub import path ---
-                        from DashAI.back.core.enums.status import DatafileStatus
-                        from DashAI.back.dependencies.database.models import (
-                            Datafile,
-                        )
-
+                        # The id is required, and it is the request that is
+                        # malformed without it, so the check stays here rather
+                        # than becoming a unit that cannot be configured.
                         datafile_id = params.get("datafile_id")
-                        selected_file = params.get("selected_file")
-
                         if datafile_id is None:
                             raise JobError("datafile_id is required for hub imports.")
 
-                        with session_factory() as db:
-                            hub_row = db.get(Datafile, datafile_id)
-                        if hub_row is None or hub_row.status != DatafileStatus.READY:
-                            raise JobError(f"Datafile {datafile_id} is not ready.")
-                        hub_work_dir = hub_row.local_path
-                        if selected_file:
-                            file_path_hub = str(Path(hub_work_dir) / selected_file)
-                        else:
-                            hub_base = Path(hub_work_dir)
-                            files = sorted(
-                                str(p)
-                                for p in hub_base.rglob("*")
-                                if p.is_file()
-                                and not any(
-                                    part.startswith(".")
-                                    for part in p.relative_to(hub_base).parts
-                                )
-                            )
-                            if not files:
-                                raise JobError("Hub download directory is empty.")
-                            file_path_hub = files[0]
-
-                        selected_dataloader = params.get("dataloader", "")
-                        _reg = component_registry._registry
-                        dl_registry = _reg.get("DataLoader", {})
-                        if selected_dataloader not in dl_registry:
-                            raise JobError(
-                                f"DataLoader '{selected_dataloader}'"
-                                " not found in registry."
-                            )
-                        dataloader = dl_registry[selected_dataloader]["class"]()
-                        log.debug(
-                            "Loading hub dataset from %s using %s",
-                            file_path_hub,
-                            selected_dataloader,
-                        )
-                        hub_loader_params = params.get("dataloader_params", {})
-                        new_dataset = dataloader.load_data(
-                            filepath_or_buffer=file_path_hub,
-                            temp_path=hub_work_dir,
-                            params=hub_loader_params,
-                            n_sample=None,
-                        )
+                        LoadDatafileDatasetUnit(
+                            dataloader={
+                                "component": params.get("dataloader", ""),
+                                "params": params.get("dataloader_params", {}),
+                            },
+                            datafile_id=datafile_id,
+                            selected_file=params.get("selected_file"),
+                        )(ctx)
                     else:
-                        # --- File / URL upload path (unchanged) ---
+                        # --- File / URL upload path ---
+                        # Validating the request's params is unpacking of how the
+                        # upload arrived, not part of reading the data: the unit
+                        # gets the reader already picked and its params already
+                        # checked. ``model_dump()`` keeps the payload the reader
+                        # receives exactly as it was.
                         parsed_params = parse_params(DatasetParams, json.dumps(params))
-                        dataloader = component_registry[parsed_params.dataloader][
-                            "class"
-                        ]()
                         log.debug("Storing dataset in %s", folder_path)
-                        new_dataset = dataloader.load_data(
-                            filepath_or_buffer=(
-                                str(file_path) if file_path is not None else url
-                            ),
+                        LoadUploadedDatasetUnit(
+                            dataloader={
+                                "component": parsed_params.dataloader,
+                                "params": parsed_params.model_dump(),
+                            },
+                            source=str(file_path) if file_path is not None else url,
                             temp_path=str(temp_dir),
-                            params=parsed_params.model_dump(),
                             n_sample=n_sample,
-                        )
+                        )(ctx)
 
+                    # The types either come with the request or are worked out
+                    # from the data. Both paths end in the same context key, so
+                    # the unit that applies them has a single input either way.
                     if params.get("inferred_types"):
-                        schema = params["inferred_types"]
-                    elif new_dataset.types:
-                        schema = {
-                            col: typ.to_string()
-                            for col, typ in new_dataset.types.items()
-                        }
+                        ctx.put_ref("inferred_types", params["inferred_types"])
                     else:
-                        schema = infer_types(
-                            new_dataset.to_pandas(), method="DashAIPtype"
-                        )
-                    if "column_renames" in params:
-                        renames = params["column_renames"]
-                        original_names = new_dataset.arrow_table.schema.names
-                        new_names = [renames.get(col, col) for col in original_names]
+                        InferDatasetTypesUnit(method="DashAIPtype")(ctx)
 
-                        if len(new_names) != len(set(new_names)):
-                            duplicate_names = set()
-                            seen = set()
-                            for name in new_names:
-                                if name in seen:
-                                    duplicate_names.add(name)
-                                else:
-                                    seen.add(name)
-                            msg = (
-                                "Invalid column_renames: resulting column names "
-                                "contain duplicates: "
-                                f"{sorted(duplicate_names)}"
-                            )
-                            raise JobError(msg)
-
-                        arrow_table = new_dataset.arrow_table.rename_columns(new_names)
-                        new_dataset = new_dataset.__class__(
-                            arrow_table,
-                            splits=new_dataset.splits,
-                            types=new_dataset.types,
-                        )
-                        schema = {renames.get(col, col): schema[col] for col in schema}
-
-                    new_dataset = transform_dataset_with_schema(new_dataset, schema)
+                    ApplyDatasetSchemaUnit(
+                        column_renames=params.get("column_renames"),
+                    )(ctx)
 
                 self.report_progress(0.5, "Computing metadata")
 
-                compute_meta = params.get("compute_metadata", True)
-                extended_keys = (
-                    "general_info",
-                    "numeric_stats",
-                    "categorical_stats",
-                    "text_stats",
-                    "quality_info",
-                    "correlations",
-                )
-
-                if from_notebook_no_converters:
-                    # No converters applied - saved data matches the source
-                    # dataset byte-for-byte. Reuse the source's splits.json
-                    # (already loaded into ``new_dataset.splits`` by
-                    # ``load_dataset``) instead of recomputing.
-                    has_extended = any(k in new_dataset.splits for k in extended_keys)
-                    if compute_meta:
-                        # Use source's full metadata if present, else compute.
-                        if not has_extended:
-                            new_dataset.compute_metadata()
-                    else:
-                        # Keep only base metadata; drop any inherited extended.
-                        if "total_rows" not in new_dataset.splits:
-                            new_dataset.compute_base_metadata()
-                        for stale_key in extended_keys:
-                            new_dataset.splits.pop(stale_key, None)
-                elif compute_meta:
-                    new_dataset.compute_metadata()
-                else:
-                    new_dataset.compute_base_metadata()
-                    # Defensive: strip any extended keys that may have been
-                    # inherited from a source dataset (e.g. notebook flow
-                    # with converters that ran before this rule existed).
-                    for stale_key in extended_keys:
-                        new_dataset.splits.pop(stale_key, None)
+                # ``from_notebook_no_converters`` means the saved data matches
+                # the source dataset byte-for-byte, so the metadata it arrived
+                # with still describes it. That is a policy decision this job
+                # makes from the notebook's converter history; the unit only
+                # needs the answer.
+                ComputeDatasetMetadataUnit(
+                    compute_metadata=params.get("compute_metadata", True),
+                    trust_inherited_metadata=from_notebook_no_converters,
+                )(ctx)
                 gc.collect()
 
                 self.report_progress(0.8, "Saving dataset")
 
                 dataset_save_path = folder_path / "dataset"
                 log.debug("Saving dataset in %s", str(dataset_save_path))
-                save_dataset(new_dataset, dataset_save_path)
+                SaveDatasetToPathUnit(path=str(dataset_save_path))(ctx)
             except Exception as e:
                 log.exception(e)
-                shutil.rmtree(folder_path, ignore_errors=True)
+                if folder_is_ours:
+                    shutil.rmtree(folder_path, ignore_errors=True)
                 raise JobError(f"Error loading dataset: {str(e)}") from e
 
-            # Add dataset to database
+            # Add dataset to database. The counts are read back off the dataset
+            # rather than published by the metadata unit: they describe the
+            # dataset as it is right now, and a key holding them would go stale
+            # the moment anything else transformed it.
+            stored_metadata = ctx.require("dataset").splits
             with session_factory() as db:
                 log.debug("Storing dataset metadata in database.")
                 try:
                     folder_path = os.path.realpath(folder_path)
                     dataset = db.get(Dataset, dataset_id)
+                    # Re-read, so it can be gone by now: the row is deletable
+                    # through the API while the job runs. Without this guard the
+                    # assignment below raises AttributeError on None, and the
+                    # data just written to disk is orphaned.
+                    if dataset is None:
+                        raise JobError(
+                            f"Dataset with ID {dataset_id} no longer exists."
+                        )
                     dataset.file_path = folder_path
-                    dataset.total_rows = new_dataset.splits.get("total_rows")
-                    dataset.total_columns = len(
-                        new_dataset.splits.get("column_names", [])
-                    )
+                    dataset.total_rows = stored_metadata.get("total_rows")
+                    dataset.total_columns = len(stored_metadata.get("column_names", []))
                     dataset.set_status_as_finished()
                     db.commit()
                     db.refresh(dataset)
 
                 except exc.SQLAlchemyError as e:
                     log.exception(e)
-                    shutil.rmtree(folder_path, ignore_errors=True)
+                    if folder_is_ours:
+                        shutil.rmtree(folder_path, ignore_errors=True)
                     raise JobError("Internal database error") from e
+                except Exception:
+                    # Anything else here leaves a dataset on disk that no row
+                    # points at, so it has to be cleaned up too. Re-raised
+                    # unchanged; the handler below writes the status.
+                    if folder_is_ours:
+                        shutil.rmtree(folder_path, ignore_errors=True)
+                    raise
 
             log.debug("Dataset creation successfully finished.")
 
-        except JobError as e:
+        except Exception as e:
+            # Every failure, not just ``JobError``. Nothing else moves this row
+            # out of STARTED: Huey's error signal writes to its own ``task_copy``
+            # table and never touches ``Dataset``, so an exception this handler
+            # does not see leaves the dataset stuck as in-progress forever, and
+            # the UI keeps showing a spinner for work that already died.
             log.error(f"Dataset creation failed: {e}")
-            with session_factory() as db:
-                dataset = db.get(Dataset, dataset_id)
-                if dataset:
-                    dataset.set_status_as_error()
-                    db.commit()
-                    db.refresh(dataset)
-            raise e
+            try:
+                with session_factory() as db:
+                    dataset = db.get(Dataset, dataset_id)
+                    if dataset:
+                        dataset.set_status_as_error()
+                        db.commit()
+                        db.refresh(dataset)
+            except Exception as bookkeeping_error:
+                # Never let the bookkeeping mask what actually went wrong.
+                log.exception(bookkeeping_error)
+            # Re-raised as-is: the message is the contract, and wrapping it here
+            # would change what every branch above reports.
+            raise
 
         finally:
+            ctx.clear_cache()
             gc.collect()
             if temp_dir and os.path.exists(temp_dir):
                 try:

--- a/DashAI/back/units/apply_dataset_schema_unit.py
+++ b/DashAI/back/units/apply_dataset_schema_unit.py
@@ -1,0 +1,129 @@
+"""Unit that renames columns and casts them to their declared types."""
+
+import logging
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    none_type,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.job.base_job import JobError
+from DashAI.back.units.base_unit import BaseUnit
+from DashAI.back.units.context import ExecutionContext
+
+log = logging.getLogger(__name__)
+
+
+class ApplyDatasetSchemaSchema(BaseSchema):
+    column_renames: schema_field(
+        none_type(dict),
+        placeholder=None,
+        description=MultilingualString(
+            en="Mapping of current column name to new name, applied before the "
+            "types are cast. Columns not mentioned keep their name. The "
+            "resulting names have to stay unique.",
+            es="Mapa de nombre de columna actual a nombre nuevo, aplicado antes "
+            "de convertir los tipos. Las columnas no mencionadas conservan su "
+            "nombre. Los nombres resultantes tienen que seguir siendo únicos.",
+            pt="Mapa de nome de coluna atual para nome novo, aplicado antes de "
+            "converter os tipos. As colunas não mencionadas mantêm o seu nome. "
+            "Os nomes resultantes têm de continuar únicos.",
+            de="Zuordnung von aktuellem zu neuem Spaltennamen, angewendet vor "
+            "der Typumwandlung. Nicht genannte Spalten behalten ihren Namen. "
+            "Die resultierenden Namen müssen eindeutig bleiben.",
+            zh="当前列名到新列名的映射，在类型转换前应用。未提及的列保留原名。"
+            "结果列名必须保持唯一。",
+        ),
+        alias=MultilingualString(
+            en="Column renames",
+            es="Renombres de columnas",
+            pt="Renomeações de colunas",
+            de="Spaltenumbenennungen",
+            zh="列重命名",
+        ),
+    )  # type: ignore
+
+
+class ApplyDatasetSchemaUnit(BaseUnit):
+    """Rename the dataset's columns and cast them to their declared types.
+
+    Takes the type declaration from the context (``inferred_types``) rather than
+    from its own configuration, so a single path feeds it whether the types were
+    inferred upstream or handed in by whoever set up the run. Renaming and
+    casting are one unit because a rename has to carry the declared types with
+    it: the type declared for ``Species`` has to end up on ``Variety``, not be
+    re-inferred from the data.
+
+    ``validate`` rejects a declaration that names columns the dataset does not
+    have. Without that check the mismatch is silent — the underlying transform
+    passes unknown columns through untouched — so a stale declaration would
+    quietly leave columns with inferred types instead of the requested ones.
+
+    Note the deliberate asymmetry: the unit does **not** republish a renamed
+    ``inferred_types``. After a rename that key describes column names that no
+    longer exist, and republishing it would invite a second consumer to trust a
+    declaration that no longer matches the dataset. Whoever needs types after
+    this unit reads them off the dataset.
+    """
+
+    SCHEMA = ApplyDatasetSchemaSchema
+
+    REQUIRES = ("dataset", "inferred_types")
+    PROVIDES = ("dataset",)
+
+    def validate(self, ctx: ExecutionContext) -> None:
+        dataset = ctx.require("dataset")
+        schema = ctx.require("inferred_types")
+
+        unknown = sorted(set(schema) - set(dataset.column_names))
+        if unknown:
+            raise JobError(
+                f"The declared types name columns the dataset does not have: {unknown}"
+            )
+
+    def execute(self, ctx: ExecutionContext) -> None:
+        from DashAI.back.dataloaders.classes.dashai_dataset import (
+            transform_dataset_with_schema,
+        )
+
+        dataset = ctx.require("dataset")
+        schema = ctx.require("inferred_types")
+        renames = self.config.get("column_renames")
+
+        if renames:
+            dataset, schema = _rename_columns(dataset, schema, renames)
+
+        ctx.put("dataset", transform_dataset_with_schema(dataset, schema))
+
+
+def _rename_columns(dataset, schema: dict, renames: dict):
+    """Return the dataset with renamed columns and the schema remapped to match.
+
+    A plain helper: it takes and returns values and never touches the context, so
+    the unit's declared contract cannot hide inside it.
+    """
+    original_names = dataset.arrow_table.schema.names
+    new_names = [renames.get(column, column) for column in original_names]
+
+    if len(new_names) != len(set(new_names)):
+        duplicate_names = set()
+        seen = set()
+        for name in new_names:
+            if name in seen:
+                duplicate_names.add(name)
+            else:
+                seen.add(name)
+        raise JobError(
+            "Invalid column_renames: resulting column names contain duplicates: "
+            f"{sorted(duplicate_names)}"
+        )
+
+    arrow_table = dataset.arrow_table.rename_columns(new_names)
+    renamed = dataset.__class__(
+        arrow_table,
+        splits=dataset.splits,
+        types=dataset.types,
+    )
+    remapped_schema = {renames.get(column, column): schema[column] for column in schema}
+    return renamed, remapped_schema

--- a/DashAI/back/units/compute_dataset_metadata_unit.py
+++ b/DashAI/back/units/compute_dataset_metadata_unit.py
@@ -1,0 +1,136 @@
+"""Unit that computes the metadata stored alongside a dataset."""
+
+import logging
+
+from DashAI.back.core.schema_fields import BaseSchema, bool_field, schema_field
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.units.base_unit import BaseUnit
+from DashAI.back.units.context import ExecutionContext
+
+log = logging.getLogger(__name__)
+
+#: Metadata keys produced by ``compute_metadata`` on top of the base ones.
+#:
+#: They are expensive (correlations and per-column statistics over the whole
+#: dataset) and optional, so the unit both skips computing them and strips any it
+#: finds already present when they were not asked for.
+EXTENDED_METADATA_KEYS = (
+    "general_info",
+    "numeric_stats",
+    "categorical_stats",
+    "text_stats",
+    "quality_info",
+    "correlations",
+)
+
+
+class ComputeDatasetMetadataSchema(BaseSchema):
+    compute_metadata: schema_field(
+        bool_field(),
+        placeholder=True,
+        description=MultilingualString(
+            en="Whether to compute the extended exploratory metadata "
+            "(per-column statistics, quality report, correlations) on top of "
+            "the base one. Disabling it makes large datasets much faster to "
+            "store, at the cost of the exploration views.",
+            es="Si se debe calcular la metadata exploratoria extendida "
+            "(estadísticas por columna, informe de calidad, correlaciones) "
+            "además de la básica. Desactivarla hace mucho más rápido el "
+            "guardado de conjuntos de datos grandes, a costa de las vistas de "
+            "exploración.",
+            pt="Se deve calcular a metadata exploratória estendida "
+            "(estatísticas por coluna, relatório de qualidade, correlações) "
+            "além da básica. Desativá-la torna o armazenamento de grandes "
+            "conjuntos de dados muito mais rápido, ao custo das vistas de "
+            "exploração.",
+            de="Ob die erweiterten explorativen Metadaten (Spaltenstatistiken, "
+            "Qualitätsbericht, Korrelationen) zusätzlich zu den Basisdaten "
+            "berechnet werden. Das Deaktivieren beschleunigt das Speichern "
+            "großer Datensätze erheblich, auf Kosten der Explorationsansichten.",
+            zh="是否在基础元数据之外计算扩展的探索性元数据（各列统计、质量报告、"
+            "相关性）。禁用后可大幅加快大型数据集的存储速度，但会失去探索视图。",
+        ),
+        alias=MultilingualString(
+            en="Compute extended metadata",
+            es="Calcular metadata extendida",
+            pt="Calcular metadata estendida",
+            de="Erweiterte Metadaten berechnen",
+            zh="计算扩展元数据",
+        ),
+    )  # type: ignore
+    trust_inherited_metadata: schema_field(
+        bool_field(),
+        placeholder=False,
+        description=MultilingualString(
+            en="Whether the metadata the dataset already carries can be reused "
+            "as-is. Only safe when the data has not changed since that metadata "
+            "was computed; otherwise every value is recomputed from scratch.",
+            es="Si la metadata que el conjunto de datos ya trae puede reusarse "
+            "tal cual. Solo es seguro cuando los datos no cambiaron desde que "
+            "esa metadata se calculó; si no, todo se recalcula desde cero.",
+            pt="Se a metadata que o conjunto de dados já carrega pode ser "
+            "reutilizada como está. Só é seguro quando os dados não mudaram "
+            "desde que essa metadata foi calculada; caso contrário, tudo é "
+            "recalculado do zero.",
+            de="Ob die vom Datensatz mitgeführten Metadaten unverändert "
+            "weiterverwendet werden können. Nur sicher, wenn sich die Daten "
+            "seit deren Berechnung nicht geändert haben; andernfalls wird alles "
+            "neu berechnet.",
+            zh="数据集已携带的元数据是否可以原样重用。仅当数据自该元数据计算后"
+            "未发生变化时才安全；否则将全部重新计算。",
+        ),
+        alias=MultilingualString(
+            en="Trust existing metadata",
+            es="Confiar en la metadata existente",
+            pt="Confiar na metadata existente",
+            de="Vorhandene Metadaten vertrauen",
+            zh="信任现有元数据",
+        ),
+    )  # type: ignore
+
+
+class ComputeDatasetMetadataUnit(BaseUnit):
+    """Fill in the metadata a dataset carries in its ``splits`` mapping.
+
+    Two independent knobs, because "how much metadata" and "can the metadata
+    already there be trusted" are different questions:
+
+    * ``compute_metadata`` picks the depth: base only (column names, row count,
+      NaN counts) or base plus the extended exploratory fields.
+    * ``trust_inherited_metadata`` says the dataset arrived carrying metadata
+      that still describes it — the case of a copy whose bytes never changed.
+      Then the unit fills only what is missing instead of recomputing.
+
+    Either way the requested depth is what ends up stored: asking for base only
+    always strips the extended keys, even ones inherited from elsewhere, so the
+    result never depends on where the dataset came from.
+
+    Re-publishes ``dataset`` although it mutates it in place: the key is what
+    makes the unit chainable, and the contract audit reads the ``ctx.put`` call.
+    """
+
+    SCHEMA = ComputeDatasetMetadataSchema
+
+    REQUIRES = ("dataset",)
+    PROVIDES = ("dataset",)
+
+    def execute(self, ctx: ExecutionContext) -> None:
+        dataset = ctx.require("dataset")
+
+        compute_extended = self.config.get("compute_metadata", True)
+        trust_inherited = self.config.get("trust_inherited_metadata", False)
+
+        if compute_extended:
+            has_extended = any(key in dataset.splits for key in EXTENDED_METADATA_KEYS)
+            if not (trust_inherited and has_extended):
+                dataset.compute_metadata()
+        else:
+            if not (trust_inherited and "total_rows" in dataset.splits):
+                dataset.compute_base_metadata()
+            # Strip extended keys the dataset may have arrived with, so the
+            # stored metadata matches what was asked for rather than the
+            # history of the file.
+            for stale_key in EXTENDED_METADATA_KEYS:
+                dataset.splits.pop(stale_key, None)
+
+        ctx.put("dataset", dataset)

--- a/DashAI/back/units/explanation_artifacts.py
+++ b/DashAI/back/units/explanation_artifacts.py
@@ -55,8 +55,8 @@ def build_explainer(scope: str, selected: dict, trained_model: Any) -> Any:
     except Exception as e:
         log.exception(e)
         raise JobError(
-            f"""Unable to find the {scope} explainer with name
-                            {explainer_name} in registry.""",
+            f"Unable to find the {scope} explainer with name "
+            f"{explainer_name} in registry.",
         ) from e
 
     try:

--- a/DashAI/back/units/infer_dataset_types_unit.py
+++ b/DashAI/back/units/infer_dataset_types_unit.py
@@ -1,0 +1,76 @@
+"""Unit that works out what type each column of a dataset holds."""
+
+import logging
+
+from DashAI.back.core.schema_fields import BaseSchema, schema_field, string_field
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.units.base_unit import BaseUnit
+from DashAI.back.units.context import ExecutionContext
+
+log = logging.getLogger(__name__)
+
+
+class InferDatasetTypesSchema(BaseSchema):
+    method: schema_field(
+        string_field(),
+        placeholder="DashAIPtype",
+        description=MultilingualString(
+            en="Inference method used when the dataset does not already carry "
+            "types of its own.",
+            es="Método de inferencia que se usa cuando el conjunto de datos no "
+            "trae tipos propios.",
+            pt="Método de inferência usado quando o conjunto de dados não traz "
+            "tipos próprios.",
+            de="Inferenzmethode, die verwendet wird, wenn der Datensatz keine "
+            "eigenen Typen mitbringt.",
+            zh="当数据集本身未携带类型时使用的推断方法。",
+        ),
+        alias=MultilingualString(
+            en="Inference method",
+            es="Método de inferencia",
+            pt="Método de inferência",
+            de="Inferenzmethode",
+            zh="推断方法",
+        ),
+    )  # type: ignore
+
+
+class InferDatasetTypesUnit(BaseUnit):
+    """Publish a type declaration for every column of the dataset.
+
+    Prefers the types the dataset already carries: a dataloader that can read
+    them from the source (a Parquet schema, a typed database column) knows better
+    than any inference over the values, so re-inferring would throw that away.
+    Only when there are none does it fall back to inferring from the data.
+
+    Publishes the declaration as a plain reference rather than applying it, so
+    the decision and the transformation stay separable — the same declaration can
+    be shown to a user for review before anything is cast.
+
+    Note the reference names columns, so it goes stale the moment something
+    renames or drops one. It is meant to be consumed by the next step, not
+    carried across a chain of transformations.
+    """
+
+    SCHEMA = InferDatasetTypesSchema
+
+    REQUIRES = ("dataset",)
+    PROVIDES = ("inferred_types",)
+
+    def execute(self, ctx: ExecutionContext) -> None:
+        from DashAI.back.types.inf.type_inference import infer_types
+
+        dataset = ctx.require("dataset")
+
+        if dataset.types:
+            schema = {
+                column: dashai_type.to_string()
+                for column, dashai_type in dataset.types.items()
+            }
+        else:
+            schema = infer_types(
+                dataset.to_pandas(),
+                method=self.config.get("method", "DashAIPtype"),
+            )
+
+        ctx.put_ref("inferred_types", schema)

--- a/DashAI/back/units/load_datafile_dataset_unit.py
+++ b/DashAI/back/units/load_datafile_dataset_unit.py
@@ -133,11 +133,15 @@ class LoadDatafileDatasetUnit(BaseUnit):
 
         source = _resolve_source_file(work_dir, selected_file)
 
+        # Looked up among the readers specifically, not with the registry's
+        # global ``registry[name]``: that one walks every component type, so a
+        # metric or a model whose name happened to be passed here would be
+        # instantiated as if it could read a file instead of being rejected.
         dataloader_name = dataloader_config["component"]
-        registry = component_registry.registry.get("DataLoader", {})
-        if dataloader_name not in registry:
+        readers = component_registry.registry.get("DataLoader", {})
+        if dataloader_name not in readers:
             raise JobError(f"DataLoader '{dataloader_name}' not found in registry.")
-        dataloader = registry[dataloader_name]["class"]()
+        dataloader = readers[dataloader_name]["class"]()
 
         log.debug("Loading hub dataset from %s using %s", source, dataloader_name)
         ctx.put(

--- a/DashAI/back/units/load_datafile_dataset_unit.py
+++ b/DashAI/back/units/load_datafile_dataset_unit.py
@@ -1,0 +1,178 @@
+"""Unit that reads a dataset out of an already downloaded datafile."""
+
+import logging
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    component_field,
+    int_field,
+    none_type,
+    schema_field,
+    string_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.job.base_job import JobError
+from DashAI.back.units.base_unit import BaseUnit
+from DashAI.back.units.context import ExecutionContext
+
+log = logging.getLogger(__name__)
+
+
+class LoadDatafileDatasetSchema(BaseSchema):
+    dataloader: schema_field(
+        component_field(parent="BaseDataLoader"),
+        placeholder={"component": "CSVDataLoader", "params": {"separator": ","}},
+        description=MultilingualString(
+            en="Reader used to parse the downloaded file, together with its own "
+            "configuration.",
+            es="Lector usado para interpretar el archivo descargado, junto con "
+            "su propia configuración.",
+            pt="Leitor usado para interpretar o ficheiro descarregado, junto com "
+            "a sua própria configuração.",
+            de="Leser zum Parsen der heruntergeladenen Datei samt eigener "
+            "Konfiguration.",
+            zh="用于解析已下载文件的读取器及其自身配置。",
+        ),
+        alias=MultilingualString(
+            en="Data loader",
+            es="Cargador de datos",
+            pt="Carregador de dados",
+            de="Datenlader",
+            zh="数据加载器",
+        ),
+    )  # type: ignore
+    datafile_id: schema_field(
+        int_field(gt=0),
+        placeholder=1,
+        description=MultilingualString(
+            en="Identifier of the completed download to read from. It has to have "
+            "finished successfully; a download still running has no files yet.",
+            es="Identificador de la descarga completada desde la que leer. Tiene "
+            "que haber terminado con éxito; una descarga en curso todavía no "
+            "tiene archivos.",
+            pt="Identificador da descarga concluída de onde ler. Tem de ter "
+            "terminado com sucesso; uma descarga em curso ainda não tem "
+            "ficheiros.",
+            de="Kennung des abgeschlossenen Downloads, aus dem gelesen wird. Er "
+            "muss erfolgreich beendet sein; ein laufender Download hat noch "
+            "keine Dateien.",
+            zh="要读取的已完成下载的标识符。必须已成功完成；仍在进行的下载尚无文件。",
+        ),
+        alias=MultilingualString(
+            en="Downloaded file",
+            es="Archivo descargado",
+            pt="Ficheiro descarregado",
+            de="Heruntergeladene Datei",
+            zh="已下载文件",
+        ),
+    )  # type: ignore
+    selected_file: schema_field(
+        none_type(string_field()),
+        placeholder=None,
+        description=MultilingualString(
+            en="Which file inside the download to read, relative to its root. "
+            "Leave empty to take the first one, ignoring hidden files.",
+            es="Qué archivo dentro de la descarga leer, relativo a su raíz. "
+            "Dejar vacío para tomar el primero, ignorando archivos ocultos.",
+            pt="Qual ficheiro dentro da descarga ler, relativo à sua raiz. "
+            "Deixar vazio para tomar o primeiro, ignorando ficheiros ocultos.",
+            de="Welche Datei innerhalb des Downloads gelesen wird, relativ zu "
+            "dessen Wurzel. Leer lassen, um die erste zu nehmen; versteckte "
+            "Dateien werden übersprungen.",
+            zh="读取下载内容中的哪个文件（相对于其根目录）。留空则取第一个，忽略"
+            "隐藏文件。",
+        ),
+        alias=MultilingualString(
+            en="File",
+            es="Archivo",
+            pt="Ficheiro",
+            de="Datei",
+            zh="文件",
+        ),
+    )  # type: ignore
+
+
+class LoadDatafileDatasetUnit(BaseUnit):
+    """Parse a dataset out of a download that already completed.
+
+    Separate from ``LoadUploadedDatasetUnit`` even though both end in the same
+    reader call, because finding *what* to read is the whole job here: the
+    download is a directory tree recorded in the database, not a file the caller
+    hands over. The unit re-reads that row in its own read-only session, the same
+    way ``LoadDatasetUnit`` does, and never writes to it.
+
+    Publishes only ``dataset``, for the same reason as its sibling: an imported
+    file is not a stored dataset yet, so there is no id to correlate and no path
+    to save back to.
+    """
+
+    SCHEMA = LoadDatafileDatasetSchema
+
+    PROVIDES = ("dataset",)
+
+    def execute(self, ctx: ExecutionContext) -> None:
+        from kink import di
+
+        from DashAI.back.core.enums.status import DatafileStatus
+        from DashAI.back.dependencies.database.models import Datafile
+
+        component_registry = di["component_registry"]
+        session_factory = di["session_factory"]
+
+        datafile_id = self.config["datafile_id"]
+        selected_file = self.config.get("selected_file")
+        dataloader_config = self.config["dataloader"]
+
+        with session_factory() as db:
+            datafile = db.get(Datafile, datafile_id)
+            # A missing row and an unfinished download are the same problem from
+            # here: there are no files to read either way.
+            if datafile is None or datafile.status != DatafileStatus.READY:
+                raise JobError(f"Datafile {datafile_id} is not ready.")
+            work_dir = datafile.local_path
+
+        source = _resolve_source_file(work_dir, selected_file)
+
+        dataloader_name = dataloader_config["component"]
+        registry = component_registry.registry.get("DataLoader", {})
+        if dataloader_name not in registry:
+            raise JobError(f"DataLoader '{dataloader_name}' not found in registry.")
+        dataloader = registry[dataloader_name]["class"]()
+
+        log.debug("Loading hub dataset from %s using %s", source, dataloader_name)
+        ctx.put(
+            "dataset",
+            dataloader.load_data(
+                filepath_or_buffer=source,
+                temp_path=work_dir,
+                params=dataloader_config.get("params") or {},
+                n_sample=None,
+            ),
+        )
+
+
+def _resolve_source_file(work_dir: str, selected_file) -> str:
+    """Pick the file to read inside a completed download.
+
+    A plain helper: takes and returns values, never touches the context.
+
+    With no explicit choice it walks the tree and takes the first file in sorted
+    order, skipping anything under a dot-prefixed path component — download tools
+    leave metadata directories (``.cache``, ``.git``) behind that sort before the
+    real data and would otherwise win.
+    """
+    from pathlib import Path
+
+    if selected_file:
+        return str(Path(work_dir) / selected_file)
+
+    base = Path(work_dir)
+    files = sorted(
+        str(path)
+        for path in base.rglob("*")
+        if path.is_file()
+        and not any(part.startswith(".") for part in path.relative_to(base).parts)
+    )
+    if not files:
+        raise JobError("Hub download directory is empty.")
+    return files[0]

--- a/DashAI/back/units/load_uploaded_dataset_unit.py
+++ b/DashAI/back/units/load_uploaded_dataset_unit.py
@@ -1,0 +1,154 @@
+"""Unit that reads a dataset from an uploaded file or a URL."""
+
+import logging
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    component_field,
+    int_field,
+    none_type,
+    schema_field,
+    string_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.units.base_unit import BaseUnit
+from DashAI.back.units.context import ExecutionContext
+
+log = logging.getLogger(__name__)
+
+
+class LoadUploadedDatasetSchema(BaseSchema):
+    dataloader: schema_field(
+        component_field(parent="BaseDataLoader"),
+        placeholder={"component": "CSVDataLoader", "params": {"separator": ","}},
+        description=MultilingualString(
+            en="Reader used to parse the source, together with its own "
+            "configuration (delimiter, sheet, encoding, and so on).",
+            es="Lector usado para interpretar el origen, junto con su propia "
+            "configuración (delimitador, hoja, codificación, etc.).",
+            pt="Leitor usado para interpretar a origem, junto com a sua própria "
+            "configuração (delimitador, folha, codificação, etc.).",
+            de="Leser zum Parsen der Quelle samt eigener Konfiguration "
+            "(Trennzeichen, Blatt, Kodierung usw.).",
+            zh="用于解析数据源的读取器及其自身配置（分隔符、工作表、编码等）。",
+        ),
+        alias=MultilingualString(
+            en="Data loader",
+            es="Cargador de datos",
+            pt="Carregador de dados",
+            de="Datenlader",
+            zh="数据加载器",
+        ),
+    )  # type: ignore
+    source: schema_field(
+        string_field(),
+        placeholder="",
+        description=MultilingualString(
+            en="Where to read from: a path to a local file or a URL. Archives "
+            "are downloaded and extracted before being parsed.",
+            es="Desde dónde leer: una ruta a un archivo local o una URL. Los "
+            "archivos comprimidos se descargan y extraen antes de interpretarse.",
+            pt="De onde ler: um caminho para um ficheiro local ou um URL. Os "
+            "arquivos comprimidos são descarregados e extraídos antes de serem "
+            "interpretados.",
+            de="Woher gelesen wird: ein Pfad zu einer lokalen Datei oder eine "
+            "URL. Archive werden vor dem Parsen heruntergeladen und entpackt.",
+            zh="读取来源：本地文件路径或 URL。压缩包会先下载并解压再解析。",
+        ),
+        alias=MultilingualString(
+            en="Source",
+            es="Origen",
+            pt="Origem",
+            de="Quelle",
+            zh="来源",
+        ),
+    )  # type: ignore
+    temp_path: schema_field(
+        string_field(),
+        placeholder="",
+        description=MultilingualString(
+            en="Scratch directory for downloads and extracted archives. Whoever "
+            "sets it up is responsible for removing it afterwards.",
+            es="Directorio temporal para descargas y archivos extraídos. Quien "
+            "lo crea es responsable de borrarlo después.",
+            pt="Diretório temporário para descargas e ficheiros extraídos. Quem "
+            "o cria é responsável por removê-lo depois.",
+            de="Arbeitsverzeichnis für Downloads und entpackte Archive. Wer es "
+            "anlegt, ist für das Entfernen verantwortlich.",
+            zh="用于下载和解压归档的临时目录。创建者负责事后清理。",
+        ),
+        alias=MultilingualString(
+            en="Temporary path",
+            es="Ruta temporal",
+            pt="Caminho temporário",
+            de="Temporärer Pfad",
+            zh="临时路径",
+        ),
+    )  # type: ignore
+    n_sample: schema_field(
+        none_type(int_field(gt=0)),
+        placeholder=None,
+        description=MultilingualString(
+            en="Read only this many rows instead of the whole source. Leave "
+            "empty to read everything.",
+            es="Leer solo esta cantidad de filas en vez de todo el origen. "
+            "Dejar vacío para leer todo.",
+            pt="Ler apenas esta quantidade de linhas em vez de toda a origem. "
+            "Deixar vazio para ler tudo.",
+            de="Nur so viele Zeilen lesen statt der gesamten Quelle. Leer "
+            "lassen, um alles zu lesen.",
+            zh="仅读取这么多行而非整个数据源。留空表示全部读取。",
+        ),
+        alias=MultilingualString(
+            en="Row sample",
+            es="Muestra de filas",
+            pt="Amostra de linhas",
+            de="Zeilenstichprobe",
+            zh="行采样",
+        ),
+    )  # type: ignore
+
+
+class LoadUploadedDatasetUnit(BaseUnit):
+    """Parse a file or URL into a dataset with the chosen reader.
+
+    The counterpart of ``LoadDatasetUnit``: that one materialises something DashAI
+    already stores, this one brings in data that is not a dataset yet. So it
+    publishes only ``dataset`` — there is no stored id to correlate against and no
+    path to save back to, because nothing decided yet where the result belongs.
+
+    Types are not applied here. What the reader produces is whatever the source
+    suggests; declaring and casting types is a separate step, so the same load can
+    be reviewed before anything is committed to.
+    """
+
+    SCHEMA = LoadUploadedDatasetSchema
+
+    PROVIDES = ("dataset",)
+
+    def execute(self, ctx: ExecutionContext) -> None:
+        from kink import di
+
+        component_registry = di["component_registry"]
+
+        dataloader_config = self.config["dataloader"]
+        source = self.config["source"]
+
+        # Raises KeyError with the registry's own wording when the reader does
+        # not exist. That message reaches the user, so it is not reworded here.
+        dataloader = component_registry[dataloader_config["component"]]["class"]()
+
+        log.debug(
+            "Loading dataset from %s using %s",
+            source,
+            dataloader_config["component"],
+        )
+        ctx.put(
+            "dataset",
+            dataloader.load_data(
+                filepath_or_buffer=source,
+                temp_path=self.config["temp_path"],
+                params=dataloader_config.get("params") or {},
+                n_sample=self.config.get("n_sample"),
+            ),
+        )

--- a/DashAI/back/units/save_dataset_to_path_unit.py
+++ b/DashAI/back/units/save_dataset_to_path_unit.py
@@ -1,0 +1,78 @@
+"""Unit that writes the dataset in the context to a destination of its own."""
+
+import logging
+
+from DashAI.back.core.schema_fields import BaseSchema, schema_field, string_field
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.job.base_job import JobError
+from DashAI.back.units.base_unit import BaseUnit
+from DashAI.back.units.context import ExecutionContext
+
+log = logging.getLogger(__name__)
+
+
+class SaveDatasetToPathSchema(BaseSchema):
+    path: schema_field(
+        string_field(),
+        placeholder="",
+        description=MultilingualString(
+            en="Destination directory for the dataset. Unlike saving in place, "
+            "this writes wherever it is told, so it can store a dataset that "
+            "was loaded from somewhere else entirely.",
+            es="Directorio de destino del conjunto de datos. A diferencia de "
+            "guardar en su lugar, escribe donde se le indique, así que puede "
+            "almacenar un conjunto de datos cargado desde otro origen.",
+            pt="Diretório de destino do conjunto de dados. Ao contrário de "
+            "guardar no lugar, escreve onde lhe for indicado, pelo que pode "
+            "armazenar um conjunto de dados carregado de outra origem.",
+            de="Zielverzeichnis für den Datensatz. Anders als beim Speichern am "
+            "Ursprungsort schreibt diese Einheit dorthin, wo es ihr gesagt "
+            "wird, und kann so einen anderswo geladenen Datensatz ablegen.",
+            zh="数据集的目标目录。与原地保存不同，它会写入指定位置，因此可以存储"
+            "从其他来源加载的数据集。",
+        ),
+        alias=MultilingualString(
+            en="Destination path",
+            es="Ruta de destino",
+            pt="Caminho de destino",
+            de="Zielpfad",
+            zh="目标路径",
+        ),
+    )  # type: ignore
+
+
+class SaveDatasetToPathUnit(BaseUnit):
+    """Write the dataset to a destination given in the configuration.
+
+    The sibling of ``SaveDatasetUnit``, and deliberately a separate unit rather
+    than a flag on it. ``SaveDatasetUnit`` saves back to ``dataset_path`` — where
+    the load came from — which is what makes editing a dataset in place safe. This
+    one stores the dataset as something new, so it never reads ``dataset_path``:
+    if it did, a flow that loads a working copy and registers the result as a
+    fresh dataset would overwrite the copy it read.
+
+    Declares no outputs — its result is on disk, not in the context.
+
+    The error message keeps the original exception's text. A failure here is an
+    infrastructure failure (out of space, permissions, a path the filesystem
+    rejects), and only the message of the outermost error reaches the user: the
+    job queue stores ``str(exc)``, never the ``__cause__`` chain. Swallowing it
+    would drop the diagnosis exactly when it is needed.
+    """
+
+    SCHEMA = SaveDatasetToPathSchema
+
+    REQUIRES = ("dataset",)
+    PROVIDES = ()
+
+    def execute(self, ctx: ExecutionContext) -> None:
+        from DashAI.back.dataloaders.classes.dashai_dataset import save_dataset
+
+        dataset = ctx.require("dataset")
+        path = self.config["path"]
+
+        try:
+            save_dataset(dataset, path)
+        except Exception as e:
+            log.exception(e)
+            raise JobError(f"Can not save dataset to path {path}: {e}") from e

--- a/DashAI/back/units/save_dataset_unit.py
+++ b/DashAI/back/units/save_dataset_unit.py
@@ -16,6 +16,12 @@ class SaveDatasetUnit(BaseUnit):
     whichever unit loaded the dataset, so a save can never land somewhere the
     load did not come from. Declares no outputs — its result is on disk, not in
     the context.
+
+    The error message keeps the original exception's text. A failure here is an
+    infrastructure failure (out of space, permissions, a path the filesystem
+    rejects), and only the message of the outermost error reaches the user: the
+    job queue stores ``str(exc)``, never the ``__cause__`` chain. Swallowing it
+    would drop the diagnosis exactly when it is needed.
     """
 
     REQUIRES = ("dataset", "dataset_path")
@@ -31,4 +37,4 @@ class SaveDatasetUnit(BaseUnit):
             save_dataset(dataset, dataset_path)
         except Exception as e:
             log.exception(e)
-            raise JobError(f"Can not save dataset to path {dataset_path}") from e
+            raise JobError(f"Can not save dataset to path {dataset_path}: {e}") from e

--- a/tests/back/api/test_dataset_job.py
+++ b/tests/back/api/test_dataset_job.py
@@ -1,0 +1,1094 @@
+"""End-to-end regression net for ``DatasetJob``.
+
+Written before the job is decomposed into atomic units, and asserted against the
+monolithic implementation, so the refactor has something to be measured against.
+The assertions are deliberately explicit — exact status values, exact row/column
+counts, exact keys in ``splits.json``, exact error message text — instead of the
+looser ``status in ["finished", "error"]`` style used elsewhere in this suite,
+which cannot tell a unit that silently stopped doing part of its work from one
+that did it.
+
+``DatasetJob`` has the widest blast radius of any job in the repo: it is the
+bootstrap fixture of half the suite (``tests/back/api/conftest.py``,
+``tests/back/models/conftest.py``, ``tests/back/api/test_predict_api.py``,
+``tests/back/types/load_preview_test.py``). Everything here has to keep passing
+through every slice of the refactor.
+
+Lives under ``tests/back/api`` to reuse the ``client`` and ``dataset_1``
+fixtures from this package's ``conftest.py``.
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from fastapi.testclient import TestClient
+
+from DashAI.back.core.enums.status import DatafileStatus, DatasetStatus
+from DashAI.back.dataloaders.classes.dashai_dataset import load_dataset
+from DashAI.back.dependencies.database.models import Datafile, Dataset
+from DashAI.back.job.base_job import JobError
+from DashAI.back.job.dataset_job import DatasetJob
+
+IRIS_COLUMNS = [
+    "SepalLengthCm",
+    "SepalWidthCm",
+    "PetalLengthCm",
+    "PetalWidthCm",
+    "Species",
+]
+IRIS_ROWS = 150
+
+IRIS_SCHEMA = {
+    "SepalLengthCm": {"type": "Float", "dtype": "float64"},
+    "SepalWidthCm": {"type": "Float", "dtype": "float64"},
+    "PetalLengthCm": {"type": "Float", "dtype": "float64"},
+    "PetalWidthCm": {"type": "Float", "dtype": "float64"},
+    "Species": {"type": "Categorical", "dtype": "string"},
+}
+
+#: The extended EDA keys ``compute_metadata=False`` has to leave out.
+EXTENDED_KEYS = (
+    "general_info",
+    "numeric_stats",
+    "categorical_stats",
+    "text_stats",
+    "quality_info",
+    "correlations",
+)
+
+IRIS_CSV = Path(__file__).parent / "iris.csv"
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+
+def _session_factory(client):
+    return client.app.container["session_factory"]
+
+
+def _new_dataset_row(client, name: str) -> int:
+    """Create a ``Dataset`` row in DELIVERED, the state the job expects."""
+    with _session_factory(client)() as db:
+        entry = Dataset(name=name, file_path="")
+        entry.set_status_as_delivered()
+        db.add(entry)
+        db.commit()
+        db.refresh(entry)
+        return entry.id
+
+
+def _stored(client, dataset_id: int) -> Optional[dict]:
+    """Read the ``Dataset`` row straight from the database.
+
+    No ``start_time`` / ``end_time``: unlike ``Run`` or ``Explorer``, this table
+    declares no such columns. The status setters used to assign them anyway,
+    which only set attributes that were dropped at commit.
+    """
+    with _session_factory(client)() as db:
+        row = db.get(Dataset, dataset_id)
+        if row is None:
+            return None
+        return {
+            "status": row.status,
+            "file_path": row.file_path,
+            "total_rows": row.total_rows,
+            "total_columns": row.total_columns,
+            "last_modified": row.last_modified,
+        }
+
+
+def _run_job(client, dataset_id: int, params: dict, **extra) -> None:
+    """Run ``DatasetJob`` synchronously, the way every fixture in the suite does."""
+    kwargs = {
+        "dataset_id": dataset_id,
+        "url": "",
+        "params": params,
+        "file_path": IRIS_CSV,
+        **extra,
+    }
+    DatasetJob(job_type="DatasetJob", kwargs=kwargs).run()
+
+
+def _csv_params(name: str, **overrides) -> dict:
+    params = {
+        "dataloader": "CSVDataLoader",
+        "separator": ",",
+        "name": name,
+        "schema": IRIS_SCHEMA,
+    }
+    params.update(overrides)
+    return params
+
+
+def _splits(file_path: str) -> dict:
+    with open(Path(file_path) / "dataset" / "splits.json", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _cleanup(client, dataset_id: int) -> None:
+    row = _stored(client, dataset_id)
+    if row and row["file_path"]:
+        shutil.rmtree(row["file_path"], ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# status bookkeeping
+# --------------------------------------------------------------------------- #
+
+
+class TestTheRowIsNeverLeftStuckInStarted:
+    """Whatever goes wrong, the row must not stay in STARTED.
+
+    Nothing else moves it: Huey's ``SIGNAL_ERROR`` writes to its own
+    ``task_copy`` table and never to the ``Dataset`` row
+    (``huey_job_queue.py:201-211``), so an exception the job's own handler does
+    not see leaves the dataset advertised as in-progress forever and the UI
+    spinning on work that already died.
+
+    Both cases below used to escape — the handler only caught ``JobError``, and
+    the final database block only caught ``SQLAlchemyError``. They are the
+    reason the handler now catches ``Exception``.
+    """
+
+    def test_a_mkdir_failure_that_is_not_file_exists_still_marks_the_row(
+        self, client, monkeypatch
+    ):
+        """Creating the destination folder can fail with more than
+        ``FileExistsError``: no permission, no space, a path the filesystem
+        rejects. The status was already committed as STARTED by then."""
+        dataset_id = _new_dataset_row(client, "stuck_on_mkdir")
+
+        def deny(self, *args, **kwargs):
+            raise PermissionError("cannot create the dataset folder")
+
+        monkeypatch.setattr(Path, "mkdir", deny)
+
+        with pytest.raises(PermissionError):
+            _run_job(client, dataset_id, _csv_params("stuck_on_mkdir"))
+
+        assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+    def test_a_row_deleted_mid_run_is_reported_instead_of_crashing(self, client):
+        """The row is deletable through the API while the job runs, so the final
+        block can find it gone. It used to assign to ``None`` and raise
+        ``AttributeError`` from inside a block that only caught database errors.
+        """
+        dataset_id = _new_dataset_row(client, "stuck_on_deleted_row")
+        datasets_dir = _datasets_dir(client)
+        before = _folders_in(datasets_dir)
+
+        from DashAI.back.dataloaders.classes import dashai_dataset
+
+        real_save = dashai_dataset.save_dataset
+
+        def save_then_delete(dataset, path):
+            real_save(dataset, path)
+            with _session_factory(client)() as db:
+                db.delete(db.get(Dataset, dataset_id))
+                db.commit()
+
+        dashai_dataset.save_dataset = save_then_delete
+        try:
+            with pytest.raises(JobError) as excinfo:
+                _run_job(client, dataset_id, _csv_params("stuck_on_deleted_row"))
+        finally:
+            dashai_dataset.save_dataset = real_save
+
+        assert str(excinfo.value) == (f"Dataset with ID {dataset_id} no longer exists.")
+        # The row is gone, so there is no status to write — but the data written
+        # to disk has to go with it instead of being orphaned.
+        assert _stored(client, dataset_id) is None
+        assert _folders_in(datasets_dir) == before
+
+    def test_a_non_database_failure_in_the_final_block_still_marks_the_row(
+        self, client
+    ):
+        """The mirror of the case above for a row that does still exist: the
+        block catches ``SQLAlchemyError`` by name, so anything else has to be
+        handled further out rather than escaping."""
+        dataset_id = _new_dataset_row(client, "stuck_on_final_block")
+        datasets_dir = _datasets_dir(client)
+        before = _folders_in(datasets_dir)
+
+        real_set_finished = Dataset.set_status_as_finished
+
+        def boom(self):
+            raise RuntimeError("not a database error")
+
+        Dataset.set_status_as_finished = boom
+        try:
+            with pytest.raises(RuntimeError):
+                _run_job(client, dataset_id, _csv_params("stuck_on_final_block"))
+        finally:
+            Dataset.set_status_as_finished = real_set_finished
+
+        assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+        assert _folders_in(datasets_dir) == before
+
+
+# --------------------------------------------------------------------------- #
+# file / URL branch — the happy path
+# --------------------------------------------------------------------------- #
+
+
+def test_the_file_branch_finishes_and_writes_every_column_of_the_row(client):
+    """Status transitions, the row's columns, and the dataset on disk."""
+    dataset_id = _new_dataset_row(client, "net_file_happy")
+    before = _stored(client, dataset_id)
+    assert before["status"] == DatasetStatus.DELIVERED
+
+    _run_job(client, dataset_id, _csv_params("net_file_happy"))
+
+    row = _stored(client, dataset_id)
+    assert row["status"] == DatasetStatus.FINISHED
+    assert row["total_rows"] == IRIS_ROWS
+    assert row["total_columns"] == len(IRIS_COLUMNS)
+    assert row["last_modified"] > before["last_modified"]
+
+    # The path is a realpath under DATASETS_PATH, and the dataset is really there.
+    datasets_path = client.app.container["config"]["DATASETS_PATH"]
+    assert Path(row["file_path"]).parent == Path(os.path.realpath(datasets_path))
+
+    dataset = load_dataset(f"{row['file_path']}/dataset")
+    assert dataset.column_names == IRIS_COLUMNS
+    assert len(dataset) == IRIS_ROWS
+
+    _cleanup(client, dataset_id)
+
+
+def test_the_declared_schema_lands_on_the_stored_types(client):
+    """``transform_dataset_with_schema`` is what makes Species categorical."""
+    dataset_id = _new_dataset_row(client, "net_file_types")
+
+    _run_job(client, dataset_id, _csv_params("net_file_types"))
+
+    row = _stored(client, dataset_id)
+    dataset = load_dataset(f"{row['file_path']}/dataset")
+    types = dataset.types
+
+    assert type(types["Species"]).__name__ == "Categorical"
+    for column in IRIS_COLUMNS[:4]:
+        assert type(types[column]).__name__ == "Float"
+
+    _cleanup(client, dataset_id)
+
+
+def test_inferred_types_in_the_params_win_over_inference(client):
+    """``params["inferred_types"]`` is the first branch of the schema cascade."""
+    dataset_id = _new_dataset_row(client, "net_file_inferred")
+    # Species declared as plain text instead of categorical: only an honoured
+    # override can produce this.
+    override = dict(IRIS_SCHEMA, Species={"type": "Text", "dtype": "string"})
+
+    _run_job(
+        client,
+        dataset_id,
+        _csv_params("net_file_inferred", inferred_types=override),
+    )
+
+    row = _stored(client, dataset_id)
+    types = load_dataset(f"{row['file_path']}/dataset").types
+    assert type(types["Species"]).__name__ != "Categorical"
+
+    _cleanup(client, dataset_id)
+
+
+def test_the_schema_is_inferred_when_the_params_declare_nothing(client):
+    """Third branch of the cascade: ``infer_types(..., "DashAIPtype")``."""
+    dataset_id = _new_dataset_row(client, "net_file_no_schema")
+
+    _run_job(
+        client,
+        dataset_id,
+        {"dataloader": "CSVDataLoader", "separator": ",", "name": "net_file_no_schema"},
+    )
+
+    row = _stored(client, dataset_id)
+    assert row["status"] == DatasetStatus.FINISHED
+    dataset = load_dataset(f"{row['file_path']}/dataset")
+    assert dataset.column_names == IRIS_COLUMNS
+    # Inference ran and produced a type for every column.
+    assert set(dataset.types) == set(IRIS_COLUMNS)
+
+    _cleanup(client, dataset_id)
+
+
+def test_column_renames_rewrite_the_columns_and_remap_the_schema(client):
+    """The rename remaps ``schema`` too (lines 291-297), so the renamed column
+    keeps the type its old name declared."""
+    dataset_id = _new_dataset_row(client, "net_file_renames")
+
+    _run_job(
+        client,
+        dataset_id,
+        _csv_params(
+            "net_file_renames",
+            inferred_types=IRIS_SCHEMA,
+            column_renames={"Species": "Variety", "SepalLengthCm": "SepalLength"},
+        ),
+    )
+
+    row = _stored(client, dataset_id)
+    dataset = load_dataset(f"{row['file_path']}/dataset")
+
+    assert dataset.column_names == [
+        "SepalLength",
+        "SepalWidthCm",
+        "PetalLengthCm",
+        "PetalWidthCm",
+        "Variety",
+    ]
+    # The type followed the rename rather than being re-inferred.
+    assert type(dataset.types["Variety"]).__name__ == "Categorical"
+    assert row["total_columns"] == len(IRIS_COLUMNS)
+
+    _cleanup(client, dataset_id)
+
+
+# --------------------------------------------------------------------------- #
+# metadata policy
+# --------------------------------------------------------------------------- #
+
+
+def test_compute_metadata_true_writes_base_and_extended_metadata(client):
+    dataset_id = _new_dataset_row(client, "net_meta_full")
+
+    _run_job(client, dataset_id, _csv_params("net_meta_full", compute_metadata=True))
+
+    splits = _splits(_stored(client, dataset_id)["file_path"])
+    assert splits["total_rows"] == IRIS_ROWS
+    assert splits["column_names"] == IRIS_COLUMNS
+    assert "nan" in splits
+    for key in EXTENDED_KEYS:
+        assert key in splits, f"missing {key} when compute_metadata=True"
+
+    _cleanup(client, dataset_id)
+
+
+def test_compute_metadata_false_writes_base_metadata_only(client):
+    dataset_id = _new_dataset_row(client, "net_meta_base")
+
+    _run_job(client, dataset_id, _csv_params("net_meta_base", compute_metadata=False))
+
+    row = _stored(client, dataset_id)
+    splits = _splits(row["file_path"])
+    assert splits["total_rows"] == IRIS_ROWS
+    assert splits["column_names"] == IRIS_COLUMNS
+    assert "nan" in splits
+    for key in EXTENDED_KEYS:
+        assert key not in splits, f"unexpected {key} when compute_metadata=False"
+
+    # The row's columns come from splits, so they must survive the base-only path.
+    assert row["total_rows"] == IRIS_ROWS
+    assert row["total_columns"] == len(IRIS_COLUMNS)
+
+    _cleanup(client, dataset_id)
+
+
+def test_omitting_the_flag_defaults_to_full_metadata(client):
+    """Backward compatibility: the 4 bootstrap fixtures never pass the flag."""
+    dataset_id = _new_dataset_row(client, "net_meta_default")
+
+    _run_job(client, dataset_id, _csv_params("net_meta_default"))
+
+    splits = _splits(_stored(client, dataset_id)["file_path"])
+    for key in EXTENDED_KEYS:
+        assert key in splits
+
+    _cleanup(client, dataset_id)
+
+
+# --------------------------------------------------------------------------- #
+# notebook branch
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(name="notebook")
+def create_notebook(client: TestClient, dataset_1):
+    """A notebook holding its own copy of the iris dataset.
+
+    ``POST /notebook/`` copies the dataset folder, so the notebook branch of the
+    job reads a private working copy and never the source dataset.
+    """
+    response = client.post(
+        "/api/v1/notebook/",
+        json={"dataset_id": dataset_1.id, "name": "dataset job net"},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def _add_converter(client, notebook_id: int) -> int:
+    """Register a converter against the notebook.
+
+    The job only asks *whether any Converter row exists* for the notebook
+    (lines 174-180); it never runs it. So a row is enough to flip
+    ``from_notebook_no_converters`` to False.
+    """
+    response = client.post(
+        "/api/v1/converter/",
+        json={
+            "notebook_id": notebook_id,
+            "converter": "StandardScaler",
+            "parameters": {
+                "order": 0,
+                "params": {},
+                "scope": {"columns": [], "rows": []},
+                "target": None,
+            },
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def test_the_notebook_branch_copies_the_working_copy_into_a_new_dataset(
+    client, notebook
+):
+    dataset_id = _new_dataset_row(client, "net_notebook_happy")
+
+    _run_job(
+        client,
+        dataset_id,
+        {"name": "net_notebook_happy"},
+        notebook_id=notebook["id"],
+        file_path=None,
+    )
+
+    row = _stored(client, dataset_id)
+    assert row["status"] == DatasetStatus.FINISHED
+    assert row["total_rows"] == IRIS_ROWS
+    assert row["total_columns"] == len(IRIS_COLUMNS)
+
+    # A new folder, not the notebook's own copy.
+    assert Path(row["file_path"]) != Path(notebook["file_path"])
+    dataset = load_dataset(f"{row['file_path']}/dataset")
+    assert dataset.column_names == IRIS_COLUMNS
+    assert len(dataset) == IRIS_ROWS
+
+    # And the notebook is untouched.
+    assert load_dataset(f"{notebook['file_path']}/dataset").column_names == IRIS_COLUMNS
+
+    _cleanup(client, dataset_id)
+
+
+def test_a_notebook_without_converters_reuses_the_source_metadata(client, notebook):
+    """No converters means the bytes match the source, so ``splits.json`` is
+    inherited rather than recomputed (lines 313-328)."""
+    dataset_id = _new_dataset_row(client, "net_notebook_inherit")
+
+    _run_job(
+        client,
+        dataset_id,
+        {"name": "net_notebook_inherit", "compute_metadata": True},
+        notebook_id=notebook["id"],
+        file_path=None,
+    )
+
+    splits = _splits(_stored(client, dataset_id)["file_path"])
+    # dataset_1 was built with the default (full metadata), so the inherited
+    # splits already carry the extended keys.
+    for key in EXTENDED_KEYS:
+        assert key in splits
+    assert splits["total_rows"] == IRIS_ROWS
+
+    _cleanup(client, dataset_id)
+
+
+def test_a_notebook_without_converters_still_drops_extended_when_asked(
+    client, notebook
+):
+    """``compute_metadata=False`` purges the extended keys the source carried."""
+    dataset_id = _new_dataset_row(client, "net_notebook_purge")
+
+    _run_job(
+        client,
+        dataset_id,
+        {"name": "net_notebook_purge", "compute_metadata": False},
+        notebook_id=notebook["id"],
+        file_path=None,
+    )
+
+    splits = _splits(_stored(client, dataset_id)["file_path"])
+    assert splits["total_rows"] == IRIS_ROWS
+    for key in EXTENDED_KEYS:
+        assert key not in splits, f"inherited {key} was not purged"
+
+    _cleanup(client, dataset_id)
+
+
+def test_a_notebook_with_converters_recomputes_the_metadata(client, notebook):
+    """One Converter row is enough to stop trusting the source's splits."""
+    _add_converter(client, notebook["id"])
+    dataset_id = _new_dataset_row(client, "net_notebook_recompute")
+
+    _run_job(
+        client,
+        dataset_id,
+        {"name": "net_notebook_recompute", "compute_metadata": True},
+        notebook_id=notebook["id"],
+        file_path=None,
+    )
+
+    splits = _splits(_stored(client, dataset_id)["file_path"])
+    for key in EXTENDED_KEYS:
+        assert key in splits
+    assert splits["total_rows"] == IRIS_ROWS
+
+    _cleanup(client, dataset_id)
+
+
+def test_the_notebook_branch_never_applies_a_schema_or_renames(client, notebook):
+    """Lines 260-299 sit in the ``else`` of the notebook check, so neither
+    ``inferred_types`` nor ``column_renames`` has any effect here."""
+    dataset_id = _new_dataset_row(client, "net_notebook_no_schema")
+
+    _run_job(
+        client,
+        dataset_id,
+        {
+            "name": "net_notebook_no_schema",
+            "column_renames": {"Species": "ShouldBeIgnored"},
+        },
+        notebook_id=notebook["id"],
+        file_path=None,
+    )
+
+    row = _stored(client, dataset_id)
+    dataset = load_dataset(f"{row['file_path']}/dataset")
+    assert dataset.column_names == IRIS_COLUMNS
+
+    _cleanup(client, dataset_id)
+
+
+# --------------------------------------------------------------------------- #
+# hub branch
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(name="datafile")
+def create_datafile(client, tmp_path_factory, request):
+    """A READY ``Datafile`` row pointing at a directory holding iris.csv.
+
+    Built by hand: the hub branch only reads the row and the files on disk, so
+    no network is involved. ``dataset_id`` carries the test name because the
+    table has a ``UNIQUE(source_name, dataset_id)`` constraint and each test
+    gets its own row.
+    """
+    work_dir = tmp_path_factory.mktemp("hub_download")
+    shutil.copy(IRIS_CSV, work_dir / "iris.csv")
+
+    with _session_factory(client)() as db:
+        row = Datafile(
+            source_name="HuggingFaceDatasetSource",
+            dataset_id=f"net/iris/{request.node.name}",
+            name="net iris",
+            local_path=str(work_dir),
+            status=DatafileStatus.READY,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return {"id": row.id, "local_path": str(work_dir)}
+
+
+def _hub_params(name: str, datafile_id: int, **overrides) -> dict:
+    params = {
+        "name": name,
+        "dataloader": "CSVDataLoader",
+        "dataloader_params": {"separator": ","},
+        "datafile_id": datafile_id,
+    }
+    params.update(overrides)
+    return params
+
+
+def _run_hub_job(client, dataset_id: int, params: dict) -> None:
+    DatasetJob(
+        job_type="DatasetJob",
+        kwargs={
+            "dataset_id": dataset_id,
+            "source_name": "HuggingFaceDatasetSource",
+            "dataset_source_id": "net/iris",
+            "params": params,
+        },
+    ).run()
+
+
+def test_the_hub_branch_finishes_from_an_explicit_selected_file(client, datafile):
+    dataset_id = _new_dataset_row(client, "net_hub_selected")
+
+    _run_hub_job(
+        client,
+        dataset_id,
+        _hub_params("net_hub_selected", datafile["id"], selected_file="iris.csv"),
+    )
+
+    row = _stored(client, dataset_id)
+    assert row["status"] == DatasetStatus.FINISHED
+    assert row["total_rows"] == IRIS_ROWS
+    assert row["total_columns"] == len(IRIS_COLUMNS)
+    assert load_dataset(f"{row['file_path']}/dataset").column_names == IRIS_COLUMNS
+
+    _cleanup(client, dataset_id)
+
+
+def test_the_hub_branch_picks_the_first_file_when_none_is_selected(client, datafile):
+    """No ``selected_file``: the first entry of a sorted ``rglob`` wins."""
+    dataset_id = _new_dataset_row(client, "net_hub_first")
+
+    _run_hub_job(client, dataset_id, _hub_params("net_hub_first", datafile["id"]))
+
+    row = _stored(client, dataset_id)
+    assert row["status"] == DatasetStatus.FINISHED
+    assert row["total_rows"] == IRIS_ROWS
+
+    _cleanup(client, dataset_id)
+
+
+def test_the_hub_branch_ignores_dotted_files_when_picking(client, datafile):
+    """Any path component starting with a dot is skipped (lines 213-217).
+
+    ``.hidden`` sorts before ``iris.csv``, so without the filter it would win
+    and the job would fail on an unreadable file.
+    """
+    hidden = Path(datafile["local_path"]) / ".hidden"
+    hidden.mkdir()
+    (hidden / "junk.csv").write_text("not,a,dataset\n", encoding="utf-8")
+
+    dataset_id = _new_dataset_row(client, "net_hub_hidden")
+
+    _run_hub_job(client, dataset_id, _hub_params("net_hub_hidden", datafile["id"]))
+
+    row = _stored(client, dataset_id)
+    assert row["status"] == DatasetStatus.FINISHED
+    assert row["total_rows"] == IRIS_ROWS
+
+    _cleanup(client, dataset_id)
+
+
+def test_the_hub_branch_applies_the_schema_and_the_renames(client, datafile):
+    """Unlike the notebook branch, hub imports do go through lines 260-299."""
+    dataset_id = _new_dataset_row(client, "net_hub_renames")
+
+    _run_hub_job(
+        client,
+        dataset_id,
+        _hub_params(
+            "net_hub_renames",
+            datafile["id"],
+            selected_file="iris.csv",
+            inferred_types=IRIS_SCHEMA,
+            column_renames={"Species": "Variety"},
+        ),
+    )
+
+    row = _stored(client, dataset_id)
+    dataset = load_dataset(f"{row['file_path']}/dataset")
+    assert dataset.column_names[-1] == "Variety"
+    assert type(dataset.types["Variety"]).__name__ == "Categorical"
+
+    _cleanup(client, dataset_id)
+
+
+# --------------------------------------------------------------------------- #
+# error messages, by exact text
+# --------------------------------------------------------------------------- #
+#
+# These travel verbatim to ``task_copy.error_msg`` (``huey_job_queue.py:210``
+# stores ``str(exc)``) and from there to ``GET /job/status/{id}`` and the UI, so
+# the text *is* the contract. Everything raised inside the try at line 153 comes
+# back wrapped as ``Error loading dataset: <message>``.
+
+
+def _datasets_dir(client) -> Path:
+    return Path(client.app.container["config"]["DATASETS_PATH"])
+
+
+def _folders_in(path: Path) -> set:
+    return {p.name for p in path.iterdir() if p.is_dir()}
+
+
+def test_a_missing_dataset_row_is_reported_by_id(client):
+    """Raised before the status is touched, so nothing is left behind."""
+    with pytest.raises(JobError) as excinfo:
+        _run_job(client, 987654, _csv_params("net_missing_row"))
+
+    assert str(excinfo.value) == "Dataset with ID 987654 not found."
+
+
+def test_a_file_exists_collision_names_the_generated_folder(client, monkeypatch):
+    dataset_id = _new_dataset_row(client, "net_collision")
+
+    def collide(self, *args, **kwargs):
+        raise FileExistsError(self)
+
+    monkeypatch.setattr(Path, "mkdir", collide)
+
+    with pytest.raises(JobError) as excinfo:
+        _run_job(client, dataset_id, _csv_params("net_collision"))
+
+    message = str(excinfo.value)
+    assert message.startswith("A dataset with the name ")
+    assert message.endswith(" already exists.")
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_a_missing_notebook_is_reported_with_the_original_wording(client):
+    """The wording says "has no associated dataset" even though what is missing
+    is the Notebook row itself. Preserved verbatim: it reaches the UI."""
+    dataset_id = _new_dataset_row(client, "net_missing_notebook")
+
+    with pytest.raises(JobError) as excinfo:
+        _run_job(
+            client,
+            dataset_id,
+            {"name": "net_missing_notebook"},
+            notebook_id=987654,
+            file_path=None,
+        )
+
+    assert str(excinfo.value) == (
+        "Error loading dataset: Notebook with ID 987654 has no associated dataset."
+    )
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_an_unreadable_notebook_copy_names_the_path_it_could_not_read(client, notebook):
+    """The notebook branch reads a stored dataset off disk. When that read fails
+    the message names the path instead of quoting the reader's exception.
+
+    This is the one intentional wording change of the refactor: the branch now
+    goes through the same loading step as every other flow that materialises a
+    stored dataset, and that step reports failures by path. The path is the
+    actionable part — the reader's own text ("the arrow file is truncated") says
+    nothing about *which* file.
+    """
+    dataset_id = _new_dataset_row(client, "net_unreadable_notebook")
+
+    from DashAI.back.dataloaders.classes import dashai_dataset
+
+    real_load = dashai_dataset.load_dataset
+
+    def fail_to_load(path):
+        raise OSError("the arrow file is truncated")
+
+    dashai_dataset.load_dataset = fail_to_load
+    try:
+        with pytest.raises(JobError) as excinfo:
+            _run_job(
+                client,
+                dataset_id,
+                {"name": "net_unreadable_notebook"},
+                notebook_id=notebook["id"],
+                file_path=None,
+            )
+    finally:
+        dashai_dataset.load_dataset = real_load
+
+    assert str(excinfo.value) == (
+        f"Error loading dataset: Can not load dataset from path {notebook['file_path']}"
+    )
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_an_unknown_dataloader_in_the_file_branch_reports_the_registry_key_error(
+    client,
+):
+    """The file branch uses ``component_registry[name]``, whose ``KeyError``
+    stringifies *with* the quotes."""
+    dataset_id = _new_dataset_row(client, "net_bad_loader_file")
+
+    with pytest.raises(JobError) as excinfo:
+        _run_job(
+            client,
+            dataset_id,
+            _csv_params("net_bad_loader_file", dataloader="NoSuchDataLoader"),
+        )
+
+    assert str(excinfo.value) == (
+        "Error loading dataset: \"Component 'NoSuchDataLoader' does not exists "
+        'in the registry."'
+    )
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_an_unknown_dataloader_in_the_hub_branch_has_its_own_wording(client, datafile):
+    """The hub branch looks the loader up itself, with a different message than
+    the file branch. Both have to survive the refactor."""
+    dataset_id = _new_dataset_row(client, "net_bad_loader_hub")
+
+    with pytest.raises(JobError) as excinfo:
+        _run_hub_job(
+            client,
+            dataset_id,
+            _hub_params(
+                "net_bad_loader_hub", datafile["id"], dataloader="NoSuchDataLoader"
+            ),
+        )
+
+    assert str(excinfo.value) == (
+        "Error loading dataset: DataLoader 'NoSuchDataLoader' not found in registry."
+    )
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_a_hub_import_without_a_datafile_id_says_so(client):
+    dataset_id = _new_dataset_row(client, "net_hub_no_id")
+
+    with pytest.raises(JobError) as excinfo:
+        _run_hub_job(
+            client,
+            dataset_id,
+            {"name": "net_hub_no_id", "dataloader": "CSVDataLoader"},
+        )
+
+    assert str(excinfo.value) == (
+        "Error loading dataset: datafile_id is required for hub imports."
+    )
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_a_datafile_that_is_not_ready_is_reported_by_id(client, datafile):
+    dataset_id = _new_dataset_row(client, "net_hub_not_ready")
+    with _session_factory(client)() as db:
+        row = db.get(Datafile, datafile["id"])
+        row.status = DatafileStatus.DOWNLOADING
+        db.commit()
+
+    with pytest.raises(JobError) as excinfo:
+        _run_hub_job(
+            client, dataset_id, _hub_params("net_hub_not_ready", datafile["id"])
+        )
+
+    assert str(excinfo.value) == (
+        f"Error loading dataset: Datafile {datafile['id']} is not ready."
+    )
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_a_missing_datafile_row_is_also_reported_as_not_ready(client):
+    """``hub_row is None`` and ``status != READY`` share one branch and one
+    message, so a nonexistent id reads as "not ready"."""
+    dataset_id = _new_dataset_row(client, "net_hub_missing_row")
+
+    with pytest.raises(JobError) as excinfo:
+        _run_hub_job(client, dataset_id, _hub_params("net_hub_missing_row", 987654))
+
+    assert str(excinfo.value) == "Error loading dataset: Datafile 987654 is not ready."
+
+
+def test_an_empty_hub_download_directory_says_so(client, tmp_path_factory):
+    dataset_id = _new_dataset_row(client, "net_hub_empty")
+    empty_dir = tmp_path_factory.mktemp("hub_empty")
+    with _session_factory(client)() as db:
+        row = Datafile(
+            source_name="HuggingFaceDatasetSource",
+            dataset_id="net/iris/empty",
+            name="empty",
+            local_path=str(empty_dir),
+            status=DatafileStatus.READY,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        datafile_id = row.id
+
+    with pytest.raises(JobError) as excinfo:
+        _run_hub_job(client, dataset_id, _hub_params("net_hub_empty", datafile_id))
+
+    assert str(excinfo.value) == (
+        "Error loading dataset: Hub download directory is empty."
+    )
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_column_renames_that_collide_list_the_duplicates_sorted(client):
+    dataset_id = _new_dataset_row(client, "net_dup_renames")
+
+    with pytest.raises(JobError) as excinfo:
+        _run_job(
+            client,
+            dataset_id,
+            _csv_params(
+                "net_dup_renames",
+                inferred_types=IRIS_SCHEMA,
+                column_renames={
+                    "SepalWidthCm": "Same",
+                    "PetalWidthCm": "Same",
+                    "Species": "SepalLengthCm",
+                },
+            ),
+        )
+
+    assert str(excinfo.value) == (
+        "Error loading dataset: Invalid column_renames: resulting column names "
+        "contain duplicates: ['Same', 'SepalLengthCm']"
+    )
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_a_database_error_on_the_final_commit_is_reported_generically(client):
+    """The last block (lines 351-368) catches only ``SQLAlchemyError`` and
+    replaces it with a fixed message, dropping the database's own text.
+
+    Note the asymmetry with everything above: this one is raised *outside* the
+    try at line 153, so it is not prefixed with "Error loading dataset: ".
+    """
+    from sqlalchemy import exc as sa_exc
+
+    dataset_id = _new_dataset_row(client, "net_db_error")
+    datasets_dir = _datasets_dir(client)
+    before = _folders_in(datasets_dir)
+
+    real_set_finished = Dataset.set_status_as_finished
+
+    def boom(self):
+        raise sa_exc.InvalidRequestError("the database said no")
+
+    Dataset.set_status_as_finished = boom
+    try:
+        with pytest.raises(JobError) as excinfo:
+            _run_job(client, dataset_id, _csv_params("net_db_error"))
+    finally:
+        Dataset.set_status_as_finished = real_set_finished
+
+    assert str(excinfo.value) == "Internal database error"
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+    # This branch cleans up the folder too.
+    assert _folders_in(datasets_dir) == before
+
+
+# --------------------------------------------------------------------------- #
+# side effects of a failure
+# --------------------------------------------------------------------------- #
+
+
+def test_a_failure_after_the_folder_was_created_removes_it(client):
+    """The generated folder is created before loading, and the ``except`` at
+    line 345 has to clean it up — otherwise every failed import leaks a folder
+    under DATASETS_PATH."""
+    dataset_id = _new_dataset_row(client, "net_leak_check")
+    datasets_dir = _datasets_dir(client)
+    before = _folders_in(datasets_dir)
+
+    with pytest.raises(JobError):
+        _run_job(
+            client,
+            dataset_id,
+            _csv_params("net_leak_check", dataloader="NoSuchDataLoader"),
+        )
+
+    assert _folders_in(datasets_dir) == before
+    assert _stored(client, dataset_id)["file_path"] == ""
+
+
+def test_a_failure_does_not_delete_a_folder_the_job_did_not_create(client, tmp_path):
+    """Re-importing into an existing dataset reuses that dataset's own folder
+    instead of creating one (the ``n_sample`` branch).
+
+    The cleanup on failure removes the destination folder, which is right when
+    the job created it and destructive when it did not: the row survives the
+    failure pointing at a path whose contents would be gone.
+    """
+    existing = tmp_path / "already_stored"
+    existing.mkdir()
+    (existing / "dataset").mkdir()
+    (existing / "dataset" / "data.arrow").write_text("payload", encoding="utf-8")
+
+    with _session_factory(client)() as db:
+        entry = Dataset(name="net_reused_folder", file_path=str(existing))
+        entry.set_status_as_delivered()
+        db.add(entry)
+        db.commit()
+        db.refresh(entry)
+        dataset_id = entry.id
+
+    with pytest.raises(JobError):
+        _run_job(
+            client,
+            dataset_id,
+            _csv_params("net_reused_folder", dataloader="NoSuchDataLoader"),
+            n_sample=10,
+        )
+
+    assert (existing / "dataset" / "data.arrow").read_text(
+        encoding="utf-8"
+    ) == "payload"
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR
+
+
+def test_the_temp_dir_is_removed_even_on_the_happy_path(client, tmp_path_factory):
+    """The ``finally`` removes ``temp_dir`` whether the job worked or not."""
+    dataset_id = _new_dataset_row(client, "net_temp_happy")
+    temp_dir = tmp_path_factory.mktemp("net_temp_happy")
+
+    _run_job(client, dataset_id, _csv_params("net_temp_happy"), temp_dir=str(temp_dir))
+
+    assert not temp_dir.exists()
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.FINISHED
+
+    _cleanup(client, dataset_id)
+
+
+def test_the_temp_dir_is_removed_after_a_failure(client, tmp_path_factory):
+    dataset_id = _new_dataset_row(client, "net_temp_failure")
+    temp_dir = tmp_path_factory.mktemp("net_temp_failure")
+
+    with pytest.raises(JobError):
+        _run_job(
+            client,
+            dataset_id,
+            _csv_params("net_temp_failure", dataloader="NoSuchDataLoader"),
+            temp_dir=str(temp_dir),
+        )
+
+    assert not temp_dir.exists()
+
+
+def test_a_failed_notebook_import_leaves_the_notebook_intact(client, notebook):
+    """The cleanup ``rmtree`` targets the *generated* folder. If it ever pointed
+    at the loaded path instead, this is what would catch it: the notebook's own
+    working copy would be gone."""
+    dataset_id = _new_dataset_row(client, "net_notebook_failure")
+    notebook_dataset = Path(notebook["file_path"]) / "dataset"
+    assert notebook_dataset.exists()
+
+    from DashAI.back.dataloaders.classes import dashai_dataset
+
+    real_save = dashai_dataset.save_dataset
+
+    def fail_to_save(dataset, path):
+        raise OSError("disk full")
+
+    dashai_dataset.save_dataset = fail_to_save
+    try:
+        with pytest.raises(JobError) as excinfo:
+            _run_job(
+                client,
+                dataset_id,
+                {"name": "net_notebook_failure"},
+                notebook_id=notebook["id"],
+                file_path=None,
+            )
+    finally:
+        dashai_dataset.save_dataset = real_save
+
+    # The message gained the destination path, and deliberately kept the
+    # original exception's text: a save failure is an infrastructure failure and
+    # only the outermost message reaches the user (``huey_job_queue.py:210``
+    # stores ``str(exc)``, never the ``__cause__`` chain), so swallowing it would
+    # drop the diagnosis exactly when it matters.
+    message = str(excinfo.value)
+    assert message.startswith("Error loading dataset: Can not save dataset to path ")
+    assert message.endswith(": disk full")
+
+    assert notebook_dataset.exists()
+    assert load_dataset(str(notebook_dataset)).column_names == IRIS_COLUMNS
+    assert _stored(client, dataset_id)["status"] == DatasetStatus.ERROR

--- a/tests/back/api/test_explainer_job.py
+++ b/tests/back/api/test_explainer_job.py
@@ -503,8 +503,11 @@ def test_a_model_that_cannot_be_loaded_names_the_path(client, run_id):
 def test_an_unknown_explainer_name_is_reported_with_the_multiline_message(
     client, run_id
 ):
-    """The message is a triple-quoted f-string, so its newline and indentation
-    are literally part of the text the user sees. Pinned as-is."""
+    """One line, so it stays readable wherever it surfaces.
+
+    It used to be a triple-quoted f-string, which put a newline and the source
+    file's indentation literally inside the text the user reads.
+    """
     explainer_id = _create_global_explainer(
         client, run_id, explainer_name="NoSuchExplainer"
     )
@@ -513,8 +516,7 @@ def test_an_unknown_explainer_name_is_reported_with_the_multiline_message(
         ExplainerJob(explainer_id=explainer_id, explainer_scope="global").run()
 
     assert str(excinfo.value) == (
-        "Unable to find the global explainer with name\n"
-        "                            NoSuchExplainer in registry."
+        "Unable to find the global explainer with name NoSuchExplainer in registry."
     )
 
 

--- a/tests/back/api/test_units_api.py
+++ b/tests/back/api/test_units_api.py
@@ -27,6 +27,12 @@ EXPECTED_UNITS = {
     "PrepareExplanationDataUnit",
     "GenerateGlobalExplanationUnit",
     "GenerateLocalExplanationUnit",
+    "LoadUploadedDatasetUnit",
+    "LoadDatafileDatasetUnit",
+    "InferDatasetTypesUnit",
+    "ApplyDatasetSchemaUnit",
+    "ComputeDatasetMetadataUnit",
+    "SaveDatasetToPathUnit",
 }
 
 
@@ -108,6 +114,30 @@ def test_unit_schemas_describe_their_configuration(units):
     assert set(units["GenerateGlobalExplanationUnit"]["schema"]["properties"]) == {
         "explainer_id"
     }
+    assert set(units["LoadUploadedDatasetUnit"]["schema"]["properties"]) == {
+        "dataloader",
+        "source",
+        "temp_path",
+        "n_sample",
+    }
+    assert set(units["LoadDatafileDatasetUnit"]["schema"]["properties"]) == {
+        "dataloader",
+        "datafile_id",
+        "selected_file",
+    }
+    assert set(units["InferDatasetTypesUnit"]["schema"]["properties"]) == {"method"}
+    # The type declaration arrives through the context, not the configuration,
+    # so the only thing to configure here is the renaming.
+    assert set(units["ApplyDatasetSchemaUnit"]["schema"]["properties"]) == {
+        "column_renames"
+    }
+    assert set(units["ComputeDatasetMetadataUnit"]["schema"]["properties"]) == {
+        "compute_metadata",
+        "trust_inherited_metadata",
+    }
+    # The sibling of SaveDatasetUnit: that one saves where the load said, this
+    # one is told where to save.
+    assert set(units["SaveDatasetToPathUnit"]["schema"]["properties"]) == {"path"}
 
 
 def test_component_fields_tell_the_front_which_components_to_offer(units):
@@ -122,10 +152,17 @@ def test_component_fields_tell_the_front_which_components_to_offer(units):
     converter = units["ApplyConverterUnit"]["schema"]["properties"]["converter"]
     explorer = units["RunExplorationUnit"]["schema"]["properties"]["explorer"]
 
+    uploaded = units["LoadUploadedDatasetUnit"]["schema"]["properties"]["dataloader"]
+    datafile = units["LoadDatafileDatasetUnit"]["schema"]["properties"]["dataloader"]
+
     assert model["parent"] == "BaseModel"
     assert optimizer["parent"] == "BaseOptimizer"
     assert converter["parent"] == "BaseConverter"
     assert explorer["parent"] == "BaseExplorer"
+    # Both loading units offer the same readers; what differs is how each one
+    # finds the bytes to hand them.
+    assert uploaded["parent"] == "BaseDataLoader"
+    assert datafile["parent"] == "BaseDataLoader"
 
     # Global and local explainers are separate registries with separate base
     # classes, and a component field carries a single parent hint. Hence two

--- a/tests/back/units/test_dataset_ingest_units.py
+++ b/tests/back/units/test_dataset_ingest_units.py
@@ -1,0 +1,491 @@
+"""Contract tests for the units DatasetJob is built from.
+
+The context is built by hand rather than through the job, which is what exposes
+composability mistakes: a job always wires the context "correctly", so an
+end-to-end run cannot tell a real contract from a lucky one.
+"""
+
+import pandas as pd
+import pytest
+from kink import di
+
+from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+from DashAI.back.job.base_job import JobError
+from DashAI.back.units.apply_dataset_schema_unit import ApplyDatasetSchemaUnit
+from DashAI.back.units.compute_dataset_metadata_unit import (
+    EXTENDED_METADATA_KEYS,
+    ComputeDatasetMetadataUnit,
+)
+from DashAI.back.units.context import ExecutionContext, UnitContractError
+from DashAI.back.units.infer_dataset_types_unit import InferDatasetTypesUnit
+from DashAI.back.units.load_datafile_dataset_unit import LoadDatafileDatasetUnit
+from DashAI.back.units.load_uploaded_dataset_unit import LoadUploadedDatasetUnit
+from DashAI.back.units.save_dataset_to_path_unit import SaveDatasetToPathUnit
+
+SCHEMA = {
+    "n": {"type": "Float", "dtype": "float64"},
+    "label": {"type": "Categorical", "dtype": "string"},
+}
+
+
+@pytest.fixture(name="dataset")
+def fixture_dataset():
+    frame = pd.DataFrame({"n": [1.0, 2.0, 3.0], "label": ["a", "b", "a"]})
+    return to_dashai_dataset(frame)
+
+
+@pytest.fixture(name="ctx")
+def fixture_ctx(dataset):
+    ctx = ExecutionContext()
+    ctx.put("dataset", dataset)
+    return ctx
+
+
+# --------------------------------------------------------------------------- #
+# ComputeDatasetMetadataUnit
+# --------------------------------------------------------------------------- #
+
+
+def test_metadata_unit_computes_the_extended_keys_by_default(ctx):
+    ComputeDatasetMetadataUnit(compute_metadata=True)(ctx)
+
+    splits = ctx.require("dataset").splits
+    assert splits["total_rows"] == 3
+    for key in EXTENDED_METADATA_KEYS:
+        assert key in splits
+
+
+def test_metadata_unit_strips_extended_keys_it_did_not_ask_for(ctx):
+    """A dataset can arrive carrying metadata from wherever it was copied from.
+
+    Asking for base only has to mean base only, whatever the file happened to
+    bring — otherwise the result depends on the dataset's history.
+    """
+    dataset = ctx.require("dataset")
+    dataset.splits["correlations"] = {"stale": "value"}
+    dataset.splits["general_info"] = {"stale": "value"}
+
+    ComputeDatasetMetadataUnit(compute_metadata=False)(ctx)
+
+    splits = ctx.require("dataset").splits
+    assert splits["total_rows"] == 3
+    for key in EXTENDED_METADATA_KEYS:
+        assert key not in splits
+
+
+def test_metadata_unit_reuses_trusted_extended_metadata(ctx):
+    """Trusting what is there is the whole point of the flag: the marker value
+    below survives only because nothing was recomputed."""
+    dataset = ctx.require("dataset")
+    for key in EXTENDED_METADATA_KEYS:
+        dataset.splits[key] = {"marker": key}
+
+    ComputeDatasetMetadataUnit(compute_metadata=True, trust_inherited_metadata=True)(
+        ctx
+    )
+
+    splits = ctx.require("dataset").splits
+    assert splits["correlations"] == {"marker": "correlations"}
+
+
+def test_metadata_unit_computes_when_there_is_nothing_to_trust(ctx):
+    """Trusting metadata that is not there would silently store none at all."""
+    ComputeDatasetMetadataUnit(compute_metadata=True, trust_inherited_metadata=True)(
+        ctx
+    )
+
+    splits = ctx.require("dataset").splits
+    assert splits["total_rows"] == 3
+    for key in EXTENDED_METADATA_KEYS:
+        assert key in splits
+
+
+def test_metadata_unit_keeps_the_same_dataset_object(ctx):
+    """It fills the dataset in place, so downstream units that already hold a
+    reference see the metadata too. Asserted with ``is``: an equal copy would
+    pass ``==`` and still break that."""
+    before = ctx.require("dataset")
+
+    ComputeDatasetMetadataUnit(compute_metadata=False)(ctx)
+
+    assert ctx.require("dataset") is before
+
+
+def test_metadata_unit_refuses_to_run_without_a_dataset():
+    with pytest.raises(UnitContractError):
+        ComputeDatasetMetadataUnit(compute_metadata=True)(ExecutionContext())
+
+
+# --------------------------------------------------------------------------- #
+# InferDatasetTypesUnit
+# --------------------------------------------------------------------------- #
+
+
+def test_infer_types_unit_publishes_a_type_per_column(ctx):
+    InferDatasetTypesUnit(method="DashAIPtype")(ctx)
+
+    inferred = ctx.require("inferred_types")
+    assert set(inferred) == {"n", "label"}
+
+
+def test_infer_types_unit_prefers_the_types_the_dataset_already_carries(ctx):
+    """A reader that got types from the source knows better than inference over
+    the values, so those have to win."""
+    typed = ApplyDatasetSchemaUnit(column_renames=None)
+    ctx.put_ref("inferred_types", SCHEMA)
+    typed(ctx)
+
+    InferDatasetTypesUnit(method="DashAIPtype")(ctx)
+
+    inferred = ctx.require("inferred_types")
+    assert inferred["label"]["type"] == "Categorical"
+
+
+def test_infer_types_unit_publishes_something_json_serializable(ctx):
+    """It is a ref, not a live object: it has to survive ``put_ref``'s check."""
+    InferDatasetTypesUnit(method="DashAIPtype")(ctx)
+
+    # Round-trips through the serializable half without raising.
+    assert "inferred_types" in ctx.to_dict()
+
+
+# --------------------------------------------------------------------------- #
+# ApplyDatasetSchemaUnit
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_schema_unit_casts_the_declared_types(ctx):
+    ctx.put_ref("inferred_types", SCHEMA)
+
+    ApplyDatasetSchemaUnit(column_renames=None)(ctx)
+
+    types = ctx.require("dataset").types
+    assert type(types["label"]).__name__ == "Categorical"
+
+
+def test_apply_schema_unit_carries_the_types_through_a_rename(ctx):
+    """The declared type has to follow the column, not the old name."""
+    ctx.put_ref("inferred_types", SCHEMA)
+
+    ApplyDatasetSchemaUnit(column_renames={"label": "variety"})(ctx)
+
+    dataset = ctx.require("dataset")
+    assert dataset.column_names == ["n", "variety"]
+    assert type(dataset.types["variety"]).__name__ == "Categorical"
+
+
+def test_apply_schema_unit_rejects_renames_that_collide(ctx):
+    ctx.put_ref("inferred_types", SCHEMA)
+
+    with pytest.raises(JobError) as excinfo:
+        ApplyDatasetSchemaUnit(column_renames={"label": "n"})(ctx)
+
+    assert "contain duplicates: ['n']" in str(excinfo.value)
+
+
+def test_apply_schema_unit_rejects_a_declaration_for_columns_that_are_gone(ctx):
+    """The underlying transform passes unknown columns through untouched, so a
+    stale declaration would silently leave columns with the wrong types. This is
+    the check that turns that into an error.
+    """
+    ctx.put_ref("inferred_types", dict(SCHEMA, removed_column={"type": "Float"}))
+
+    with pytest.raises(JobError) as excinfo:
+        ApplyDatasetSchemaUnit(column_renames=None)(ctx)
+
+    assert "removed_column" in str(excinfo.value)
+
+
+def test_apply_schema_unit_validate_runs_before_any_work(ctx):
+    """``validate`` is a precondition check, so it must not need the transform to
+    have run — and ``__call__`` runs it on its own."""
+    ctx.put_ref("inferred_types", {"not_a_column": {"type": "Float"}})
+
+    with pytest.raises(JobError):
+        ApplyDatasetSchemaUnit(column_renames=None).validate(ctx)
+
+
+def test_apply_schema_unit_refuses_to_run_without_a_declaration(ctx):
+    """Declared in REQUIRES, so a missing value is a wiring mistake and has to
+    read as one instead of as "no types to apply"."""
+    with pytest.raises(UnitContractError):
+        ApplyDatasetSchemaUnit(column_renames=None)(ctx)
+
+
+def test_infer_then_apply_compose_over_the_same_key(ctx):
+    """The pair is meant to chain: one publishes what the other consumes."""
+    InferDatasetTypesUnit(method="DashAIPtype")(ctx)
+    ApplyDatasetSchemaUnit(column_renames={"n": "number"})(ctx)
+
+    assert ctx.require("dataset").column_names == ["number", "label"]
+
+
+# --------------------------------------------------------------------------- #
+# SaveDatasetToPathUnit
+# --------------------------------------------------------------------------- #
+
+
+def test_save_to_path_unit_writes_where_it_is_told(ctx, tmp_path):
+    from DashAI.back.dataloaders.classes.dashai_dataset import load_dataset
+
+    destination = tmp_path / "somewhere" / "dataset"
+    ComputeDatasetMetadataUnit(compute_metadata=False)(ctx)
+
+    SaveDatasetToPathUnit(path=str(destination))(ctx)
+
+    assert load_dataset(str(destination)).column_names == ["n", "label"]
+
+
+def test_save_to_path_unit_ignores_dataset_path_entirely(ctx, tmp_path):
+    """Its whole reason to exist: a context left over from a load must not be
+    able to redirect the save back onto the source."""
+    from DashAI.back.dataloaders.classes.dashai_dataset import load_dataset
+
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    ctx.put_ref("dataset_path", str(source))
+    ComputeDatasetMetadataUnit(compute_metadata=False)(ctx)
+
+    SaveDatasetToPathUnit(path=str(destination))(ctx)
+
+    assert not source.exists()
+    assert load_dataset(str(destination)).column_names == ["n", "label"]
+
+
+def test_save_to_path_unit_keeps_the_underlying_error_text(ctx, tmp_path):
+    """A save failure is an infrastructure failure, and only the outermost
+    message reaches the user — so the original text has to stay in it."""
+    destination = tmp_path / "dataset"
+
+    from DashAI.back.dataloaders.classes import dashai_dataset
+
+    real_save = dashai_dataset.save_dataset
+
+    def fail(dataset, path):
+        raise OSError("no space left on device")
+
+    dashai_dataset.save_dataset = fail
+    try:
+        with pytest.raises(JobError) as excinfo:
+            SaveDatasetToPathUnit(path=str(destination))(ctx)
+    finally:
+        dashai_dataset.save_dataset = real_save
+
+    message = str(excinfo.value)
+    assert str(destination) in message
+    assert "no space left on device" in message
+
+
+# --------------------------------------------------------------------------- #
+# the loading units
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(name="csv_file")
+def fixture_csv_file(tmp_path):
+    path = tmp_path / "data.csv"
+    path.write_text("n,label\n1.0,a\n2.0,b\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture(name="registry")
+def fixture_registry():
+    """A registry holding only the CSV reader, injected without an app."""
+    from DashAI.back.dataloaders.classes.csv_dataloader import CSVDataLoader
+    from DashAI.back.dependencies.registry import ComponentRegistry
+
+    registry = ComponentRegistry(initial_components=[CSVDataLoader])
+    di["component_registry"] = registry
+    yield registry
+    del di["component_registry"]
+
+
+def test_uploaded_unit_reads_the_file_and_publishes_the_dataset(
+    registry, csv_file, tmp_path
+):
+    ctx = ExecutionContext()
+
+    LoadUploadedDatasetUnit(
+        dataloader={"component": "CSVDataLoader", "params": {"separator": ","}},
+        source=str(csv_file),
+        temp_path=str(tmp_path),
+        n_sample=None,
+    )(ctx)
+
+    assert ctx.require("dataset").column_names == ["n", "label"]
+
+
+def test_uploaded_unit_publishes_no_path_and_no_id(registry, csv_file, tmp_path):
+    """An uploaded file is not a stored dataset yet: there is no id to correlate
+    against and nowhere it belongs on disk. Publishing either would hand a later
+    unit a value that describes something else."""
+    ctx = ExecutionContext()
+
+    LoadUploadedDatasetUnit(
+        dataloader={"component": "CSVDataLoader", "params": {"separator": ","}},
+        source=str(csv_file),
+        temp_path=str(tmp_path),
+        n_sample=None,
+    )(ctx)
+
+    assert not ctx.has("dataset_path")
+    assert not ctx.has("dataset_id")
+
+
+def test_uploaded_unit_reports_an_unknown_reader_with_the_registry_wording(
+    registry, csv_file, tmp_path
+):
+    ctx = ExecutionContext()
+
+    with pytest.raises(KeyError) as excinfo:
+        LoadUploadedDatasetUnit(
+            dataloader={"component": "NoSuchLoader", "params": {}},
+            source=str(csv_file),
+            temp_path=str(tmp_path),
+            n_sample=None,
+        )(ctx)
+
+    assert "does not exists in the registry" in str(excinfo.value)
+
+
+class _DatafileRow:
+    def __init__(self, local_path, status):
+        self.local_path = local_path
+        self.status = status
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get(self, model, row_id):
+        return self._rows.get(row_id)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+class _FakeSessionFactory:
+    """A class, not a lambda: kink calls any registered lambda with the container
+    to resolve it, so a lambda would be invoked as a service factory instead of
+    handed to the unit as one."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __call__(self):
+        return _FakeSession(self._rows)
+
+
+@pytest.fixture(name="datafile_rows")
+def fixture_datafile_rows():
+    rows = {}
+    di["session_factory"] = _FakeSessionFactory(rows)
+    yield rows
+    del di["session_factory"]
+
+
+def test_datafile_unit_reads_the_selected_file(
+    registry, datafile_rows, csv_file, tmp_path
+):
+    from DashAI.back.core.enums.status import DatafileStatus
+
+    datafile_rows[7] = _DatafileRow(str(tmp_path), DatafileStatus.READY)
+    ctx = ExecutionContext()
+
+    LoadDatafileDatasetUnit(
+        dataloader={"component": "CSVDataLoader", "params": {"separator": ","}},
+        datafile_id=7,
+        selected_file="data.csv",
+    )(ctx)
+
+    assert ctx.require("dataset").column_names == ["n", "label"]
+
+
+def test_datafile_unit_skips_dotted_paths_when_choosing(
+    registry, datafile_rows, csv_file, tmp_path
+):
+    """Download tools leave metadata directories behind that sort before the real
+    data, so without the filter the wrong file would win."""
+    from DashAI.back.core.enums.status import DatafileStatus
+
+    hidden = tmp_path / ".cache"
+    hidden.mkdir()
+    (hidden / "aaa.csv").write_text("junk\n", encoding="utf-8")
+    datafile_rows[7] = _DatafileRow(str(tmp_path), DatafileStatus.READY)
+    ctx = ExecutionContext()
+
+    LoadDatafileDatasetUnit(
+        dataloader={"component": "CSVDataLoader", "params": {"separator": ","}},
+        datafile_id=7,
+        selected_file=None,
+    )(ctx)
+
+    assert ctx.require("dataset").column_names == ["n", "label"]
+
+
+def test_datafile_unit_rejects_a_download_that_is_not_finished(
+    registry, datafile_rows, tmp_path
+):
+    from DashAI.back.core.enums.status import DatafileStatus
+
+    datafile_rows[7] = _DatafileRow(str(tmp_path), DatafileStatus.DOWNLOADING)
+
+    with pytest.raises(JobError) as excinfo:
+        LoadDatafileDatasetUnit(
+            dataloader={"component": "CSVDataLoader", "params": {}},
+            datafile_id=7,
+            selected_file=None,
+        )(ExecutionContext())
+
+    assert str(excinfo.value) == "Datafile 7 is not ready."
+
+
+def test_datafile_unit_treats_a_missing_row_the_same_way(registry, datafile_rows):
+    with pytest.raises(JobError) as excinfo:
+        LoadDatafileDatasetUnit(
+            dataloader={"component": "CSVDataLoader", "params": {}},
+            datafile_id=99,
+            selected_file=None,
+        )(ExecutionContext())
+
+    assert str(excinfo.value) == "Datafile 99 is not ready."
+
+
+def test_datafile_unit_reports_an_empty_download(registry, datafile_rows, tmp_path):
+    from DashAI.back.core.enums.status import DatafileStatus
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    datafile_rows[7] = _DatafileRow(str(empty), DatafileStatus.READY)
+
+    with pytest.raises(JobError) as excinfo:
+        LoadDatafileDatasetUnit(
+            dataloader={"component": "CSVDataLoader", "params": {}},
+            datafile_id=7,
+            selected_file=None,
+        )(ExecutionContext())
+
+    assert str(excinfo.value) == "Hub download directory is empty."
+
+
+def test_datafile_unit_has_its_own_wording_for_an_unknown_reader(
+    registry, datafile_rows, csv_file, tmp_path
+):
+    """Deliberately different from the uploaded unit's, which surfaces the
+    registry's own ``KeyError``. Both texts reach users today."""
+    from DashAI.back.core.enums.status import DatafileStatus
+
+    datafile_rows[7] = _DatafileRow(str(tmp_path), DatafileStatus.READY)
+
+    with pytest.raises(JobError) as excinfo:
+        LoadDatafileDatasetUnit(
+            dataloader={"component": "NoSuchLoader", "params": {}},
+            datafile_id=7,
+            selected_file="data.csv",
+        )(ExecutionContext())
+
+    assert str(excinfo.value) == "DataLoader 'NoSuchLoader' not found in registry."

--- a/tests/back/units/test_dataset_ingest_units.py
+++ b/tests/back/units/test_dataset_ingest_units.py
@@ -489,3 +489,34 @@ def test_datafile_unit_has_its_own_wording_for_an_unknown_reader(
         )(ExecutionContext())
 
     assert str(excinfo.value) == "DataLoader 'NoSuchLoader' not found in registry."
+
+
+def test_datafile_unit_rejects_a_component_that_is_not_a_reader(
+    datafile_rows, csv_file, tmp_path
+):
+    """A registered component of some other kind is still not a reader.
+
+    The registry's ``registry[name]`` indexer searches every type at once, so
+    looking the name up that way would find, say, a metric and call it as if it
+    could parse a file. The lookup is deliberately scoped to the readers.
+    """
+    from DashAI.back.core.enums.status import DatafileStatus
+    from DashAI.back.dataloaders.classes.csv_dataloader import CSVDataLoader
+    from DashAI.back.dependencies.registry import ComponentRegistry
+    from DashAI.back.metrics.classification.accuracy import Accuracy
+
+    di["component_registry"] = ComponentRegistry(
+        initial_components=[CSVDataLoader, Accuracy]
+    )
+    datafile_rows[7] = _DatafileRow(str(tmp_path), DatafileStatus.READY)
+    try:
+        with pytest.raises(JobError) as excinfo:
+            LoadDatafileDatasetUnit(
+                dataloader={"component": "Accuracy", "params": {}},
+                datafile_id=7,
+                selected_file="data.csv",
+            )(ExecutionContext())
+    finally:
+        del di["component_registry"]
+
+    assert str(excinfo.value) == "DataLoader 'Accuracy' not found in registry."


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the backend, focusing on explainability model integration, job unit modularization, and bug fixes for dataset status handling. The most significant changes include the addition of a robust wrapper for SHAP model prediction to improve compatibility, a major refactor of the converter job to use new modular "unit" classes, and the registration of these units in the system's component registry. There are also minor dependency and bug fixes.

**Explainability Integration and SHAP Compatibility:**

- Added a new `as_shap_predictor` function in `model_input.py` to wrap model prediction methods as plain functions, improving compatibility with SHAP and preventing errors with read-only properties in certain models (e.g., LightGBM, XGBoost). All SHAP explainer classes now use this wrapper instead of passing bound methods directly. [[1]](diffhunk://#diff-37af273bad977347a1b89577cd1186c83872bdc06de21e0d439adc30bd15bce1L17-R60) [[2]](diffhunk://#diff-c7c773ba216e90192c3109f52b26fac1f5f24a5e88463d9609d3fcc86919ecccL241-R244) [[3]](diffhunk://#diff-c7c773ba216e90192c3109f52b26fac1f5f24a5e88463d9609d3fcc86919ecccL257-R260) [[4]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L336-R339) [[5]](diffhunk://#diff-b886b10bbb53208a8d722424b0b390d8df25c8606e49e2525bbb1bfdba54b197L368-R371) [[6]](diffhunk://#diff-4b4b39967b4f51b89600913b007e8ff179680df6c7ed3739876a96d6235443baL182-R185) [[7]](diffhunk://#diff-4b4b39967b4f51b89600913b007e8ff179680df6c7ed3739876a96d6235443baL198-R201)

**Job and Unit System Refactor:**

- Refactored `converter_job.py` to remove the internal dataset transformation logic and instead leverage new modular "unit" classes (`ApplyConverterUnit`, `LoadDatasetUnit`, `SaveDatasetUnit`, etc.), streamlining the job's structure and reducing code duplication. [[1]](diffhunk://#diff-07cf5ad9232d4433f84da4417d7479365e47e4a3b82b7b45ef890de46e3e63f3L2-L120) [[2]](diffhunk://#diff-07cf5ad9232d4433f84da4417d7479365e47e4a3b82b7b45ef890de46e3e63f3L201-R104)
- Registered all new unit classes in `initial_components.py` so they are available system-wide for orchestration and dependency injection. [[1]](diffhunk://#diff-a28477ed1650ad56eedb57df3d07c5d0dfb6370c6e162eb81d5c692b3d7e32f8R352-R386) [[2]](diffhunk://#diff-a28477ed1650ad56eedb57df3d07c5d0dfb6370c6e162eb81d5c692b3d7e32f8R551-R580)

**Bug Fixes and Dependency Updates:**

- Fixed a bug in `models.py` where dataset status methods attempted to set `start_time` and `end_time` attributes that do not exist for the `Dataset` table, preventing unnecessary AttributeErrors.
- Cleaned up dependencies in the `preview_manual_prediction` API endpoint by removing the unused `component_registry` parameter. [[1]](diffhunk://#diff-b65e9a8af6a71dec16d74da9721b14c93ce9a70d8e890ef7df3bcfac7721d9ecL255) [[2]](diffhunk://#diff-b65e9a8af6a71dec16d74da9721b14c93ce9a70d8e890ef7df3bcfac7721d9ecL338)