### PR TITLE
Enable Date type

### DIFF
--- a/DashAI/back/api/api_v1/endpoints/datasets.py
+++ b/DashAI/back/api/api_v1/endpoints/datasets.py
@@ -2157,13 +2157,16 @@ async def validate_type_changes(
                 filepath_or_buffer=tmp_file_path, params=parsed_params, n_rows=1000
             )
 
-            all_valid, errors = validate_multiple_type_changes(
+            all_valid, errors, resolved_dtypes = validate_multiple_type_changes(
                 sample_df, parsed_type_changes
             )
 
             return {
                 "valid": all_valid,
                 "errors": errors,
+                # A Date column's strptime format is detected from the data, so
+                # the frontend learns it here rather than choosing it.
+                "resolved_dtypes": resolved_dtypes,
             }
 
         finally:

--- a/DashAI/back/dataloaders/classes/dashai_dataset.py
+++ b/DashAI/back/dataloaders/classes/dashai_dataset.py
@@ -817,8 +817,23 @@ def transform_dataset_with_schema(
                     # we are saving them as strings to preserve the original format.
                     # Can modify classes in value_types.py
                     # if want to use PyArrow date, time or timestamp types.
+                    #
+                    # Two dict shapes reach this function. The one built by
+                    # type inference and by get_columns_spec carries the
+                    # strptime format in "dtype"; the one a column emits
+                    # through to_string() carries it in "format" and leaves
+                    # "dtype" as the arrow type. Reading only "dtype" turned
+                    # the second shape's format into the literal "string".
+                    _format = info.get("format") or dtype
+                    if not _format:
+                        raise ValueError(
+                            f"Column '{column_name}' is typed as {_type} but "
+                            "carries no format. A date, time or timestamp "
+                            "column is stored as text plus a strptime format, "
+                            "so the format has to be resolved before saving."
+                        )
                     dashai_types[column_name] = arrow_to_dashai_types(
-                        arrow_type=_type, format=dtype
+                        arrow_type=_type, format=_format
                     )
                     pa_type = to_arrow_types("string")
                     dai_table[column_name] = table.column(column_name)

--- a/DashAI/back/types/date_utils.py
+++ b/DashAI/back/types/date_utils.py
@@ -52,6 +52,30 @@ def _as_clean_text(values: Any) -> "pd.Series":
     return text.mask(text == "")
 
 
+def _names_a_full_date(date_format: str) -> bool:
+    """Check that a strptime format pins down a specific day.
+
+    A format naming only a year and a month, such as ``"%Y-%m"``, parses
+    cleanly but silently invents a day of the month. Treating such a column as
+    a Date would hand every consumer a date the data never stated, so those
+    columns are better left as text.
+
+    Parameters
+    ----------
+    date_format : str
+        The strptime format to check.
+
+    Returns
+    -------
+    bool
+        ``True`` when the format names a day, a month and a year.
+    """
+    has_day = "%d" in date_format
+    has_month = any(token in date_format for token in ("%m", "%b", "%B"))
+    has_year = "%Y" in date_format or "%y" in date_format
+    return has_day and has_month and has_year
+
+
 def parse_date_column(values: Any, format: str = DEFAULT_DATE_FORMAT) -> "pd.Series":
     """Parse a column of date strings into datetimes.
 
@@ -146,6 +170,8 @@ def detect_date_format(values: Any, hint: Optional[str] = None) -> Optional[str]
     candidates.extend(fmt for fmt in extras if fmt not in candidates)
 
     for candidate in candidates:
+        if not _names_a_full_date(candidate):
+            continue
         try:
             parse_date_column(text, candidate)
         except ValueError:

--- a/DashAI/back/types/date_utils.py
+++ b/DashAI/back/types/date_utils.py
@@ -1,0 +1,189 @@
+"""Helpers for reading DashAI ``Date`` columns.
+
+A ``Date`` column is stored as text plus a strptime format, so anything that
+needs real datetimes has to parse first. This module is the only place that
+does, because text ordering agrees with chronological ordering for ISO layouts
+alone: ``"31-01-2020" < "01-02-2020"`` holds as text and fails as dates.
+"""
+
+from typing import TYPE_CHECKING, Any, Final, List, Optional, Union
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+# The strptime format a Date column falls back to when nothing better is known.
+DEFAULT_DATE_FORMAT: Final[str] = "%Y-%m-%d"
+
+# Layouts ``pandas.guess_datetime_format`` does not produce. Two digit years
+# are the ones that matter: it returns None for "1/31/20". They are grouped by
+# component ordering so a day first hint can put the day first candidates ahead
+# of the month first ones, which is the only thing separating "01/02/20" from
+# itself read the other way round.
+_DAY_FIRST_EXTRA: Final[List[str]] = ["%d/%m/%y", "%d-%m-%y", "%d.%m.%y"]
+_MONTH_FIRST_EXTRA: Final[List[str]] = ["%m/%d/%y", "%m-%d-%y"]
+_YEAR_FIRST_EXTRA: Final[List[str]] = ["%y-%m-%d", "%y/%m/%d"]
+
+EXTRA_DATE_FORMATS: Final[List[str]] = (
+    _MONTH_FIRST_EXTRA + _DAY_FIRST_EXTRA + _YEAR_FIRST_EXTRA
+)
+
+# How many distinct values are handed to the format guesser. A single value can
+# be ambiguous ("01/02/2020"); a handful rarely all are.
+_SAMPLE_SIZE: Final[int] = 5
+
+
+def _as_clean_text(values: Any) -> "pd.Series":
+    """Normalise a column to stripped text with blanks treated as missing.
+
+    Parameters
+    ----------
+    values : Any
+        The column values. Anything ``pandas.Series`` accepts.
+
+    Returns
+    -------
+    pandas.Series
+        A string dtype series where empty and whitespace only entries are NA.
+    """
+    import pandas as pd  # local import
+
+    series = values if isinstance(values, pd.Series) else pd.Series(list(values))
+    text = series.reset_index(drop=True).astype("string").str.strip()
+    return text.mask(text == "")
+
+
+def parse_date_column(values: Any, format: str = DEFAULT_DATE_FORMAT) -> "pd.Series":
+    """Parse a column of date strings into datetimes.
+
+    Parameters
+    ----------
+    values : Any
+        The column values to parse.
+    format : str, optional
+        A strptime format such as ``"%d/%m/%Y"``. Defaults to
+        ``DEFAULT_DATE_FORMAT``.
+
+    Returns
+    -------
+    pandas.Series
+        The parsed datetimes. Missing and blank entries stay ``NaT``.
+
+    Raises
+    ------
+    ValueError
+        If any non-missing value does not match ``format``. The message names
+        up to three of the offending values.
+    """
+    import pandas as pd  # local import
+
+    text = _as_clean_text(values)
+    parsed = pd.to_datetime(text, format=format, errors="coerce")
+
+    failed = text.notna() & parsed.isna()
+    if failed.any():
+        sample = ", ".join(repr(value) for value in text[failed].unique()[:3])
+        raise ValueError(
+            f"{int(failed.sum())} value(s) do not match the date format "
+            f"'{format}': {sample}"
+        )
+
+    return parsed
+
+
+def detect_date_format(values: Any, hint: Optional[str] = None) -> Optional[str]:
+    """Find a strptime format that reads every value in a column.
+
+    Candidates come from ``pandas.guess_datetime_format`` applied to a sample
+    of the values under both day first and month first readings, followed by
+    ``EXTRA_DATE_FORMATS``. Each candidate is then checked against the whole
+    column, which is what catches a guess that only fits the first few rows.
+
+    Parameters
+    ----------
+    values : Any
+        The column values to inspect.
+    hint : str, optional
+        The ptype label for this column. ``"date-eu"`` means day first, which
+        is the only thing that can disambiguate a value like ``"01/02/2020"``.
+
+    Returns
+    -------
+    str or None
+        A strptime format that parses every non-missing value, or ``None``
+        when no candidate does.
+    """
+    import warnings  # local import
+
+    from pandas.tseries.api import guess_datetime_format  # local import
+
+    text = _as_clean_text(values).dropna()
+    if text.empty:
+        return None
+
+    day_first = hint == "date-eu"
+    sample = text.drop_duplicates().head(_SAMPLE_SIZE)
+
+    candidates: List[str] = []
+    # Trying both readings is the point, so pandas warning that a value looks
+    # day first while asked month first says nothing new. Left unsuppressed it
+    # fires for most columns of every upload.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        for first in (day_first, not day_first):
+            for value in sample:
+                try:
+                    guess = guess_datetime_format(value, dayfirst=first)
+                except (ValueError, TypeError):
+                    guess = None
+                if guess and guess not in candidates:
+                    candidates.append(guess)
+
+    extras = (
+        _DAY_FIRST_EXTRA + _MONTH_FIRST_EXTRA + _YEAR_FIRST_EXTRA
+        if day_first
+        else EXTRA_DATE_FORMATS
+    )
+    candidates.extend(fmt for fmt in extras if fmt not in candidates)
+
+    for candidate in candidates:
+        try:
+            parse_date_column(text, candidate)
+        except ValueError:
+            continue
+        return candidate
+
+    return None
+
+
+def infer_frequency(dates: Any) -> Union[str, "pd.Timedelta", None]:
+    """Describe the calendar spacing of a parsed date series.
+
+    Parameters
+    ----------
+    dates : Any
+        Already parsed datetimes, in ascending order.
+
+    Returns
+    -------
+    str or pandas.Timedelta or None
+        A pandas frequency alias when the dates sit on a regular grid, the
+        most common gap between consecutive dates when they do not, and
+        ``None`` when there is too little data to say anything.
+    """
+    import pandas as pd  # local import
+
+    parsed = pd.to_datetime(pd.Series(list(dates)), errors="coerce").dropna()
+    if len(parsed) < 3:
+        return None
+
+    index = pd.DatetimeIndex(parsed)
+    try:
+        alias = pd.infer_freq(index)
+    except ValueError:
+        alias = None
+    if alias is not None:
+        return alias
+
+    gaps = index.to_series().diff().dropna()
+    modes = gaps.mode()
+    return modes.iloc[0] if not modes.empty else None

--- a/DashAI/back/types/inf/inference_methods.py
+++ b/DashAI/back/types/inf/inference_methods.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 import DashAI.back.types.inf.ptype.Machine as Machine
+from DashAI.back.types.date_utils import detect_date_format
 from DashAI.back.types.inf.Inference import InferenceMethod
 from DashAI.back.types.inf.ptype.Machines import MACHINES, Machines
 from DashAI.back.types.inf.ptype.PtypeCat import PtypeCat
@@ -96,6 +97,21 @@ class DashAIPtype(PtypeCat, InferenceMethod):
                 else:
                     dashai_info["encoder"] = "one_hot"
 
+            # A Date column stores a strptime format, and the ptype label does
+            # not name one: "01-01-2020" and "01/02/2020" both come back as
+            # "date-eu". Read the layout off the values, and stay Text when
+            # nothing fits, which is what happened for every date before this.
+            elif dashai_info["type"] == "Date":
+                detected = detect_date_format(data[col_name].dropna(), hint=ptype_type)
+                if detected is None:
+                    dashai_info = {
+                        "type": "Text",
+                        "dtype": "string",
+                        "encoding": "utf-8",
+                    }
+                else:
+                    dashai_info["dtype"] = detected
+
             reason = getattr(col_object, "inference_reason", None)
             if reason is not None:
                 reason = {**reason}
@@ -171,7 +187,10 @@ class DummyCategoricalInference(InferenceMethod):
             elif pd.api.types.is_bool_dtype(dtype):
                 inferred_types[col] = PTYPE_TO_DASHAI["boolean"]
             elif pd.api.types.is_datetime64_any_dtype(dtype):
-                inferred_types[col] = PTYPE_TO_DASHAI["date-iso-8601"]
+                # This method does no format detection, so it cannot produce a
+                # usable Date. "string" is the same dict the date entry held
+                # before Date was enabled, so behaviour here is unchanged.
+                inferred_types[col] = PTYPE_TO_DASHAI["string"]
             else:
                 inferred_types[col] = PTYPE_TO_DASHAI["string"]
         return inferred_types

--- a/DashAI/back/types/type_validation.py
+++ b/DashAI/back/types/type_validation.py
@@ -6,7 +6,10 @@ from beartype import beartype
 
 @beartype
 def validate_type_change(
-    column_data: pd.Series, current_type: str, new_type: str, new_dtype: str = None
+    column_data: pd.Series,
+    current_type: str,
+    new_type: str,
+    new_dtype: Optional[str] = None,
 ) -> Tuple[bool, str, Optional[pd.Series]]:
     """
     Validates if a column can be safely converted to a new type.
@@ -48,8 +51,9 @@ def validate_type_change(
         ("Float", "Text"): lambda x: (True, "", x.astype(str)),
         ("Text", "Integer"): _validate_text_to_int,
         ("Text", "Float"): _validate_text_to_float,
-        # Date/Time/Timestamp conversions disabled - uncomment when supported
-        # ("Text", "Date"): lambda x: _validate_text_to_date(x, new_dtype),
+        ("Text", "Date"): lambda x: _validate_text_to_date(x, new_dtype),
+        ("Date", "Text"): lambda x: (True, "", x.astype(str)),
+        # Time and Timestamp stay disabled: no format can be inferred for them.
         # ("Text", "Time"): lambda x: _validate_text_to_time(x, new_dtype),
         # ("Text", "Timestamp"): lambda x: _validate_text_to_timestamp(x, new_dtype),
         ("Categorical", "Text"): lambda x: (True, "", x.astype(str)),
@@ -179,22 +183,42 @@ def _validate_text_to_float(data: pd.Series) -> Tuple[bool, str, Optional[pd.Ser
 def _validate_text_to_date(
     data: pd.Series, format_str: str = None
 ) -> Tuple[bool, str, Optional[pd.Series]]:
-    """Validate conversion from Text to Date."""
+    """Validate conversion from Text to Date.
+
+    A Date column is stored as text plus a strptime format, so a successful
+    conversion returns the original strings untouched. Only the parse is
+    checked.
+
+    Parameters
+    ----------
+    data : pd.Series
+        The column values, already stripped of nulls by the caller.
+    format_str : str, optional
+        The strptime format to check against. Detected from the values when
+        absent.
+
+    Returns
+    -------
+    Tuple[bool, str, Optional[pd.Series]]
+        Whether the conversion is valid, an error message when it is not, and
+        the unchanged values when it is.
+    """
+    from DashAI.back.types.date_utils import detect_date_format, parse_date_column
+
+    resolved = format_str or detect_date_format(data)
+    if not resolved:
+        return (
+            False,
+            "No known date format reads every value in this column",
+            None,
+        )
+
     try:
-        converted = pd.to_datetime(data, format=format_str, errors="coerce")
+        parse_date_column(data, resolved)
+    except ValueError as e:
+        return False, str(e), None
 
-        failed_conversions = converted.isna().sum()
-
-        if failed_conversions > 0:
-            return (
-                False,
-                f"{failed_conversions} values cannot be converted to Date",
-                None,
-            )
-
-        return True, "", converted
-    except Exception as e:
-        return False, f"Text to Date conversion failed: {str(e)}", None
+    return True, "", data
 
 
 def _validate_text_to_time(
@@ -289,7 +313,7 @@ def _validate_categorical_to_float(
 @beartype
 def validate_multiple_type_changes(
     data: pd.DataFrame, type_changes: Dict[str, Dict[str, str]]
-) -> Tuple[bool, Dict[str, str]]:
+) -> Tuple[bool, Dict[str, str], Dict[str, str]]:
     """
     Validate multiple column type changes at once.
 
@@ -303,11 +327,15 @@ def validate_multiple_type_changes(
 
     Returns
     -------
-    Tuple[bool, Dict[str, str]]
+    Tuple[bool, Dict[str, str], Dict[str, str]]
         - all_valid: Whether all changes are valid
         - errors: Dictionary of column names to error messages
+        - resolved_dtypes: Dictionary of column names to the dtype actually
+          used. For a Date column this is the detected strptime format, which
+          the caller has no other way to learn.
     """
     errors = {}
+    resolved_dtypes = {}
 
     for column_name, change in type_changes.items():
         if column_name not in data.columns:
@@ -318,14 +346,23 @@ def validate_multiple_type_changes(
         new_type = change.get("new_type")
         new_dtype = change.get("new_dtype")
 
+        if new_type == "Date" and not new_dtype:
+            # The user picks the type; the layout is read off the data, so a
+            # Date column works whatever format it happens to use.
+            from DashAI.back.types.date_utils import detect_date_format
+
+            new_dtype = detect_date_format(data[column_name].dropna())
+
         is_valid, error_msg, _ = validate_type_change(
             data[column_name], current_type, new_type, new_dtype
         )
 
         if not is_valid:
             errors[column_name] = error_msg
+        elif new_dtype:
+            resolved_dtypes[column_name] = new_dtype
 
-    return len(errors) == 0, errors
+    return len(errors) == 0, errors, resolved_dtypes
 
 
 def validate_categorical_suitability(

--- a/DashAI/back/types/type_validation.py
+++ b/DashAI/back/types/type_validation.py
@@ -59,6 +59,11 @@ def validate_type_change(
         ("Categorical", "Text"): lambda x: (True, "", x.astype(str)),
         ("Categorical", "Integer"): _validate_categorical_to_int,
         ("Categorical", "Float"): _validate_categorical_to_float,
+        # A date column with few enough distinct values is inferred as
+        # Categorical. Its values are the same date strings a Text column
+        # holds, so the check is identical, and without this the user has to
+        # detour through Text to correct the type.
+        ("Categorical", "Date"): lambda x: _validate_text_to_date(x, new_dtype),
     }
 
     # Get the appropriate validation function

--- a/DashAI/back/types/type_validation.py
+++ b/DashAI/back/types/type_validation.py
@@ -357,6 +357,16 @@ def validate_multiple_type_changes(
             from DashAI.back.types.date_utils import detect_date_format
 
             new_dtype = detect_date_format(data[column_name].dropna())
+            if not new_dtype:
+                # A Date column is meaningless without a format, and
+                # validate_type_change would wave an all-null column through:
+                # it answers "valid" for any target before looking at the
+                # values. Saying yes here hands the frontend a change with no
+                # dtype, which crashes the dataset job when it builds the type.
+                errors[column_name] = (
+                    "No known date format reads every value in this column"
+                )
+                continue
 
         is_valid, error_msg, _ = validate_type_change(
             data[column_name], current_type, new_type, new_dtype

--- a/DashAI/back/types/utils.py
+++ b/DashAI/back/types/utils.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Final, List
 
 from DashAI.back.types.categorical import Categorical
 from DashAI.back.types.dashai_data_type import DashAIDataType
+from DashAI.back.types.date_utils import DEFAULT_DATE_FORMAT
 from DashAI.back.types.value_types import (
     Binary,
     DashAIValue,
@@ -235,6 +236,17 @@ def get_types_from_arrow_metadata(
 
                 dtype = info.get("dtype", "struct")
                 dashai_types[column] = DashAIImage(dtype=dtype)
+            elif _type == "Date":
+                # A Date column is text plus a strptime format, so its stored
+                # dtype is "string" and the layout lives in "format". Routing
+                # it through the dtype map below would rebuild it as Text and
+                # drop the format, which is exactly the bug this branch fixes.
+                import pyarrow as pa  # local import
+
+                dashai_types[column] = Date(
+                    arrow_type=pa.string(),
+                    format=info.get("format", DEFAULT_DATE_FORMAT),
+                )
             else:
                 dtype = info.get("dtype")
                 dtype_map = _get_dtype_arrow_map()

--- a/DashAI/back/types/utils.py
+++ b/DashAI/back/types/utils.py
@@ -73,9 +73,13 @@ PTYPE_TO_DASHAI = {
     # For simplicity, we use categorical for booleans.
     "boolean": {"type": "Categorical", "dtype": "string"},
     "categorical": {"type": "Categorical", "dtype": "string"},
-    # Date types mapped to Text until date support is implemented
-    "date-iso-8601": {"type": "Text", "dtype": "string", "encoding": "utf-8"},
-    "date-eu": {"type": "Text", "dtype": "string", "encoding": "utf-8"},
+    # The dtype is a placeholder. The real strptime format is detected from the
+    # column in DashAIPtype.infer_types, because the ptype label names the
+    # component ordering but not the separator.
+    "date-iso-8601": {"type": "Date", "dtype": "%Y-%m-%d"},
+    "date-eu": {"type": "Date", "dtype": "%Y-%m-%d"},
+    # No format can be inferred for the rest, and guessing one would corrupt
+    # data silently, so they stay Text.
     "date-non-std": {"type": "Text", "dtype": "string", "encoding": "utf-8"},
     "date-non-std-subtype": {"type": "Text", "dtype": "string", "encoding": "utf-8"},
     "time": {"type": "Text", "dtype": "string", "encoding": "utf-8"},

--- a/DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx
@@ -17,7 +17,14 @@ const TYPE_TO_DEFAULT_DTYPE = {
   Image: "string",
 };
 
-const TYPE_OPTIONS = ["Integer", "Float", "Text", "Categorical", "Image"];
+const TYPE_OPTIONS = [
+  "Integer",
+  "Float",
+  "Text",
+  "Categorical",
+  "Date",
+  "Image",
+];
 
 const PAGE_SIZE = 5;
 
@@ -100,10 +107,14 @@ function PreviewDatasetTable({
       const currentType = columnTypes[field]?.type;
       if (currentType === newType) return;
       const currentDtype = columnTypes[field]?.dtype;
+      // A Date column's dtype is a strptime format, which only the backend can
+      // work out from the values. Sending null asks it to detect one.
       const newDtype =
-        newType === "Categorical" && currentDtype
-          ? currentDtype
-          : TYPE_TO_DEFAULT_DTYPE[newType] || "string";
+        newType === "Date"
+          ? null
+          : newType === "Categorical" && currentDtype
+            ? currentDtype
+            : TYPE_TO_DEFAULT_DTYPE[newType] || "string";
       setPendingChanges({
         [field]: {
           current_type: currentType,

--- a/DashAI/front/src/components/notebooks/datasetCreation/TypeChangeValidator.jsx
+++ b/DashAI/front/src/components/notebooks/datasetCreation/TypeChangeValidator.jsx
@@ -18,6 +18,18 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import { validateTypeChanges } from "../../../api/datasets";
 import { useTranslation } from "react-i18next";
 
+// The backend reads a Date column's strptime format off the data, so the
+// confirmed change has to carry what it resolved rather than what we sent.
+const withResolvedDtypes = (typeChanges, validationResult) => {
+  const resolved = validationResult?.resolved_dtypes || {};
+  return Object.fromEntries(
+    Object.entries(typeChanges).map(([column, change]) => [
+      column,
+      resolved[column] ? { ...change, new_dtype: resolved[column] } : change,
+    ]),
+  );
+};
+
 export const TypeChangeValidator = ({
   open,
   onClose,
@@ -137,7 +149,9 @@ export const TypeChangeValidator = ({
           {t("common:cancel")}
         </Button>
         <Button
-          onClick={() => onConfirm(typeChanges)}
+          onClick={() =>
+            onConfirm(withResolvedDtypes(typeChanges, validationResult))
+          }
           disabled={!validationResult?.valid || validating}
           variant="contained"
           color="primary"

--- a/tests/back/api/test_validate_type_changes_dates.py
+++ b/tests/back/api/test_validate_type_changes_dates.py
@@ -1,0 +1,47 @@
+import io
+import json
+
+from fastapi.testclient import TestClient
+
+# The module scoped ``client`` fixture comes from tests/back/api/conftest.py.
+# Defining a local one here would shadow it and break the autouse fixtures
+# that depend on it.
+
+
+def _post(client, csv_text, type_changes):
+    return client.post(
+        "/api/v1/dataset/validate_type_changes",
+        data={
+            "type_changes": json.dumps(type_changes),
+            "params": json.dumps(
+                {"dataloader_name": "CSVDataLoader", "separator": ","}
+            ),
+        },
+        files={"file": ("series.csv", io.BytesIO(csv_text.encode()), "text/csv")},
+    )
+
+
+def test_endpoint_returns_the_detected_date_format(client: TestClient):
+    csv_text = "when,sales\n01/02/2020,100\n05/02/2020,120\n13/02/2020,115\n"
+
+    response = _post(
+        client, csv_text, {"when": {"current_type": "Text", "new_type": "Date"}}
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["valid"] is True, payload["errors"]
+    assert payload["resolved_dtypes"]["when"] == "%d/%m/%Y"
+
+
+def test_endpoint_reports_an_unreadable_date_column(client: TestClient):
+    csv_text = "when,sales\nQ1 2020,100\nQ2 2020,120\n"
+
+    response = _post(
+        client, csv_text, {"when": {"current_type": "Text", "new_type": "Date"}}
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["valid"] is False
+    assert "when" in payload["errors"]

--- a/tests/back/types/date_inference_test.py
+++ b/tests/back/types/date_inference_test.py
@@ -1,0 +1,93 @@
+import pandas as pd
+
+from DashAI.back.types.inf.type_inference import infer_types
+
+
+def _infer(values):
+    one_column = pd.DataFrame({"col": values})
+    return infer_types(one_column, "DashAIPtype")["col"]
+
+
+def test_iso_dates_are_inferred_as_date():
+    result = _infer(
+        [
+            "2020-01-01",
+            "2020-01-02",
+            "2020-01-03",
+            "2020-01-04",
+            "2020-01-05",
+            "2020-01-06",
+        ]
+    )
+
+    assert result["type"] == "Date"
+    assert result["dtype"] == "%Y-%m-%d"
+
+
+def test_dash_separated_eu_dates_keep_their_separator():
+    result = _infer(
+        [
+            "01-01-2020",
+            "02-01-2020",
+            "03-01-2020",
+            "04-01-2020",
+            "05-01-2020",
+            "06-01-2020",
+        ]
+    )
+
+    assert result["type"] == "Date"
+    assert result["dtype"] == "%d-%m-%Y"
+
+
+def test_slash_separated_eu_dates_keep_their_separator():
+    # ptype labels this "date-eu" too, so only detection tells the two apart.
+    result = _infer(
+        [
+            "01/02/2020",
+            "02/02/2020",
+            "03/02/2020",
+            "04/02/2020",
+            "05/02/2020",
+            "06/02/2020",
+        ]
+    )
+
+    assert result["type"] == "Date"
+    assert result["dtype"] == "%d/%m/%Y"
+
+
+def test_two_digit_years_are_inferred_as_date():
+    # ptype labels these "date-eu"; guess_datetime_format cannot read them, so
+    # this proves the EXTRA_DATE_FORMATS fallback runs inside inference too.
+    result = _infer(["1/31/20", "2/28/20", "3/15/20", "4/02/20", "5/19/20", "6/07/20"])
+
+    assert result["type"] == "Date"
+    assert result["dtype"] == "%m/%d/%y"
+
+
+def test_month_name_dates_are_not_reached_by_inference():
+    # A documented limit, not a wish. ptype labels "31 January 2020" as
+    # "string", so it never enters the date branch at all. Such a column
+    # becomes a Date only through a manual type change, where
+    # detect_date_format does read it. If ptype is ever taught to label these
+    # as a date type, this test starts failing and should become an assertion
+    # that the column is a Date with format "%d %B %Y".
+    result = _infer(
+        [
+            "31 January 2020",
+            "01 February 2020",
+            "15 March 2020",
+            "02 April 2020",
+            "19 May 2020",
+            "07 June 2020",
+        ]
+    )
+
+    assert result["type"] != "Date"
+
+
+def test_numeric_columns_are_untouched():
+    result = _infer([100, 120, 115, 140, 150, 160])
+
+    assert result["type"] == "Integer"

--- a/tests/back/types/date_metadata_test.py
+++ b/tests/back/types/date_metadata_test.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pyarrow as pa
+import pytest
 
 from DashAI.back.dataloaders.classes.dashai_dataset import (
     load_dataset,
@@ -76,3 +77,31 @@ def test_text_columns_are_unaffected():
     restored = get_types_from_arrow_metadata(table)
 
     assert isinstance(restored["note"], Text)
+
+
+def test_a_date_survives_a_schema_built_from_to_string():
+    # Two dict shapes reach transform_dataset_with_schema. Inference and
+    # get_columns_spec put the strptime format in "dtype"; to_string() puts it
+    # in "format" and leaves "dtype" as the arrow type. predict_job and
+    # dataset_job build their schema the second way, which used to overwrite
+    # the format with the literal "string".
+    frame = pd.DataFrame({"when": ["31/01/2020", "15/02/2020"]})
+    dataset = transform_dataset_with_schema(
+        to_dashai_dataset(frame), {"when": {"type": "Date", "dtype": "%d/%m/%Y"}}
+    )
+
+    schema = {col: typ.to_string() for col, typ in dataset.types.items()}
+    reloaded = transform_dataset_with_schema(dataset, schema)
+
+    assert reloaded.types["when"].format == "%d/%m/%Y"
+
+
+def test_a_date_without_a_resolvable_format_is_refused():
+    # Better a named error than the AttributeError raised deep in
+    # arrow_to_dashai_types when it is handed a format of None.
+    frame = pd.DataFrame({"when": ["31/01/2020"]})
+
+    with pytest.raises(ValueError, match="carries no format"):
+        transform_dataset_with_schema(
+            to_dashai_dataset(frame), {"when": {"type": "Date", "dtype": None}}
+        )

--- a/tests/back/types/date_metadata_test.py
+++ b/tests/back/types/date_metadata_test.py
@@ -1,0 +1,45 @@
+import pyarrow as pa
+
+from DashAI.back.types.utils import (
+    get_types_from_arrow_metadata,
+    save_types_in_arrow_metadata,
+)
+from DashAI.back.types.value_types import Date, Text
+
+
+def _table_with_date_type(fmt):
+    table = pa.table({"when": pa.array(["2020-01-31", "2020-02-29"])})
+    date_type = Date(arrow_type=pa.string(), format=fmt)
+    return save_types_in_arrow_metadata(table, {"when": date_type.to_string()})
+
+
+def test_date_type_survives_the_arrow_metadata_round_trip():
+    table = _table_with_date_type("%d/%m/%Y")
+
+    restored = get_types_from_arrow_metadata(table)
+
+    assert isinstance(restored["when"], Date)
+    assert restored["when"].format == "%d/%m/%Y"
+
+
+def test_date_without_a_stored_format_falls_back_to_iso():
+    table = pa.table({"when": pa.array(["2020-01-31"])})
+    table = save_types_in_arrow_metadata(
+        table, {"when": {"type": "Date", "dtype": "string"}}
+    )
+
+    restored = get_types_from_arrow_metadata(table)
+
+    assert isinstance(restored["when"], Date)
+    assert restored["when"].format == "%Y-%m-%d"
+
+
+def test_text_columns_are_unaffected():
+    table = pa.table({"note": pa.array(["hello"])})
+    table = save_types_in_arrow_metadata(
+        table, {"note": Text(arrow_type=pa.string()).to_string()}
+    )
+
+    restored = get_types_from_arrow_metadata(table)
+
+    assert isinstance(restored["note"], Text)

--- a/tests/back/types/date_metadata_test.py
+++ b/tests/back/types/date_metadata_test.py
@@ -1,5 +1,12 @@
+import pandas as pd
 import pyarrow as pa
 
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    load_dataset,
+    save_dataset,
+    to_dashai_dataset,
+    transform_dataset_with_schema,
+)
 from DashAI.back.types.utils import (
     get_types_from_arrow_metadata,
     save_types_in_arrow_metadata,
@@ -32,6 +39,32 @@ def test_date_without_a_stored_format_falls_back_to_iso():
 
     assert isinstance(restored["when"], Date)
     assert restored["when"].format == "%Y-%m-%d"
+
+
+def test_a_date_column_survives_a_real_save_and_load(tmp_path):
+    # The end to end version of the round trip: a schema carrying a Date goes
+    # through transform, save and load, and comes back a Date with its format
+    # and its original text intact.
+    frame = pd.DataFrame(
+        {"when": ["31/01/2020", "15/02/2020", "03/03/2020"], "sales": [100, 120, 115]}
+    )
+    schema = {
+        "when": {"type": "Date", "dtype": "%d/%m/%Y"},
+        "sales": {"type": "Integer", "dtype": "int64"},
+    }
+
+    dataset = transform_dataset_with_schema(to_dashai_dataset(frame), schema)
+    save_dataset(dataset, tmp_path / "dataset")
+    restored = load_dataset(str(tmp_path / "dataset"))
+
+    assert isinstance(restored.types["when"], Date)
+    assert restored.types["when"].format == "%d/%m/%Y"
+    # Text preserved byte for byte, since nothing parses at rest.
+    assert restored.arrow_table.column("when").to_pylist() == [
+        "31/01/2020",
+        "15/02/2020",
+        "03/03/2020",
+    ]
 
 
 def test_text_columns_are_unaffected():

--- a/tests/back/types/date_utils_test.py
+++ b/tests/back/types/date_utils_test.py
@@ -64,6 +64,57 @@ def test_detect_date_format_resolves_ambiguity_from_the_whole_column():
     assert detected == "%d/%m/%Y"
 
 
+TEST_COLUMNS = [
+    (["2026-01-05", "2026-02-14", "2026-12-25"], "%Y-%m-%d"),
+    (["01/05/2026", "02/14/2026", "12/25/2026"], "%m/%d/%Y"),
+    (["05/01/2026", "14/02/2026", "25/12/2026"], "%d/%m/%Y"),
+    (["05/01/26", "14/02/26", "25/12/26"], "%d/%m/%y"),
+    (["January 5 2026", "February 14 2026", "December 25 2026"], "%B %d %Y"),
+    (["5 Jan 2026", "14 Feb 2026", "25 Dec 2026"], "%d %b %Y"),
+    (
+        ["2026-01-05T09:30:00", "2026-02-14T14:20:00", "2026-12-25T16:30:00"],
+        "%Y-%m-%dT%H:%M:%S",
+    ),
+    (
+        ["2026-01-05 09:30:00", "2026-02-14 14:20:00", "2026-12-25 16:30:00"],
+        "%Y-%m-%d %H:%M:%S",
+    ),
+    (
+        ["01/05/2026 09:30 AM", "02/14/2026 02:20 PM", "12/25/2026 04:30 PM"],
+        "%m/%d/%Y %I:%M %p",
+    ),
+    (
+        ["05/01/2026 09:30", "14/02/2026 14:20", "25/12/2026 16:30"],
+        "%d/%m/%Y %H:%M",
+    ),
+    (
+        [
+            "2026-01-05T09:30:00-03:00",
+            "2026-02-14T14:20:00-03:00",
+            "2026-12-25T16:30:00-03:00",
+        ],
+        "%Y-%m-%dT%H:%M:%S%z",
+    ),
+    # A year and a month name no day, so reading them as dates would invent one.
+    (["2026-01", "2026-02", "2026-12"], None),
+    (["Jan-2026", "Feb-2026", "Dec-2026"], None),
+    (["1767616200", "1771093200", "1798227000"], None),
+]
+
+
+@pytest.mark.parametrize(("values", "expected"), TEST_COLUMNS)
+def test_detect_date_format_on_test_columns(values, expected):
+    assert detect_date_format(values) == expected
+
+
+def test_detect_date_format_rejects_a_column_with_one_odd_value():
+    # A single stray value is enough to disqualify a format, which is what
+    # makes whole column validation worth doing. A shifted CSV row lands here.
+    values = ["2026-01-05T09:30:00-03:00", "2026-02-14T14:20:00-03:00", "2026-12"]
+
+    assert detect_date_format(values) is None
+
+
 def test_detect_date_format_returns_none_for_unreadable_values():
     assert detect_date_format(["Q1 2020", "Q2 2020"]) is None
 

--- a/tests/back/types/date_utils_test.py
+++ b/tests/back/types/date_utils_test.py
@@ -1,0 +1,94 @@
+import pandas as pd
+import pytest
+
+from DashAI.back.types.date_utils import (
+    detect_date_format,
+    infer_frequency,
+    parse_date_column,
+)
+
+
+def test_parse_date_column_reads_iso_dates():
+    parsed = parse_date_column(["2020-01-31", "2020-02-29"], "%Y-%m-%d")
+
+    assert list(parsed.astype(str)) == ["2020-01-31", "2020-02-29"]
+
+
+def test_parse_date_column_reads_month_names():
+    parsed = parse_date_column(["31 January 2020"], "%d %B %Y")
+
+    assert list(parsed.astype(str)) == ["2020-01-31"]
+
+
+def test_parse_date_column_keeps_nulls_as_nat():
+    parsed = parse_date_column(["2020-01-31", None, ""], "%Y-%m-%d")
+
+    assert parsed.isna().tolist() == [False, True, True]
+
+
+def test_parse_date_column_names_the_values_it_cannot_read():
+    with pytest.raises(ValueError, match="banana"):
+        parse_date_column(["2020-01-31", "banana"], "%Y-%m-%d")
+
+
+def test_detect_date_format_finds_iso():
+    assert detect_date_format(["2020-01-31", "2020-02-29"]) == "%Y-%m-%d"
+
+
+def test_detect_date_format_separates_dash_and_slash_eu_dates():
+    # ptype labels both of these "date-eu"; only the data tells them apart.
+    assert detect_date_format(["31-01-2020"], hint="date-eu") == "%d-%m-%Y"
+    assert detect_date_format(["31/01/2020"], hint="date-eu") == "%d/%m/%Y"
+
+
+def test_detect_date_format_finds_month_names():
+    assert detect_date_format(["31 January 2020"]) == "%d %B %Y"
+
+
+def test_detect_date_format_finds_two_digit_years():
+    # guess_datetime_format returns None here, so this exercises the
+    # EXTRA_DATE_FORMATS fallback.
+    assert detect_date_format(["1/31/20", "2/28/20"]) == "%m/%d/%y"
+
+
+def test_detect_date_format_honours_the_day_first_hint_for_two_digit_years():
+    # Every value here reads both ways, so only the hint can decide.
+    assert detect_date_format(["01/02/20", "05/02/20"], hint="date-eu") == "%d/%m/%y"
+    assert detect_date_format(["01/02/20", "05/02/20"]) == "%m/%d/%y"
+
+
+def test_detect_date_format_resolves_ambiguity_from_the_whole_column():
+    # The first value alone guesses month first. The third value rules it out.
+    detected = detect_date_format(["01/02/2020", "05/02/2020", "13/02/2020"])
+
+    assert detected == "%d/%m/%Y"
+
+
+def test_detect_date_format_returns_none_for_unreadable_values():
+    assert detect_date_format(["Q1 2020", "Q2 2020"]) is None
+
+
+def test_detect_date_format_returns_none_for_an_empty_column():
+    assert detect_date_format([None, ""]) is None
+
+
+def test_infer_frequency_reads_a_daily_grid():
+    dates = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])
+
+    assert infer_frequency(dates) == "D"
+
+
+def test_infer_frequency_reads_a_monthly_grid():
+    dates = pd.to_datetime(["2020-01-01", "2020-02-01", "2020-03-01"])
+
+    assert infer_frequency(dates) == "MS"
+
+
+def test_infer_frequency_falls_back_to_the_most_common_gap():
+    dates = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-05", "2020-01-06"])
+
+    assert infer_frequency(dates) == pd.Timedelta(days=1)
+
+
+def test_infer_frequency_gives_up_on_too_few_dates():
+    assert infer_frequency(pd.to_datetime(["2020-01-01"])) is None

--- a/tests/back/types/date_validation_test.py
+++ b/tests/back/types/date_validation_test.py
@@ -35,6 +35,40 @@ def test_text_to_date_detects_the_format_when_none_is_given():
     assert is_valid, message
 
 
+def test_categorical_to_date_is_allowed():
+    # A date column with few enough distinct values is inferred as Categorical,
+    # and the user should be able to correct that in one step rather than
+    # detouring through Text.
+    column = pd.Series(["05/01/2026", "14/02/2026", "25/12/2026"])
+
+    is_valid, message, converted = validate_type_change(
+        column, "Categorical", "Date", "%d/%m/%Y"
+    )
+
+    assert is_valid, message
+    assert list(converted) == ["05/01/2026", "14/02/2026", "25/12/2026"]
+
+
+def test_categorical_to_date_detects_the_format_when_none_is_given():
+    data = pd.DataFrame({"when": ["05/01/2026", "14/02/2026", "25/12/2026"]})
+
+    all_valid, errors, resolved = validate_multiple_type_changes(
+        data, {"when": {"current_type": "Categorical", "new_type": "Date"}}
+    )
+
+    assert all_valid, errors
+    assert resolved["when"] == "%d/%m/%Y"
+
+
+def test_categorical_to_date_rejects_values_that_are_not_dates():
+    column = pd.Series(["red", "green", "blue"])
+
+    is_valid, message, _ = validate_type_change(column, "Categorical", "Date", None)
+
+    assert not is_valid
+    assert message
+
+
 def test_date_to_text_is_allowed():
     column = pd.Series(["2020-01-31"])
 

--- a/tests/back/types/date_validation_test.py
+++ b/tests/back/types/date_validation_test.py
@@ -99,3 +99,19 @@ def test_multiple_changes_report_an_unreadable_date_column():
     assert not all_valid
     assert "when" in errors
     assert resolved == {}
+
+
+def test_an_empty_column_is_not_accepted_as_a_date():
+    # validate_type_change waves any target through for a column with no
+    # values, which would report a Date change as valid with no format to go
+    # with it. The frontend then sends a Date column with a null dtype and the
+    # dataset job dies building the type.
+    data = pd.DataFrame({"when": [None, None, None]})
+
+    all_valid, errors, resolved = validate_multiple_type_changes(
+        data, {"when": {"current_type": "Text", "new_type": "Date"}}
+    )
+
+    assert not all_valid
+    assert "when" in errors
+    assert resolved == {}

--- a/tests/back/types/date_validation_test.py
+++ b/tests/back/types/date_validation_test.py
@@ -1,0 +1,67 @@
+import pandas as pd
+
+from DashAI.back.types.type_validation import (
+    validate_multiple_type_changes,
+    validate_type_change,
+)
+
+
+def test_text_to_date_accepts_a_matching_format():
+    column = pd.Series(["2020-01-31", "2020-02-29"])
+
+    is_valid, message, converted = validate_type_change(
+        column, "Text", "Date", "%Y-%m-%d"
+    )
+
+    assert is_valid, message
+    # Storage is text, so the values must come back untouched.
+    assert list(converted) == ["2020-01-31", "2020-02-29"]
+
+
+def test_text_to_date_rejects_a_mismatched_format():
+    column = pd.Series(["31/01/2020"])
+
+    is_valid, message, _ = validate_type_change(column, "Text", "Date", "%Y-%m-%d")
+
+    assert not is_valid
+    assert "31/01/2020" in message
+
+
+def test_text_to_date_detects_the_format_when_none_is_given():
+    column = pd.Series(["31 January 2020", "01 February 2020"])
+
+    is_valid, message, _ = validate_type_change(column, "Text", "Date", None)
+
+    assert is_valid, message
+
+
+def test_date_to_text_is_allowed():
+    column = pd.Series(["2020-01-31"])
+
+    is_valid, message, converted = validate_type_change(column, "Date", "Text")
+
+    assert is_valid, message
+    assert list(converted) == ["2020-01-31"]
+
+
+def test_multiple_changes_report_the_resolved_date_format():
+    data = pd.DataFrame({"when": ["01/02/2020", "05/02/2020", "13/02/2020"]})
+
+    all_valid, errors, resolved = validate_multiple_type_changes(
+        data, {"when": {"current_type": "Text", "new_type": "Date"}}
+    )
+
+    assert all_valid, errors
+    assert resolved["when"] == "%d/%m/%Y"
+
+
+def test_multiple_changes_report_an_unreadable_date_column():
+    data = pd.DataFrame({"when": ["Q1 2020", "Q2 2020"]})
+
+    all_valid, errors, resolved = validate_multiple_type_changes(
+        data, {"when": {"current_type": "Text", "new_type": "Date"}}
+    )
+
+    assert not all_valid
+    assert "when" in errors
+    assert resolved == {}

--- a/tests/back/types/inference_test.py
+++ b/tests/back/types/inference_test.py
@@ -98,7 +98,11 @@ def test_infer_date_and_time():
 
     inferred = infer_types(date_df, method="DashAIPtype")
 
-    assert inferred["fecha"]["type"] == "Text"
+    # Dates are a real type now, carrying the strptime format read off the
+    # values. Times are not: no format can be inferred for them, so they stay
+    # Text until something needs them.
+    assert inferred["fecha"]["type"] == "Date"
+    assert inferred["fecha"]["dtype"] == "%Y-%m-%d"
     assert inferred["hora"]["type"] == "Text"
     assert "type" in inferred["float_col"]
     assert "type" in inferred["text_col"]


### PR DESCRIPTION
## Summary

Makes `Date` a real, usable DashAI column type, so a forecasting dataset can carry a date column that survives a save and load. 

A `Date` column is stored as an Arrow `string` plus a **strptime** `format` (`%d/%m/%Y`, `%d %B %Y`, `%Y-%m-%dT%H:%M:%S%z`); the original text is never rewritten. A fixed vocabulary of dashAI tokens was rejected because it cannot mean "every date", while strptime can. The scaffolding for this type already existed but was unreachable: `Date` was filtered out at every entry point.

The format is detected from the values rather than from the ptype label, because the label is not specific enough: ptype returns `date-eu` for both `01-01-2020` and `01/02/2020`, naming the ordering but not the separator.

---

## Type of Change

Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/types/date_utils.py`: new. The only place anything turns date text into datetimes, since text ordering matches chronological ordering for ISO layouts alone. Provides `parse_date_column`, `detect_date_format` and `infer_frequency`.
- `DashAI/back/types/utils.py`: map the `date-iso-8601` and `date-eu` ptypes to `Date`; add the missing `Date` branch to `get_types_from_arrow_metadata`.
- `DashAI/back/types/inf/inference_methods.py`: detect each date column's format from its values; fall back to `Text` when nothing fits.
- `DashAI/back/types/type_validation.py`: enable `Text` to `Date`, `Date` to `Text` and `Categorical` to `Date`; return the resolved dtype per column; widen `new_dtype` to `Optional[str]`.
- `DashAI/back/api/api_v1/endpoints/datasets.py`: return the resolved date format from `/dataset/validate_type_changes`.
- `DashAI/front/src/components/notebooks/datasetCreation/PreviewDatasetTable.jsx`: offer `Date` in the type editor and ask the backend to detect the format.
- `DashAI/front/src/components/notebooks/datasetCreation/TypeChangeValidator.jsx`: carry the resolved format into the confirmed change.
- `tests/back/types/`, `tests/back/api/`: 4 new test files covering parsing, detection, inference, metadata round trip and conversion.

---

## Testing (optional)

- Upload a CSV whose dates are not ISO, for example `31/01/2020`. It should infer as `Date` with format `%d/%m/%Y`, and the values should come back identical after a save and load.

Checked against a 16 column spreadsheet mixing 14 date layouts. All 11 genuine date columns detect correctly, including `2026-01-05T09:30:00-03:00`. The 3 non-dates (`2026-01`, `Jan-2026`, unix timestamps) are refused. 

