### PR TITLE
Fix float conversion to handle blank and non string values

### DIFF
--- a/DashAI/back/types/utils.py
+++ b/DashAI/back/types/utils.py
@@ -353,16 +353,48 @@ def is_image_path(value: Any) -> bool:
 # Like "1.234,56" or "1,234.56"
 # So it doesn't overwrite already good floats
 def comma_float_to_float(array: Any) -> Any:
-    """Convert a PyArrow array of float strings with commas to a PyArrow float64 array."""  # noqa: E501
-    # Remove commas and convert to float
-    try:
-        import pyarrow as pa  # local import
+    """Convert a PyArrow array of numeric strings to a PyArrow float64 array.
 
-        if pa.types.is_floating(array.type):
-            return array
-        else:
-            return pa.array(
-                array.to_pandas().str.replace(",", ".").astype(float), type=pa.float64()
-            )
-    except Exception as e:
-        print("Unable to convert array to float:", e)
+    Strings may use either "." or "," as decimal separator. Empty and
+    whitespace only entries are treated as missing values, since delimited files
+    commonly use them to represent an absent number.
+
+    Parameters
+    ----------
+    array : pa.Array or pa.ChunkedArray
+        The array to convert. Floating arrays are returned unchanged.
+
+    Returns
+    -------
+    pa.Array or pa.ChunkedArray
+        A float64 array with the converted values.
+
+    Raises
+    ------
+    ValueError
+        If the array holds values that cannot be read as floats.
+    """
+    import pandas as pd  # local import
+    import pyarrow as pa  # local import
+
+    if pa.types.is_floating(array.type):
+        return array
+
+    if not (pa.types.is_string(array.type) or pa.types.is_large_string(array.type)):
+        try:
+            return array.cast(pa.float64())
+        except pa.ArrowInvalid as e:
+            raise ValueError(
+                f"Unable to convert values of type {array.type} to float: {e}"
+            ) from e
+
+    values = array.to_pandas().str.strip().str.replace(",", ".", regex=False)
+    values = values.mask(values == "")
+    converted = pd.to_numeric(values, errors="coerce")
+
+    unconvertible = values.notna() & converted.isna()
+    if unconvertible.any():
+        sample = ", ".join(repr(value) for value in values[unconvertible].unique()[:3])
+        raise ValueError(f"Unable to convert values to float: {sample}")
+
+    return pa.array(converted.astype(float), type=pa.float64())


### PR DESCRIPTION
## Summary
Uploading a CSV whose Float typed column contains blank entries (a single space, `" "`) crashed dataset creation with `TypeError: 'NoneType' object is not iterable`. `comma_float_to_float` caught every conversion error, printed it, and fell off the end returning `None`; that `None` was then handed to `pa.table()` inside `transform_dataset_with_schema`. Integer columns typed as Float hit the same path, since the `.str` accessor fails on non string series.

The conversion now treats empty and whitespace only entries as nulls, casts non string numeric arrays directly, and raises a `ValueError` naming the offending values instead of silently returning `None`.

---

## Type of Change

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/types/utils.py`: rewrote `comma_float_to_float`. Floating arrays still return unchanged; non string arrays (integer, decimal) cast to `float64` directly; string arrays are stripped, `,` normalized to `.`, empty and whitespace only values masked to null, then converted with `pd.to_numeric`. Values that still fail conversion raise `ValueError` listing up to three samples, so the job surfaces a readable message instead of a `NoneType` crash. Added NumPy style docstring.

---

## Testing

Upload a CSV with a Float column containing blanks. Before: job fails with `Error loading dataset: 'NoneType' object is not iterable`. After: blanks land as nulls, numeric values preserved as `double`.
