### PR TITLE
Fix notebook name counter standardization

### DIFF
--- a/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
+++ b/DashAI/front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx
@@ -59,6 +59,7 @@ export const DatasetsAndNotebooksProvider = ({ children }) => {
     clearSelectedNotebook,
     deleteNotebookById,
     editNotebook,
+    addNotebookOptimistically,
     removeNotebooksByDatasetId,
   } = useNotebooks({ t });
 
@@ -108,6 +109,7 @@ export const DatasetsAndNotebooksProvider = ({ children }) => {
     clearSelectedNotebook,
     deleteNotebookById,
     editNotebook,
+    addNotebookOptimistically,
     removeNotebooksByDatasetId,
     selectedOption,
     setSelectedOption,

--- a/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
@@ -24,7 +24,7 @@ export default function DatasetsCenterContent() {
     selectedNotebookId,
     setRightBarContent,
     step,
-    fetchNotebooks,
+    addNotebookOptimistically,
     selectedOption,
   } = useDatasetsAndNotebooks();
 
@@ -69,8 +69,8 @@ export default function DatasetsCenterContent() {
     [tourContext, navigate],
   );
 
-  const handleNotebookCreated = async (createdNotebook) => {
-    await fetchNotebooks();
+  const handleNotebookCreated = (createdNotebook) => {
+    addNotebookOptimistically(createdNotebook);
     navigate(`/app/data/notebooks/${createdNotebook.id}`);
   };
 

--- a/DashAI/front/src/components/notebooks/notebookCreation/UploadNotebookSteps.jsx
+++ b/DashAI/front/src/components/notebooks/notebookCreation/UploadNotebookSteps.jsx
@@ -8,6 +8,7 @@ import NoteBox from "../NoteBox";
 import { useTourContext } from "../../tour/TourProvider";
 import { useTranslation } from "react-i18next";
 import StepperNavigationFooter from "../../shared/StepperNavigationFooter";
+import { generateSequentialName } from "../../../utils/nameGenerator";
 
 export default function UploadNotebookSteps({
   backHome,
@@ -25,13 +26,11 @@ export default function UploadNotebookSteps({
   const tourContext = useTourContext();
   const { t } = useTranslation(["datasets", "common"]);
 
-  const defaultName = useMemo(() => {
-    const maxId = existingNotebooks.reduce(
-      (max, nb) => Math.max(max, nb.id ?? 0),
-      0,
-    );
-    return `Notebook_${maxId + 1}`;
-  }, [existingNotebooks]);
+  const { defaultName } = useMemo(
+    () =>
+      generateSequentialName({ base: "Notebook", items: existingNotebooks }),
+    [existingNotebooks],
+  );
 
   const lastAutoFilledRef = useRef(null);
 

--- a/DashAI/front/src/hooks/datasets/useNotebooks.js
+++ b/DashAI/front/src/hooks/datasets/useNotebooks.js
@@ -74,6 +74,11 @@ export function useNotebooks({ t }) {
     }
   };
 
+  const addNotebookOptimistically = (notebook) => {
+    setNotebooks((prev) => [...prev, notebook]);
+    setSelectedNotebookId(notebook.id);
+  };
+
   const removeNotebooksByDatasetId = (datasetId) => {
     setNotebooks((prev) => prev.filter((n) => n.dataset_id !== datasetId));
 
@@ -97,6 +102,7 @@ export function useNotebooks({ t }) {
     deleteNotebookById,
     editNotebook,
 
+    addNotebookOptimistically,
     removeNotebooksByDatasetId,
   };
 }


### PR DESCRIPTION
## Summary
Notebook default naming didn't follow the same convention as Datasets and other modules (Explainers, Sessions, Pipelines), causing the auto-generated name to skip numbers whenever custom-named notebooks existed. Fixing this also surfaced a race condition where the name field would briefly flicker to the next number right after saving. Both are fixed here to bring Notebooks in line with the rest of the app.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `front/src/componennotebook to local state synchronously.
- `front/src/components/custom/contexts/DatasetsAndNotebooksContext.jsx`: exposed `addNotebookOptimistically` through the context.
- `front/src/components/notebooks/dataset/DatasetsCenterContent.jsx`: `handleNotebookCreated` now updates state optimistically and navigates immediately, instead of `await`-ing a full `fetchNotebooks()` network refetch before navigating. This removes the async window that caused the name field to briefly flicker to the next number after saving.

---

## Testing (optional)
- Manually created notebooks with and without custom names to confirm the default name now correctly follows the highest existing `Notebook_N` suffix instead of the DB id count.
- Verified the name field no longer flickers to the next number when saving.
