### PR TITLE
Add time series plot explorer for numeric and date columns

### DIFF
--- a/DashAI/back/exploration/explorers/time_series_plot.py
+++ b/DashAI/back/exploration/explorers/time_series_plot.py
@@ -1,0 +1,305 @@
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from DashAI.back.core.artifacts import Artifact, PlotlyArtifact
+from DashAI.back.core.schema_fields import bool_field, schema_field
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.dependencies.database.models import Explorer, Notebook
+from DashAI.back.exploration.base_explorer import BaseExplorerSchema
+from DashAI.back.exploration.relationship_explorer import RelationshipExplorer
+from DashAI.back.types.value_types import Date, Float, Integer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+# Semantic types that can be plotted as a series against time.
+_VALUE_TYPES = ("Float", "Integer")
+
+
+class TimeSeriesPlotSchema(BaseExplorerSchema):
+    """Schema for TimeSeriesPlotExplorer hyperparameters."""
+
+    markers: schema_field(
+        bool_field(),
+        False,
+        description=MultilingualString(
+            en=(
+                "Draw a point at each observation as well as the line. Useful "
+                "for short or irregular series, where the line alone hides "
+                "how many readings there actually are."
+            ),
+            es=(
+                "Dibuja un punto en cada observacion ademas de la linea. Util "
+                "para series cortas o irregulares, donde la linea por si sola "
+                "oculta cuantas mediciones hay en realidad."
+            ),
+            pt=(
+                "Desenha um ponto em cada observacao alem da linha. Util para "
+                "series curtas ou irregulares, nas quais a linha sozinha "
+                "esconde quantas leituras existem de fato."
+            ),
+            de=(
+                "Zeichnet zusaetzlich zur Linie einen Punkt pro Beobachtung. "
+                "Nuetzlich bei kurzen oder unregelmaessigen Reihen, wo die "
+                "Linie allein verbirgt, wie viele Messwerte es wirklich gibt."
+            ),
+            zh=(
+                "除折线外，在每个观测点绘制一个标记。"
+                "对于较短或不规则的序列很有用，"
+                "因为仅有折线会掩盖实际的观测数量。"
+            ),
+        ),
+        alias=MultilingualString(
+            en="Show markers",
+            es="Mostrar marcadores",
+            pt="Mostrar marcadores",
+            de="Markierungen anzeigen",
+            zh="显示标记",
+        ),
+    )  # type: ignore
+
+
+class TimeSeriesPlotExplorer(RelationshipExplorer):
+    """Plot one or more numeric columns against a date column, over time.
+
+    Select the date column plus the series to look at. The dates are read with
+    the format the column already carries, sorted, and handed to the plot as
+    real datetimes, so the horizontal axis is a genuine time axis: gaps show
+    up as gaps and irregular spacing is visible rather than flattened into
+    evenly spaced categories.
+
+    This is the plot to look at before forecasting anything, since trend,
+    seasonality, level shifts, missing stretches and outliers are all obvious
+    here and nearly invisible in a summary table.
+
+    Several numeric columns can be selected at once and are drawn as separate
+    lines sharing the time axis.
+    """
+
+    DISPLAY_NAME = MultilingualString(
+        en="Time Series Plot",
+        es="Grafico de Serie Temporal",
+        pt="Grafico de Serie Temporal",
+        de="Zeitreihendiagramm",
+        zh="时间序列图",
+    )
+    DESCRIPTION = MultilingualString(
+        en=(
+            "Draws one or more numeric columns against a date column as lines "
+            "over time. The dates are sorted and plotted on a real time axis, "
+            "so gaps and uneven spacing are visible instead of being "
+            "flattened into evenly spaced points. Select the date column and "
+            "the columns to plot."
+        ),
+        es=(
+            "Dibuja una o mas columnas numericas frente a una columna de fecha "
+            "como lineas en el tiempo. Las fechas se ordenan y se grafican en "
+            "un eje temporal real, de modo que los huecos y el espaciado "
+            "irregular quedan visibles en lugar de aplanarse en puntos "
+            "equidistantes. Selecciona la columna de fecha y las columnas a "
+            "graficar."
+        ),
+        pt=(
+            "Desenha uma ou mais colunas numericas em relacao a uma coluna de "
+            "data como linhas ao longo do tempo. As datas sao ordenadas e "
+            "plotadas em um eixo temporal real, de modo que lacunas e "
+            "espacamento irregular ficam visiveis em vez de serem achatados em "
+            "pontos equidistantes. Selecione a coluna de data e as colunas a "
+            "plotar."
+        ),
+        de=(
+            "Zeichnet eine oder mehrere numerische Spalten gegen eine "
+            "Datumsspalte als Linien ueber die Zeit. Die Daten werden sortiert "
+            "und auf einer echten Zeitachse dargestellt, sodass Luecken und "
+            "ungleichmaessige Abstaende sichtbar bleiben, statt zu "
+            "gleichmaessigen Punkten zusammengedrueckt zu werden. Waehlen Sie "
+            "die Datumsspalte und die zu zeichnenden Spalten aus."
+        ),
+        zh=(
+            "将一列或多列数值列相对于日期列绘制为随时间变化的折线。"
+            "日期会被排序并绘制在真实的时间轴上，"
+            "因此间隔和不规则的时间间距清晰可见，而不会被压缩为等距的点。"
+            "请选择日期列以及要绘制的列。"
+        ),
+    )
+
+    SCHEMA = TimeSeriesPlotSchema
+    metadata: Dict[str, Any] = {
+        "allowed_types": [Date, Float, Integer],
+        "allowed_dtypes": [],
+        "input_cardinality": {"min": 2},
+    }
+
+    def __init__(self, **kwargs) -> None:
+        """Initialize the explorer.
+
+        Parameters
+        ----------
+        **kwargs
+            Configuration keyword arguments. Recognized keys:
+            markers (bool, optional): Draw a point per observation in addition
+            to the line. Defaults to False.
+        """
+        self.markers = bool(kwargs.get("markers", False))
+        super().__init__(**kwargs)
+
+    @classmethod
+    def validate_columns(
+        cls, explorer_info: Explorer, column_spec: Dict[str, Dict[str, str]]
+    ) -> bool:
+        """Check the selection is one date column plus at least one series.
+
+        The inherited check only asks that every column is of an allowed type,
+        which would pass a selection of two numbers and no date, or of two
+        dates and no series. Neither can be plotted, so both are refused here
+        rather than failing later with an unhelpful error.
+
+        Parameters
+        ----------
+        explorer_info : Explorer
+            The database record for the explorer instance, including the
+            selected columns.
+        column_spec : Dict[str, Dict[str, str]]
+            A mapping from column name to a dict with at least ``"type"`` and
+            ``"dtype"``.
+
+        Returns
+        -------
+        bool
+            True if the selection holds exactly one Date column and at least
+            one numeric column, and the inherited checks also pass.
+        """
+        if not super().validate_columns(explorer_info, column_spec):
+            return False
+
+        types = [
+            column_spec.get(column["columnName"], {}).get("type", "")
+            for column in explorer_info.columns
+        ]
+        return types.count("Date") == 1 and any(t in _VALUE_TYPES for t in types)
+
+    def launch_exploration(self, dataset: "DashAIDataset", explorer_info: Explorer):
+        """Draw the selected series against the selected date column.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The prepared dataset holding the selected columns.
+        explorer_info : Explorer
+            Explorer record with the column names and optional display name.
+
+        Returns
+        -------
+        plotly.graph_objects.Figure
+            An interactive line plot with a time axis.
+
+        Raises
+        ------
+        ValueError
+            If no selected column is a Date, or if the date values do not
+            match the format the column declares.
+        """
+        import plotly.express as px
+
+        from DashAI.back.types.date_utils import DEFAULT_DATE_FORMAT, parse_date_column
+
+        columns = [column["columnName"] for column in explorer_info.columns]
+        date_columns = [
+            name for name in columns if isinstance(dataset.types.get(name), Date)
+        ]
+        if not date_columns:
+            raise ValueError(
+                "TimeSeriesPlotExplorer needs a Date column among the selected "
+                f"columns, got {', '.join(columns)}."
+            )
+
+        date_column = date_columns[0]
+        value_columns = [name for name in columns if name != date_column]
+
+        frame = dataset.to_pandas()
+        # Read with the format the column already declares rather than
+        # guessing, so the plot can never disagree with the stored type. A
+        # column whose format is wrong raises here instead of drawing a
+        # plausible but wrong picture.
+        date_format = (
+            getattr(dataset.types[date_column], "format", None) or DEFAULT_DATE_FORMAT
+        )
+        frame[date_column] = parse_date_column(frame[date_column], date_format)
+        frame = frame.sort_values(date_column)
+
+        figure = px.line(
+            frame,
+            x=date_column,
+            y=value_columns,
+            markers=self.markers,
+            title=f"{', '.join(value_columns)} over {date_column}",
+        )
+        figure.update_layout(xaxis_title=date_column, yaxis_title="")
+
+        if explorer_info.name is not None and explorer_info.name != "":
+            figure.update_layout(title=f"{explorer_info.name}")
+
+        return figure
+
+    def save_notebook(
+        self,
+        __notebook_info__: Notebook,
+        explorer_info: Explorer,
+        save_path: "Path",
+        result: Any,
+    ) -> str:
+        """Save the figure to disk (JSON content, ``.pickle`` extension).
+
+        Notes
+        -----
+        Despite the ``.pickle`` file extension, the file is written using
+        ``write_json`` and contains JSON-serialized Plotly figure data. This
+        matches every other plot explorer.
+
+        Parameters
+        ----------
+        __notebook_info__ : Notebook
+            The notebook database record (unused).
+        explorer_info : Explorer
+            The explorer record used for filename generation.
+        save_path : Path
+            Directory where the file will be saved.
+        result : Any
+            The Plotly figure returned by ``launch_exploration``.
+
+        Returns
+        -------
+        str
+            The path of the saved file as a POSIX string.
+        """
+        import os
+        from pathlib import Path
+
+        filename = f"{explorer_info.id}.pickle"
+        path = Path(os.path.join(save_path, filename))
+
+        result.write_json(path.as_posix())
+        return path.as_posix()
+
+    def get_results(
+        self, exploration_path: str, options: Dict[str, Any]
+    ) -> List[Artifact]:
+        """Load and return the saved figure for the frontend.
+
+        Parameters
+        ----------
+        exploration_path : str
+            Path to the JSON file saved by ``save_notebook``.
+        options : Dict[str, Any]
+            Rendering options from the frontend (unused).
+
+        Returns
+        -------
+        List[Artifact]
+            A single-element list with the plotly artifact of the saved figure.
+        """
+        with open(exploration_path, "r", encoding="utf-8") as f:
+            result = f.read()
+
+        return [PlotlyArtifact(payload=result)]

--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -140,6 +140,9 @@ from DashAI.back.exploration.explorers.parallel_cordinates import (
 )
 from DashAI.back.exploration.explorers.scatter_matrix import ScatterMatrixExplorer
 from DashAI.back.exploration.explorers.scatter_plot import ScatterPlotExplorer
+from DashAI.back.exploration.explorers.time_series_plot import (
+    TimeSeriesPlotExplorer,
+)
 from DashAI.back.exploration.explorers.wordcloud import WordcloudExplorer
 
 # Jobs
@@ -644,6 +647,7 @@ def get_initial_components():
         ECDFPlotExplorer,
         HistogramPlotExplorer,
         ScatterMatrixExplorer,
+        TimeSeriesPlotExplorer,
         ParallelCategoriesExplorer,
         ParallelCordinatesExplorer,
         # Converters

--- a/tests/back/exploration/test_time_series_plot.py
+++ b/tests/back/exploration/test_time_series_plot.py
@@ -1,0 +1,159 @@
+import pandas as pd
+import pytest
+
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    to_dashai_dataset,
+    transform_dataset_with_schema,
+)
+from DashAI.back.exploration.explorers.time_series_plot import TimeSeriesPlotExplorer
+
+DATES = ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]
+SALES = [100, 120, 115, 140]
+COSTS = [10.5, 12.0, 11.5, 14.0]
+
+
+class _Explorer:
+    """Stand-in for the Explorer database record the explorers receive."""
+
+    def __init__(self, columns, name=""):
+        self.id = 1
+        self.name = name
+        self.columns = [{"columnName": col} for col in columns]
+
+
+def _dataset(columns=None):
+    frame = pd.DataFrame(columns or {"date": DATES, "sales": SALES, "costs": COSTS})
+    schema = {
+        "date": {"type": "Date", "dtype": "%Y-%m-%d"},
+        "sales": {"type": "Integer", "dtype": "int64"},
+        "costs": {"type": "Float", "dtype": "float64"},
+    }
+    schema = {name: schema[name] for name in frame.columns}
+    return transform_dataset_with_schema(to_dashai_dataset(frame), schema)
+
+
+def _spec(**types):
+    return {name: {"type": t, "dtype": d} for name, (t, d) in types.items()}
+
+
+DEFAULT_SPEC = _spec(
+    date=("Date", "%Y-%m-%d"),
+    sales=("Integer", "int64"),
+    costs=("Float", "float64"),
+)
+
+
+def test_plots_one_series_against_time():
+    explorer = TimeSeriesPlotExplorer()
+
+    figure = explorer.launch_exploration(_dataset(), _Explorer(["date", "sales"]))
+
+    assert len(figure.data) == 1
+    assert list(figure.data[0].y) == SALES
+
+
+def test_the_time_axis_holds_real_dates_not_text():
+    # The whole reason this is not a scatter plot with a Date bolted on: the
+    # axis has to be a time axis, which means real datetimes.
+    explorer = TimeSeriesPlotExplorer()
+
+    figure = explorer.launch_exploration(_dataset(), _Explorer(["date", "sales"]))
+
+    assert list(figure.data[0].x) == list(pd.to_datetime(DATES))
+
+
+def test_several_series_share_the_time_axis():
+    explorer = TimeSeriesPlotExplorer()
+
+    figure = explorer.launch_exploration(
+        _dataset(), _Explorer(["date", "sales", "costs"])
+    )
+
+    assert len(figure.data) == 2
+    assert {trace.name for trace in figure.data} == {"sales", "costs"}
+
+
+def test_rows_out_of_order_are_plotted_chronologically():
+    order = [2, 0, 3, 1]
+    dataset = _dataset(
+        {
+            "date": [DATES[i] for i in order],
+            "sales": [SALES[i] for i in order],
+            "costs": [COSTS[i] for i in order],
+        }
+    )
+    explorer = TimeSeriesPlotExplorer()
+
+    figure = explorer.launch_exploration(dataset, _Explorer(["date", "sales"]))
+
+    assert list(figure.data[0].x) == list(pd.to_datetime(DATES))
+    assert list(figure.data[0].y) == SALES
+
+
+def test_a_selection_with_one_date_and_one_number_is_accepted():
+    assert TimeSeriesPlotExplorer.validate_columns(
+        _Explorer(["date", "sales"]), DEFAULT_SPEC
+    )
+
+
+def test_a_selection_without_a_date_is_rejected():
+    assert not TimeSeriesPlotExplorer.validate_columns(
+        _Explorer(["sales", "costs"]), DEFAULT_SPEC
+    )
+
+
+def test_a_selection_with_two_dates_is_rejected():
+    spec = _spec(
+        date=("Date", "%Y-%m-%d"),
+        other=("Date", "%Y-%m-%d"),
+    )
+
+    assert not TimeSeriesPlotExplorer.validate_columns(
+        _Explorer(["date", "other"]), spec
+    )
+
+
+def test_a_selection_without_a_numeric_column_is_rejected():
+    spec = _spec(date=("Date", "%Y-%m-%d"), label=("Categorical", "string"))
+
+    assert not TimeSeriesPlotExplorer.validate_columns(
+        _Explorer(["date", "label"]), spec
+    )
+
+
+def test_a_single_column_is_rejected():
+    assert not TimeSeriesPlotExplorer.validate_columns(
+        _Explorer(["date"]), DEFAULT_SPEC
+    )
+
+
+def test_markers_are_off_by_default_and_can_be_turned_on():
+    plain = TimeSeriesPlotExplorer().launch_exploration(
+        _dataset(), _Explorer(["date", "sales"])
+    )
+    marked = TimeSeriesPlotExplorer(markers=True).launch_exploration(
+        _dataset(), _Explorer(["date", "sales"])
+    )
+
+    assert plain.data[0].mode == "lines"
+    assert "markers" in marked.data[0].mode
+
+
+def test_the_explorer_name_overrides_the_title():
+    explorer = TimeSeriesPlotExplorer()
+
+    figure = explorer.launch_exploration(
+        _dataset(), _Explorer(["date", "sales"], name="Weekly sales")
+    )
+
+    assert figure.layout.title.text == "Weekly sales"
+
+
+def test_a_dataset_whose_dates_do_not_match_their_format_is_refused():
+    dataset = _dataset({"date": DATES, "sales": SALES})
+    # Claim a layout the values do not follow.
+    dataset.types["date"].format = "%d/%m/%Y"
+    explorer = TimeSeriesPlotExplorer()
+
+    with pytest.raises(ValueError, match="do not match the date format"):
+        explorer.launch_exploration(dataset, _Explorer(["date", "sales"]))


### PR DESCRIPTION
## Summary

Adds `TimeSeriesPlotExplorer`, so a target column can actually be looked at over time.

`ScatterPlotExplorer` was the nearest existing thing and does not work here for two independent reasons. Its `allowed_types` is `[Float, Integer, Categorical]`, so it will not accept a `Date` column at all. And because a dashAI `Date` is stored as text, adding `Date` to that list would make Plotly treat the axis as unordered categories drawn in row order rather than chronological order. That is a wrong plot, not a limited one.

---

## Type of Change

Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/exploration/explorers/time_series_plot.py`: new explorer. Reads the dates with the format the column already declares, sorts them, and passes real datetimes to Plotly, so the horizontal axis is a genuine time axis and gaps stay visible. `allowed_types = [Date, Float, Integer]`, `input_cardinality = {"min": 2}`. `validate_columns` is tightened past the inherited check, which would accept two numbers and no date, or two dates and no series.
- `DashAI/back/initial_components.py`: register the explorer.
- `tests/back/exploration/test_time_series_plot.py`: new. 12 tests.

---

## Testing (optional)

- Create the plot inside the app with a time series dataset.

---

## Notes (optional)

`input_cardinality` is a minimum rather than exactly two on purpose: one date plus several series on shared axes is the more useful version and costs nothing, since `px.line` takes a list of y columns.

Dates are read with the declared format rather than reguessed, so the plot can never disagree with the stored type. A column whose format is wrong raises instead of drawing a plausible but wrong picture.