### PR TITLE
Add credential and download gating to tool cards in notebook

### DIFF
--- a/DashAI/back/converters/base_converter.py
+++ b/DashAI/back/converters/base_converter.py
@@ -70,6 +70,8 @@ class BaseConverter(ConfigObject, ABC):
         meta["category"] = cls.CATEGORY if cls.CATEGORY else "Other"
         meta["icon"] = cls.ICON if cls.ICON else Icon.Extension.value
         meta["color"] = cls.COLOR if cls.COLOR else "rgb(255, 255, 255)"
+        meta["requires_download"] = bool(getattr(cls, "REQUIRES_DOWNLOAD", False))
+        meta["download_size_bytes"] = getattr(cls, "DOWNLOAD_SIZE_BYTES", None)
         meta["supervised"] = cls.SUPERVISED
         meta["changes_row_count"] = cls.CHANGES_ROW_COUNT
         meta["n_components_features_bounded"] = getattr(

--- a/DashAI/back/exploration/base_explorer.py
+++ b/DashAI/back/exploration/base_explorer.py
@@ -89,6 +89,8 @@ class BaseExplorer(ConfigObject, ABC):
         meta["category"] = cls.CATEGORY if cls.CATEGORY else "Other"
         meta["icon"] = cls.ICON if cls.ICON else Icon.Extension.value
         meta["color"] = cls.COLOR if cls.COLOR else "rgb(255, 255, 255)"
+        meta["requires_download"] = bool(getattr(cls, "REQUIRES_DOWNLOAD", False))
+        meta["download_size_bytes"] = getattr(cls, "DOWNLOAD_SIZE_BYTES", None)
 
         if meta.get("input_cardinality") is None:
             meta["input_cardinality"] = {"min": 1}

--- a/DashAI/front/src/components/notebooks/tool/ToolGrid.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolGrid.jsx
@@ -6,14 +6,30 @@ import { useTourContext } from "../../tour/TourProvider";
 import { groupByCategory, sortCategories } from "./toolCategories";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@mui/material/styles";
+import { useSnackbar } from "notistack";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
+import { startComponentDownload } from "../../models/model/ComponentDownloadControl";
+import CredentialsDialog from "../../credentials/CredentialsDialog";
+import { useToolGate } from "./useToolGate";
+
+function ResolveDrop({ tool, onUse, onDownload, onNeedsCredentials }) {
+  const gate = useToolGate(tool);
+  useEffect(() => {
+    gate.resolve({ onUse, onDownload, onNeedsCredentials });
+    // Resolve once when the dropped tool changes; re-resolving on every state
+    // change could restart a download or reopen the dialog.
+  }, [tool?.name]);
+  return null;
+}
 
 export default function ToolGrid({ tools, notebook, FormComponent }) {
   const [open, setOpen] = useState(false);
   const [selectedTool, setSelectedTool] = useState(null);
+  const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
   const tourContext = useTourContext();
   const { t } = useTranslation(["datasets", "common"]);
   const theme = useTheme();
+  const { enqueueSnackbar } = useSnackbar();
   const { pendingDropTool, setPendingDropTool } = useExplorersAndConverters();
 
   const grouped = useMemo(() => groupByCategory(tools), [tools]);
@@ -22,7 +38,7 @@ export default function ToolGrid({ tools, notebook, FormComponent }) {
     [grouped],
   );
 
-  const handleToolClick = (tool) => {
+  const handleUseTool = (tool) => {
     setSelectedTool(tool);
     setOpen(true);
 
@@ -41,14 +57,23 @@ export default function ToolGrid({ tools, notebook, FormComponent }) {
     }
   };
 
+  const handleDownloadTool = (tool) => {
+    startComponentDownload({ component: tool, enqueueSnackbar, t });
+  };
+
+  const handleNeedsCredentials = () => {
+    setCredentialsDialogOpen(true);
+  };
+
+  const droppedTool = useMemo(
+    () => tools.find((tool) => tool.name === pendingDropTool?.name),
+    [pendingDropTool, tools],
+  );
+
   useEffect(() => {
-    if (!pendingDropTool) return;
-    const match = tools.find((t) => t.name === pendingDropTool.name);
-    if (match) {
-      handleToolClick(match);
-      setPendingDropTool(null);
-    }
-  }, [pendingDropTool, tools]);
+    if (!droppedTool) return;
+    setPendingDropTool(null);
+  }, [droppedTool, setPendingDropTool]);
 
   if (!tools || tools.length === 0) {
     return (
@@ -114,13 +139,24 @@ export default function ToolGrid({ tools, notebook, FormComponent }) {
                     key={tool.name}
                     tool={tool}
                     disabled={tool.disabled}
-                    onClick={() => handleToolClick(tool)}
+                    onUse={() => handleUseTool(tool)}
+                    onDownload={() => handleDownloadTool(tool)}
+                    onNeedsCredentials={handleNeedsCredentials}
                   />
                 ))}
             </Box>
           </Box>
         );
       })}
+
+      {droppedTool && (
+        <ResolveDrop
+          tool={droppedTool}
+          onUse={() => handleUseTool(droppedTool)}
+          onDownload={() => handleDownloadTool(droppedTool)}
+          onNeedsCredentials={handleNeedsCredentials}
+        />
+      )}
 
       {selectedTool && (
         <ConfigureToolModal
@@ -134,6 +170,11 @@ export default function ToolGrid({ tools, notebook, FormComponent }) {
           FormSection={FormComponent}
         />
       )}
+
+      <CredentialsDialog
+        open={credentialsDialogOpen}
+        onClose={() => setCredentialsDialogOpen(false)}
+      />
     </Box>
   );
 }

--- a/DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx
@@ -1,20 +1,34 @@
 import React, { useState } from "react";
-import { Box, Typography, Chip, Tooltip } from "@mui/material";
+import { Box, Typography, Tooltip, Stack } from "@mui/material";
+import { VpnKeyOutlined as KeyIcon } from "@mui/icons-material";
 import HoverToolInfo from "./HoverToolInfo";
 import api from "../../../api/api";
 import { CategoryIcon } from "./CategoryIcon";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@mui/material/styles";
 import { setCustomDragImage } from "../../../utils/dragImage";
+import ModelDownloadStatusIcon from "../../models/model/ModelDownloadStatusIcon";
+import { useToolGate } from "./useToolGate";
 
-export default function ToolGridItem({ tool, disabled, onClick }) {
+export default function ToolGridItem({
+  tool,
+  disabled,
+  onUse,
+  onDownload,
+  onNeedsCredentials,
+}) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [hoveredTool, setHoveredTool] = useState(null);
-  const { t } = useTranslation(["common"]);
+  const { t } = useTranslation(["common", "credentials"]);
   const theme = useTheme();
 
+  const gate = useToolGate({ ...tool, disabled });
+
+  const handleClick = () =>
+    gate.resolve({ onUse, onDownload, onNeedsCredentials });
+
   const handleMouseEnter = (event, tool) => {
-    if (!disabled) {
+    if (!gate.blocked) {
       setAnchorEl(event.currentTarget);
       setHoveredTool(tool);
     }
@@ -25,10 +39,28 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
     setHoveredTool(null);
   };
 
+  const action =
+    gate.locked || gate.requiresDownload ? (
+      <Stack direction="row" spacing={0.5} alignItems="center">
+        {gate.locked && (
+          <Tooltip
+            title={t("credentials:requiredTooltip", {
+              platform: gate.requiredPlatforms,
+            })}
+          >
+            <KeyIcon fontSize="small" color="warning" />
+          </Tooltip>
+        )}
+        {gate.requiresDownload && (
+          <ModelDownloadStatusIcon model={tool} disabled={gate.locked} />
+        )}
+      </Stack>
+    ) : null;
+
   return (
     <>
       <Tooltip
-        title={disabled && tool.tooltip ? tool.tooltip : tool.description}
+        title={gate.blocked && tool.tooltip ? tool.tooltip : tool.description}
         arrow
         placement="top"
         slotProps={{
@@ -36,7 +68,7 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
             sx: {
               bgcolor: theme.palette.background.paper,
               color: theme.palette.text.primary,
-              display: disabled ? "block" : "none",
+              display: gate.blocked ? "block" : "none",
               border: `1px solid ${theme.palette.divider}`,
               fontSize: "0.75rem",
               maxWidth: 300,
@@ -52,9 +84,9 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
       >
         <Box
           key={tool.id}
-          draggable={!disabled}
+          draggable={!gate.blocked}
           onDragStart={
-            !disabled
+            !gate.blocked
               ? (e) => {
                   e.dataTransfer.setData(
                     "application/x-dashai-tool",
@@ -67,30 +99,36 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
           }
           onMouseEnter={(e) => handleMouseEnter(e, tool)}
           onMouseLeave={handleMouseLeave}
-          onClick={disabled ? null : onClick}
+          onClick={handleClick}
           sx={{
             position: "relative",
-            bgcolor: disabled
+            bgcolor: gate.blocked
               ? theme.palette.ui.disabled
               : theme.palette.ui.box,
             border: `1px solid ${theme.palette.ui.border}`,
             borderRadius: 1.5,
             overflow: "hidden",
-            cursor: disabled ? "not-allowed" : "grab",
+            cursor: gate.blocked
+              ? gate.gated
+                ? "pointer"
+                : "not-allowed"
+              : "grab",
             transition: "all 0.2s",
-            opacity: disabled ? 0.5 : 1,
-            filter: disabled ? "grayscale(0.6)" : "none",
+            opacity: gate.blocked ? 0.5 : 1,
+            filter: gate.blocked ? "grayscale(0.6)" : "none",
             "&:hover": {
-              bgcolor: disabled
+              bgcolor: gate.blocked
                 ? theme.palette.ui.disabled
                 : theme.palette.action.hover,
-              borderColor: disabled
+              borderColor: gate.blocked
                 ? theme.palette.ui.border
                 : tool.metadata.color,
-              transform: disabled ? "none" : "translateY(-4px)",
-              boxShadow: disabled ? "none" : `0 8px 16px rgba(0, 0, 0, 0.2)`,
+              transform: gate.blocked ? "none" : "translateY(-4px)",
+              boxShadow: gate.blocked
+                ? "none"
+                : `0 8px 16px rgba(0, 0, 0, 0.2)`,
             },
-            "&::after": disabled
+            "&::after": gate.blocked
               ? {
                   content: '""',
                   position: "absolute",
@@ -109,11 +147,13 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
             sx={{
               width: "100%",
               height: 100,
-              bgcolor: disabled
+              bgcolor: gate.blocked
                 ? theme.palette.ui.disabled
                 : theme.palette.ui.border,
               borderBottom: `1px solid ${
-                disabled ? theme.palette.ui.disabled : theme.palette.ui.border
+                gate.blocked
+                  ? theme.palette.ui.disabled
+                  : theme.palette.ui.border
               }`,
             }}
           >
@@ -124,7 +164,7 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
                 width: "100%",
                 height: "100%",
                 objectFit: "cover",
-                opacity: disabled ? 0.4 : 1,
+                opacity: gate.blocked ? 0.4 : 1,
               }}
             />
           </Box>
@@ -142,10 +182,10 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
                   height: 28,
                   p: 4,
                   borderRadius: 0.75,
-                  bgcolor: disabled
+                  bgcolor: gate.blocked
                     ? theme.palette.ui.disabled
                     : theme.palette.ui.border,
-                  color: disabled
+                  color: gate.blocked
                     ? theme.palette.text.disabled
                     : theme.palette.text.primary,
                   flexShrink: 0,
@@ -154,17 +194,32 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
                 <CategoryIcon
                   icon={tool.metadata.icon}
                   color={
-                    disabled ? theme.palette.text.disabled : tool.metadata.color
+                    gate.blocked
+                      ? theme.palette.text.disabled
+                      : tool.metadata.color
                   }
                 />
               </Box>
+
+              {action && (
+                <Box
+                  sx={{
+                    ml: "auto",
+                    display: "flex",
+                    alignItems: "center",
+                    flexShrink: 0,
+                  }}
+                >
+                  {action}
+                </Box>
+              )}
             </Box>
 
             {/* Title */}
             <Typography
               variant="body2"
               sx={{
-                color: disabled
+                color: gate.blocked
                   ? theme.palette.text.disabled
                   : theme.palette.text.primary,
                 fontWeight: 500,
@@ -185,7 +240,7 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
             <Typography
               variant="caption"
               sx={{
-                color: disabled
+                color: gate.blocked
                   ? theme.palette.text.disabled
                   : theme.palette.text.primary,
               }}
@@ -195,7 +250,7 @@ export default function ToolGridItem({ tool, disabled, onClick }) {
           </Box>
         </Box>
       </Tooltip>
-      {!disabled && (
+      {!gate.blocked && (
         <HoverToolInfo
           anchorEl={anchorEl}
           hoveredTool={hoveredTool}

--- a/DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx
@@ -28,7 +28,7 @@ export default function ToolGridItem({
     gate.resolve({ onUse, onDownload, onNeedsCredentials });
 
   const handleMouseEnter = (event, tool) => {
-    if (!gate.blocked) {
+    if (!disabled) {
       setAnchorEl(event.currentTarget);
       setHoveredTool(tool);
     }
@@ -60,7 +60,7 @@ export default function ToolGridItem({
   return (
     <>
       <Tooltip
-        title={gate.blocked && tool.tooltip ? tool.tooltip : tool.description}
+        title={disabled && tool.tooltip ? tool.tooltip : tool.description}
         arrow
         placement="top"
         slotProps={{
@@ -68,7 +68,7 @@ export default function ToolGridItem({
             sx: {
               bgcolor: theme.palette.background.paper,
               color: theme.palette.text.primary,
-              display: gate.blocked ? "block" : "none",
+              display: disabled ? "block" : "none",
               border: `1px solid ${theme.palette.divider}`,
               fontSize: "0.75rem",
               maxWidth: 300,
@@ -114,19 +114,15 @@ export default function ToolGridItem({
                 : "not-allowed"
               : "grab",
             transition: "all 0.2s",
-            opacity: gate.blocked ? 0.5 : 1,
-            filter: gate.blocked ? "grayscale(0.6)" : "none",
             "&:hover": {
-              bgcolor: gate.blocked
+              bgcolor: disabled
                 ? theme.palette.ui.disabled
                 : theme.palette.action.hover,
-              borderColor: gate.blocked
+              borderColor: disabled
                 ? theme.palette.ui.border
                 : tool.metadata.color,
-              transform: gate.blocked ? "none" : "translateY(-4px)",
-              boxShadow: gate.blocked
-                ? "none"
-                : `0 8px 16px rgba(0, 0, 0, 0.2)`,
+              transform: disabled ? "none" : "translateY(-4px)",
+              boxShadow: disabled ? "none" : `0 8px 16px rgba(0, 0, 0, 0.2)`,
             },
             "&::after": gate.blocked
               ? {
@@ -142,7 +138,9 @@ export default function ToolGridItem({
               : {},
           }}
         >
-          {/* Preview Image */}
+          {/* Preview Image — dimmed when blocked; the download/credential icons
+              below are kept out of every dimmed subtree so they keep full
+              color. */}
           <Box
             sx={{
               width: "100%",
@@ -155,6 +153,8 @@ export default function ToolGridItem({
                   ? theme.palette.ui.disabled
                   : theme.palette.ui.border
               }`,
+              opacity: gate.blocked ? 0.5 : 1,
+              filter: gate.blocked ? "grayscale(0.6)" : "none",
             }}
           >
             <img
@@ -189,6 +189,8 @@ export default function ToolGridItem({
                     ? theme.palette.text.disabled
                     : theme.palette.text.primary,
                   flexShrink: 0,
+                  opacity: gate.blocked ? 0.5 : 1,
+                  filter: gate.blocked ? "grayscale(0.6)" : "none",
                 }}
               >
                 <CategoryIcon
@@ -203,11 +205,13 @@ export default function ToolGridItem({
 
               {action && (
                 <Box
+                  draggable={false}
                   sx={{
                     ml: "auto",
                     display: "flex",
                     alignItems: "center",
                     flexShrink: 0,
+                    zIndex: 3,
                   }}
                 >
                   {action}
@@ -224,6 +228,7 @@ export default function ToolGridItem({
                   : theme.palette.text.primary,
                 fontWeight: 500,
                 mb: 1,
+                opacity: gate.blocked ? 0.5 : 1,
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 display: "-webkit-box",
@@ -243,6 +248,7 @@ export default function ToolGridItem({
                 color: gate.blocked
                   ? theme.palette.text.disabled
                   : theme.palette.text.primary,
+                opacity: gate.blocked ? 0.5 : 1,
               }}
             >
               {tool.metadata.category ?? t("common:other")}
@@ -250,7 +256,7 @@ export default function ToolGridItem({
           </Box>
         </Box>
       </Tooltip>
-      {!gate.blocked && (
+      {!disabled && (
         <HoverToolInfo
           anchorEl={anchorEl}
           hoveredTool={hoveredTool}

--- a/DashAI/front/src/components/notebooks/tool/ToolList.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolList.jsx
@@ -14,14 +14,30 @@ import ConfigureToolModal from "./ConfigureToolModal";
 import { useTourContext } from "../../tour/TourProvider";
 import { groupByCategory, sortCategories } from "./toolCategories";
 import { useTranslation } from "react-i18next";
+import { useSnackbar } from "notistack";
 import { useExplorersAndConverters } from "../context/ExplorersAndConvertersContext";
+import { startComponentDownload } from "../../models/model/ComponentDownloadControl";
+import CredentialsDialog from "../../credentials/CredentialsDialog";
+import { useToolGate } from "./useToolGate";
+
+function ResolveDrop({ tool, onUse, onDownload, onNeedsCredentials }) {
+  const gate = useToolGate(tool);
+  useEffect(() => {
+    gate.resolve({ onUse, onDownload, onNeedsCredentials });
+    // Resolve once when the dropped tool changes; re-resolving on every state
+    // change could restart a download or reopen the dialog.
+  }, [tool?.name]);
+  return null;
+}
 
 export default function ToolList({ tools, notebook, FormComponent }) {
   const theme = useTheme();
   const [open, setOpen] = useState(false);
   const [selectedTool, setSelectedTool] = useState(null);
+  const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
   const tourContext = useTourContext();
   const { t } = useTranslation(["datasets", "common"]);
+  const { enqueueSnackbar } = useSnackbar();
   const { pendingDropTool, setPendingDropTool } = useExplorersAndConverters();
 
   const grouped = useMemo(() => groupByCategory(tools), [tools]);
@@ -30,7 +46,7 @@ export default function ToolList({ tools, notebook, FormComponent }) {
     [grouped],
   );
 
-  const handleToolClick = (tool) => {
+  const handleUseTool = (tool) => {
     setSelectedTool(tool);
     setOpen(true);
     if (tourContext && tourContext.run) {
@@ -40,14 +56,23 @@ export default function ToolList({ tools, notebook, FormComponent }) {
     }
   };
 
+  const handleDownloadTool = (tool) => {
+    startComponentDownload({ component: tool, enqueueSnackbar, t });
+  };
+
+  const handleNeedsCredentials = () => {
+    setCredentialsDialogOpen(true);
+  };
+
+  const droppedTool = useMemo(
+    () => tools.find((tool) => tool.name === pendingDropTool?.name),
+    [pendingDropTool, tools],
+  );
+
   useEffect(() => {
-    if (!pendingDropTool) return;
-    const match = tools.find((t) => t.name === pendingDropTool.name);
-    if (match) {
-      handleToolClick(match);
-      setPendingDropTool(null);
-    }
-  }, [pendingDropTool, tools]);
+    if (!droppedTool) return;
+    setPendingDropTool(null);
+  }, [droppedTool, setPendingDropTool]);
 
   if (!tools || tools.length === 0) {
     return (
@@ -129,7 +154,9 @@ export default function ToolList({ tools, notebook, FormComponent }) {
                       key={tool.name}
                       tool={tool}
                       disabled={tool.disabled}
-                      onClick={() => handleToolClick(tool)}
+                      onUse={() => handleUseTool(tool)}
+                      onDownload={() => handleDownloadTool(tool)}
+                      onNeedsCredentials={handleNeedsCredentials}
                     />
                   ))}
               </Box>
@@ -137,6 +164,15 @@ export default function ToolList({ tools, notebook, FormComponent }) {
           </Accordion>
         );
       })}
+
+      {droppedTool && (
+        <ResolveDrop
+          tool={droppedTool}
+          onUse={() => handleUseTool(droppedTool)}
+          onDownload={() => handleDownloadTool(droppedTool)}
+          onNeedsCredentials={handleNeedsCredentials}
+        />
+      )}
 
       {selectedTool && (
         <ConfigureToolModal
@@ -150,6 +186,11 @@ export default function ToolList({ tools, notebook, FormComponent }) {
           FormSection={FormComponent}
         />
       )}
+
+      <CredentialsDialog
+        open={credentialsDialogOpen}
+        onClose={() => setCredentialsDialogOpen(false)}
+      />
     </Box>
   );
 }

--- a/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
@@ -1,25 +1,35 @@
 import React, { useState } from "react";
-import { Box, Typography, Chip, Tooltip } from "@mui/material";
+import { Box, Typography, Tooltip, Stack } from "@mui/material";
+import { VpnKeyOutlined as KeyIcon } from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import HoverToolInfo from "./HoverToolInfo";
 import api from "../../../api/api";
 import { CategoryIcon } from "./CategoryIcon";
 import { useTranslation } from "react-i18next";
 import { setCustomDragImage } from "../../../utils/dragImage";
+import ModelDownloadStatusIcon from "../../models/model/ModelDownloadStatusIcon";
+import { useToolGate } from "./useToolGate";
 
 export default function ToolListItem({
   tool,
   disabled = false,
-  onClick,
+  onUse,
+  onDownload,
+  onNeedsCredentials,
   ...props
 }) {
   const theme = useTheme();
   const [anchorEl, setAnchorEl] = useState(null);
   const [hoveredTool, setHoveredTool] = useState(null);
-  const { t } = useTranslation(["common"]);
+  const { t } = useTranslation(["common", "credentials"]);
+
+  const gate = useToolGate({ ...tool, disabled });
+
+  const handleClick = () =>
+    gate.resolve({ onUse, onDownload, onNeedsCredentials });
 
   const handleMouseEnter = (event, tool) => {
-    if (!disabled) {
+    if (!gate.blocked) {
       setAnchorEl(event.currentTarget);
       setHoveredTool(tool);
     }
@@ -43,10 +53,28 @@ export default function ToolListItem({
     setHoveredTool(null);
   };
 
+  const action =
+    gate.locked || gate.requiresDownload ? (
+      <Stack direction="row" spacing={0.5} alignItems="center">
+        {gate.locked && (
+          <Tooltip
+            title={t("credentials:requiredTooltip", {
+              platform: gate.requiredPlatforms,
+            })}
+          >
+            <KeyIcon fontSize="small" color="warning" />
+          </Tooltip>
+        )}
+        {gate.requiresDownload && (
+          <ModelDownloadStatusIcon model={tool} disabled={gate.locked} />
+        )}
+      </Stack>
+    ) : null;
+
   return (
     <>
       <Tooltip
-        title={disabled && tool.tooltip ? tool.tooltip : tool.description}
+        title={gate.blocked && tool.tooltip ? tool.tooltip : tool.description}
         arrow
         placement="top"
         slotProps={{
@@ -54,7 +82,7 @@ export default function ToolListItem({
             sx: {
               bgcolor: theme.palette.background.paper,
               color: theme.palette.text.primary,
-              display: disabled ? "block" : "none",
+              display: gate.blocked ? "block" : "none",
               border: `1px solid ${theme.palette.divider}`,
               fontSize: "0.75rem",
               maxWidth: 300,
@@ -72,9 +100,9 @@ export default function ToolListItem({
           key={tool.id}
           data-tour={getTourAttribute()}
           {...props}
-          draggable={!disabled}
+          draggable={!gate.blocked}
           onDragStart={
-            !disabled
+            !gate.blocked
               ? (e) => {
                   e.dataTransfer.setData(
                     "application/x-dashai-tool",
@@ -87,32 +115,36 @@ export default function ToolListItem({
           }
           onMouseEnter={(e) => handleMouseEnter(e, tool)}
           onMouseLeave={handleMouseLeave}
-          onClick={disabled ? null : onClick}
+          onClick={handleClick}
           sx={{
             display: "flex",
             alignItems: "center",
             gap: 6,
             p: 6,
-            bgcolor: disabled
+            bgcolor: gate.blocked
               ? theme.palette.ui.disabled
               : theme.palette.ui.box,
             border: `1px solid ${theme.palette.ui.border}`,
             borderRadius: 1,
-            cursor: disabled ? "not-allowed" : "grab",
+            cursor: gate.blocked
+              ? gate.gated
+                ? "pointer"
+                : "not-allowed"
+              : "grab",
             transition: "all 0.2s",
-            opacity: disabled ? 0.5 : 1,
-            filter: disabled ? "grayscale(0.6)" : "none",
+            opacity: gate.blocked ? 0.5 : 1,
+            filter: gate.blocked ? "grayscale(0.6)" : "none",
             position: "relative",
             "&:hover": {
-              bgcolor: disabled
+              bgcolor: gate.blocked
                 ? theme.palette.ui.disabled
                 : theme.palette.action.hover,
-              borderColor: disabled
+              borderColor: gate.blocked
                 ? theme.palette.ui.border
                 : tool.metadata.color,
-              transform: disabled ? "none" : "translateX(4px)",
+              transform: gate.blocked ? "none" : "translateX(4px)",
             },
-            "&::after": disabled
+            "&::after": gate.blocked
               ? {
                   content: '""',
                   position: "absolute",
@@ -134,10 +166,10 @@ export default function ToolListItem({
               width: 36,
               height: 36,
               borderRadius: 1,
-              bgcolor: disabled
+              bgcolor: gate.blocked
                 ? theme.palette.ui.disabled
                 : theme.palette.ui.border,
-              color: disabled
+              color: gate.blocked
                 ? theme.palette.text.disabled
                 : theme.palette.text.primary,
               flexShrink: 0,
@@ -146,7 +178,7 @@ export default function ToolListItem({
             <CategoryIcon
               icon={tool.metadata.icon}
               color={
-                disabled ? theme.palette.text.disabled : tool.metadata.color
+                gate.blocked ? theme.palette.text.disabled : tool.metadata.color
               }
             />
           </Box>
@@ -164,7 +196,7 @@ export default function ToolListItem({
               <Typography
                 variant="body2"
                 sx={{
-                  color: disabled
+                  color: gate.blocked
                     ? theme.palette.text.disabled
                     : theme.palette.text.primary,
                   fontWeight: 500,
@@ -189,7 +221,7 @@ export default function ToolListItem({
               <Typography
                 variant="caption"
                 sx={{
-                  color: disabled
+                  color: gate.blocked
                     ? theme.palette.text.disabled
                     : theme.palette.text.secondary,
                   overflow: "hidden",
@@ -204,17 +236,29 @@ export default function ToolListItem({
             </Box>
           </Box>
 
+          {/* Download/credential status (e.g. a locked key or download icon) */}
+          {action && (
+            <Box
+              draggable={false}
+              sx={{ flexShrink: 0, display: "flex", alignItems: "center" }}
+            >
+              {action}
+            </Box>
+          )}
+
           {/* Preview Thumbnail */}
           <Box
             sx={{
               width: 60,
               height: 40,
               borderRadius: 0.75,
-              bgcolor: disabled
+              bgcolor: gate.blocked
                 ? theme.palette.ui.disabled
                 : theme.palette.ui.border,
               border: `1px solid ${
-                disabled ? theme.palette.ui.disabled : theme.palette.ui.border
+                gate.blocked
+                  ? theme.palette.ui.disabled
+                  : theme.palette.ui.border
               }`,
               display: { xs: "none", lg: "none", xl: "block" },
               overflow: "hidden",
@@ -228,13 +272,13 @@ export default function ToolListItem({
                 width: "100%",
                 height: "100%",
                 objectFit: "cover",
-                opacity: disabled ? 0.4 : 1,
+                opacity: gate.blocked ? 0.4 : 1,
               }}
             />
           </Box>
         </Box>
       </Tooltip>
-      {!disabled && (
+      {!gate.blocked && (
         <HoverToolInfo
           anchorEl={anchorEl}
           hoveredTool={hoveredTool}

--- a/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
+++ b/DashAI/front/src/components/notebooks/tool/ToolListItem.jsx
@@ -29,7 +29,7 @@ export default function ToolListItem({
     gate.resolve({ onUse, onDownload, onNeedsCredentials });
 
   const handleMouseEnter = (event, tool) => {
-    if (!gate.blocked) {
+    if (!disabled) {
       setAnchorEl(event.currentTarget);
       setHoveredTool(tool);
     }
@@ -72,9 +72,9 @@ export default function ToolListItem({
     ) : null;
 
   return (
-    <>
+    <Box sx={{ display: "flex", alignItems: "center", gap: 6 }}>
       <Tooltip
-        title={gate.blocked && tool.tooltip ? tool.tooltip : tool.description}
+        title={disabled && tool.tooltip ? tool.tooltip : tool.description}
         arrow
         placement="top"
         slotProps={{
@@ -82,7 +82,7 @@ export default function ToolListItem({
             sx: {
               bgcolor: theme.palette.background.paper,
               color: theme.palette.text.primary,
-              display: gate.blocked ? "block" : "none",
+              display: disabled ? "block" : "none",
               border: `1px solid ${theme.palette.divider}`,
               fontSize: "0.75rem",
               maxWidth: 300,
@@ -121,6 +121,8 @@ export default function ToolListItem({
             alignItems: "center",
             gap: 6,
             p: 6,
+            flex: 1,
+            minWidth: 0,
             bgcolor: gate.blocked
               ? theme.palette.ui.disabled
               : theme.palette.ui.box,
@@ -132,17 +134,15 @@ export default function ToolListItem({
                 : "not-allowed"
               : "grab",
             transition: "all 0.2s",
-            opacity: gate.blocked ? 0.5 : 1,
-            filter: gate.blocked ? "grayscale(0.6)" : "none",
             position: "relative",
             "&:hover": {
-              bgcolor: gate.blocked
+              bgcolor: disabled
                 ? theme.palette.ui.disabled
                 : theme.palette.action.hover,
-              borderColor: gate.blocked
+              borderColor: disabled
                 ? theme.palette.ui.border
                 : tool.metadata.color,
-              transform: gate.blocked ? "none" : "translateX(4px)",
+              transform: disabled ? "none" : "translateX(4px)",
             },
             "&::after": gate.blocked
               ? {
@@ -157,90 +157,108 @@ export default function ToolListItem({
               : {},
           }}
         >
-          {/* Icon */}
+          {/* Content (tool icon, text) dimmed when the card is blocked; the
+              download/credential icons below stay outside it so they keep full
+              color. */}
           <Box
             sx={{
               display: "flex",
               alignItems: "center",
-              justifyContent: "center",
-              width: 36,
-              height: 36,
-              borderRadius: 1,
-              bgcolor: gate.blocked
-                ? theme.palette.ui.disabled
-                : theme.palette.ui.border,
-              color: gate.blocked
-                ? theme.palette.text.disabled
-                : theme.palette.text.primary,
-              flexShrink: 0,
+              gap: 6,
+              flex: 1,
+              minWidth: 0,
+              opacity: gate.blocked ? 0.5 : 1,
+              filter: gate.blocked ? "grayscale(0.6)" : "none",
             }}
           >
-            <CategoryIcon
-              icon={tool.metadata.icon}
-              color={
-                gate.blocked ? theme.palette.text.disabled : tool.metadata.color
-              }
-            />
-          </Box>
-
-          {/* Content */}
-          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {/* Icon */}
             <Box
               sx={{
                 display: "flex",
                 alignItems: "center",
-                gap: 4,
-                mb: 2,
+                justifyContent: "center",
+                width: 36,
+                height: 36,
+                borderRadius: 1,
+                bgcolor: gate.blocked
+                  ? theme.palette.ui.disabled
+                  : theme.palette.ui.border,
+                color: gate.blocked
+                  ? theme.palette.text.disabled
+                  : theme.palette.text.primary,
+                flexShrink: 0,
               }}
             >
-              <Typography
-                variant="body2"
-                sx={{
-                  color: gate.blocked
-                    ? theme.palette.text.disabled
-                    : theme.palette.text.primary,
-                  fontWeight: 500,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  width: 0,
-                  flexGrow: 1,
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {tool.display_name || tool.name}
-              </Typography>
+              <CategoryIcon
+                icon={tool.metadata.icon}
+                color={tool.metadata.color}
+              />
             </Box>
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 4,
-                mb: 2,
-              }}
-            >
-              <Typography
-                variant="caption"
+
+            {/* Content */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Box
                 sx={{
-                  color: gate.blocked
-                    ? theme.palette.text.disabled
-                    : theme.palette.text.secondary,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  width: 0,
-                  flexGrow: 1,
-                  whiteSpace: "nowrap",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 4,
+                  mb: 2,
                 }}
               >
-                {tool.metadata.category ?? t("common:other")}
-              </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{
+                    color: gate.blocked
+                      ? theme.palette.text.disabled
+                      : theme.palette.text.primary,
+                    fontWeight: 500,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    width: 0,
+                    flexGrow: 1,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {tool.display_name || tool.name}
+                </Typography>
+              </Box>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 4,
+                  mb: 2,
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: gate.blocked
+                      ? theme.palette.text.disabled
+                      : theme.palette.text.secondary,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    width: 0,
+                    flexGrow: 1,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {tool.metadata.category ?? t("common:other")}
+                </Typography>
+              </Box>
             </Box>
           </Box>
 
-          {/* Download/credential status (e.g. a locked key or download icon) */}
+          {/* Download/credential status — left of the thumbnail, full color */}
           {action && (
             <Box
               draggable={false}
-              sx={{ flexShrink: 0, display: "flex", alignItems: "center" }}
+              sx={{
+                flexShrink: 0,
+                display: "flex",
+                alignItems: "center",
+                zIndex: 1,
+              }}
             >
               {action}
             </Box>
@@ -278,13 +296,14 @@ export default function ToolListItem({
           </Box>
         </Box>
       </Tooltip>
-      {!gate.blocked && (
+
+      {!disabled && (
         <HoverToolInfo
           anchorEl={anchorEl}
           hoveredTool={hoveredTool}
           handleMouseLeave={handleMouseLeave}
         />
       )}
-    </>
+    </Box>
   );
 }

--- a/DashAI/front/src/components/notebooks/tool/useToolGate.js
+++ b/DashAI/front/src/components/notebooks/tool/useToolGate.js
@@ -1,0 +1,56 @@
+import { useComponentDownloadState } from "../../models/model/ComponentDownloadControl";
+import {
+  useCredentialStatuses,
+  getComponentCredentialState,
+} from "../../credentials/credentialStatus";
+
+/**
+ * Shared download/credential gating for explorer/converter tool cards, mirroring
+ * how model rows in the models side bar are gated. A tool is blocked when its
+ * dataset columns don't fit it (`disabled`) OR it requires an authenticated
+ * credential (`locked`) OR it requires a download that has not finished.
+ *
+ * Returns the gate state plus a `resolve` helper that dispatches a click to the
+ * right handler: credentials dialog, download start, or the normal "use" action.
+ */
+export const useToolGate = (tool) => {
+  const requiresDownload = Boolean(tool?.metadata?.requires_download);
+  const { downloaded, downloading } = useComponentDownloadState(
+    tool || { name: "" },
+  );
+  const { statuses, loaded } = useCredentialStatuses();
+  const { locked, requiredPlatforms } = getComponentCredentialState(
+    tool || {},
+    statuses,
+    loaded,
+  );
+  const ready = !locked && (!requiresDownload || (downloaded && !downloading));
+  const blocked = Boolean(tool?.disabled) || !ready;
+  const gated = locked || (requiresDownload && !(downloaded && !downloading));
+
+  const resolve = ({ onUse, onDownload, onNeedsCredentials }) => {
+    if (downloading) return;
+    if (locked) {
+      onNeedsCredentials?.();
+      return;
+    }
+    if (requiresDownload && !(downloaded && !downloading)) {
+      onDownload?.();
+      return;
+    }
+    if (tool?.disabled) return;
+    onUse?.();
+  };
+
+  return {
+    requiresDownload,
+    downloaded,
+    downloading,
+    locked,
+    requiredPlatforms,
+    ready,
+    blocked,
+    gated,
+    resolve,
+  };
+};

--- a/tests/back/converters/test_base_converter_metadata.py
+++ b/tests/back/converters/test_base_converter_metadata.py
@@ -21,6 +21,22 @@ class _FloatIntConverter(BaseConverter):
         return x
 
 
+class _DownloadableConverter(BaseConverter):
+    SCHEMA = None
+    metadata = {}
+    REQUIRES_DOWNLOAD = True
+    DOWNLOAD_SIZE_BYTES = 1234
+
+    def get_output_type(self, column_name=None):
+        return None
+
+    def fit(self, x, y=None):
+        return self
+
+    def transform(self, x, y=None):
+        return x
+
+
 class _StarDtypeConverter(BaseConverter):
     SCHEMA = None
     metadata = {"allowed_types": [], "allowed_dtypes": ["*"]}
@@ -90,6 +106,18 @@ def test_get_metadata_none_metadata_produces_empty_lists():
     assert meta["allowed_types"] == []
     assert meta["allowed_dtypes"] == []
     assert "restricted_dtypes" not in meta
+
+
+def test_get_metadata_plain_converter_not_downloadable():
+    meta = _FloatIntConverter.get_metadata()
+    assert meta["requires_download"] is False
+    assert meta["download_size_bytes"] is None
+
+
+def test_get_metadata_downloadable_converter_metadata():
+    meta = _DownloadableConverter.get_metadata()
+    assert meta["requires_download"] is True
+    assert meta["download_size_bytes"] == 1234
 
 
 def test_get_metadata_categorical_text_serialized_correctly():

--- a/tests/back/exploration/test_base_explorer_metadata.py
+++ b/tests/back/exploration/test_base_explorer_metadata.py
@@ -22,6 +22,27 @@ def _make_explorer(**metadata_fields):
     return _StubExplorer
 
 
+def _make_downloadable_explorer():
+    """Return a minimal concrete BaseExplorer that requires a download."""
+
+    class _DownloadableExplorer(BaseExplorer):
+        SCHEMA = BaseExplorerSchema
+        metadata = {}
+        REQUIRES_DOWNLOAD = True
+        DOWNLOAD_SIZE_BYTES = 5678
+
+        def launch_exploration(self, dataset, explorer_info):
+            return None
+
+        def save_notebook(self, notebook_info, explorer_info, save_path, result):
+            return ""
+
+        def get_results(self, exploration_path, options):
+            return {}
+
+    return _DownloadableExplorer
+
+
 # --- get_metadata tests ---
 
 
@@ -70,6 +91,20 @@ def test_get_metadata_none_metadata_defaults():
     assert meta["allowed_types"] == []
     assert meta["allowed_dtypes"] == []
     assert "restricted_dtypes" not in meta
+
+
+def test_get_metadata_plain_explorer_not_downloadable():
+    cls = _make_explorer()
+    meta = cls.get_metadata()
+    assert meta["requires_download"] is False
+    assert meta["download_size_bytes"] is None
+
+
+def test_get_metadata_downloadable_explorer_metadata():
+    cls = _make_downloadable_explorer()
+    meta = cls.get_metadata()
+    assert meta["requires_download"] is True
+    assert meta["download_size_bytes"] == 5678
 
 
 def test_get_metadata_does_not_mutate_class_attribute():


### PR DESCRIPTION
## Summary
Explorer and converter tool cards now gate on the same credential/download rules as the model rows in the models side bar. A tool that needs an authenticated platform credential opens the credentials dialog on click; one that needs a model download starts the download instead of opening the config form. Cards show a key icon and/or a download/spinner/delete icon for their state, and the icons stay in full color instead of inheriting the card's dimmed style. Backend exposes `requires_download` / `download_size_bytes` in converter and explorer metadata so the frontend can gate on it.

<img width="1336" height="592" alt="image" src="https://github.com/user-attachments/assets/c1b2e4cd-90e3-473c-be59-bf24df4b5415" />

<img width="1062" height="453" alt="image" src="https://github.com/user-attachments/assets/cb53327c-9b9a-4afe-b580-1968f89c8f07" />


---

## Type of Change

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

Backend
- `DashAI/back/converters/base_converter.py`: emit `requires_download` (from `REQUIRES_DOWNLOAD`) and `download_size_bytes` (from `DOWNLOAD_SIZE_BYTES`) in the converter metadata.
- `DashAI/back/exploration/base_explorer.py`: same two metadata keys for explorers.
- `tests/back/converters/test_base_converter_metadata.py`: new, asserts the metadata defaults and the declared attribute path.
- `tests/back/exploration/test_base_explorer_metadata.py`: new, same coverage for explorers.

Frontend
- `DashAI/front/src/components/notebooks/tool/useToolGate.js`: new shared hook. Combines dataset incompatibility (`disabled`), credential lock and download state into `blocked` / `gated` / `locked` / `requiresDownload`, plus a `resolve()` that routes a click to the credentials dialog, the download start, or the normal use action.
- `DashAI/front/src/components/notebooks/tool/ToolGrid.jsx`: split `onClick` into `onUse` / `onDownload` / `onNeedsCredentials`, wire `startComponentDownload` and `CredentialsDialog`, and route the pending drag and drop tool through the same gate via a small `ResolveDrop` child (resolves once per dropped tool so a rerender can't restart a download or reopen the dialog).
- `DashAI/front/src/components/notebooks/tool/ToolList.jsx`: same handler split, download and credentials wiring, and gated drop resolution.
- `DashAI/front/src/components/notebooks/tool/ToolGridItem.jsx`: consume `useToolGate`; render the key icon and `ModelDownloadStatusIcon` in the card header; dim the preview, category icon and text individually instead of the whole card so the status icons keep their color, and lift them above the hatch overlay; hover description popover and lift animation now key off `disabled` only, so a credential locked or not yet downloaded tool still previews on hover.
- `DashAI/front/src/components/notebooks/tool/ToolListItem.jsx`: same gating and status icons for the list layout, with the icons kept outside the dimmed subtree and the slide animation restored for gated but not incompatible tools.
