### PR TITLE
Restore getModelSessionById usage broken by CV branch merge

### DIFF
--- a/DashAI/front/src/components/models/LiveMetricsChart.jsx
+++ b/DashAI/front/src/components/models/LiveMetricsChart.jsx
@@ -309,10 +309,11 @@ export function LiveMetricsChart({ run, modelSessionDetail = null }) {
 
   // Save the evaluation strategy from the session
   const isCV = useMemo(() => {
-    if (!run.model_session_id) return false;
-    const session = getModelSessionById(run.model_session_id.toString());
-    return session.evaluation_strategy === "CrossValidationEvaluationStrategy";
-  }, [run.model_session_id]);
+    return (
+      modelSessionDetail?.evaluation_strategy ===
+      "CrossValidationEvaluationStrategy"
+    );
+  }, [modelSessionDetail]);
 
   return (
     <Box


### PR DESCRIPTION
## Summary
Fixes a runtime crash (`getModelSessionById is not defined`) when opening a run's results. An earlier refactor (`ca699b142`) removed the local `getModelSessionById` import/fetch from `LiveMetricsChart` in favor of the `modelSessionDetail` prop already fetched by the parent, but left a separate `isCV` check still calling the now-unimported function directly (and synchronously, even though it's async). This block now reuses `modelSessionDetail` instead of re-fetching the session.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/models/LiveMetricsChart.jsx`: replaced the broken `isCV` `useMemo` (which called an unimported `getModelSessionById` synchronously) with a derivation from the already-available `modelSessionDetail` prop.

---

## Testing
- Manually verified: opening a run's results (both CV and non-CV sessions) no longer throws and the CV-specific view renders correctly.
