### PR TITLE
fix: add missing timeouts to the PyPI requests in plugins utils

### DIFF
--- a/DashAI/back/plugins/utils.py
+++ b/DashAI/back/plugins/utils.py
@@ -91,7 +91,7 @@ def _get_all_plugins() -> List[str]:
     headers = {"Accept": "application/vnd.pypi.simple.v1+json"}
 
     # Send a GET request to the API
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
 
     # Check for a successful response
     if response.status_code == 200:
@@ -126,7 +126,8 @@ def get_plugin_by_name_from_pypi(plugin_name: str) -> dict:
         When the plugin is not found or the response is invalid
     """
     response: requests.Response = requests.get(
-        f"https://pypi.org/pypi/{plugin_name}/json"
+        f"https://pypi.org/pypi/{plugin_name}/json",
+        timeout=_REQUEST_TIMEOUT_SECONDS,
     )
 
     response_data = response.json()
@@ -189,7 +190,7 @@ def get_plugins_from_pypi() -> List[dict]:
 
             plugin_info = get_plugin_by_name_from_pypi(plugin_name)
             plugins.append(plugin_info)
-        except ValueError as e:
+        except (ValueError, requests.RequestException) as e:
             print(f"Error al obtener información del plugin {plugin_name}: {str(e)}")
             continue
 

--- a/tests/back/plugins/test_plugin_utils.py
+++ b/tests/back/plugins/test_plugin_utils.py
@@ -4,6 +4,7 @@ from typing import Final
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 from DashAI.back.config_object import ConfigObject
 from DashAI.back.dependencies.registry.component_registry import ComponentRegistry
@@ -288,3 +289,55 @@ def test_unregister_plugin_components():
     assert len(registry_components) == 1
     assert "DummyComponent1" not in registry_components
     assert "DummyComponent2" in registry_components
+
+
+def test_get_all_plugins_sets_a_request_timeout():
+    response_mock = Mock()
+    response_mock.status_code = 200
+    response_mock.json.return_value = {"projects": []}
+
+    with patch("requests.get", return_value=response_mock) as get_mock:
+        _get_all_plugins()
+
+    assert get_mock.call_args.kwargs.get("timeout") is not None
+
+
+def test_get_plugin_by_name_from_pypi_sets_a_request_timeout():
+    response_mock = Mock()
+    response_mock.json.return_value = {
+        "info": {
+            "author": "DashAI Team",
+            "version": "0.1.0",
+            "keywords": "",
+            "name": "dashai-test-package",
+        },
+    }
+
+    with patch("requests.get", return_value=response_mock) as get_mock:
+        get_plugin_by_name_from_pypi("dashai-test-package")
+
+    assert get_mock.call_args.kwargs.get("timeout") is not None
+
+
+def test_get_plugins_from_pypi_skips_a_plugin_when_pypi_does_not_answer():
+    """A network failure on one plugin must not abort the whole listing."""
+    with (
+        patch(
+            "DashAI.back.plugins.utils._get_all_plugins",
+            return_value=["dashai-first", "dashai-second"],
+        ),
+        patch(
+            "DashAI.back.plugins.utils._get_pypi_project_status",
+            return_value="active",
+        ),
+        patch(
+            "DashAI.back.plugins.utils.get_plugin_by_name_from_pypi",
+            side_effect=[
+                requests.exceptions.ReadTimeout("pypi did not answer"),
+                {"name": "dashai-second"},
+            ],
+        ),
+    ):
+        plugins = get_plugins_from_pypi()
+
+    assert plugins == [{"name": "dashai-second"}]


### PR DESCRIPTION
Two of the three PyPI calls in `plugins/utils.py` have no timeout, so `requests` waits forever. `_get_pypi_project_status` already passes `_REQUEST_TIMEOUT_SECONDS`, these two just never got it.

`POST /plugins/index` calls both, so if PyPI stops answering while someone refreshes the plugin list, that request never comes back.

I also widened the `except` in `get_plugins_from_pypi` to catch `requests.RequestException`. That loop already skips a plugin and carries on when one fails, but `ReadTimeout` inherits from `OSError`, not `ValueError`, so it would escape and turn into a 500. Say the word if you'd rather it fail loudly and I'll drop that bit.

The timeout caps this at 15s but doesn't remove it: `refresh_plugins_record` is `async def` doing blocking I/O, so the event loop is stuck while it waits. Same pattern in 129 of the 139 endpoints, so that's your call rather than mine. Can open an issue if it helps.

Tests: 3 new ones in `tests/back/plugins/test_plugin_utils.py`, they fail before this change and pass after. Full plugin suite 30 passed, ruff clean.
