### PR TITLE
Add prepared prediction methods and refactor sklearn model integration

### DIFF
--- a/DashAI/back/explainability/explainers/contrastive_shap.py
+++ b/DashAI/back/explainability/explainers/contrastive_shap.py
@@ -241,8 +241,9 @@ class ContrastiveShap(BaseLocalExplainer):
         from DashAI.back.explainability.model_input import prepare_model_input
 
         x, y = background_dataset
-        # SHAP calls the model with perturbed frames, which skip the model
-        # preparation, so the background must be in the model feature space.
+        # SHAP calls the model with perturbed matrices, so the background must
+        # be in the model feature space and the model must be queried through
+        # predict_prepared.
         x_train = prepare_model_input(self.model, x["train"])
         y_train = y["train"]
 
@@ -254,7 +255,7 @@ class ContrastiveShap(BaseLocalExplainer):
             background_data = shap.sample(background_data, n_samples)
 
         self.explainer = shap.KernelExplainer(
-            model=self.model.predict,
+            model=self.model.predict_prepared,
             data=background_data,
             feature_names=feature_names,
         )

--- a/DashAI/back/explainability/explainers/dice_counterfactual.py
+++ b/DashAI/back/explainability/explainers/dice_counterfactual.py
@@ -127,7 +127,9 @@ class _SklearnProbaShim:
 
     DashAI classifiers override ``predict`` to return probabilities; DiCE
     expects ``predict`` to return class labels and ``predict_proba`` to
-    return probabilities.
+    return probabilities. DiCE queries with frames that are already in the
+    model feature space, so the model is reached through its prepared-matrix
+    hook.
     """
 
     def __init__(self, model):
@@ -135,13 +137,13 @@ class _SklearnProbaShim:
 
     def predict_proba(self, x):
         """Return the class-probability matrix for ``x``."""
-        return self._model.predict_proba(x)
+        return self._model.predict_proba_prepared(x)
 
     def predict(self, x):
         """Return hard class labels derived from the probabilities."""
         import numpy as np
 
-        return np.argmax(self._model.predict_proba(x), axis=1)
+        return np.argmax(self.predict_proba(x), axis=1)
 
 
 class DiceCounterfactual(BaseLocalExplainer):

--- a/DashAI/back/explainability/explainers/kernel_shap.py
+++ b/DashAI/back/explainability/explainers/kernel_shap.py
@@ -338,7 +338,8 @@ class KernelShap(BaseLocalExplainer):
         x, y = background_dataset
 
         # SHAP perturbs the background frame and calls the model with it, so
-        # the background must already be in the model's feature space.
+        # the background must already be in the model's feature space and the
+        # model must be queried through predict_prepared.
         x_train = prepare_model_input(self.model, x["train"])
         y_train = y["train"]
 
@@ -360,12 +361,11 @@ class KernelShap(BaseLocalExplainer):
                 categorical_features,
             )
 
-        # TODO: consider the case where the predictor is not a Sklearn model
         # Lazy import of shap
         import shap
 
         self.explainer = shap.KernelExplainer(
-            model=self.model.predict,
+            model=self.model.predict_prepared,
             data=background_data,
             feature_names=feature_names,
             link=self.link,

--- a/DashAI/back/explainability/explainers/partial_dependence.py
+++ b/DashAI/back/explainability/explainers/partial_dependence.py
@@ -206,13 +206,17 @@ class PartialDependence(BaseGlobalExplainer):
         import numpy as np
         from sklearn.inspection import partial_dependence
 
-        from DashAI.back.explainability.model_input import prepare_model_input
+        from DashAI.back.explainability.model_input import (
+            as_sklearn_estimator,
+            prepare_model_input,
+        )
 
         x, y = dataset
 
-        # scikit-learn's partial_dependence calls the model with plain frames,
-        # bypassing the model preparation, so both splits are moved into the
-        # model feature space here.
+        # scikit-learn's partial_dependence calls the estimator with plain
+        # frames, bypassing the model preparation, so both splits are moved
+        # into the model feature space here and the model is reached through
+        # an adapter over its prepared-matrix hooks.
         x_test_dataset = prepare_model_input(self.model, x["test"])
         x_test = x_test_dataset.to_pandas()
 
@@ -235,9 +239,12 @@ class PartialDependence(BaseGlobalExplainer):
 
         explanation = {"metadata": {"target_names": target_names}}
 
+        # Convert model to a sklearn estimator for compatibility
+        estimator = as_sklearn_estimator(self.model, classes=target_names)
+
         for idx in range(len(features_names)):
             pd = partial_dependence(
-                estimator=self.model,
+                estimator=estimator,
                 X=x_test,
                 features=idx,
                 categorical_features=categorical_features,

--- a/DashAI/back/explainability/explainers/permutation_feature_importance.py
+++ b/DashAI/back/explainability/explainers/permutation_feature_importance.py
@@ -338,16 +338,14 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
         y_array = y_sample.to_numpy().ravel()
         column_names = list(x_sample.columns)
 
-        # Access the underlying sklearn model
-        sklearn_model = self.model
-
         def get_predictions(data):
             """Obtain predicted class probabilities for the given data.
 
             Parameters
             ----------
             data : pandas.DataFrame
-                Input features as a DataFrame with the original column names.
+                Input features as a DataFrame with the original column names,
+                already in the model feature space.
 
             Returns
             -------
@@ -356,7 +354,7 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
                 probabilities for each class.
             """
             # Keep as DataFrame to preserve column names
-            return sklearn_model.predict_proba(data)
+            return self.model.predict_proba_prepared(data)
 
         def calc_score(y_true, y_pred_probas):
             """Compute the scoring metric from probability predictions.
@@ -442,12 +440,15 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
         from sklearn.metrics import make_scorer
         from sklearn.preprocessing import LabelEncoder
 
-        from DashAI.back.explainability.model_input import prepare_model_input
+        from DashAI.back.explainability.model_input import (
+            as_sklearn_estimator,
+            prepare_model_input,
+        )
 
         x, y = dataset
 
-        # permutation_importance permutes the frame and calls the model with
-        # it, bypassing the model preparation.
+        # permutation_importance permutes the frame and calls the estimator
+        # with it, bypassing the model preparation.
         x_test = prepare_model_input(self.model, x["test"])
         y_test = y["test"]
 
@@ -510,7 +511,9 @@ class PermutationFeatureImportance(BaseGlobalExplainer):
                 return self.scoring(y_true, np.argmax(y_pred_probas, axis=1))
 
             pfi = permutation_importance(
-                estimator=self.model,
+                estimator=as_sklearn_estimator(
+                    self.model, classes=np.unique(y_df.to_numpy().ravel())
+                ),
                 X=X_df,
                 y=y_df,
                 scoring=make_scorer(patched_metric),

--- a/DashAI/back/explainability/explainers/regression_kernel_shap.py
+++ b/DashAI/back/explainability/explainers/regression_kernel_shap.py
@@ -182,8 +182,9 @@ class RegressionKernelShap(BaseLocalExplainer):
         from DashAI.back.explainability.model_input import prepare_model_input
 
         x, y = background_dataset
-        # SHAP calls the model with perturbed frames, which skip the model
-        # preparation, so the background must be in the model feature space.
+        # SHAP calls the model with perturbed matrices, so the background must
+        # be in the model feature space and the model must be queried through
+        # predict_prepared.
         x_train = prepare_model_input(self.model, x["train"])
         y_train = y["train"]
 
@@ -195,7 +196,7 @@ class RegressionKernelShap(BaseLocalExplainer):
             background_data = shap.sample(background_data, n_samples)
 
         self.explainer = shap.KernelExplainer(
-            model=self.model.predict,
+            model=self.model.predict_prepared,
             data=background_data,
             feature_names=feature_names,
         )

--- a/DashAI/back/explainability/explainers/regression_partial_dependence.py
+++ b/DashAI/back/explainability/explainers/regression_partial_dependence.py
@@ -175,8 +175,8 @@ class RegressionPartialDependence(BaseGlobalExplainer):
         from DashAI.back.explainability.model_input import prepare_model_input
 
         x, y = dataset
-        # The grid frames are passed straight to the model, bypassing the
-        # model preparation.
+        # The grid frames are already in the model feature space, so the model
+        # is queried through predict_prepared to skip a second preparation.
         x_test = prepare_model_input(self.model, x["test"]).to_pandas()
 
         # Cap rows to bound the number of model evaluations.
@@ -200,7 +200,7 @@ class RegressionPartialDependence(BaseGlobalExplainer):
             frame = x_test.copy()
             for grid_value in grid:
                 frame[column] = grid_value
-                predictions = np.asarray(self.model.predict(frame)).ravel()
+                predictions = np.asarray(self.model.predict_prepared(frame)).ravel()
                 averages.append(float(np.round(np.mean(predictions), 4)))
 
             explanation[column] = {

--- a/DashAI/back/explainability/explainers/regression_permutation_feature_importance.py
+++ b/DashAI/back/explainability/explainers/regression_permutation_feature_importance.py
@@ -248,8 +248,9 @@ class RegressionPermutationFeatureImportance(BaseGlobalExplainer):
         from DashAI.back.explainability.model_input import prepare_model_input
 
         x, y = dataset
-        # The permuted frames are passed straight to the model, bypassing the
-        # model preparation.
+        # The permuted frames are already in the model feature space, so the
+        # model is queried through predict_prepared to skip a second
+        # preparation.
         x_test = prepare_model_input(self.model, x["test"]).to_pandas()
         y_test = y["test"].to_pandas().to_numpy().ravel()
 
@@ -260,7 +261,7 @@ class RegressionPermutationFeatureImportance(BaseGlobalExplainer):
         y_sample = y_test[sample_indexes]
 
         baseline_score = self.scoring(
-            y_sample, np.asarray(self.model.predict(x_sample)).ravel()
+            y_sample, np.asarray(self.model.predict_prepared(x_sample)).ravel()
         )
 
         results = {"features": [], "importances_mean": [], "importances_std": []}
@@ -272,7 +273,8 @@ class RegressionPermutationFeatureImportance(BaseGlobalExplainer):
                     rng.permutation(n_samples)
                 ]
                 permuted_score = self.scoring(
-                    y_sample, np.asarray(self.model.predict(x_permuted)).ravel()
+                    y_sample,
+                    np.asarray(self.model.predict_prepared(x_permuted)).ravel(),
                 )
                 importances.append(baseline_score - permuted_score)
 

--- a/DashAI/back/explainability/model_input.py
+++ b/DashAI/back/explainability/model_input.py
@@ -11,10 +11,13 @@ to a third party library (SHAP, DiCE, scikit-learn inspection) must work in
 the model's own feature space, because those libraries call the model with
 plain frames that bypass the model preparation. Such explainers call
 :func:`prepare_model_input` on both the background data and the instances so
-that both live in the same space.
+that both live in the same space, and must query the model through
+``model.predict_prepared`` / ``model.predict_proba_prepared`` (or wrap it with
+:func:`as_sklearn_estimator`) instead of ``model.predict``, which would prepare
+the already prepared matrix a second time.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, List, Optional
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -40,3 +43,58 @@ def prepare_model_input(model: Any, dataset: "DashAIDataset") -> "DashAIDataset"
     if prepare is None:
         return dataset
     return prepare(dataset, is_fit=False)
+
+
+def as_sklearn_estimator(model: Any, classes: Optional[List[Any]] = None) -> Any:
+    """Wrap a model so scikit-learn inspection tools can query it.
+
+    ``sklearn.inspection`` utilities (``partial_dependence``,
+    ``permutation_importance``) call ``estimator.predict`` /
+    ``estimator.predict_proba`` with plain feature matrices. Passing a DashAI
+    model directly only works when the model happens to be a scikit-learn
+    estimator; this adapter routes those calls to the prepared-matrix hooks
+    instead, so any model family works.
+
+    Parameters
+    ----------
+    model : Any
+        The DashAI classification model being explained.
+    classes : list, optional
+        Class labels of the model, exposed as ``classes_``. Defaults to the
+        model's own ``classes_`` when available.
+
+    Returns
+    -------
+    Any
+        A fitted-looking scikit-learn classifier delegating to ``model``.
+    """
+    import numpy as np
+    from sklearn.base import BaseEstimator, ClassifierMixin
+
+    class _PreparedClassifier(ClassifierMixin, BaseEstimator):
+        """Scikit-learn facade over a DashAI model's prepared-matrix hooks."""
+
+        def __init__(self, wrapped, classes_):
+            self._wrapped = wrapped
+            self.classes_ = classes_
+
+        def __sklearn_is_fitted__(self) -> bool:
+            """Report the estimator as fitted; the wrapped model is trained."""
+            return True
+
+        def fit(self, x, y=None):
+            """No-op; the wrapped model is already trained."""
+            return self
+
+        def predict(self, x):
+            """Delegate to the wrapped model's ``predict_prepared``."""
+            return model.predict_prepared(x)
+
+        def predict_proba(self, x):
+            """Delegate to the wrapped model's ``predict_proba_prepared``."""
+            return model.predict_proba_prepared(x)
+
+    known_classes = classes if classes is not None else getattr(model, "classes_", None)
+    if known_classes is None:
+        known_classes = []
+    return _PreparedClassifier(model, np.asarray(known_classes))

--- a/DashAI/back/models/base_model.py
+++ b/DashAI/back/models/base_model.py
@@ -322,6 +322,70 @@ class BaseModel(ConfigObject, metaclass=ABCMeta):
         """
         return dataset
 
+    def predict_prepared(self, features: Any) -> Any:
+        """Predict from data that is already in this model's feature space.
+
+        ``predict`` takes a ``DashAIDataset`` with the raw columns and runs
+        ``prepare_dataset`` itself. Explainers that perturb the feature matrix
+        (SHAP, partial dependence, permutation importance, DiCE) instead hold a
+        frame that ``prepare_dataset`` already produced, and must not have it
+        prepared a second time. They call this method.
+
+        Subclasses that can consume a feature matrix must override it, and
+        should implement ``predict`` as
+        ``self.predict_prepared(self.prepare_dataset(x, is_fit=False).to_pandas())``
+        so both paths share the same estimator call.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as returned by ``prepare_dataset(..., is_fit=False)``.
+            No further preparation is applied to it.
+
+        Returns
+        -------
+        Any
+            The same kind of output as ``predict``: predicted values for
+            regressors, class probabilities for DashAI classifiers.
+
+        Raises
+        ------
+        NotImplementedError
+            If the model cannot consume a raw feature matrix.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support prediction from a prepared "
+            "feature matrix, so explainers that perturb the model input are not "
+            "available for it."
+        )
+
+    def predict_proba_prepared(self, features: Any) -> Any:
+        """Return class probabilities for data already in the feature space.
+
+        Classification counterpart of ``predict_prepared``, for explainers that
+        need the sklearn-native ``predict_proba`` semantics.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as returned by ``prepare_dataset(..., is_fit=False)``.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape ``(n_samples, n_classes)`` with class probabilities.
+
+        Raises
+        ------
+        NotImplementedError
+            If the model cannot consume a raw feature matrix.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support probability prediction from "
+            "a prepared feature matrix, so explainers that perturb the model "
+            "input are not available for it."
+        )
+
     def prepare_output(
         self, dataset: "DashAIDataset", is_fit: bool = False
     ) -> "DashAIDataset":

--- a/DashAI/back/models/scikit_learn/linear_svc_classifier.py
+++ b/DashAI/back/models/scikit_learn/linear_svc_classifier.py
@@ -343,7 +343,7 @@ class LinearSVCClassifier(
 
         Parameters
         ----------
-        x_pred : DashAIDataset or pd.DataFrame
+        x_pred : DashAIDataset
             Input data.
 
         Returns
@@ -351,19 +351,28 @@ class LinearSVCClassifier(
         np.ndarray
             Class probability matrix.
         """
-        import pandas as pd
+        return self.predict_prepared(
+            self.prepare_dataset(x_pred, is_fit=False).to_pandas()
+        )
 
-        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+    def predict_proba_prepared(self, features) -> "ndarray":  # noqa: F821
+        """Return class probabilities for an already prepared feature matrix.
 
-        if isinstance(x_pred, DashAIDataset):
-            try:
-                x_prepared = self.prepare_dataset(x_pred, is_fit=False)
-            except ValueError:
-                x_prepared = x_pred
-            x_pred = x_prepared.to_pandas()
-        elif isinstance(x_pred, pd.DataFrame):
-            pass
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
 
+        Returns
+        -------
+        np.ndarray
+            Class probability matrix.
+
+        Raises
+        ------
+        NotFittedError
+            If the calibrated classifier has not been trained yet.
+        """
         from sklearn.exceptions import NotFittedError
 
         if self._calibrated is None:
@@ -371,4 +380,4 @@ class LinearSVCClassifier(
                 f"This {self.__class__.__name__} instance is not fitted yet. "
                 "Call 'train' with appropriate arguments before using this estimator."
             )
-        return self._calibrated.predict_proba(x_pred)
+        return self._calibrated.predict_proba(features)

--- a/DashAI/back/models/scikit_learn/mlp_regression.py
+++ b/DashAI/back/models/scikit_learn/mlp_regression.py
@@ -557,10 +557,26 @@ class MLPRegression(CategoricalEncoderMixin, RegressionModel):
         ndarray
             Predicted continuous values as a 1-D NumPy array.
         """
+        return self.predict_prepared(self.prepare_dataset(x, is_fit=False).to_pandas())
+
+    def predict_prepared(self, features) -> "ndarray":
+        """Predict from a feature matrix already in the model's feature space.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
+
+        Returns
+        -------
+        ndarray
+            Predicted continuous values as a 1-D NumPy array.
+        """
+        import numpy as np
         import torch
 
         self.model.eval()
-        x_proc = self.prepare_dataset(x, is_fit=False).to_pandas().values
+        x_proc = np.asarray(getattr(features, "values", features), dtype="float32")
         x_tensor = torch.tensor(x_proc, dtype=torch.float32).to(self.device)
         with torch.no_grad():
             return self.model(x_tensor).cpu().numpy().flatten()

--- a/DashAI/back/models/scikit_learn/sgd_classifier.py
+++ b/DashAI/back/models/scikit_learn/sgd_classifier.py
@@ -373,7 +373,7 @@ class SGDClassifier(TabularClassificationModel, SklearnLikeClassifier, _SGDClass
 
         Parameters
         ----------
-        x_pred : DashAIDataset or pd.DataFrame
+        x_pred : DashAIDataset
             Input data.
 
         Returns
@@ -381,19 +381,28 @@ class SGDClassifier(TabularClassificationModel, SklearnLikeClassifier, _SGDClass
         np.ndarray
             Class probability matrix.
         """
-        import pandas as pd
+        return self.predict_prepared(
+            self.prepare_dataset(x_pred, is_fit=False).to_pandas()
+        )
 
-        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+    def predict_proba_prepared(self, features) -> "ndarray":  # noqa: F821
+        """Return class probabilities for an already prepared feature matrix.
 
-        if isinstance(x_pred, DashAIDataset):
-            try:
-                x_prepared = self.prepare_dataset(x_pred, is_fit=False)
-            except ValueError:
-                x_prepared = x_pred
-            x_pred = x_prepared.to_pandas()
-        elif isinstance(x_pred, pd.DataFrame):
-            pass
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
 
+        Returns
+        -------
+        np.ndarray
+            Class probability matrix.
+
+        Raises
+        ------
+        NotFittedError
+            If the calibrated classifier has not been trained yet.
+        """
         from sklearn.exceptions import NotFittedError
 
         if self._calibrated is None:
@@ -401,4 +410,4 @@ class SGDClassifier(TabularClassificationModel, SklearnLikeClassifier, _SGDClass
                 f"This {self.__class__.__name__} instance is not fitted yet. "
                 "Call 'train' with appropriate arguments before using this estimator."
             )
-        return self._calibrated.predict_proba(x_pred)
+        return self._calibrated.predict_proba(features)

--- a/DashAI/back/models/scikit_learn/sklearn_like_classifier.py
+++ b/DashAI/back/models/scikit_learn/sklearn_like_classifier.py
@@ -37,14 +37,39 @@ class SklearnLikeClassifier(SklearnLikeModel):
         np.ndarray
             Array with the predicted target values for x_pred
         """
-        import pandas as pd
+        return self.predict_prepared(
+            self.prepare_dataset(x_pred, is_fit=False).to_pandas()
+        )
 
-        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+    def predict_prepared(self, features) -> "ndarray":
+        """Predict from a feature matrix already in the model's feature space.
 
-        if isinstance(x_pred, DashAIDataset):
-            x_prepared = self.prepare_dataset(x_pred, is_fit=False)
-            x_pred = x_prepared.to_pandas()
-        elif isinstance(x_pred, pd.DataFrame):
-            pass
+        DashAI classifiers return probabilities from ``predict``, so this
+        delegates to ``predict_proba_prepared``.
 
-        return super().predict_proba(x_pred)
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
+
+        Returns
+        -------
+        np.ndarray
+            Class probability matrix.
+        """
+        return self.predict_proba_prepared(features)
+
+    def predict_proba_prepared(self, features) -> "ndarray":
+        """Return class probabilities for an already prepared feature matrix.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
+
+        Returns
+        -------
+        np.ndarray
+            Class probability matrix.
+        """
+        return super().predict_proba(features)

--- a/DashAI/back/models/scikit_learn/sklearn_like_model.py
+++ b/DashAI/back/models/scikit_learn/sklearn_like_model.py
@@ -94,8 +94,19 @@ class SklearnLikeModel(CategoricalEncoderMixin, BaseModel):
         np.ndarray
             Predicted values.
         """
-        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+        return self.predict_prepared(self.prepare_dataset(x, is_fit=False).to_pandas())
 
-        if isinstance(x, DashAIDataset):
-            x = self.prepare_dataset(x, is_fit=False).to_pandas()
-        return super().predict(x)
+    def predict_prepared(self, features):
+        """Predict from a feature matrix already in the model's feature space.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
+
+        Returns
+        -------
+        np.ndarray
+            Predicted values.
+        """
+        return super().predict(features)

--- a/DashAI/back/models/scikit_learn/sklearn_like_regressor.py
+++ b/DashAI/back/models/scikit_learn/sklearn_like_regressor.py
@@ -1,47 +1,13 @@
-from typing import TYPE_CHECKING
-
 from DashAI.back.models.scikit_learn.sklearn_like_model import SklearnLikeModel
-
-if TYPE_CHECKING:
-    from numpy import ndarray
-
-    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
 
 class SklearnLikeRegressor(SklearnLikeModel):
     """Abstract mixin for scikit-learn-style regression models.
 
-    Extends ``SklearnLikeModel`` with a ``predict`` method that converts a
-    ``DashAIDataset`` into a NumPy array, calls the wrapped sklearn estimator's
-    ``predict``, and returns the continuous output values.  Concrete regressor
-    wrappers (e.g. ``LinearRegression``, ``RandomForestRegressor``) inherit
-    from this class and from a ``BaseSchema`` subclass.
+    Inherits the prediction pipeline from ``SklearnLikeModel``: ``predict``
+    prepares a ``DashAIDataset`` and forwards the resulting feature matrix to
+    ``predict_prepared``, which calls the wrapped sklearn estimator's
+    ``predict``.  Concrete regressor wrappers (e.g. ``LinearRegression``,
+    ``RandomForestRegressor``) inherit from this class and from a
+    ``BaseSchema`` subclass.
     """
-
-    def predict(self, x_pred: "DashAIDataset") -> "ndarray":
-        """Make a prediction with the model.
-
-        Parameters
-        ----------
-        x_pred : DashAIDataset
-            Dataset with the input data columns.
-
-        Returns
-        -------
-        np.ndarray
-            Array with the predicted target values for x_pred
-        """
-        import pandas as pd
-
-        from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
-
-        if isinstance(x_pred, DashAIDataset):
-            try:
-                x_prepared = self.prepare_dataset(x_pred, is_fit=False)
-            except ValueError:
-                x_prepared = x_pred
-            x_pred = x_prepared.to_pandas()
-        elif isinstance(x_pred, pd.DataFrame):
-            pass
-
-        return super().predict(x_pred)

--- a/tests/back/explainers/test_non_sklearn_explainers.py
+++ b/tests/back/explainers/test_non_sklearn_explainers.py
@@ -1,0 +1,637 @@
+"""Explainer tests against models that are not scikit-learn wrappers.
+
+Explainers that perturb the feature matrix (SHAP, partial dependence,
+permutation importance) hold data that ``prepare_dataset`` already produced, so
+they query the model through ``predict_prepared`` / ``predict_proba_prepared``
+instead of ``predict``, which would prepare it a second time. Before that hook
+existed, only the scikit-learn wrappers survived those calls, because their
+``predict`` forwarded anything that was not a ``DashAIDataset`` straight to the
+estimator.
+
+The two models below implement that contract with no scikit-learn estimator
+involved: a least-squares regressor and a nearest-centroid classifier, both over
+plain NumPy, sharing the categorical-encoding mixin with the torch MLP models.
+``UnsupportedRegressor`` implements no hook at all and must fail with a clear
+error instead of an ``AttributeError`` from deep inside the preparation code.
+"""
+
+import copy
+import pickle
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from DashAI.back.dataloaders.classes.csv_dataloader import CSVDataLoader
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    DashAIDataset,
+    select_columns,
+    split_dataset,
+    split_indexes,
+)
+from DashAI.back.explainability.explainers.kernel_shap import KernelShap
+from DashAI.back.explainability.explainers.partial_dependence import PartialDependence
+from DashAI.back.explainability.explainers.permutation_feature_importance import (
+    PermutationFeatureImportance,
+)
+from DashAI.back.explainability.explainers.regression_kernel_shap import (
+    RegressionKernelShap,
+)
+from DashAI.back.explainability.explainers.regression_partial_dependence import (
+    RegressionPartialDependence,
+)
+from DashAI.back.explainability.explainers.regression_permutation_feature_importance import (  # noqa: E501
+    RegressionPermutationFeatureImportance,
+)
+from DashAI.back.models.categorical_encoder_mixin import CategoricalEncoderMixin
+from DashAI.back.models.regression_model import RegressionModel
+from DashAI.back.models.tabular_classification_model import TabularClassificationModel
+from DashAI.back.types.categorical import Categorical
+from DashAI.back.types.utils import save_types_in_arrow_metadata
+from DashAI.back.types.value_types import Float
+
+INPUT_COLUMNS = [
+    "SepalLengthCm",
+    "SepalWidthCm",
+    "PetalLengthCm",
+    "Species",
+]
+OUTPUT_COLUMNS = ["PetalWidthCm"]
+SPECIES = [
+    "Iris-setosa",
+    "Iris-versicolor",
+    "Iris-virginica",
+]
+
+
+class DummyLinearRegressor(CategoricalEncoderMixin, RegressionModel):
+    """Least-squares regressor implemented with NumPy only.
+
+    Stands in for the non scikit-learn model families (torch MLP, PyMC BART,
+    plugins): ``predict`` receives a ``DashAIDataset`` and runs the model
+    preparation itself, without a type check.
+    """
+
+    def __init__(self):
+        """Initialise the encoder state and the (unfitted) coefficients."""
+        self._setup_categorical_encoders()
+        self.coefficients = None
+        self.intercept = 0.0
+
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
+        """Fit the coefficients by ordinary least squares.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            Input features for training.
+        y_train : DashAIDataset
+            Target values for training.
+        x_validation : DashAIDataset, optional
+            Unused. Defaults to None.
+        y_validation : DashAIDataset, optional
+            Unused. Defaults to None.
+
+        Returns
+        -------
+        DummyLinearRegressor
+            The fitted model (``self``).
+        """
+        x = self.prepare_dataset(x_train, is_fit=True).to_pandas().values.astype(float)
+        y = (
+            self.prepare_output(y_train, is_fit=True)
+            .to_pandas()
+            .values.astype(float)
+            .ravel()
+        )
+
+        design = np.column_stack([x, np.ones(len(x))])
+        solution, *_ = np.linalg.lstsq(design, y, rcond=None)
+        self.coefficients = solution[:-1]
+        self.intercept = float(solution[-1])
+        return self
+
+    def predict(self, x: "DashAIDataset") -> np.ndarray:
+        """Predict target values for the input dataset.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            Input features, before the model preparation.
+
+        Returns
+        -------
+        np.ndarray
+            Predicted values as a 1-D array.
+        """
+        return self.predict_prepared(self.prepare_dataset(x, is_fit=False).to_pandas())
+
+    def predict_prepared(self, features) -> np.ndarray:
+        """Predict from a feature matrix already in the model feature space.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
+
+        Returns
+        -------
+        np.ndarray
+            Predicted values as a 1-D array.
+        """
+        matrix = np.asarray(getattr(features, "values", features), dtype=float)
+        return matrix @ self.coefficients + self.intercept
+
+    def save(self, filename: str) -> None:
+        """Persist the fitted state to disk.
+
+        Parameters
+        ----------
+        filename : str
+            Destination path.
+        """
+        with open(filename, "wb") as file:
+            pickle.dump(
+                {
+                    "coefficients": self.coefficients,
+                    "intercept": self.intercept,
+                    "encodings": self.encodings,
+                    "one_hot_encoder": self.one_hot_encoder,
+                    "categorical_columns": self.categorical_columns,
+                },
+                file,
+            )
+
+    def load(self, filename: str):
+        """Restore the fitted state from disk.
+
+        Parameters
+        ----------
+        filename : str
+            Path written by :meth:`save`.
+
+        Returns
+        -------
+        DummyLinearRegressor
+            The restored model (``self``).
+        """
+        with open(filename, "rb") as file:
+            state = pickle.load(file)
+        self.coefficients = state["coefficients"]
+        self.intercept = state["intercept"]
+        self.encodings = state["encodings"]
+        self.one_hot_encoder = state["one_hot_encoder"]
+        self.categorical_columns = state["categorical_columns"]
+        return self
+
+
+class DummyCentroidClassifier(CategoricalEncoderMixin, TabularClassificationModel):
+    """Nearest-centroid classifier implemented with NumPy only.
+
+    Stands in for a non scikit-learn tabular classifier: ``predict`` returns
+    the class-probability matrix, as every DashAI classifier does.
+    """
+
+    def __init__(self):
+        """Initialise the encoder state and the (unfitted) centroids."""
+        self._setup_categorical_encoders()
+        self.centroids = None
+        self.classes_ = None
+
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
+        """Fit one centroid per class.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            Input features for training.
+        y_train : DashAIDataset
+            Target labels for training.
+        x_validation : DashAIDataset, optional
+            Unused. Defaults to None.
+        y_validation : DashAIDataset, optional
+            Unused. Defaults to None.
+
+        Returns
+        -------
+        DummyCentroidClassifier
+            The fitted model (``self``).
+        """
+        x = self.prepare_dataset(x_train, is_fit=True).to_pandas().values.astype(float)
+        y = (
+            self.prepare_output(y_train, is_fit=True)
+            .to_pandas()
+            .values.ravel()
+            .astype(int)
+        )
+
+        self.classes_ = np.unique(y)
+        self.centroids = np.vstack(
+            [x[y == label].mean(axis=0) for label in self.classes_]
+        )
+        return self
+
+    def predict(self, x_pred: "DashAIDataset") -> np.ndarray:
+        """Return the class-probability matrix for the input dataset.
+
+        Parameters
+        ----------
+        x_pred : DashAIDataset
+            Input features, before the model preparation.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape ``(n_samples, n_classes)``.
+        """
+        return self.predict_prepared(
+            self.prepare_dataset(x_pred, is_fit=False).to_pandas()
+        )
+
+    def predict_prepared(self, features) -> np.ndarray:
+        """Return probabilities for an already prepared feature matrix.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape ``(n_samples, n_classes)``.
+        """
+        return self.predict_proba_prepared(features)
+
+    def predict_proba_prepared(self, features) -> np.ndarray:
+        """Softmax over the negative distance to each class centroid.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame or numpy.ndarray
+            Feature matrix as produced by ``prepare_dataset``.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape ``(n_samples, n_classes)``.
+        """
+        matrix = np.asarray(getattr(features, "values", features), dtype=float)
+        distances = np.linalg.norm(
+            matrix[:, None, :] - self.centroids[None, :, :], axis=2
+        )
+        scores = -distances
+        scores = scores - scores.max(axis=1, keepdims=True)
+        exponentials = np.exp(scores)
+        return exponentials / exponentials.sum(axis=1, keepdims=True)
+
+    def save(self, filename: str) -> None:
+        """Persist the fitted state to disk.
+
+        Parameters
+        ----------
+        filename : str
+            Destination path.
+        """
+        with open(filename, "wb") as file:
+            pickle.dump({"centroids": self.centroids, "classes": self.classes_}, file)
+
+    def load(self, filename: str):
+        """Restore the fitted state from disk.
+
+        Parameters
+        ----------
+        filename : str
+            Path written by :meth:`save`.
+
+        Returns
+        -------
+        DummyCentroidClassifier
+            The restored model (``self``).
+        """
+        with open(filename, "rb") as file:
+            state = pickle.load(file)
+        self.centroids = state["centroids"]
+        self.classes_ = state["classes"]
+        return self
+
+
+class UnsupportedRegressor(RegressionModel):
+    """Model that does not implement the prepared-feature-matrix contract."""
+
+    def train(self, x_train, y_train, x_validation=None, y_validation=None):
+        """Pretend to train.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            Unused.
+        y_train : DashAIDataset
+            Unused.
+        x_validation : DashAIDataset, optional
+            Unused. Defaults to None.
+        y_validation : DashAIDataset, optional
+            Unused. Defaults to None.
+
+        Returns
+        -------
+        UnsupportedRegressor
+            ``self``.
+        """
+        return self
+
+    def predict(self, x):
+        """Predict a constant value per row.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            Input features.
+
+        Returns
+        -------
+        np.ndarray
+            Array of zeros.
+        """
+        return np.zeros(x.num_rows)
+
+    def save(self, filename: str) -> None:
+        """Do nothing.
+
+        Parameters
+        ----------
+        filename : str
+            Unused.
+        """
+
+    def load(self, filename: str):
+        """Do nothing.
+
+        Parameters
+        ----------
+        filename : str
+            Unused.
+
+        Returns
+        -------
+        UnsupportedRegressor
+            ``self``.
+        """
+        return self
+
+
+def _load_iris_dataset():
+    """Load iris with DashAI types and return it as a single DashAIDataset."""
+    dataloader = CSVDataLoader()
+    datasetdict = dataloader.load_data(
+        filepath_or_buffer="tests/back/explainers/iris.csv",
+        temp_path="tests/back/explainers",
+        params={
+            "separator": ",",
+            "schema": {
+                "SepalLengthCm": {"type": "Float", "dtype": "float64"},
+                "SepalWidthCm": {"type": "Float", "dtype": "float64"},
+                "PetalLengthCm": {"type": "Float", "dtype": "float64"},
+                "PetalWidthCm": {"type": "Float", "dtype": "float64"},
+                "Species": {"type": "Categorical", "dtype": "string"},
+            },
+        },
+    )
+    datasetdict.types = {
+        "SepalLengthCm": Float(arrow_type=pa.float64()),
+        "SepalWidthCm": Float(arrow_type=pa.float64()),
+        "PetalLengthCm": Float(arrow_type=pa.float64()),
+        "PetalWidthCm": Float(arrow_type=pa.float64()),
+        "Species": Categorical(values=SPECIES),
+    }
+
+    new_table = save_types_in_arrow_metadata(
+        datasetdict.arrow_table,
+        {col: dtype.to_string() for col, dtype in datasetdict.types.items()},
+    )
+    datasetdict = DashAIDataset(
+        new_table, splits=datasetdict.splits, types=datasetdict.types
+    )
+
+    train_indexes, test_indexes, val_indexes = split_indexes(
+        total_rows=datasetdict.num_rows, train_size=0.7, test_size=0.1, val_size=0.2
+    )
+    split_dataset_dict = split_dataset(
+        datasetdict,
+        train_indexes=train_indexes,
+        test_indexes=test_indexes,
+        val_indexes=val_indexes,
+    )
+
+    return split_dataset_dict
+
+
+def _split_columns(split_dataset_dict, input_columns, output_columns):
+    """Select the input/output columns and re-split both sides."""
+    x, y = select_columns(split_dataset_dict, input_columns, output_columns)
+    return split_dataset(x), split_dataset(y)
+
+
+@pytest.fixture(scope="module", name="dataset")
+def regression_dataset_fixture():
+    """Iris as a regression dataset, with one categorical input feature."""
+    return _split_columns(_load_iris_dataset(), INPUT_COLUMNS, OUTPUT_COLUMNS)
+
+
+@pytest.fixture(scope="module", name="classification_dataset")
+def classification_dataset_fixture():
+    """Iris as a classification dataset: numeric features, Species target."""
+    return _split_columns(
+        _load_iris_dataset(),
+        ["SepalLengthCm", "SepalWidthCm", "PetalLengthCm", "PetalWidthCm"],
+        ["Species"],
+    )
+
+
+@pytest.fixture(scope="module", name="trained_model")
+def trained_model_fixture(dataset):
+    """Train the dummy non scikit-learn regressor."""
+    x, y = dataset
+    model = DummyLinearRegressor()
+    model.train(x["train"], y["train"])
+    return model
+
+
+@pytest.fixture(scope="module", name="trained_classifier")
+def trained_classifier_fixture(classification_dataset):
+    """Train the dummy non scikit-learn classifier."""
+    x, y = classification_dataset
+    model = DummyCentroidClassifier()
+    model.train(x["train"], y["train"])
+    return model
+
+
+def test_dummy_model_predicts_from_dashai_dataset(trained_model, dataset):
+    """The model itself works through the regular DashAIDataset path."""
+    x, y = dataset
+    predictions = np.asarray(trained_model.predict(x["test"])).ravel()
+
+    assert predictions.shape == (x["test"].num_rows,)
+    assert np.isfinite(predictions).all()
+
+    targets = y["test"].to_pandas().to_numpy().ravel()
+    # Petal width is well explained by the other iris columns.
+    assert np.corrcoef(predictions, targets)[0, 1] > 0.8
+
+
+def test_regression_partial_dependence(trained_model, dataset):
+    """Partial dependence perturbs the feature matrix and calls predict."""
+    explainer = RegressionPartialDependence(
+        trained_model, grid_resolution=5, lower_percentile=0.05, upper_percentile=0.95
+    )
+    explanation = explainer.explain(copy.deepcopy(dataset))
+
+    assert explanation["metadata"]["output_column"] == OUTPUT_COLUMNS[0]
+
+    curves = {key: value for key, value in explanation.items() if key != "metadata"}
+    # The three numeric features, plus the one-hot columns of Species.
+    assert set(curves) >= {"SepalLengthCm", "SepalWidthCm", "PetalLengthCm"}
+    for curve in curves.values():
+        assert len(curve["grid_values"]) == 5
+        assert len(curve["average"]) == 5
+
+
+def test_regression_permutation_feature_importance(trained_model, dataset):
+    """Permutation importance calls predict with permuted frames."""
+    explainer = RegressionPermutationFeatureImportance(
+        trained_model,
+        scoring="r2",
+        n_repeats=2,
+        random_state=0,
+        max_samples_fraction=1.0,
+    )
+    explanation = explainer.explain(copy.deepcopy(dataset))
+
+    assert len(explanation["features"]) == len(explanation["importances_mean"])
+    assert len(explanation["features"]) == len(explanation["importances_std"])
+    assert all(np.isfinite(explanation["importances_mean"]))
+    # Petal length dominates petal width in iris.
+    top_feature = explanation["features"][
+        int(np.argmax(explanation["importances_mean"]))
+    ]
+    assert top_feature == "PetalLengthCm"
+
+
+def test_regression_kernel_shap(trained_model, dataset):
+    """SHAP queries the model with sampled coalitions of the feature matrix."""
+    x, _ = dataset
+
+    explainer = RegressionKernelShap(trained_model)
+    explainer.fit(
+        copy.deepcopy(dataset),
+        sample_background_data=True,
+        background_fraction=0.2,
+    )
+
+    instances = x["test"].select(range(2))
+    explanation = explainer.explain_instance(instances)
+
+    instance_keys = [
+        key for key in explanation if key not in ("metadata", "base_value")
+    ]
+    assert len(instance_keys) == 2
+    for key in instance_keys:
+        instance = explanation[key]
+        contributions = np.asarray(instance["shap_values"])
+        assert np.isfinite(contributions).all()
+        # SHAP is additive: base value plus contributions equals the prediction.
+        assert np.isclose(
+            explanation["base_value"] + contributions.sum(),
+            instance["model_prediction"],
+            atol=0.1,
+        )
+
+
+def test_classifier_predicts_probabilities(trained_classifier, classification_dataset):
+    """The dummy classifier returns a probability matrix, as DashAI expects."""
+    x, _ = classification_dataset
+    probabilities = trained_classifier.predict(x["test"])
+
+    assert probabilities.shape == (x["test"].num_rows, len(SPECIES))
+    assert np.allclose(probabilities.sum(axis=1), 1.0)
+
+
+def test_partial_dependence_classification(trained_classifier, classification_dataset):
+    """sklearn's partial_dependence reaches the model through the adapter."""
+    explainer = PartialDependence(
+        trained_classifier,
+        lower_percentile=0.05,
+        upper_percentile=0.95,
+        grid_resolution=5,
+    )
+    explanation = explainer.explain(copy.deepcopy(classification_dataset))
+
+    assert set(explanation["metadata"]["target_names"]) == set(SPECIES)
+    curves = {key: value for key, value in explanation.items() if key != "metadata"}
+    assert set(curves) == {
+        "SepalLengthCm",
+        "SepalWidthCm",
+        "PetalLengthCm",
+        "PetalWidthCm",
+    }
+    for curve in curves.values():
+        averages = np.asarray(curve["average"])
+        assert len(curve["grid_values"]) > 0
+        # One averaged curve per class, evaluated on the whole grid.
+        assert averages.shape[-1] == len(curve["grid_values"])
+        assert np.isfinite(averages).all()
+
+
+def test_permutation_feature_importance_classification(
+    trained_classifier, classification_dataset
+):
+    """sklearn's permutation_importance reaches the model through the adapter."""
+    explainer = PermutationFeatureImportance(
+        trained_classifier,
+        scoring="accuracy",
+        n_repeats=2,
+        random_state=0,
+        max_samples_fraction=1.0,
+    )
+    explanation = explainer.explain(copy.deepcopy(classification_dataset))
+
+    assert len(explanation["features"]) == 4
+    assert all(np.isfinite(explanation["importances_mean"]))
+    top_feature = explanation["features"][
+        int(np.argmax(explanation["importances_mean"]))
+    ]
+    assert top_feature in ("PetalLengthCm", "PetalWidthCm")
+
+
+def test_kernel_shap_classification(trained_classifier, classification_dataset):
+    """SHAP perturbs the feature matrix of a non scikit-learn classifier."""
+    x, _ = classification_dataset
+
+    explainer = KernelShap(trained_classifier)
+    explainer.fit(
+        copy.deepcopy(classification_dataset),
+        sample_background_data=True,
+        background_fraction=0.2,
+        sampling_method="shuffle",
+    )
+
+    instances = x["test"].select(range(2))
+    explanation = explainer.explain_instance(instances)
+
+    instance_keys = [
+        key for key in explanation if key not in ("metadata", "base_values")
+    ]
+    assert len(instance_keys) == 2
+    for key in instance_keys:
+        contributions = np.asarray(explanation[key]["shap_values"])
+        assert contributions.shape[0] == len(SPECIES)
+        assert np.isfinite(contributions).all()
+
+
+def test_model_without_prepared_hook_reports_clearly(dataset):
+    """A model that cannot take a feature matrix fails with a clear error."""
+    model = UnsupportedRegressor()
+
+    explainer = RegressionPartialDependence(model, grid_resolution=5)
+    with pytest.raises(NotImplementedError, match="prepared feature matrix"):
+        explainer.explain(copy.deepcopy(dataset))


### PR DESCRIPTION
## Summary

Explainers that perturb the model input (SHAP, partial dependence, permutation importance, DiCE) only worked with scikit-learn models. Their `predict` had an `isinstance(x, DashAIDataset)` check that let a raw feature matrix pass straight to the estimator; every other model family applied `prepare_dataset` unconditionally and crashed with `AttributeError: 'DataFrame' object has no attribute 'types'`.

Splits that implicit type dispatch into a named contract: `predict` prepares its input and delegates, `predict_prepared` / `predict_proba_prepared` take a matrix that is already in the model feature space. Models that have no feature matrix (text, image, translation) inherit a default that raises `NotImplementedError` naming the limitation, instead of failing deep inside the encoding code.

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

**Model contract**
- `DashAI/back/models/base_model.py`: add `predict_prepared` and `predict_proba_prepared` methods, both raising `NotImplementedError` by default.
- `DashAI/back/models/scikit_learn/sklearn_like_model.py`: `predict` prepares and delegates; `predict_prepared` calls the estimator. `isinstance` guard removed.
- `DashAI/back/models/scikit_learn/sklearn_like_classifier.py`: same split, plus `predict_proba_prepared` returning the probability matrix.
- `DashAI/back/models/scikit_learn/sklearn_like_regressor.py`: `predict` override deleted, behaviour now inherited.
- `DashAI/back/models/scikit_learn/linear_svc_classifier.py`, `sgd_classifier.py`: calibrated probability path moved into `predict_proba_prepared`; drops the `except ValueError` fallback that hid double preparation.
- `DashAI/back/models/scikit_learn/mlp_regression.py`: torch inference moved into `predict_prepared` (the model in the reported traceback).

**Explainers**
- `DashAI/back/explainability/model_input.py`: add `as_sklearn_estimator`, a fitted-looking sklearn classifier facade delegating to the prepared hooks, for the inspection utilities that require an estimator object.
- `DashAI/back/explainability/explainers/regression_partial_dependence.py`, `regression_permutation_feature_importance.py`, `regression_kernel_shap.py`: query the model through `predict_prepared`.
- `DashAI/back/explainability/explainers/kernel_shap.py`, `contrastive_shap.py`: SHAP callable is now `model.predict_prepared`.
- `DashAI/back/explainability/explainers/dice_counterfactual.py`: proba shim calls `predict_proba_prepared`.
- `DashAI/back/explainability/explainers/permutation_feature_importance.py`: grouped path calls `predict_proba_prepared`, ungrouped path wraps the model with `as_sklearn_estimator`.
- `DashAI/back/explainability/explainers/partial_dependence.py`: passes the adapter to sklearn's `partial_dependence` instead of the model.

**Tests**
- `tests/back/explainers/test_non_sklearn_explainers.py`: new. A least squares regressor and a nearest centroid classifier written with NumPy only, plus a model implementing no prepared hook, exercised through the perturbation based explainers.

---

## Testing

- Reproduce the original failure on `develop`: train an `MLPRegression` on a tabular dataset with a categorical feature and run Partial Dependence (regression) on it. It fails with `AttributeError: 'DataFrame' object has no attribute 'types'`. On this branch it completes.
