### PR TITLE
docs: make CONTRIBUTING match the actual project setup

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,9 +8,10 @@ little bit helps, and credit will always be given.
 Bug reports
 ===========
 
-When `reporting a bug <https://github.com/DashAISoftware/DashAI/issues>`_ please include:
+When `reporting a bug <https://github.com/DashAISoftware/dashAI/issues>`_ please include:
 
     * Your operating system name and version.
+    * The DashAI version (``pip show dashai``) or the commit you are on.
     * Any details about your local setup that might be helpful in troubleshooting.
     * Detailed steps to reproduce the bug.
 
@@ -24,7 +25,8 @@ articles, and such.
 Feature requests and feedback
 =============================
 
-The best way to send feedback is to file an issue at https://github.com/DashAISoftware/DashAI/issues.
+The best way to send feedback is to file an issue at
+https://github.com/DashAISoftware/dashAI/issues.
 
 If you are proposing a feature:
 
@@ -35,52 +37,95 @@ If you are proposing a feature:
 Development
 ===========
 
-To set up `DashAI` for local development:
+DashAI uses `uv <https://docs.astral.sh/uv/>`_ to manage the Python environment
+and dependencies, and `Yarn <https://yarnpkg.com/>`_ for the frontend.
 
-1. Fork `DashAI <https://github.com/ionelmc/DashAI>`_
+To set up ``DashAI`` for local development:
+
+1. Fork `DashAI <https://github.com/DashAISoftware/dashAI>`_
    (look for the "Fork" button).
+
 2. Clone your fork locally::
 
     git clone git@github.com:YOURGITHUBNAME/DashAI.git
+    cd DashAI
 
-3. Create a branch for local development::
+3. Install the backend and the development dependencies::
+
+    uv sync                 # add --extra cpu on machines without an NVIDIA GPU
+    uv run pre-commit install
+
+   If you sync with ``--extra cpu`` (or ``--extra cuda``), pass the same
+   ``--extra`` to every ``uv run``; a plain ``uv run`` re-syncs to the default
+   torch build.
+
+4. Create a branch for local development::
 
     git checkout -b name-of-your-bugfix-or-feature
 
-   Now you can make your changes locally.
+   Now you can make your changes locally. To run the development server::
 
-4. When you're done making changes run all the checks and docs builder with `tox <https://tox.wiki/en/latest/install.html>`_ one command::
+    uv run python -m DashAI --no-browser --logging-level DEBUG
 
-    tox
+5. When you're done making changes, run the linter and the test suite::
 
-5. Commit your changes and push your branch to GitHub::
+    uv run ruff check --fix
+    uv run ruff format
+    uv run pytest tests/
+
+   To run a single test file or a single test::
+
+    uv run pytest tests/back/api/test_components_api.py -v
+    uv run pytest tests/back/api/test_components_api.py::test_function_name -v
+
+6. Commit your changes and push your branch to GitHub::
 
     git add .
     git commit -m "Your detailed description of your changes."
     git push origin name-of-your-bugfix-or-feature
 
-6. Submit a pull request through the GitHub website.
+7. Submit a pull request through the GitHub website, targeting ``develop``.
+
+Frontend
+--------
+
+The frontend lives in ``DashAI/front`` and requires Node LTS and Yarn 3.5.0::
+
+    cd DashAI/front
+    yarn install
+    yarn start        # dev server on http://localhost:3000
+    yarn lint
+    yarn test
 
 Pull Request Guidelines
 -----------------------
 
-If you need some code review or feedback while you're developing the code just make the pull request.
+If you need some code review or feedback while you're developing the code just
+make the pull request.
 
 For merging, you should:
 
-1. Include passing tests (run ``tox``) and .
-2. Update documentation when there's new API, functionality etc.
-3. Add a note to ``CHANGELOG.rst`` about the changes.
-4. Add yourself to ``AUTHORS.rst``.
-
+1. Include passing tests (``uv run pytest tests/``).
+2. Make sure the linter is clean (``uv run ruff check``); ``pre-commit`` runs it
+   for you on every commit.
+3. Update documentation when there's new API, functionality etc.
+4. Add a note to ``CHANGELOG.rst`` about the changes.
 
 Tips
 ----
 
-To run a subset of tests::
+To run a subset of tests by keyword::
 
-    tox -e envname -- pytest -k test_myfeature
+    uv run pytest tests/ -k test_myfeature
 
-To run all the test environments in *parallel*::
+To run the tests with a coverage report::
 
-    tox -p auto
+    uv run pytest tests/ --cov=DashAI
+
+Backend tests use an in-memory SQLite database, so no database setup is needed.
+
+To add or remove a dependency (this updates both ``pyproject.toml`` and
+``uv.lock``)::
+
+    uv add <package>
+    uv remove <package>


### PR DESCRIPTION
## Summary

`CONTRIBUTING.rst` still contains cookiecutter boilerplate that no longer
describes this project. A contributor following the development steps in order
fails at step 4, because the command it tells them to run does not exist here.

---

## Type of Change

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [x] Documentation

---

## Changes (by file)

- `CONTRIBUTING.rst`: rewrote the Development, Pull Request Guidelines and Tips
  sections so they match the repository as it is today:
  - Step 1 pointed to fork `ionelmc/DashAI`, the cookiecutter author's
    namespace, not this project.
  - Steps 4, 6 and Tips told contributors to run `tox`. There is no `tox.ini`
    and tox is not a dependency, so the command fails.
  - The merge checklist asked contributors to add themselves to `AUTHORS.rst`,
    which does not exist in the repository.
  - `uv`, `ruff` and `pre-commit` — all configured in the repo — were not
    mentioned at all.
  - Added a short Frontend section (yarn) and noted that PRs target `develop`.

---

## Testing

Documentation only; no code or configuration is touched.

The file was rendered with docutils at `halt_level=2` (warnings treated as
errors) and produced no warnings.

---

## Notes

The replacement commands are taken from the repository's own `CLAUDE.md`, which
is up to date — so this only brings the human-facing guide in line with what is
already documented for agents.