### PR TITLE
 Remove duplicate "most_frequent" option in SimpleImputer strategy dropdown

### DIFF
--- a/DashAI/back/converters/scikit_learn/simple_imputer.py
+++ b/DashAI/back/converters/scikit_learn/simple_imputer.py
@@ -40,7 +40,6 @@ class SimpleImputerSchema(BaseSchema):
             [
                 "mean",
                 "median",
-                ["most_frequent", "constant"][0],
                 "most_frequent",
                 "constant",
             ]


### PR DESCRIPTION
## Summary
Fixes a duplicate entry in the `strategy` dropdown of the SimpleImputer converter, where `most_frequent` appeared twice. The duplication came from a redundant expression (`["most_frequent", "constant"][0]`) that simply evaluated to the string `"most_frequent"` again inside the enum list. Both entries were functionally identical (same string value, same behavior), so this is a purely cosmetic fix with no behavior change.

---

## Type of Change
- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/converters/scikit_learn/simple_imputer.py`: removed the redundant `["most_frequent", "constant"][0]` entry from the `strategy` enum list in `SimpleImputerSchema`, leaving a clean `["mean", "median", "most_frequent", "constant"]`.

---

## Testing (optional)
- Manually verified in the UI that the "Configure Converter: Simple Imputer" strategy dropdown now shows `most_frequent` only once.

Before
<img width="1430" height="915" alt="image" src="https://github.com/user-attachments/assets/9f343887-65b1-4dd4-b3a0-5dae6ed48fe3" />

After
<img width="1420" height="884" alt="image" src="https://github.com/user-attachments/assets/86cd3438-b259-40d5-a17f-524518e8af23" />
