### PR TITLE
Document requirements and add AVX2 warning for AppImage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,28 @@ AI models
 .. image:: ./images/dashai-logo.svg
    :alt: dashAI Logo
 
+Requirements
+============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * -
+     - Desktop installers
+     - PyPI / source install
+   * - **Operating system**
+     - Windows 10/11 x64, macOS 14+ on Apple Silicon (no Intel Mac build),
+       Linux x64 with glibc 2.35 or newer and FUSE 2
+     - Windows, macOS or Linux x64
+   * - **CPU**
+     - x86_64 **with AVX2** (Intel Haswell 2013+, AMD Excavator / Zen+), or
+       Apple Silicon
+     - x86_64 or Apple Silicon, AVX2 not required
+   * - **Python**
+     - Nothing to install: the installers bundle their own Python 3.12
+     - You install it yourself: Python 3.10 or greater (3.12 recommended)
+
 Desktop installers (Windows / macOS / Linux)
 =============================================
 
@@ -28,7 +50,6 @@ Download the file for your system from the
 
 * **Windows (x64):** ``dashAI-<version>-x64-windows.exe``
 * **macOS (Apple Silicon):** ``dashAI-<version>-arm-osx.dmg``
-* **macOS (Intel):** ``dashAI-<version>-x64-osx.dmg``
 * **Linux (x64):** ``dashAI-<version>-x64-linux.AppImage``
 
 On Windows and macOS, run the installer, launch dashAI, and the graphical
@@ -55,6 +76,11 @@ and opens the browser as usual.
 **Note:** the desktop installers ship with CPU only PyTorch and
 ``llama-cpp-python``. For NVIDIA (CUDA) or AMD (ROCm) GPU acceleration, use the
 pip installation below.
+
+**Note:** the installers need a CPU with AVX2 (Intel 2013+, AMD Excavator /
+Zen+). On older hardware they crash with ``Illegal instruction``; clone the
+repository and install from source to get a possible AVX or SSE2 build.
+(it may still crash if the CPU is too old, but it is worth trying).
 
 
 Installation (PyPI)

--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,11 @@ and opens the browser as usual.
 pip installation below.
 
 **Note:** the installers need a CPU with AVX2 (Intel 2013+, AMD Excavator /
-Zen+). On older hardware they crash with ``Illegal instruction``; clone the
-repository and install from source to get a possible AVX or SSE2 build.
-(it may still crash if the CPU is too old, but it is worth trying).
+Zen+). The bundled native libraries, PyTorch and the ``libggml`` shipped inside
+``llama-cpp-python``, are built for it, and on older hardware whichever one is
+imported first kills the process with ``Illegal instruction``. Clone the
+repository and install from source instead, which pulls wheels that run on
+older CPUs (it may still fail if the CPU is very old, but it is worth trying).
 
 
 Installation (PyPI)

--- a/appimage/entrypoint.sh
+++ b/appimage/entrypoint.sh
@@ -21,4 +21,17 @@ if [ ! -t 1 ] && [ -z "${DASHAI_IN_TERMINAL}" ]; then
     fi
 fi
 
+# The bundled PyTorch requires AVX2, so on a pre-2013 x86 CPU the app dies with
+# "Illegal instruction" once torch is imported, with no hint about why. Warn,
+# but never block: some VMs mask the CPUID bit even when AVX2 works.
+if [ "$(uname -m)" = "x86_64" ] && [ -r /proc/cpuinfo ] &&
+   ! grep -q '\bavx2\b' /proc/cpuinfo; then
+    echo "WARNING: this CPU does not report AVX2 support (Intel Haswell 2013+," >&2
+    echo "AMD Excavator / Zen+ have it). The bundled PyTorch needs AVX2, so" >&2
+    echo "dashAI will probably crash with 'Illegal instruction'. If it does," >&2
+    echo "install from source instead: uv sync --extra cpu" >&2
+    echo "Some virtual machines hide the flag even when AVX2 works, so this" >&2
+    echo "warning may be a false alarm." >&2
+fi
+
 exec "{{ python-executable }}" "${APPDIR}/opt/python{{ python-version }}/bin/dashai" "$@"

--- a/appimage/entrypoint.sh
+++ b/appimage/entrypoint.sh
@@ -21,15 +21,19 @@ if [ ! -t 1 ] && [ -z "${DASHAI_IN_TERMINAL}" ]; then
     fi
 fi
 
-# The bundled PyTorch requires AVX2, so on a pre-2013 x86 CPU the app dies with
-# "Illegal instruction" once torch is imported, with no hint about why. Warn,
-# but never block: some VMs mask the CPUID bit even when AVX2 works.
+# Several bundled native libraries assume AVX2, so on an old x86 CPU the app
+# dies with "Illegal instruction" as soon as one of them is imported, with no
+# hint about why. Which library blows up first depends on the CPU generation:
+# llama-cpp-python (libggml-cpu) has been seen crashing on a Nehalem i7 where
+# PyTorch still ran fine. Warn, but never block: some VMs mask the CPUID bit
+# even when AVX2 works.
 if [ "$(uname -m)" = "x86_64" ] && [ -r /proc/cpuinfo ] &&
    ! grep -q '\bavx2\b' /proc/cpuinfo; then
     echo "WARNING: this CPU does not report AVX2 support (Intel Haswell 2013+," >&2
-    echo "AMD Excavator / Zen+ have it). The bundled PyTorch needs AVX2, so" >&2
-    echo "dashAI will probably crash with 'Illegal instruction'. If it does," >&2
-    echo "install from source instead: uv sync --extra cpu" >&2
+    echo "AMD Excavator / Zen+ have it). A bundled native dependency (PyTorch" >&2
+    echo "and/or llama-cpp-python) needs AVX2, so dashAI will probably crash" >&2
+    echo "with 'Illegal instruction'. If it does, install from source instead:" >&2
+    echo "uv sync --extra cpu" >&2
     echo "Some virtual machines hide the flag even when AVX2 works, so this" >&2
     echo "warning may be a false alarm." >&2
 fi


### PR DESCRIPTION
## Summary
Legacy CPUs without AVX2 (pre 2013 Intel, pre Excavator AMD) get no usable signal from the desktop installers: the app starts, runs the database migration, then dies with a bare ``Illegal instruction (core dumped)``, because the bundled PyTorch binaries assume AVX2. Reported in #802 on an Intel i5-3210M (Ivy Bridge, 2012).

This adds the missing information in two places: a Requirements table at the top of the README covering OS, CPU and Python per install method, and a startup check in the AppImage entrypoint that names the cause and points at the source install before the crash happens.

---

## Type of Change

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [x] Build / Packaging change
- [ ] Bug fix
- [x] Documentation

---

## Changes (by file)
- `README.rst`: new Requirements section with a per install method table (operating system, CPU, Python). Documents the AVX2 requirement for the desktop installers, and that the PyPI / source install does not need it. Corrects the macOS entry to Apple Silicon only, since the Intel DMG job is `continue-on-error` and its artifact is never staged into the release (`publish.yml:187`, `publish.yml:300-342`). Adds a note in the installers section about the `Illegal instruction` crash.
- `appimage/entrypoint.sh`: AVX2 check before the `exec`, placed after the terminal relaunch so the message is visible in the log window. Prints the reason and the `uv sync --extra cpu` workaround.

---

## Testing
The check is advisory and gated on three conditions, so it should stay silent on normal hardware:

    $ grep -c avx2 /proc/cpuinfo     # non zero on any 2013+ CPU, no warning expected

To see the warning path on a machine that does have AVX2, force the branch by pointing the grep at an empty file, or run under a QEMU guest with `-cpu qemu64` (this is not recommended given qemu64 is a generic cpu that is in fact really slow, so setting up dashAI would take a lot of time and effort, pointing to an empty file is recommended given this case).

---

## Notes
- The check never exits: it only prints to stderr and continues. A missing CPUID bit can also come from a VM that masks it while AVX2 still works, and blocking a working install is worse than an occasional false warning. The message says so explicitly.
- Guards: only runs on `x86_64` (ARM has no `avx2` flag and would always warn), only when `/proc/cpuinfo` is readable, and matches `\bavx2\b` so substrings do not produce a false pass.