### PR TITLE
Keep the right panel content mounted while it is collapsed

### DIFF
--- a/DashAI/front/src/components/threeSectionLayout/panels/RightPanel.jsx
+++ b/DashAI/front/src/components/threeSectionLayout/panels/RightPanel.jsx
@@ -58,27 +58,39 @@ export default function RightPanel({
         data-tour={dataTour}
       >
         {rightBarVisible && (
-          <>
-            <Box
-              {...bindRightResize}
-              sx={{
-                position: "absolute",
-                left: -2,
-                top: 0,
-                bottom: 0,
-                width: "5px",
-                cursor: "col-resize",
-                bgcolor: "transparent",
-                transition: "background-color 0.2s ease",
-                "&:hover": {
-                  bgcolor: "primary.main",
-                },
-                zIndex: 10,
-              }}
-            />
-            {children}
-          </>
+          <Box
+            {...bindRightResize}
+            sx={{
+              position: "absolute",
+              left: -2,
+              top: 0,
+              bottom: 0,
+              width: "5px",
+              cursor: "col-resize",
+              bgcolor: "transparent",
+              transition: "background-color 0.2s ease",
+              "&:hover": {
+                bgcolor: "primary.main",
+              },
+              zIndex: 10,
+            }}
+          />
         )}
+        {/* The content stays mounted while the panel is collapsed. Several
+            flows keep their configuration form in this panel and only enable
+            the button that finishes the step once that form has registered
+            itself, so unmounting the content left the button disabled forever
+            for anyone who had collapsed the panel. `display: none` keeps the
+            content out of the layout, the tab order and the accessibility
+            tree, exactly like unmounting did, but the React state and the
+            effects that register the form survive. */}
+        <Box
+          width="100%"
+          height="100%"
+          sx={{ display: rightBarVisible ? "block" : "none" }}
+        >
+          {children}
+        </Box>
       </Box>
     </>
   );


### PR DESCRIPTION
## Summary

  Fixes #827. The right panel unmounted its children while collapsed, so any flow that keeps its configuration form there lost the form entirely. Dataset
  upload gates the "Upload" button on that form having registered itself, so a user who collapsed the panel got a permanently disabled button with nothing on
  screen explaining why. The collapsed state is persisted in `localStorage` per module, so once someone collapsed the panel the flow stayed broken across
  reloads.

  The content now stays mounted and is hidden with `display: none` instead.

  ---

  ## Type of Change

  Check all that apply like this [x]:

  - [ ] Backend change
  - [x] Frontend change
  - [ ] CI / Workflow change
  - [ ] Build / Packaging change
  - [x] Bug fix
  - [ ] Documentation

  ---

  ## Changes (by file)

  - `src/components/threeSectionLayout/panels/RightPanel.jsx`: `{children}` moves out of the `rightBarVisible &&` branch into a wrapper whose `display`
  toggles between `block` and `none`. The resize handle stays conditional, since it is absolutely positioned at `left: -2` and has nothing to resize on a
  zero-width panel.

  That is the whole change. For context, the chain it repairs:

  RightPanel.jsx:60          {rightBarVisible && (... {children})}   // content never mounted
    UploadDatasetSteps.jsx:136   renders <DataloaderConfigBar formSubmitRef={...} />
      MainForm.jsx:45              formSubmitRef.current = formik    // effect never ran
  ConfigureAndUploadDatasetStep.jsx:219
                             if (!formSubmitRef.current) return false;  // button disabled

  `display: none` keeps the content out of layout, out of the tab order and out of the accessibility tree, exactly as unmounting did, but React effects still
  run, so the form registers itself and pushes its schema defaults through `onValuesChange`.

  ---

  ## Testing

  Reproduce on `develop` first: collapse the right panel, go to `/app/data/datasets/new`, pick a dataloader, drop a file in. The "Upload" button stays
  disabled no matter what. On this branch it enables once the preview loads, and the dataloader parameters reach the backend.

  Worth a second pair of eyes on the layout, since the wrapper is a new element between the panel and its content. It is `width: 100%; height: 100%` and
  `position: static`, which should be transparent: `ModuleContainer` is a flex row with a definite height, the panel is a stretched flex item, and every
  right-panel child is rooted at `SideBar` (already `100%` / `100%`). Being `static` also means it does not become the containing block for anything
  positioned against the panel. Quick check across the modules that use it: Datasets, Models, Generative, RAG Documents, RAG Prompts.

  Existing suite passes (14 suites, 46 tests), plus prettier and eslint. None of it covers this component, hence the manual steps above.

  ---

  ## Notes

  **Scope is narrower than the issue thread suggests.** The reporter's video also shows "Create Session" blocked, but that button is gated by `canCreate` in
  `CreateSessionCenter.jsx:113`, which depends on the model selection and `formik.values.name` from `CreateSessionContext`, mounted above the panel.
  Collapsing the bar does not affect it. If that is genuinely broken it is a different bug and needs its own repro, so I would keep #827 open until the
  reporter confirms which flows are fixed.

  **Behavior change worth knowing.** Right-panel content now mounts even when the panel is collapsed, so components that fetch on mount (`ModelsRightBar`
  requests the model list for the session's task) will issue that request where they previously did not. The upside is the panel is populated the moment you
  open it; the cost is one request per session change for users who work with the panel closed.

  **`LeftPanel.jsx` has the identical unmount pattern.** Left it alone: its content is navigation and does not gate any button, so there is no bug to fix
  there today. Flagging it in case someone later moves a form into the left bar.
