### PR TITLE
fix(optimizers): apply Optuna best params to the parameter's real owner

### DIFF
--- a/DashAI/back/optimizers/optuna_optimizer.py
+++ b/DashAI/back/optimizers/optuna_optimizer.py
@@ -205,12 +205,18 @@ class OptunaOptimizer(BaseOptimizer):
 
         study.optimize(objective, n_trials=self.n_trials)
 
+        # Write the best values back onto the objects that actually declare them.
+        # `self.parameters` holds (owner, key, bounds, dtype) tuples built by
+        # ModelFactory, where `owner` may be a nested sub-component rather than the
+        # top-level model. Assigning to the wrapper instead leaves the sub-component
+        # holding whatever the last trial set, so the model that gets retrained and
+        # serialized is the last one tried, not the best one. This mirrors what
+        # `objective` already does above.
         best_params = study.best_params
-        best_model = self.model
-        for hyperparameter, value in best_params.items():
-            setattr(best_model, hyperparameter, value)
-        best_model.train(self.input_dataset["train"], self.output_dataset["train"])
-        self.model = best_model
+        for obj, key, _bounds, _dtype in self.parameters:
+            if key in best_params:
+                setattr(obj, key, best_params[key])
+        self.model.train(self.input_dataset["train"], self.output_dataset["train"])
         self.study = study
 
     def get_model(self):

--- a/tests/back/optimizers/test_optuna_best_params.py
+++ b/tests/back/optimizers/test_optuna_best_params.py
@@ -1,0 +1,160 @@
+"""OptunaOptimizer must retrain the BEST trial's model, not the last one.
+
+`ModelFactory` hands the optimizer a list of ``(owner, key, bounds, dtype)``
+tuples where ``owner`` is the object that actually declares the parameter, which
+for a composite model is a nested sub-component rather than the top-level model.
+Writing the best values onto the wrapper leaves the sub-component holding the
+last trial's value, so the model that is retrained and serialized is not the one
+the study selected.
+"""
+
+import pytest
+
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
+from DashAI.back.optimizers.optuna_optimizer import OptunaOptimizer
+
+TARGET = 5.0
+BOUNDS = (0.01, 10.0)
+
+
+class DummySubComponent:
+    """Stands in for a nested component such as the SVC inside a bag-of-words model."""
+
+    def __init__(self):
+        self.C = 1.0
+
+
+class DummyModel:
+    """Minimal model whose prediction depends only on the sub-component."""
+
+    def __init__(self):
+        self.sub = DummySubComponent()
+        self.trained_with = None
+
+    def train(self, x, y):
+        # Record what the model was actually fitted with, which is the value the
+        # sub-component holds at that moment.
+        self.trained_with = self.sub.C
+
+    def predict(self, dataset):
+        return self.sub.C
+
+    def calculate_metrics(self, split=None, level=None):
+        assert split in (SplitEnum.TRAIN, SplitEnum.VALIDATION)
+        assert level is LevelEnum.TRIAL
+
+    def prepare_output(self, dataset, is_fit=False):
+        return dataset
+
+
+class DummyMetric:
+    """Score peaks at C == TARGET, so the best trial is whichever lands closest."""
+
+    @staticmethod
+    def score(y_true, y_pred):
+        return -abs(y_pred - TARGET)
+
+
+@pytest.fixture
+def dataset():
+    return {"train": [0], "validation": [0]}
+
+
+def _optimize(model, parameters, dataset, n_trials=12):
+    optimizer = OptunaOptimizer(n_trials=n_trials, sampler="RandomSampler", pruner=None)
+    optimizer.optimize(
+        model,
+        dataset,
+        dataset,
+        parameters,
+        {"class": DummyMetric, "metadata": {"maximize": True}},
+        "TabularClassificationTask",
+    )
+    return optimizer
+
+
+def test_nested_component_keeps_best_params_not_last_trial(dataset):
+    """The nested sub-component must end up holding the study's best value."""
+    model = DummyModel()
+    # The owner is the sub-component, exactly as ModelFactory would report it.
+    parameters = [(model.sub, "C", BOUNDS, "number")]
+
+    optimizer = _optimize(model, parameters, dataset)
+    best = optimizer.get_best_params()["C"]
+
+    assert pytest.approx(best) == model.sub.C, (
+        "the sub-component kept a value that is not the best one found; "
+        "the best params were written onto the wrapper instead of the owner"
+    )
+    assert model.trained_with == pytest.approx(best), (
+        "the final retrain used a value other than the best one"
+    )
+
+
+def test_nested_component_ignores_wrapper_attribute(dataset):
+    """Writing onto the wrapper is inert: nothing reads a `C` set on the parent."""
+    model = DummyModel()
+    parameters = [(model.sub, "C", BOUNDS, "number")]
+
+    optimizer = _optimize(model, parameters, dataset)
+    best = optimizer.get_best_params()["C"]
+
+    # `predict` and `train` only ever look at `model.sub.C`. If the fix regressed
+    # and the value went to the wrapper, `model.sub.C` would hold the last trial's
+    # value and this comparison would fail.
+    assert pytest.approx(best) == model.sub.C
+    assert getattr(model, "C", None) is None, (
+        "the optimizer set an attribute on the wrapper that nothing reads"
+    )
+
+
+def test_flat_model_still_works(dataset):
+    """On a flat model the owner IS the model, and behaviour must not change."""
+
+    class FlatModel(DummyModel):
+        def __init__(self):
+            super().__init__()
+            self.C = 1.0
+
+        def train(self, x, y):
+            self.trained_with = self.C
+
+        def predict(self, dataset):
+            return self.C
+
+    model = FlatModel()
+    parameters = [(model, "C", BOUNDS, "number")]
+
+    optimizer = _optimize(model, parameters, dataset)
+    best = optimizer.get_best_params()["C"]
+
+    assert pytest.approx(best) == model.C
+    assert model.trained_with == pytest.approx(best)
+
+
+def test_integer_parameters_keep_their_type(dataset):
+    """Integer hyperparameters must survive as ints on the owner."""
+
+    class IntSub:
+        def __init__(self):
+            self.n = 1
+
+    class IntModel(DummyModel):
+        def __init__(self):
+            super().__init__()
+            self.sub = IntSub()
+
+        def train(self, x, y):
+            self.trained_with = self.sub.n
+
+        def predict(self, dataset):
+            return float(self.sub.n)
+
+    model = IntModel()
+    parameters = [(model.sub, "n", (1, 10), "integer")]
+
+    optimizer = _optimize(model, parameters, dataset)
+    best = optimizer.get_best_params()["n"]
+
+    assert model.sub.n == best
+    assert isinstance(model.sub.n, int)


### PR DESCRIPTION
Closes #809.

`OptunaOptimizer` wrote `study.best_params` onto the top-level model instead of
the object that declares each parameter. For a model with a nested component the
sub-component kept whatever the last trial assigned, so the model that gets
retrained, returned by `get_model()` and serialized is the last trial's, not the
best one. `setattr` never fails, so nothing surfaced it.

The fix walks `self.parameters` and assigns to the owner, mirroring what
`objective()` already does a few lines above. `HyperOptOptimizer` resolves the
owner the same way, so this aligns the two optimizers. Flat models are
unaffected: there the owner *is* the model.

Also removes the `best_model = self.model` / `self.model = best_model` aliasing,
which was a no-op on the same object and part of what made the bug hard to see.

## Tests

Adds `tests/back/optimizers/` — there were no tests for that package. Four tests,
and **three of them fail against the previous code**:

```
before the fix:  3 failed, 1 passed
after the fix:   4 passed
```

The one that passes either way is `test_flat_model_still_works`, and that is the
point: it shows the defect does not exist on flat models and that this change
does not alter that path.

## Verification

- Applies cleanly on `develop` @ `431e51b`.
- `ruff check` and `ruff format` clean.
- Full suite: **772 of 779 pass**. The 7 that do not are environmental in my
  container — one needs the frontend built, six download models from Hugging
  Face, which my network blocks. None mention `optuna` or `best_params`.
- Does not conflict with #804: that branch does not modify
  `optuna_optimizer.py`. It does move the call site to
  `units/fit_model_unit.py`, which this change is orthogonal to.