### PR TITLE
Add ForecastingTask and temporal splitters for time series

### DIFF
--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -420,8 +420,10 @@ from DashAI.back.splitters.repeated_k_fold import RepeatedKFoldSplitter
 from DashAI.back.splitters.repeated_stratified_k_fold import (
     RepeatedStratifiedKFoldSplitter,
 )
+from DashAI.back.splitters.rolling_origin import RollingOriginSplitter
 from DashAI.back.splitters.stratified_group_k_fold import StratifiedGroupKFoldSplitter
 from DashAI.back.splitters.stratified_k_fold import StratifiedKFoldSplitter
+from DashAI.back.splitters.temporal_holdout import TemporalHoldoutSplitter
 from DashAI.back.statistical_tests.anova_test import AnovaTest
 from DashAI.back.statistical_tests.corrected_paired_t_test import (
     CorrectedPairedTTest,
@@ -441,6 +443,7 @@ from DashAI.back.statistical_tests.wilcoxon_sr_test import (
     WilcoxonSRTest,
 )
 from DashAI.back.tasks.controlnet_task import ControlNetTask
+from DashAI.back.tasks.forecasting_task import ForecastingTask
 from DashAI.back.tasks.image_classification_task import ImageClassificationTask
 
 # Tasks
@@ -473,6 +476,7 @@ def get_initial_components():
         TextClassificationTask,
         TranslationTask,
         RegressionTask,
+        ForecastingTask,
         TextToImageGenerationTask,
         TextToTextGenerationTask,
         ControlNetTask,
@@ -702,6 +706,8 @@ def get_initial_components():
         RandomUnderSamplerConverter,
         # Splitters
         HoldoutSplitter,
+        TemporalHoldoutSplitter,
+        RollingOriginSplitter,
         KFoldSplitter,
         StratifiedKFoldSplitter,
         StratifiedGroupKFoldSplitter,

--- a/DashAI/back/splitters/fold_splitter.py
+++ b/DashAI/back/splitters/fold_splitter.py
@@ -168,6 +168,16 @@ class FoldSplitter(BaseSplitter):
         indexes = np.arange(len(x))
         seed = self.random_state
 
+        if self.TEST_SPLIT_STRATEGY == "temporal":
+            # The reserved rows must be the most recent ones. Every other
+            # strategy samples them from anywhere in the dataset, which for a
+            # series would scatter future rows through the training data of
+            # every fold and report a score that cannot be reproduced in use.
+            return (
+                [int(i) for i in indexes[-n_test:]],
+                [int(i) for i in indexes[:-n_test]],
+            )
+
         if self.TEST_SPLIT_STRATEGY == "group":
             from sklearn.model_selection import GroupShuffleSplit
 

--- a/DashAI/back/splitters/rolling_origin.py
+++ b/DashAI/back/splitters/rolling_origin.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    float_field,
+    int_field,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+
+from .fold_splitter import FoldSplitter
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class RollingOriginSplitterSchema(BaseSchema):
+    """Schema that configures the rolling origin splitter."""
+
+    n_splits: schema_field(
+        int_field(ge=2),
+        placeholder=5,
+        description=MultilingualString(
+            en=(
+                "How many times the model is refitted and scored, each time "
+                "with more history than the last."
+            ),
+            es=(
+                "Cuantas veces se reentrena y evalua el modelo, cada vez con "
+                "mas historia que la anterior."
+            ),
+            pt=(
+                "Quantas vezes o modelo e retreinado e avaliado, cada vez com "
+                "mais historia que a anterior."
+            ),
+            de=(
+                "Wie oft das Modell neu angepasst und bewertet wird, jedes Mal "
+                "mit mehr Vergangenheit als zuvor."
+            ),
+            zh="模型被重新拟合并评估的次数，每次使用的历史数据都比上一次更多。",
+        ),
+        alias=MultilingualString(
+            en="Number of origins",
+            es="Numero de origenes",
+            pt="Numero de origens",
+            de="Anzahl der Ursprunge",
+            zh="origin 数量",
+        ),
+    )  # type: ignore
+    horizon: schema_field(
+        int_field(ge=1),
+        placeholder=1,
+        description=MultilingualString(
+            en="How many steps ahead each refit is scored on.",
+            es="Cuantos pasos hacia adelante se evalua cada reentrenamiento.",
+            pt="Quantos passos a frente cada retreinamento e avaliado.",
+            de="Wie viele Schritte voraus jede Anpassung bewertet wird.",
+            zh="每次重新拟合后向前评估的步数。",
+        ),
+        alias=MultilingualString(
+            en="Horizon", es="Horizonte", pt="Horizonte", de="Horizont", zh="预测步长"
+        ),
+    )  # type: ignore
+    step: schema_field(
+        int_field(ge=1),
+        placeholder=1,
+        description=MultilingualString(
+            en="How many rows the origin advances between one refit and the next.",
+            es=(
+                "Cuantas filas avanza el origen entre un reentrenamiento y el "
+                "siguiente."
+            ),
+            pt=("Quantas linhas o origem avanca entre um retreinamento e o seguinte."),
+            de=(
+                "Um wie viele Zeilen der Ursprung zwischen zwei Anpassungen vorrueckt."
+            ),
+            zh="两次重新拟合之间 origin 前移的行数。",
+        ),
+        alias=MultilingualString(
+            en="Step", es="Paso", pt="Passo", de="Schritt", zh="步进"
+        ),
+    )  # type: ignore
+    test_size: schema_field(
+        float_field(ge=0, lt=1),
+        placeholder=0.1,
+        description=MultilingualString(
+            en=(
+                "Proportion of the most recent rows held back from every "
+                "origin, used once to score the final model."
+            ),
+            es=(
+                "Proporcion de las filas mas recientes reservadas de todos los "
+                "origenes, usada una sola vez para evaluar el modelo final."
+            ),
+            pt=(
+                "Proporcao das linhas mais recentes reservadas de todas as "
+                "origens, usada uma unica vez para avaliar o modelo final."
+            ),
+            de=(
+                "Anteil der neuesten Zeilen, der von allen Ursprungen "
+                "zurueckgehalten und einmal zur Bewertung des endgueltigen "
+                "Modells verwendet wird."
+            ),
+            zh="从所有 origin 中保留的最近行的比例，仅用于最终模型的一次评估。",
+        ),
+        alias=MultilingualString(
+            en="Test size",
+            es="Tamano de prueba",
+            pt="Tamanho de teste",
+            de="Testgroesse",
+            zh="测试集比例",
+        ),
+    )  # type: ignore
+
+
+class RollingOriginSplitter(FoldSplitter):
+    """Cross-validate a series by walking the origin forward through time.
+
+    Each fold trains on everything up to a point and is scored on the rows
+    just after it, then the point moves forward and the model is refitted with
+    more history. The training window only ever grows.
+
+    With four origins, a horizon of one and a reserved tail::
+
+        Reserved test, in no fold:              Nov Dec
+
+        Fold 1:  train Jan Feb Mar      | validation Apr
+        Fold 2:  train Jan .. Apr       | validation May
+        Fold 3:  train Jan .. May       | validation Jun
+        Fold 4:  train Jan .. Jun       | validation Jul
+
+        Final:   train Jan .. Oct       | test Nov Dec
+
+    This is what k-fold cannot do for a series: its folds train on rows that
+    come after the ones they score, which measures interpolation rather than
+    forecasting and reports a number that will not survive contact with real
+    use.
+
+    The size of the first training window is not asked for. It follows from the
+    other three settings, since the last origin has to leave a full horizon of
+    rows to score::
+
+        initial_train_size = n - horizon - (n_splits - 1) * step
+
+    Row order is taken as time order, and the reserved rows are the tail rather
+    than a random sample, which is what ``TEST_SPLIT_STRATEGY = "temporal"``
+    selects in the base class.
+    """
+
+    SCHEMA = RollingOriginSplitterSchema
+    TEST_SPLIT_STRATEGY: str = "temporal"
+    COMPATIBLE_COMPONENTS = ["ForecastingTask", "RegressionTask"]
+    COMPATIBLE_INNER_SPLITTERS = ["RollingOriginSplitter"]
+    DISPLAY_NAME: str = MultilingualString(
+        en="Rolling Origin",
+        es="Origen Movil",
+        pt="Origem Movel",
+        de="Rollierender Ursprung",
+        zh="滚动起点",
+    )
+
+    def __init__(self, splits_data):
+        """Initialize the splitter with the requested origins and horizon.
+
+        Parameters
+        ----------
+        splits_data : dict
+            Configuration dictionary with the number of origins, the horizon,
+            the step between origins and the reserved proportion.
+        """
+        super().__init__(splits_data)
+        self.horizon = splits_data.get("horizon", 1)
+        self.step = splits_data.get("step", 1)
+        # Nothing here is random, and the base class defaults shuffling on.
+        self.shuffle = False
+
+    def split_indexes(
+        self, x: "DashAIDataset", y: "DashAIDataset"
+    ) -> List[Tuple[List, List]]:
+        """Build one expanding train and validation pair per origin.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            The rows left after the reserved tail was carved off.
+        y : DashAIDataset
+            Target values associated with ``x``. Unused: where the cuts fall
+            depends only on position, never on the target.
+
+        Returns
+        -------
+        list[tuple[List, List]]
+            One ``(train, validation)`` pair per origin, as positions within
+            the pool. The caller maps them back to original rows.
+
+        Raises
+        ------
+        ValueError
+            If the requested origins, horizon and step do not fit in the rows
+            available. The message names what to change.
+        """
+        total_rows = len(x)
+        initial_train_size = total_rows - self.horizon - (self.n_splits - 1) * self.step
+
+        if initial_train_size <= 0:
+            raise ValueError(
+                f"{self.n_splits} origins with a horizon of {self.horizon} and "
+                f"a step of {self.step} need more than {total_rows} rows: the "
+                "first one would train on nothing. Reduce n_splits, horizon or "
+                "step, or reserve a smaller test set."
+            )
+
+        folds = []
+        for fold in range(self.n_splits):
+            origin = initial_train_size + fold * self.step
+            folds.append(
+                (list(range(origin)), list(range(origin, origin + self.horizon)))
+            )
+
+        return folds

--- a/DashAI/back/splitters/temporal_holdout.py
+++ b/DashAI/back/splitters/temporal_holdout.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple
+
+from pydantic import model_validator
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    float_field,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+
+from .holdout import HoldoutSplitter
+
+if TYPE_CHECKING:
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class TemporalHoldoutSplitterSchema(BaseSchema):
+    """Schema that configures the temporal holdout splitter.
+
+    Deliberately smaller than the holdout schema it mirrors: there is no
+    shuffle, no random state and no stratification, because nothing here is
+    random and offering a seed that changes nothing would be a lie.
+    """
+
+    train: schema_field(
+        float_field(ge=0, le=1),
+        placeholder=0.6,
+        description=MultilingualString(
+            en="Proportion of the earliest rows used for training.",
+            es="Proporcion de las filas mas antiguas usadas para entrenar.",
+            pt="Proporcao das linhas mais antigas usadas para treinar.",
+            de="Anteil der aeltesten Zeilen, der zum Training verwendet wird.",
+            zh="用于训练的最早那部分行的比例。",
+        ),
+        alias=MultilingualString(
+            en="Train", es="Entrenamiento", pt="Treinamento", de="Training", zh="训练集"
+        ),
+    )  # type: ignore
+    validation: schema_field(
+        float_field(ge=0, le=1),
+        placeholder=0.2,
+        description=MultilingualString(
+            en="Proportion of the rows after training used for validation.",
+            es=(
+                "Proporcion de las filas posteriores al entrenamiento usadas "
+                "para validacion."
+            ),
+            pt=(
+                "Proporcao das linhas posteriores ao treinamento usadas para validacao."
+            ),
+            de=(
+                "Anteil der auf das Training folgenden Zeilen, der zur "
+                "Validierung verwendet wird."
+            ),
+            zh="训练之后那部分行中用于验证的比例。",
+        ),
+        alias=MultilingualString(
+            en="Validation",
+            es="Validacion",
+            pt="Validacao",
+            de="Validierung",
+            zh="验证集",
+        ),
+    )  # type: ignore
+    test: schema_field(
+        float_field(ge=0, le=1),
+        placeholder=0.2,
+        description=MultilingualString(
+            en="Proportion of the most recent rows used for testing.",
+            es="Proporcion de las filas mas recientes usadas para prueba.",
+            pt="Proporcao das linhas mais recentes usadas para teste.",
+            de="Anteil der neuesten Zeilen, der zum Testen verwendet wird.",
+            zh="用于测试的最近那部分行的比例。",
+        ),
+        alias=MultilingualString(
+            en="Test", es="Prueba", pt="Teste", de="Test", zh="测试集"
+        ),
+    )  # type: ignore
+
+    @model_validator(mode="after")
+    def check_partitions(self):
+        """Validate that the three partitions describe the whole dataset.
+
+        Returns
+        -------
+        TemporalHoldoutSplitterSchema
+            The validated schema instance.
+
+        Raises
+        ------
+        ValueError
+            If the proportions do not sum to one, or if the training partition
+            is empty.
+        """
+        total = self.train + self.test + self.validation
+        if abs(total - 1) > 1e-6:
+            raise ValueError(
+                f"train, test and validation proportions must sum to 1, got {total}."
+            )
+        if self.train <= 0:
+            raise ValueError("The train proportion must be greater than 0.")
+        return self
+
+
+class TemporalHoldoutSplitter(HoldoutSplitter):
+    """Split a series in time order: train first, then validation, then test.
+
+    Rows are cut where they lie rather than sampled, so every row a model is
+    scored on comes after every row it was fitted on. That is the only honest
+    way to estimate how a model will do on data it has not seen yet, because
+    the alternative lets it learn from the future.
+
+    Shuffling is not merely discouraged here, it is impossible: a request to
+    shuffle is overruled. Two ways of getting it wrong are worth naming, since
+    neither reports an error, they just return a score that is too good.
+
+    * A random split of a series lets the model interpolate between rows it has
+      already seen instead of extrapolating past them.
+    * On the output of ``TimeSeriesWindowConverter`` it is worse still, because
+      consecutive rows share ``window_size - 1`` of their values, so a random
+      split puts near duplicates of the training rows into the test set.
+
+    Row order is taken as time order. This splitter receives the selected input
+    columns, which for a windowed dataset no longer include a date, so it
+    cannot re-sort and does not try.
+    """
+
+    SCHEMA = TemporalHoldoutSplitterSchema
+    COMPATIBLE_COMPONENTS = ["ForecastingTask", "RegressionTask"]
+    DISPLAY_NAME: str = MultilingualString(
+        en="Temporal Holdout",
+        es="Holdout Temporal",
+        pt="Holdout Temporal",
+        de="Zeitlicher Holdout",
+        zh="时序留出法",
+    )
+
+    def __init__(self, splits_data):
+        """Initialize the splitter with the requested proportions.
+
+        Parameters
+        ----------
+        splits_data : dict
+            Configuration dictionary with the train, validation and test
+            proportions, and optionally previously computed indexes.
+        """
+        super().__init__(splits_data)
+        # The base class defaults these to values that would reintroduce
+        # randomness, and the schema does not expose either, so they are
+        # pinned here rather than trusted to arrive absent.
+        self.shuffle = False
+        self.stratify = False
+
+    def split_indexes(
+        self, x: "DashAIDataset", y: "DashAIDataset"
+    ) -> Tuple[List, List, List]:
+        """Cut the rows into three consecutive blocks in time order.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            Input dataset to partition.
+        y : DashAIDataset
+            Target values associated with ``x``. Unused: nothing here depends
+            on the target, unlike a stratified split.
+
+        Returns
+        -------
+        tuple[List, List, List]
+            Train, test and validation indexes. Note the return order matches
+            the holdout contract, while the partitions themselves run
+            train, validation, test along the timeline.
+        """
+        total_rows = len(x)
+        n_train = int(round(total_rows * (self.train_size or 0)))
+        n_validation = int(round(total_rows * (self.val_size or 0)))
+
+        # Whatever rounding leaves over belongs to the test partition, which
+        # keeps every row in exactly one place.
+        train_indexes = list(range(n_train))
+        validation_indexes = list(range(n_train, n_train + n_validation))
+        test_indexes = list(range(n_train + n_validation, total_rows))
+
+        return train_indexes, test_indexes, validation_indexes

--- a/DashAI/back/tasks/forecasting_task.py
+++ b/DashAI/back/tasks/forecasting_task.py
@@ -1,0 +1,135 @@
+from typing import TYPE_CHECKING, List, Union
+
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.tasks.base_task import BaseTask
+from DashAI.back.types.value_types import Date, Float, Integer
+
+if TYPE_CHECKING:
+    from datasets import DatasetDict
+    from numpy import ndarray
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class ForecastingTask(BaseTask):
+    """Task for predicting the future values of a single time series.
+
+    The input is one ``Date`` column and the output is one numeric column: the
+    series to forecast. Nothing else is offered to the model, so the only
+    information it has is the history of the series itself.
+
+    That restriction is the point. Models that take a date and nothing more,
+    such as ARIMA or exponential smoothing, are a different family from models
+    that also take explanatory variables.
+
+    Two routes lead to a forecast in DashAI, and this is only one of them. The
+    other is ``TimeSeriesWindowConverter``, which reshapes the same data into
+    lag columns and hands it to ``RegressionTask``, making every existing
+    regressor usable. This task exists for the models that read a date column
+    directly and cannot be expressed that way.
+    """
+
+    DESCRIPTION: str = MultilingualString(
+        en=(
+            "Predict the future values of a time series from its own history. "
+            "Takes one date column and one numeric column, with no other "
+            "variables."
+        ),
+        es=(
+            "Predice los valores futuros de una serie temporal a partir de su "
+            "propia historia. Toma una columna de fecha y una columna "
+            "numerica, sin ninguna otra variable."
+        ),
+        pt=(
+            "Preve os valores futuros de uma serie temporal a partir da sua "
+            "propria historia. Recebe uma coluna de data e uma coluna "
+            "numerica, sem nenhuma outra variavel."
+        ),
+        de=(
+            "Sagt die zukuenftigen Werte einer Zeitreihe aus ihrer eigenen "
+            "Vergangenheit voraus. Nimmt eine Datumsspalte und eine numerische "
+            "Spalte, ohne weitere Variablen."
+        ),
+        zh=(
+            "根据时间序列自身的历史预测其未来值。"
+            "接受一个日期列和一个数值列，不使用其他变量。"
+        ),
+    )
+    DISPLAY_NAME: str = MultilingualString(
+        en="Forecasting",
+        es="Pronostico",
+        pt="Previsao",
+        de="Zeitreihenprognose",
+        zh="时间序列预测",
+    )
+
+    metadata: dict = {
+        "inputs_types": [Date],
+        "outputs_types": [Float, Integer],
+        "inputs_cardinality": 1,
+        "outputs_cardinality": 1,
+    }
+
+    def prepare_for_task(
+        self,
+        dataset: Union["DatasetDict", "DashAIDataset"],
+        input_columns: List[str],
+        output_columns: List[str],
+    ) -> "DashAIDataset":
+        """Convert the dataset to a DashAIDataset and validate its types.
+
+        Parameters
+        ----------
+        dataset : DatasetDict or DashAIDataset
+            Dataset to prepare.
+        input_columns : list of str
+            The single date column.
+        output_columns : list of str
+            The single numeric column holding the series.
+
+        Returns
+        -------
+        DashAIDataset
+            Dataset with validated types.
+        """
+        return super().prepare_for_task(dataset, input_columns, output_columns)
+
+    def process_predictions(
+        self, dataset: "DashAIDataset", predictions: "ndarray", output_column: str
+    ):
+        """Return the forecast values unchanged.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            Dataset used for training.
+        predictions : np.ndarray
+            Predictions from the model.
+        output_column : str
+            Output column.
+
+        Returns
+        -------
+        np.ndarray
+            The predictions as they were produced. A forecast is already a
+            number on the scale of the series, so there is nothing to decode.
+        """
+        return predictions
+
+    def num_labels(self, dataset: "DashAIDataset", output_column: str) -> int | None:
+        """Report that this task has no labels.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            Dataset used for training.
+        output_column : str
+            Output column.
+
+        Returns
+        -------
+        int | None
+            Always ``None``: the output is continuous, so there is no class
+            count for a model to size itself against.
+        """
+        return None

--- a/tests/back/splitters/test_temporal_splitters.py
+++ b/tests/back/splitters/test_temporal_splitters.py
@@ -1,0 +1,172 @@
+import pandas as pd
+import pytest
+
+from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+from DashAI.back.splitters.rolling_origin import RollingOriginSplitter
+from DashAI.back.splitters.temporal_holdout import TemporalHoldoutSplitter
+
+
+def _xy(n=20):
+    x = to_dashai_dataset(pd.DataFrame({"lag_1": list(range(n))}))
+    y = to_dashai_dataset(pd.DataFrame({"target": list(range(n))}))
+    return x, y
+
+
+# --- TemporalHoldoutSplitter -------------------------------------------------
+
+
+def test_holdout_partitions_are_contiguous_and_in_time_order():
+    x, y = _xy(20)
+    splitter = TemporalHoldoutSplitter({"train": 0.6, "validation": 0.2, "test": 0.2})
+
+    train, test, val = splitter.split_indexes(x, y)
+
+    assert train == list(range(12))
+    assert val == list(range(12, 16))
+    assert test == list(range(16, 20))
+
+
+def test_holdout_never_lets_a_later_row_train_an_earlier_one():
+    # The whole point: everything trained on precedes everything scored on.
+    x, y = _xy(20)
+    splitter = TemporalHoldoutSplitter({"train": 0.6, "validation": 0.2, "test": 0.2})
+
+    train, test, val = splitter.split_indexes(x, y)
+
+    assert max(train) < min(val)
+    assert max(val) < min(test)
+
+
+def test_holdout_ignores_a_request_to_shuffle():
+    # Shuffling a time series is the mistake this splitter exists to prevent,
+    # so a payload asking for it is overruled rather than honoured.
+    x, y = _xy(20)
+    splitter = TemporalHoldoutSplitter(
+        {"train": 0.6, "validation": 0.2, "test": 0.2, "shuffle": True}
+    )
+
+    assert splitter.shuffle is False
+
+    train, _, _ = splitter.split_indexes(x, y)
+    assert train == sorted(train)
+
+
+def test_holdout_without_a_test_partition_still_orders_the_rest():
+    x, y = _xy(10)
+    splitter = TemporalHoldoutSplitter({"train": 0.8, "validation": 0.2, "test": 0.0})
+
+    train, test, val = splitter.split_indexes(x, y)
+
+    assert train == list(range(8))
+    assert val == list(range(8, 10))
+    assert test == []
+
+
+def test_holdout_uses_every_row_exactly_once():
+    x, y = _xy(17)
+    splitter = TemporalHoldoutSplitter({"train": 0.6, "validation": 0.2, "test": 0.2})
+
+    train, test, val = splitter.split_indexes(x, y)
+
+    assert sorted(train + val + test) == list(range(17))
+
+
+def test_holdout_reports_its_explainable_partitions():
+    partitions = TemporalHoldoutSplitter.explainable_partitions(
+        {"train_indexes": [0, 1], "test_indexes": [4], "val_indexes": [2, 3]}
+    )
+
+    assert partitions == {"train": [0, 1], "test": [4], "val": [2, 3]}
+
+
+# --- RollingOriginSplitter ---------------------------------------------------
+
+
+def test_rolling_origin_grows_the_training_window():
+    x, y = _xy(10)
+    splitter = RollingOriginSplitter(
+        {"n_splits": 4, "horizon": 1, "step": 1, "test_size": 0}
+    )
+
+    folds = splitter.split_indexes(x, y)
+
+    assert [(list(t), list(v)) for t, v in folds] == [
+        (list(range(6)), [6]),
+        (list(range(7)), [7]),
+        (list(range(8)), [8]),
+        (list(range(9)), [9]),
+    ]
+
+
+def test_every_fold_trains_only_on_the_past():
+    x, y = _xy(30)
+    splitter = RollingOriginSplitter(
+        {"n_splits": 5, "horizon": 2, "step": 2, "test_size": 0}
+    )
+
+    for train, validation in splitter.split_indexes(x, y):
+        assert max(train) < min(validation)
+
+
+def test_the_horizon_sets_how_many_rows_each_fold_scores():
+    x, y = _xy(20)
+    splitter = RollingOriginSplitter(
+        {"n_splits": 3, "horizon": 3, "step": 1, "test_size": 0}
+    )
+
+    for _, validation in splitter.split_indexes(x, y):
+        assert len(validation) == 3
+
+
+def test_the_step_sets_how_far_the_origin_moves():
+    x, y = _xy(20)
+    splitter = RollingOriginSplitter(
+        {"n_splits": 3, "horizon": 1, "step": 4, "test_size": 0}
+    )
+
+    folds = splitter.split_indexes(x, y)
+    origins = [len(train) for train, _ in folds]
+
+    assert [origins[i + 1] - origins[i] for i in range(len(origins) - 1)] == [4, 4]
+
+
+def test_the_reserved_test_rows_are_the_tail_of_the_series():
+    # A random carve would scatter future rows through every fold's training
+    # data, which is the leak this strategy exists to close.
+    x, y = _xy(20)
+    splitter = RollingOriginSplitter(
+        {"n_splits": 3, "horizon": 1, "step": 1, "test_size": 0.2}
+    )
+
+    test_rows, pool = splitter._carve_test_split(x, y)
+
+    assert test_rows == [16, 17, 18, 19]
+    assert pool == list(range(16))
+
+
+def test_an_impossible_combination_names_a_knob():
+    x, y = _xy(6)
+    splitter = RollingOriginSplitter(
+        {"n_splits": 5, "horizon": 3, "step": 2, "test_size": 0}
+    )
+
+    with pytest.raises(ValueError, match="n_splits|horizon|step"):
+        splitter.split_indexes(x, y)
+
+
+def test_folds_map_back_to_original_rows_after_a_carve():
+    # split_indexes works in pool positions; FoldSplitter maps them back. With
+    # a tail carve the pool is the head, so the mapping must stay in order.
+    x, y = _xy(20)
+    splitter = RollingOriginSplitter(
+        {"n_splits": 3, "horizon": 1, "step": 1, "test_size": 0.2}
+    )
+
+    _, _, indices = splitter.split(x, y)
+
+    assert indices["full_dataset"]["test_indexes"] == [16, 17, 18, 19]
+    for name, fold in indices.items():
+        if name == "full_dataset":
+            continue
+        assert max(fold["train_indexes"]) < min(fold["validation_indexes"])
+        assert max(fold["validation_indexes"]) < 16

--- a/tests/back/tasks/test_forecasting_task.py
+++ b/tests/back/tasks/test_forecasting_task.py
@@ -1,0 +1,96 @@
+import pandas as pd
+import pytest
+
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    to_dashai_dataset,
+    transform_dataset_with_schema,
+)
+from DashAI.back.tasks.forecasting_task import ForecastingTask
+
+DATES = ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]
+
+
+def _dataset(**columns):
+    schema = {
+        "date": {"type": "Date", "dtype": "%Y-%m-%d"},
+        "other_date": {"type": "Date", "dtype": "%Y-%m-%d"},
+        "sales": {"type": "Float", "dtype": "float64"},
+        "count": {"type": "Integer", "dtype": "int64"},
+        "label": {"type": "Text", "dtype": "string"},
+    }
+    frame = pd.DataFrame(columns)
+    return transform_dataset_with_schema(
+        to_dashai_dataset(frame), {name: schema[name] for name in frame.columns}
+    )
+
+
+def test_a_date_input_and_a_float_output_are_accepted():
+    dataset = _dataset(date=DATES, sales=[1.0, 2.0, 3.0, 4.0])
+
+    prepared = ForecastingTask().prepare_for_task(dataset, ["date"], ["sales"])
+
+    assert len(prepared) == 4
+
+
+def test_an_integer_output_is_accepted():
+    dataset = _dataset(date=DATES, count=[1, 2, 3, 4])
+
+    prepared = ForecastingTask().prepare_for_task(dataset, ["date"], ["count"])
+
+    assert len(prepared) == 4
+
+
+def test_a_text_input_is_rejected():
+    dataset = _dataset(label=["a", "b", "c", "d"], sales=[1.0, 2.0, 3.0, 4.0])
+
+    with pytest.raises(TypeError):
+        ForecastingTask().prepare_for_task(dataset, ["label"], ["sales"])
+
+
+def test_a_text_output_is_rejected():
+    dataset = _dataset(date=DATES, label=["a", "b", "c", "d"])
+
+    with pytest.raises(TypeError):
+        ForecastingTask().prepare_for_task(dataset, ["date"], ["label"])
+
+
+def test_a_second_input_column_is_rejected():
+    # Exogenous variables are a separate task by design, so a second input is
+    # refused here rather than quietly ignored.
+    dataset = _dataset(date=DATES, other_date=DATES, sales=[1.0, 2.0, 3.0, 4.0])
+
+    with pytest.raises(ValueError, match="Input cardinality"):
+        ForecastingTask().prepare_for_task(dataset, ["date", "other_date"], ["sales"])
+
+
+def test_two_output_columns_are_rejected():
+    dataset = _dataset(date=DATES, sales=[1.0, 2.0, 3.0, 4.0], count=[1, 2, 3, 4])
+
+    with pytest.raises(ValueError, match="Output cardinality"):
+        ForecastingTask().prepare_for_task(dataset, ["date"], ["sales", "count"])
+
+
+def test_it_reports_no_labels():
+    dataset = _dataset(date=DATES, sales=[1.0, 2.0, 3.0, 4.0])
+
+    assert ForecastingTask().num_labels(dataset, "sales") is None
+
+
+def test_predictions_pass_through_unchanged():
+    import numpy as np
+
+    dataset = _dataset(date=DATES, sales=[1.0, 2.0, 3.0, 4.0])
+    predictions = np.array([1.5, 2.5])
+
+    processed = ForecastingTask().process_predictions(dataset, predictions, "sales")
+
+    assert list(processed) == [1.5, 2.5]
+
+
+def test_the_metadata_the_frontend_reads():
+    metadata = ForecastingTask.get_metadata()
+
+    assert metadata["inputs_types"] == ["Date"]
+    assert set(metadata["outputs_types"]) == {"Float", "Integer"}
+    assert metadata["inputs_cardinality"] == 1
+    assert metadata["outputs_cardinality"] == 1


### PR DESCRIPTION
## Summary

Adds `ForecastingTask` and the two splitters that make evaluating a forecast honest.

The task takes one `Date` column and one numeric column and nothing else. Models that read a date directly, such as ARIMA or exponential smoothing, are a different family from models that also take explanatory variables, so forecasting with exogenous variables stays a separate task rather than becoming an option here.

```
ForecastingTask -> splitters: ['RollingOriginSplitter', 'TemporalHoldoutSplitter']
RegressionTask  -> splitters: ['GroupKFoldSplitter', 'KFoldSplitter',
                               'LeaveOneOutSplitter', 'RepeatedKFoldSplitter',
                               'RollingOriginSplitter', 'TemporalHoldoutSplitter']
```


---

## Type of Change

Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/tasks/forecasting_task.py`: new task. One `Date` input, one `Float` or `Integer` output, both with cardinality 1. `num_labels` returns `None` and predictions pass through, since a forecast is already on the scale of the series.
- `DashAI/back/splitters/temporal_holdout.py`: new splitter, subclassing `HoldoutSplitter` because it is the same partitioning with a different index rule. Cuts the rows where they lie, so everything scored on comes after everything fitted on. A request to shuffle is overruled rather than honoured, and the schema exposes no shuffle, seed or stratification.
- `DashAI/back/splitters/rolling_origin.py`: new `FoldSplitter` subclass. Walks the origin forward, refitting with more history each time. Parameters are `n_splits`, `horizon`, `step` and `test_size`; the first training window is derived rather than asked for, as `n - horizon - (n_splits - 1) * step`.
- `DashAI/back/splitters/fold_splitter.py`: add a `temporal` branch to `_carve_test_split`, reserving the tail of the series. Every existing strategy samples the reserved rows from anywhere in the dataset, which for a series scatters future rows through the training data of every fold.
- `DashAI/back/initial_components.py`: register the task and both splitters.
- `tests/back/tasks/test_forecasting_task.py`, `tests/back/splitters/test_temporal_splitters.py`: new. 9 and 13 tests.
