### PR TITLE
Fix forecasting splitters, evaluation strategies, and row handling

### DIFF
--- a/DashAI/back/converters/simple_converters/time_series_window.py
+++ b/DashAI/back/converters/simple_converters/time_series_window.py
@@ -85,7 +85,9 @@ class TimeSeriesWindowConverter(FeatureEngineeringConverter, BaseConverter):
       longer line up with the original ones.
     * Consecutive rows overlap by ``k - 1`` values. A splitter that shuffles
       will therefore put near duplicate rows on both sides of the split and
-      report a score that is too good. Split chronologically instead.
+      report a score that is too good. The output is regression data, so split
+      it chronologically by turning shuffling off on the splitter rather than
+      leaving it on.
     """
 
     SCHEMA = TimeSeriesWindowConverterSchema

--- a/DashAI/back/evaluation/base_evaluation_strategy.py
+++ b/DashAI/back/evaluation/base_evaluation_strategy.py
@@ -6,6 +6,7 @@ from typing import Callable, Final, List, Optional
 from kink import di
 
 from DashAI.back.core.artifacts import normalize_artifacts
+from DashAI.back.core.enums.metrics import SplitEnum
 from DashAI.back.dependencies.database.models import Run
 from DashAI.back.models.base_model import BaseModel
 from DashAI.back.models.model_factory import ModelFactory
@@ -21,6 +22,28 @@ class BaseEvaluationStrategy(metaclass=ABCMeta):
     """
 
     TYPE: Final[str] = "EvaluationStrategy"
+
+    # How this strategy divides the dataset. The frontend renders holdout
+    # controls or fold controls from this rather than comparing class names,
+    # which is what previously made a new strategy unreachable from the UI.
+    KIND: str = "holdout"
+
+    # Which partitions this strategy records metrics for. Scoring the training
+    # partition means predicting on rows the model was fitted on, which is a
+    # fit statistic; a forecaster has no such thing to report.
+    SCORED_SPLITS: tuple = (SplitEnum.TRAIN, SplitEnum.VALIDATION, SplitEnum.TEST)
+
+    @classmethod
+    def get_metadata(cls) -> dict:
+        """Describe the strategy for the frontend.
+
+        Returns
+        -------
+        dict
+            Mapping with ``kind``, which says whether this strategy splits the
+            dataset once or into folds.
+        """
+        return {"kind": cls.KIND}
 
     def __init__(
         self,

--- a/DashAI/back/evaluation/cv.py
+++ b/DashAI/back/evaluation/cv.py
@@ -9,7 +9,7 @@ from DashAI.back.evaluation.base_evaluation_strategy import BaseEvaluationStrate
 from DashAI.back.splitters.base_splitter import BaseSplitter
 
 
-class CrossValidationEvaluationStrategy(BaseEvaluationStrategy):
+class FoldEvaluationStrategy(BaseEvaluationStrategy):
     """Evaluation strategy implementing k-fold cross-validation with optional
     nested CV and HPO.
 
@@ -24,6 +24,8 @@ class CrossValidationEvaluationStrategy(BaseEvaluationStrategy):
     - TRIAL level: Metrics during HPO trials
     - LAST/LAST_OUTER: Aggregated metrics (mean and std) for simple/nested CV
     """
+
+    KIND: str = "cv"
 
     def execute(self, x, y, run: Run, db):
         """Execute k-fold cross-validation with optional nested CV and HPO.
@@ -107,9 +109,10 @@ class CrossValidationEvaluationStrategy(BaseEvaluationStrategy):
             model.train(x_fold["train"], y_fold["train"])
 
             # Compute and store metrics for this fold
-            model.calculate_metrics(
-                split=SplitEnum.TRAIN, level=LevelEnum.FOLD, fold_index=i
-            )
+            if SplitEnum.TRAIN in self.SCORED_SPLITS:
+                model.calculate_metrics(
+                    split=SplitEnum.TRAIN, level=LevelEnum.FOLD, fold_index=i
+                )
             model.calculate_metrics(
                 split=SplitEnum.VALIDATION, level=LevelEnum.FOLD, fold_index=i
             )
@@ -200,7 +203,11 @@ class CrossValidationEvaluationStrategy(BaseEvaluationStrategy):
             model.train(x_fold["train"], y_fold["train"])
 
             # Compute metrics on both training and validation sets
-            train_scores = model.compute_metrics(split=SplitEnum.TRAIN)
+            train_scores = (
+                model.compute_metrics(split=SplitEnum.TRAIN)
+                if SplitEnum.TRAIN in self.SCORED_SPLITS
+                else {}
+            )
             validation_scores = model.compute_metrics(split=SplitEnum.VALIDATION)
 
             # Collect the goal metric value from this fold
@@ -228,11 +235,12 @@ class CrossValidationEvaluationStrategy(BaseEvaluationStrategy):
             }
 
             # Persist averaged metrics as TRIAL level (intermediate HPO result)
-            model._save_metrics(
-                results=averaged_train_results,
-                split=SplitEnum.TRAIN,
-                level=LevelEnum.TRIAL,
-            )
+            if SplitEnum.TRAIN in self.SCORED_SPLITS:
+                model._save_metrics(
+                    results=averaged_train_results,
+                    split=SplitEnum.TRAIN,
+                    level=LevelEnum.TRIAL,
+                )
             model._save_metrics(
                 results=averaged_validation_results,
                 split=SplitEnum.VALIDATION,
@@ -313,9 +321,10 @@ class CrossValidationEvaluationStrategy(BaseEvaluationStrategy):
             outer_model.calculate_metrics(
                 split=SplitEnum.VALIDATION, level=LevelEnum.OUTER_FOLD, fold_index=i
             )
-            outer_model.calculate_metrics(
-                split=SplitEnum.TRAIN, level=LevelEnum.OUTER_FOLD, fold_index=i
-            )
+            if SplitEnum.TRAIN in self.SCORED_SPLITS:
+                outer_model.calculate_metrics(
+                    split=SplitEnum.TRAIN, level=LevelEnum.OUTER_FOLD, fold_index=i
+                )
 
         # Aggregate outer fold metrics
         # Compute mean and std of OUTER_FOLD metrics and store as LAST_OUTER level
@@ -406,3 +415,20 @@ class CrossValidationEvaluationStrategy(BaseEvaluationStrategy):
 
         # Persist aggregated metrics to database
         db.commit()
+
+
+class CrossValidationEvaluationStrategy(FoldEvaluationStrategy):
+    """Score a model across folds, recording train and validation for each.
+
+    The ordinary cross-validation evaluation. Not offered for
+    ``ForecastingTask``, whose folds have no in-sample score to report;
+    ``ForecastingCrossValidationEvaluationStrategy`` handles that.
+    """
+
+    COMPATIBLE_COMPONENTS = [
+        "TabularClassificationTask",
+        "TextClassificationTask",
+        "ImageClassificationTask",
+        "TranslationTask",
+        "RegressionTask",
+    ]

--- a/DashAI/back/evaluation/forecasting_cv.py
+++ b/DashAI/back/evaluation/forecasting_cv.py
@@ -1,0 +1,25 @@
+"""Cross-validation for models that forecast a series from its own history."""
+
+from DashAI.back.core.enums.metrics import SplitEnum
+from DashAI.back.evaluation.cv import FoldEvaluationStrategy
+
+
+class ForecastingCrossValidationEvaluationStrategy(FoldEvaluationStrategy):
+    """Rolling origin cross-validation that records no in-sample metrics.
+
+    Only one thing separates this from the ordinary cross-validation
+    strategy: the training partition of a fold is not scored. Scoring it would
+    mean asking the model about dates it was fitted on, which is a fit
+    statistic rather than a forecast and is not comparable with the validation
+    score of the same fold.
+
+    Nothing else needs to change, and that is worth stating because it was not
+    obvious. Each fold already trains on everything before its own validation
+    window, and the final refit already uses the whole pool of rows outside
+    the reserved tail, so this strategy never had the horizon problem that
+    holdout did. Pair it with ``RollingOriginSplitter``, whose folds walk the
+    origin forward through time.
+    """
+
+    COMPATIBLE_COMPONENTS = ["ForecastingTask"]
+    SCORED_SPLITS: tuple = (SplitEnum.VALIDATION, SplitEnum.TEST)

--- a/DashAI/back/evaluation/forecasting_holdout.py
+++ b/DashAI/back/evaluation/forecasting_holdout.py
@@ -1,0 +1,111 @@
+"""Holdout evaluation for models that forecast a series from its own history."""
+
+from DashAI.back.core.enums.metrics import SplitEnum
+from DashAI.back.evaluation.holdout import SinglePartitionEvaluationStrategy
+
+
+class ForecastingHoldoutEvaluationStrategy(SinglePartitionEvaluationStrategy):
+    """Holdout evaluation that treats validation as history rather than a sample.
+
+    Two things the ordinary holdout strategy assumes are wrong for a
+    forecaster, and both of them are decisions about evaluation rather than
+    about any model.
+
+    **The training partition is not scored.** Scoring it would mean asking the
+    model about dates it was fitted on. That is an in-sample fit statistic,
+    which is a real diagnostic but is not comparable with a forecast made
+    several steps out; showing the two side by side in one results table
+    invites exactly that comparison. Only validation and test are recorded.
+
+    **The kept model is fitted through validation.** For most tasks the
+    validation partition is a held out sample that has to stay out of the fit.
+    For a forecaster it is simply the most recent stretch of the series, and
+    the stretch nearest to whatever comes next. Leaving it out makes the model
+    reach across the whole validation window before arriving at the first test
+    row, so the test metrics describe a longer horizon than the one being
+    asked about.
+
+    The validation metrics are still measured on a model fitted on training
+    data alone, which is what makes them honest: they are recorded before the
+    refit. So the two columns in the results table answer different questions,
+    and both answer them fairly.
+
+        validation metrics  <- model fitted on train
+        test metrics        <- model fitted on train + validation
+
+    Hyperparameter search is untouched. Its trials are scored on validation,
+    so they must not be fitted on it.
+    """
+
+    COMPATIBLE_COMPONENTS = ["ForecastingTask"]
+    SCORED_SPLITS: tuple = (SplitEnum.VALIDATION, SplitEnum.TEST)
+
+    def execute(self, x, y, run, db):
+        """Score validation on a trial fit, then refit and score test.
+
+        Parameters
+        ----------
+        x : DatasetDict
+            Input partitions, keyed by split name.
+        y : DatasetDict
+            Target partitions, keyed by split name.
+        run : Run
+            Database model representing the current run.
+        db : Session
+            SQLAlchemy session used to persist metrics.
+
+        Returns
+        -------
+        tuple
+            The trained model and the paths of any HPO plots.
+        """
+        plot_paths = []
+        model = self.model
+
+        model.x_data = x
+        model.y_data = y
+
+        if self.optimizer and self.run_optimizable_parameters:
+            self._report_progress(0.2, "Hyperparameter optimization")
+            model = self._do_hpo(model, x, y, run, db)
+            plot_paths = self._generate_hpo_plots(run)
+
+        # Fitted on training data only, so the validation score below measures
+        # a model that has not seen the rows it is being scored on.
+        self._report_progress(0.5, "Training")
+        model.train(x["train"], y["train"])
+
+        self._report_progress(0.8, "Computing validation metrics")
+        self._calculate_metrics_if_missing(model, run, db, SplitEnum.VALIDATION)
+
+        # Now the model that gets kept: the same configuration, refitted with
+        # the validation rows included, since for a series they are history.
+        self._report_progress(0.9, "Refitting on train and validation")
+        self._fit_final_model(model, x, y)
+
+        self._report_progress(0.95, "Computing test metrics")
+        self._calculate_metrics_if_missing(model, run, db, SplitEnum.TEST)
+
+        return model, plot_paths
+
+    def _fit_final_model(self, model, x, y):
+        """Fit the kept model on the training and validation rows together.
+
+        Parameters
+        ----------
+        model : BaseModel
+            The model to fit.
+        x : DatasetDict
+            Input partitions.
+        y : DatasetDict
+            Target partitions.
+        """
+        validation_x = x.get("validation")
+        validation_y = y.get("validation")
+
+        if validation_x is None or validation_y is None or len(validation_x) == 0:
+            model.train(x["train"], y["train"])
+            return
+
+        extend = type(model)._extend
+        model.train(extend(x["train"], validation_x), extend(y["train"], validation_y))

--- a/DashAI/back/evaluation/holdout.py
+++ b/DashAI/back/evaluation/holdout.py
@@ -3,7 +3,7 @@ from DashAI.back.dependencies.database.models import Metric, Run
 from DashAI.back.evaluation.base_evaluation_strategy import BaseEvaluationStrategy
 
 
-class HoldoutEvaluationStrategy(BaseEvaluationStrategy):
+class SinglePartitionEvaluationStrategy(BaseEvaluationStrategy):
     """Evaluation strategy implementing holdout (train/validation/test split)
     validation.
 
@@ -15,6 +15,8 @@ class HoldoutEvaluationStrategy(BaseEvaluationStrategy):
     - TRIAL level: Metrics during HPO trials on validation set
     - LAST level: Final metrics computed on all three partitions after training
     """
+
+    KIND: str = "holdout"
 
     def execute(self, x, y, run: Run, db):
         """Execute holdout validation: train on training set, optimize with validation,
@@ -59,14 +61,32 @@ class HoldoutEvaluationStrategy(BaseEvaluationStrategy):
 
         # Train the model with the provided data and return it
         self._report_progress(0.5, "Training")
-        model.train(x["train"], y["train"], x["validation"], y["validation"])
+        self._fit_final_model(model, x, y)
 
         # Calculate metrics at the end of training if not done already
         self._report_progress(0.85, "Computing metrics")
-        for split in (SplitEnum.TRAIN, SplitEnum.VALIDATION, SplitEnum.TEST):
+        for split in self.SCORED_SPLITS:
             self._calculate_metrics_if_missing(model, run, db, split)
 
         return model, plot_paths
+
+    def _fit_final_model(self, model, x, y):
+        """Fit the model that gets kept.
+
+        Separate from the trial fits so a strategy can differ on what the
+        kept model is allowed to learn from, which is the one thing
+        forecasting needs to change here.
+
+        Parameters
+        ----------
+        model : BaseModel
+            The model to fit.
+        x : DatasetDict
+            Input partitions.
+        y : DatasetDict
+            Target partitions.
+        """
+        model.train(x["train"], y["train"], x["validation"], y["validation"])
 
     def _calculate_metrics_if_missing(self, model, run: Run, db, split: SplitEnum):
         """Compute and persist LAST-level metrics for a split, unless already saved.
@@ -144,3 +164,22 @@ class HoldoutEvaluationStrategy(BaseEvaluationStrategy):
         score = metric.score(output_dataset_transformed, y_pred)
 
         return score
+
+
+class HoldoutEvaluationStrategy(SinglePartitionEvaluationStrategy):
+    """Split once into train, validation and test, and score all three.
+
+    The ordinary holdout evaluation. Not offered for ``ForecastingTask``:
+    scoring the training partition of a forecaster means predicting on dates
+    it was fitted on, and keeping validation out of the final fit throws away
+    the most recent history right before asking what comes next.
+    ``ForecastingHoldoutEvaluationStrategy`` handles both.
+    """
+
+    COMPATIBLE_COMPONENTS = [
+        "TabularClassificationTask",
+        "TextClassificationTask",
+        "ImageClassificationTask",
+        "TranslationTask",
+        "RegressionTask",
+    ]

--- a/DashAI/back/evaluation/holdout.py
+++ b/DashAI/back/evaluation/holdout.py
@@ -156,8 +156,12 @@ class SinglePartitionEvaluationStrategy(BaseEvaluationStrategy):
             output_dataset["validation"], is_fit=False
         )
 
-        # Calculate metric for train and validation data each trial
-        model.calculate_metrics(split=SplitEnum.TRAIN, level=LevelEnum.TRIAL)
+        # Calculate metric for train and validation data each trial. The
+        # training partition is skipped for a strategy that does not score it,
+        # which for a forecaster is not a preference: predicting on dates it
+        # was fitted on is refused, so asking would fail every trial.
+        if SplitEnum.TRAIN in self.SCORED_SPLITS:
+            model.calculate_metrics(split=SplitEnum.TRAIN, level=LevelEnum.TRIAL)
         model.calculate_metrics(split=SplitEnum.VALIDATION, level=LevelEnum.TRIAL)
 
         # Compute the objective metric score on the validation set

--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -94,6 +94,12 @@ from DashAI.back.dataset_sources.zenodo_dataset_source import ZenodoDatasetSourc
 
 # Evaluation Strategies
 from DashAI.back.evaluation.cv import CrossValidationEvaluationStrategy
+from DashAI.back.evaluation.forecasting_cv import (
+    ForecastingCrossValidationEvaluationStrategy,
+)
+from DashAI.back.evaluation.forecasting_holdout import (
+    ForecastingHoldoutEvaluationStrategy,
+)
 from DashAI.back.evaluation.holdout import HoldoutEvaluationStrategy
 
 # Explainers
@@ -734,6 +740,8 @@ def get_initial_components():
         # Evaluation Strategies
         CrossValidationEvaluationStrategy,
         HoldoutEvaluationStrategy,
+        ForecastingHoldoutEvaluationStrategy,
+        ForecastingCrossValidationEvaluationStrategy,
         # Statistical tests
         AnovaTest,
         FriedmanTest,

--- a/DashAI/back/job/model_job.py
+++ b/DashAI/back/job/model_job.py
@@ -320,9 +320,14 @@ class ModelJob(BaseJob):
 
         try:
             # Divide the dataset into two datasets:
-            # one with the input columns and another with the output column
+            # one with the input columns and another with the output column.
+            # This reads the prepared dataset rather than the loaded one: a
+            # task may reorder or otherwise adjust the rows, and forecasting
+            # does, sorting them by date so the temporal splitter carves real
+            # periods of time. Selecting from the loaded dataset would drop
+            # that work on the floor.
             X, Y = select_columns(
-                loaded_dataset,
+                prepared_dataset,
                 model_session.input_columns,
                 model_session.output_columns,
             )

--- a/DashAI/back/models/forecasting/arima.py
+++ b/DashAI/back/models/forecasting/arima.py
@@ -217,8 +217,9 @@ class ARIMA(ForecastingModel):
         Parameters
         ----------
         x_train : DashAIDataset
-            The date column. Unused: statsmodels is given the values in order,
-            and the spacing is assumed regular.
+            The date column. statsmodels is given the values in order and the
+            spacing is assumed regular; the dates are kept so a later
+            partition can be forecast at its own dates.
         y_train : DashAIDataset
             The series to forecast.
         x_validation : DashAIDataset, optional
@@ -256,6 +257,7 @@ class ARIMA(ForecastingModel):
             self._result = _ARIMA(series, order=(self.p, self.d, self.q)).fit()
 
         self._history = list(series)
+        self._remember_dates(x_train)
         self._fitted = True
         return self
 
@@ -265,14 +267,12 @@ class ARIMA(ForecastingModel):
         Parameters
         ----------
         x : DashAIDataset
-            The rows to forecast. Only their number is used.
+            The rows to forecast, whose dates say how far ahead each one is.
 
         Returns
         -------
         np.ndarray
             One forecast value per requested row.
         """
-        import numpy as np
-
         self._require_fitted()
-        return np.asarray(self._result.forecast(steps=self._horizon(x)), dtype=float)
+        return self._forecast_at(x, lambda steps: self._result.forecast(steps=steps))

--- a/DashAI/back/models/forecasting/base_forecasting_model.py
+++ b/DashAI/back/models/forecasting/base_forecasting_model.py
@@ -6,6 +6,7 @@ from DashAI.back.models.base_model import BaseModel
 
 if TYPE_CHECKING:
     import numpy as np
+    import pandas as pd
 
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
 
@@ -45,6 +46,7 @@ class ForecastingModel(BaseModel):
         # is what lets predict turn a date into a number of steps ahead.
         self._last_train_date = None
         self._step_delta = None
+        self._freq_alias = None
         self._date_format = None
 
     @staticmethod
@@ -90,7 +92,11 @@ class ForecastingModel(BaseModel):
         x_train : DashAIDataset
             The training input, holding the date column.
         """
-        from DashAI.back.types.date_utils import DEFAULT_DATE_FORMAT, parse_date_column
+        from DashAI.back.types.date_utils import (
+            DEFAULT_DATE_FORMAT,
+            infer_frequency,
+            parse_date_column,
+        )
         from DashAI.back.types.value_types import Date
 
         date_columns = [
@@ -102,6 +108,7 @@ class ForecastingModel(BaseModel):
             # Nothing to align against; predict falls back to counting rows.
             self._last_train_date = None
             self._step_delta = None
+            self._freq_alias = None
             return
 
         self._date_format = (
@@ -119,6 +126,54 @@ class ForecastingModel(BaseModel):
         self._step_delta = gaps.median() if not gaps.empty else None
         if self._step_delta is not None and self._step_delta.total_seconds() <= 0:
             self._step_delta = None
+
+        # A calendar period is not a fixed number of days, so measuring in
+        # days drifts: months run 28 to 31, the median lands on 31, and after
+        # a couple of years the count is a whole period short. When the rows
+        # sit on a regular grid the alias names that grid, and a position on
+        # it is exact however long the horizon gets.
+        alias = infer_frequency(dates)
+        self._freq_alias = alias if isinstance(alias, str) else None
+
+    def _steps_from_grid(self, dates: "pd.Series") -> "np.ndarray | None":
+        """Read each date as a position on the calendar grid of the training rows.
+
+        Counting positions rather than dividing durations is what keeps a
+        monthly or quarterly series aligned: those periods are not a fixed
+        number of days, so a duration divided by the typical gap drifts by a
+        whole period over a long enough horizon.
+
+        Parameters
+        ----------
+        dates : pd.Series
+            The requested dates, already parsed.
+
+        Returns
+        -------
+        np.ndarray or None
+            One step number per date, or ``None`` when the grid cannot answer:
+            no regular frequency, a missing date, or a date that does not land
+            on the grid. The caller then measures by duration instead.
+        """
+        import pandas as pd
+
+        if self._freq_alias is None or dates.isna().any():
+            return None
+
+        grid = pd.date_range(
+            start=self._last_train_date, end=dates.max(), freq=self._freq_alias
+        )
+        # The grid starts at the last training date, so a position on it is
+        # already a number of steps past the end of training. date_range rolls
+        # a start that is off the grid forward, which would break that.
+        if len(grid) == 0 or grid[0] != self._last_train_date:
+            return None
+
+        positions = grid.get_indexer(pd.DatetimeIndex(dates))
+        if (positions < 0).any():
+            return None
+
+        return positions
 
     def _steps_ahead(self, x: "DashAIDataset") -> "np.ndarray":
         """Work out how many periods past training each requested date falls.
@@ -158,8 +213,13 @@ class ForecastingModel(BaseModel):
             return np.arange(1, len(x) + 1)
 
         dates = parse_date_column(x.to_pandas()[date_columns[0]], self._date_format)
-        offsets = (dates - self._last_train_date) / self._step_delta
-        steps = np.rint(offsets.to_numpy(dtype=float)).astype(int)
+
+        steps = self._steps_from_grid(dates)
+        if steps is None:
+            # No regular grid to count on, so the best available reading is
+            # how many typical gaps each date lies past the end of training.
+            offsets = (dates - self._last_train_date) / self._step_delta
+            steps = np.rint(offsets.to_numpy(dtype=float)).astype(int)
 
         if (steps < 1).any():
             raise ValueError(

--- a/DashAI/back/models/forecasting/base_forecasting_model.py
+++ b/DashAI/back/models/forecasting/base_forecasting_model.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING, Any, List
 
+from DashAI.back.core.enums.metrics import SplitEnum
 from DashAI.back.models.base_model import BaseModel
 
 if TYPE_CHECKING:
@@ -21,12 +22,13 @@ class ForecastingModel(BaseModel):
     ``train`` reads the series out of ``y_train`` and ignores the feature
     matrix, because there is nothing in it to learn from.
 
-    ``predict`` treats its argument as a request for a length rather than as
-    data to score. It is handed the rows to forecast, usually a partition's
-    date column, and returns one value per row, continuing from where the
-    training history ended. Nothing about those rows changes the answer, which
-    is what makes these models different from a regressor: the forecast for
-    step three depends on steps one and two, not on any column.
+    ``predict`` reads the **dates** it is handed and works out how far each one
+    lies beyond the end of training, then returns the forecast for exactly
+    those points. Counting rows instead would be wrong for any partition that
+    does not directly follow the training data: with a train, validation and
+    test split, the test rows start a whole validation window later, and
+    forecasting ``len(test)`` steps would score the model against the wrong
+    period entirely.
 
     That is why the windowed route through ``TimeSeriesWindowConverter`` and
     ``RegressionTask`` exists alongside this one. It turns the history into
@@ -40,6 +42,11 @@ class ForecastingModel(BaseModel):
         super().__init__(**kwargs)
         self._history: List[float] = []
         self._fitted = False
+        # Where the training data ends and how far apart its rows sit, which
+        # is what lets predict turn a date into a number of steps ahead.
+        self._last_train_date = None
+        self._step_delta = None
+        self._date_format = None
 
     @staticmethod
     def _series(y: "DashAIDataset") -> "np.ndarray":
@@ -73,22 +80,118 @@ class ForecastingModel(BaseModel):
                 "Call train before predict."
             )
 
-    @staticmethod
-    def _horizon(x: "DashAIDataset") -> int:
-        """Read how many steps to forecast from the rows requested.
+    def _remember_dates(self, x_train: "DashAIDataset") -> None:
+        """Record where the training data ends and how far apart its rows are.
+
+        Both are needed to answer "how many steps ahead is this date", which is
+        what turns a requested partition into positions in a forecast.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            The training input, holding the date column.
+        """
+        from DashAI.back.types.date_utils import DEFAULT_DATE_FORMAT, parse_date_column
+        from DashAI.back.types.value_types import Date
+
+        date_columns = [
+            name
+            for name in x_train.column_names
+            if isinstance(x_train.types.get(name), Date)
+        ]
+        if not date_columns:
+            # Nothing to align against; predict falls back to counting rows.
+            self._last_train_date = None
+            self._step_delta = None
+            return
+
+        self._date_format = (
+            getattr(x_train.types[date_columns[0]], "format", None)
+            or DEFAULT_DATE_FORMAT
+        )
+        dates = parse_date_column(
+            x_train.to_pandas()[date_columns[0]], self._date_format
+        ).sort_values()
+
+        self._last_train_date = dates.iloc[-1]
+        # The typical gap rather than the mean: monthly rows sit 28 to 31 days
+        # apart, and the median lands on a real period instead of between two.
+        gaps = dates.diff().dropna()
+        self._step_delta = gaps.median() if not gaps.empty else None
+        if self._step_delta is not None and self._step_delta.total_seconds() <= 0:
+            self._step_delta = None
+
+    def _steps_ahead(self, x: "DashAIDataset") -> "np.ndarray":
+        """Work out how many periods past training each requested date falls.
 
         Parameters
         ----------
         x : DashAIDataset
-            The rows to forecast, whose contents are irrelevant; only how many
-            there are matters.
+            The rows to forecast, holding the date column.
 
         Returns
         -------
-        int
-            The number of steps to forecast.
+        np.ndarray
+            One 1-based step number per requested row, in the order given.
+
+        Raises
+        ------
+        ValueError
+            If any requested date falls at or before the end of the training
+            data. These models forecast forward only, so returning a number
+            for a past date would be passing off a fit as a forecast.
         """
-        return len(x)
+        import numpy as np
+
+        from DashAI.back.types.date_utils import parse_date_column
+        from DashAI.back.types.value_types import Date
+
+        date_columns = [
+            name for name in x.column_names if isinstance(x.types.get(name), Date)
+        ]
+        if (
+            not date_columns
+            or self._last_train_date is None
+            or self._step_delta is None
+        ):
+            # No dates to align against, so the rows can only mean "the next
+            # len(x) periods", which is what they meant before.
+            return np.arange(1, len(x) + 1)
+
+        dates = parse_date_column(x.to_pandas()[date_columns[0]], self._date_format)
+        offsets = (dates - self._last_train_date) / self._step_delta
+        steps = np.rint(offsets.to_numpy(dtype=float)).astype(int)
+
+        if (steps < 1).any():
+            raise ValueError(
+                f"{type(self).__name__} forecasts forward only, but "
+                f"{int((steps < 1).sum())} of the requested dates fall inside "
+                "the training data rather than after it. A value for those "
+                "dates would be a fit, not a forecast."
+            )
+
+        return steps
+
+    def _forecast_at(self, x: "DashAIDataset", forecast) -> "np.ndarray":
+        """Pick the forecast values for the requested dates.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            The rows that were requested.
+        forecast : callable
+            Takes a number of steps and returns that many forecast values.
+
+        Returns
+        -------
+        np.ndarray
+            One value per requested row, in the order the rows were given.
+        """
+        import numpy as np
+
+        steps = self._steps_ahead(x)
+        values = np.asarray(forecast(int(steps.max())), dtype=float)
+        return values[steps - 1]
 
     def save(self, filename: str) -> None:
         """Serialise the model to disk using joblib.
@@ -119,3 +222,29 @@ class ForecastingModel(BaseModel):
         import joblib
 
         return joblib.load(filename)
+
+    def calculate_metrics(self, split=SplitEnum.VALIDATION, **kwargs):
+        """Record metrics for every partition except the training one.
+
+        The base implementation scores a split by predicting on it, which for
+        a forecaster would mean asking for dates it was fitted on. An in
+        sample fit statistic is not comparable with the forecast error on the
+        later partitions, and putting the two side by side in one results
+        table invites exactly that comparison, so none is recorded.
+
+        Parameters
+        ----------
+        split : SplitEnum
+            The partition to score.
+        **kwargs
+            Passed through to the base implementation.
+
+        Returns
+        -------
+        Any
+            Whatever the base implementation returns, or ``None`` for the
+            training partition.
+        """
+        if split == SplitEnum.TRAIN:
+            return None
+        return super().calculate_metrics(split=split, **kwargs)

--- a/DashAI/back/models/forecasting/base_forecasting_model.py
+++ b/DashAI/back/models/forecasting/base_forecasting_model.py
@@ -2,7 +2,6 @@
 
 from typing import TYPE_CHECKING, Any, List
 
-from DashAI.back.core.enums.metrics import SplitEnum
 from DashAI.back.models.base_model import BaseModel
 
 if TYPE_CHECKING:
@@ -193,6 +192,31 @@ class ForecastingModel(BaseModel):
         values = np.asarray(forecast(int(steps.max())), dtype=float)
         return values[steps - 1]
 
+    @staticmethod
+    def _extend(earlier: "DashAIDataset", later: "DashAIDataset") -> "DashAIDataset":
+        """Join two consecutive partitions into one continuous history.
+
+        Parameters
+        ----------
+        earlier : DashAIDataset
+            The partition that comes first in time.
+        later : DashAIDataset
+            The partition that follows it.
+
+        Returns
+        -------
+        DashAIDataset
+            The two concatenated, keeping the column types of the first.
+        """
+        import pandas as pd
+
+        from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+
+        return to_dashai_dataset(
+            pd.concat([earlier.to_pandas(), later.to_pandas()], ignore_index=True),
+            types=dict(earlier.types),
+        )
+
     def save(self, filename: str) -> None:
         """Serialise the model to disk using joblib.
 
@@ -222,29 +246,3 @@ class ForecastingModel(BaseModel):
         import joblib
 
         return joblib.load(filename)
-
-    def calculate_metrics(self, split=SplitEnum.VALIDATION, **kwargs):
-        """Record metrics for every partition except the training one.
-
-        The base implementation scores a split by predicting on it, which for
-        a forecaster would mean asking for dates it was fitted on. An in
-        sample fit statistic is not comparable with the forecast error on the
-        later partitions, and putting the two side by side in one results
-        table invites exactly that comparison, so none is recorded.
-
-        Parameters
-        ----------
-        split : SplitEnum
-            The partition to score.
-        **kwargs
-            Passed through to the base implementation.
-
-        Returns
-        -------
-        Any
-            Whatever the base implementation returns, or ``None`` for the
-            training partition.
-        """
-        if split == SplitEnum.TRAIN:
-            return None
-        return super().calculate_metrics(split=split, **kwargs)

--- a/DashAI/back/models/forecasting/exponential_smoothing.py
+++ b/DashAI/back/models/forecasting/exponential_smoothing.py
@@ -260,8 +260,9 @@ class ExponentialSmoothing(ForecastingModel):
         Parameters
         ----------
         x_train : DashAIDataset
-            The date column. Unused: statsmodels is given the values in order,
-            and the spacing is assumed regular.
+            The date column. statsmodels is given the values in order and the
+            spacing is assumed regular; the dates are kept so a later
+            partition can be forecast at its own dates.
         y_train : DashAIDataset
             The series to forecast.
         x_validation : DashAIDataset, optional
@@ -309,6 +310,7 @@ class ExponentialSmoothing(ForecastingModel):
             ).fit()
 
         self._history = list(series)
+        self._remember_dates(x_train)
         self._fitted = True
         return self
 
@@ -318,14 +320,12 @@ class ExponentialSmoothing(ForecastingModel):
         Parameters
         ----------
         x : DashAIDataset
-            The rows to forecast. Only their number is used.
+            The rows to forecast, whose dates say how far ahead each one is.
 
         Returns
         -------
         np.ndarray
             One forecast value per requested row.
         """
-        import numpy as np
-
         self._require_fitted()
-        return np.asarray(self._result.forecast(self._horizon(x)), dtype=float)
+        return self._forecast_at(x, lambda steps: self._result.forecast(steps))

--- a/DashAI/back/models/forecasting/naive.py
+++ b/DashAI/back/models/forecasting/naive.py
@@ -78,7 +78,8 @@ class NaiveForecaster(ForecastingModel):
         Parameters
         ----------
         x_train : DashAIDataset
-            The date column. Unused: this model reads only the series.
+            The date column, used to record where the training data ends so a
+            later partition can be forecast at its own dates.
         y_train : DashAIDataset
             The series to forecast.
         x_validation : DashAIDataset, optional
@@ -102,6 +103,7 @@ class NaiveForecaster(ForecastingModel):
 
         self._history = list(series)
         self._last_value = float(series[-1])
+        self._remember_dates(x_train)
         self._fitted = True
         return self
 
@@ -111,7 +113,7 @@ class NaiveForecaster(ForecastingModel):
         Parameters
         ----------
         x : DashAIDataset
-            The rows to forecast. Only their number is used.
+            The rows to forecast, whose dates say how far ahead each one is.
 
         Returns
         -------
@@ -121,4 +123,6 @@ class NaiveForecaster(ForecastingModel):
         import numpy as np
 
         self._require_fitted()
-        return np.full(self._horizon(x), self._last_value, dtype=float)
+        return self._forecast_at(
+            x, lambda steps: np.full(steps, self._last_value, dtype=float)
+        )

--- a/DashAI/back/models/forecasting/seasonal_naive.py
+++ b/DashAI/back/models/forecasting/seasonal_naive.py
@@ -156,7 +156,8 @@ class SeasonalNaiveForecaster(ForecastingModel):
         Parameters
         ----------
         x_train : DashAIDataset
-            The date column. Unused: this model reads only the series.
+            The date column, used to record where the training data ends so a
+            later partition can be forecast at its own dates.
         y_train : DashAIDataset
             The series to forecast.
         x_validation : DashAIDataset, optional
@@ -185,16 +186,17 @@ class SeasonalNaiveForecaster(ForecastingModel):
 
         self._history = list(series)
         self._last_season = [float(v) for v in series[-self.season_length :]]
+        self._remember_dates(x_train)
         self._fitted = True
         return self
 
     def predict(self, x: "DashAIDataset") -> "np.ndarray":
-        """Repeat the last full season for as many steps as requested.
+        """Repeat the last full season out to the dates requested.
 
         Parameters
         ----------
         x : DashAIDataset
-            The rows to forecast. Only their number is used.
+            The rows to forecast, whose dates say how far ahead each one is.
 
         Returns
         -------
@@ -204,8 +206,10 @@ class SeasonalNaiveForecaster(ForecastingModel):
         import numpy as np
 
         self._require_fitted()
-        horizon = self._horizon(x)
-        return np.array(
-            [self._last_season[i % self.season_length] for i in range(horizon)],
-            dtype=float,
+        return self._forecast_at(
+            x,
+            lambda steps: np.array(
+                [self._last_season[i % self.season_length] for i in range(steps)],
+                dtype=float,
+            ),
         )

--- a/DashAI/back/optimizers/optuna_optimizer.py
+++ b/DashAI/back/optimizers/optuna_optimizer.py
@@ -219,6 +219,7 @@ class OptunaOptimizer(BaseOptimizer):
         "TextClassificationTask",
         "TranslationTask",
         "RegressionTask",
+        "ForecastingTask",
     ]
 
     def __init__(self, n_trials=None, sampler=None, pruner=None):

--- a/DashAI/back/splitters/base_splitter.py
+++ b/DashAI/back/splitters/base_splitter.py
@@ -22,10 +22,31 @@ class BaseSplitter(ConfigObject, metaclass=ABCMeta):
 
     TYPE: Final[str] = "Splitter"
 
+    # How this splitter carves the dataset, which decides the evaluation
+    # strategy it belongs to and therefore where the frontend may offer it.
+    # "holdout" splitters produce one set of partitions; "folds" splitters
+    # produce several train and validation pairs. Without this the frontend
+    # cannot tell the two apart and has to hardcode a splitter name, which is
+    # how a shuffling splitter ended up being offered for time series.
+    PARTITIONING: str = "holdout"
+
     # Name of the partition the model was fitted on. Every other partition a
     # splitter declares holds rows the model never saw, so any of them can
     # carry an explanation when the test partition came out empty.
     TRAINING_PARTITION: str = "train"
+
+    @classmethod
+    def get_metadata(cls) -> Dict[str, Any]:
+        """Return metadata describing how this splitter carves the dataset.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Mapping with ``partitioning``, which the frontend uses to decide
+            whether the splitter belongs to the holdout or the
+            cross-validation strategy.
+        """
+        return {"partitioning": cls.PARTITIONING}
 
     @classmethod
     def explainable_partitions(

--- a/DashAI/back/splitters/fold_splitter.py
+++ b/DashAI/back/splitters/fold_splitter.py
@@ -47,6 +47,11 @@ class FoldSplitter(BaseSplitter):
     ones.
     """
 
+    # Every fold splitter produces several train and validation pairs rather
+    # than one set of partitions, which is what pairs it with the
+    # cross-validation strategy instead of the holdout one.
+    PARTITIONING: str = "folds"
+
     # How the rows of the test set are chosen. ``"random"`` samples them
     # uniformly, ``"stratified"`` preserves the target distribution, and
     # ``"group"`` moves whole groups so a group never spans the carve.
@@ -99,6 +104,7 @@ class FoldSplitter(BaseSplitter):
     def get_metadata(cls) -> dict:
         """Return metadata describing the splitter's compatibility."""
         return {
+            **super().get_metadata(),
             "compatibleInnerSplitters": getattr(cls, "COMPATIBLE_INNER_SPLITTERS", []),
         }
 

--- a/DashAI/back/splitters/holdout.py
+++ b/DashAI/back/splitters/holdout.py
@@ -170,7 +170,7 @@ class HoldoutSplitterSchema(BaseSchema):
         return self
 
 
-class HoldoutSplitter(BaseSplitter):
+class PartitionSplitter(BaseSplitter):
     """Splitter that creates train, test, and validation partitions for holdout
     evaluation.
 
@@ -186,8 +186,6 @@ class HoldoutSplitter(BaseSplitter):
     ----------
     - https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html
     """
-
-    SCHEMA = HoldoutSplitterSchema
 
     @classmethod
     def explainable_partitions(cls, split_indexes):
@@ -355,3 +353,28 @@ class HoldoutSplitter(BaseSplitter):
             stratify=stratify_labels_test_val,
         )
         return train_indexes.tolist(), test_indexes.tolist(), val_indexes.tolist()
+
+
+class HoldoutSplitter(PartitionSplitter):
+    """Split the dataset into train, test and validation partitions at random.
+
+    The ordinary holdout split: rows are sampled into three partitions, with
+    optional shuffling, stratification and a seed to make the sample
+    reproducible.
+
+    Not offered for ``ForecastingTask``. Sampling rows out of a series lets a
+    model train on its own future and report a score it could never reproduce
+    in use, and nothing about that failure raises an error. Forecasting uses
+    ``TemporalHoldoutSplitter``, which cuts the rows where they lie.
+    """
+
+    SCHEMA = HoldoutSplitterSchema
+    # Listed per task rather than left universal, so the frontend can resolve
+    # a holdout splitter from the task instead of hardcoding this class.
+    COMPATIBLE_COMPONENTS = [
+        "TabularClassificationTask",
+        "TextClassificationTask",
+        "ImageClassificationTask",
+        "TranslationTask",
+        "RegressionTask",
+    ]

--- a/DashAI/back/splitters/rolling_origin.py
+++ b/DashAI/back/splitters/rolling_origin.py
@@ -151,7 +151,7 @@ class RollingOriginSplitter(FoldSplitter):
 
     SCHEMA = RollingOriginSplitterSchema
     TEST_SPLIT_STRATEGY: str = "temporal"
-    COMPATIBLE_COMPONENTS = ["ForecastingTask", "RegressionTask"]
+    COMPATIBLE_COMPONENTS = ["ForecastingTask"]
     COMPATIBLE_INNER_SPLITTERS = ["RollingOriginSplitter"]
     DISPLAY_NAME: str = MultilingualString(
         en="Rolling Origin",

--- a/DashAI/back/splitters/temporal_holdout.py
+++ b/DashAI/back/splitters/temporal_holdout.py
@@ -121,7 +121,9 @@ class TemporalHoldoutSplitter(PartitionSplitter):
       already seen instead of extrapolating past them.
     * On the output of ``TimeSeriesWindowConverter`` it is worse still, because
       consecutive rows share ``window_size - 1`` of their values, so a random
-      split puts near duplicates of the training rows into the test set.
+      split puts near duplicates of the training rows into the test set. That
+      route goes through ``RegressionTask``, which this splitter is not offered
+      for; use ``HoldoutSplitter`` with shuffling turned off there.
 
     Row order is taken as time order. This splitter receives the selected input
     columns, which for a windowed dataset no longer include a date, so it
@@ -129,7 +131,7 @@ class TemporalHoldoutSplitter(PartitionSplitter):
     """
 
     SCHEMA = TemporalHoldoutSplitterSchema
-    COMPATIBLE_COMPONENTS = ["ForecastingTask", "RegressionTask"]
+    COMPATIBLE_COMPONENTS = ["ForecastingTask"]
     DISPLAY_NAME: str = MultilingualString(
         en="Temporal Holdout",
         es="Holdout Temporal",

--- a/DashAI/back/splitters/temporal_holdout.py
+++ b/DashAI/back/splitters/temporal_holdout.py
@@ -11,7 +11,7 @@ from DashAI.back.core.schema_fields import (
 )
 from DashAI.back.core.utils import MultilingualString
 
-from .holdout import HoldoutSplitter
+from .holdout import PartitionSplitter
 
 if TYPE_CHECKING:
     from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
@@ -105,7 +105,7 @@ class TemporalHoldoutSplitterSchema(BaseSchema):
         return self
 
 
-class TemporalHoldoutSplitter(HoldoutSplitter):
+class TemporalHoldoutSplitter(PartitionSplitter):
     """Split a series in time order: train first, then validation, then test.
 
     Rows are cut where they lie rather than sampled, so every row a model is

--- a/DashAI/back/tasks/forecasting_task.py
+++ b/DashAI/back/tasks/forecasting_task.py
@@ -90,9 +90,58 @@ class ForecastingTask(BaseTask):
         Returns
         -------
         DashAIDataset
-            Dataset with validated types.
+            Dataset with validated types, in date order.
         """
-        return super().prepare_for_task(dataset, input_columns, output_columns)
+        prepared = super().prepare_for_task(dataset, input_columns, output_columns)
+        return self._sort_by_date(prepared, input_columns[0])
+
+    @staticmethod
+    def _sort_by_date(dataset: "DashAIDataset", date_column: str) -> "DashAIDataset":
+        """Put the rows in date order.
+
+        Everything downstream reads row order as time order and none of it
+        checks: the temporal splitter carves its partitions by position, and
+        the models hand their values to statsmodels in the order they arrive.
+        A file that is not sorted by its date column therefore produces
+        partitions that are not periods of time and a model fitted on a
+        scrambled series, with nothing reporting a problem.
+
+        This is the task's job rather than the splitter's. The splitter is
+        handed the selected input columns, which on the windowed route through
+        ``TimeSeriesWindowConverter`` are lag columns with no date among them.
+
+        Sorting reads the format the column declares. Text order only matches
+        time order for ISO layouts: as text, "01/02/2020" precedes
+        "31/01/2020" while following it in time.
+
+        Parameters
+        ----------
+        dataset : DashAIDataset
+            The validated dataset.
+        date_column : str
+            The single input column, which the task has already checked is a
+            ``Date``.
+
+        Returns
+        -------
+        DashAIDataset
+            The same rows and types, ordered by date.
+        """
+        from DashAI.back.dataloaders.classes.dashai_dataset import to_dashai_dataset
+        from DashAI.back.types.date_utils import DEFAULT_DATE_FORMAT, parse_date_column
+
+        date_format = (
+            getattr(dataset.types[date_column], "format", None) or DEFAULT_DATE_FORMAT
+        )
+        frame = dataset.to_pandas()
+        order = parse_date_column(frame[date_column], date_format).sort_values().index
+
+        if list(order) == list(frame.index):
+            return dataset
+
+        return to_dashai_dataset(
+            frame.loc[order].reset_index(drop=True), types=dict(dataset.types)
+        )
 
     def process_predictions(
         self, dataset: "DashAIDataset", predictions: "ndarray", output_column: str

--- a/DashAI/front/src/components/models/AddModelDialog.jsx
+++ b/DashAI/front/src/components/models/AddModelDialog.jsx
@@ -351,11 +351,11 @@ function AddModelDialog({
   const isStep1Valid = Boolean(selectedModel && name.trim() !== "");
   const isStep2Valid = Boolean(
     selectedOptimizer &&
-      goalMetric &&
-      (!useNestedCV ||
-        (innerConfig.splitterType &&
-          innerConfig.nSplits > 1 &&
-          innerConfig.nSplits <= maxInnerFolds)),
+    goalMetric &&
+    (!useNestedCV ||
+      (innerConfig.splitterType &&
+        innerConfig.nSplits > 1 &&
+        innerConfig.nSplits <= maxInnerFolds)),
   );
 
   return (

--- a/DashAI/front/src/components/models/AddModelDialog.jsx
+++ b/DashAI/front/src/components/models/AddModelDialog.jsx
@@ -1,3 +1,5 @@
+import { useStrategyKind } from "../../hooks/useStrategyKind";
+import { STRATEGY_KINDS } from "../../utils/splitsPayload";
 import React, { useState, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import {
@@ -57,6 +59,11 @@ function AddModelDialog({
   onRunCreated,
 }) {
   const { enqueueSnackbar } = useSnackbar();
+  // Nested cross-validation only applies to a folded strategy, which the
+  // backend reports rather than the strategy name implying it.
+  const isCrossValidation =
+    useStrategyKind(session?.evaluation_strategy) === STRATEGY_KINDS.CV;
+
   const [activeStep, setActiveStep] = useState(0);
   const [name, setName] = useState("");
   const [selectedModel, setSelectedModel] = useState(preselectedModel || "");
@@ -344,11 +351,11 @@ function AddModelDialog({
   const isStep1Valid = Boolean(selectedModel && name.trim() !== "");
   const isStep2Valid = Boolean(
     selectedOptimizer &&
-    goalMetric &&
-    (!useNestedCV ||
-      (innerConfig.splitterType &&
-        innerConfig.nSplits > 1 &&
-        innerConfig.nSplits <= maxInnerFolds)),
+      goalMetric &&
+      (!useNestedCV ||
+        (innerConfig.splitterType &&
+          innerConfig.nSplits > 1 &&
+          innerConfig.nSplits <= maxInnerFolds)),
   );
 
   return (
@@ -455,8 +462,7 @@ function AddModelDialog({
               />
             </Box>
 
-            {session?.evaluation_strategy ===
-              "CrossValidationEvaluationStrategy" && (
+            {isCrossValidation && (
               <NestedCVSelector
                 useNestedCV={useNestedCV}
                 onChange={setUseNestedCV}

--- a/DashAI/front/src/components/models/CreateSessionSteps.jsx
+++ b/DashAI/front/src/components/models/CreateSessionSteps.jsx
@@ -38,10 +38,9 @@ function CreateSessionSteps({
       : null,
   );
 
-  // Holdout or cross-validation
-  const [evaluationStrategy, setEvaluationStrategy] = useState(
-    "HoldoutEvaluationStrategy",
-  );
+  // Which evaluation strategy the session uses. Left empty until the task's
+  // strategies load, since which ones exist depends on the task.
+  const [evaluationStrategy, setEvaluationStrategy] = useState(null);
 
   const [newExp, setNewExp] = useState({
     name: "",

--- a/DashAI/front/src/components/models/ModelComparisonTable.jsx
+++ b/DashAI/front/src/components/models/ModelComparisonTable.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { useStrategyKind } from "../../hooks/useStrategyKind";
+import { STRATEGY_KINDS } from "../../utils/splitsPayload";
 import PropTypes from "prop-types";
 import {
   MaterialReactTable,
@@ -91,8 +93,7 @@ function ModelComparisonTable({
   // ────────────────────────────────────────────────────────────────────────
 
   const isCrossValidation =
-    selectedSession?.evaluation_strategy ===
-    "CrossValidationEvaluationStrategy";
+    useStrategyKind(selectedSession?.evaluation_strategy) === STRATEGY_KINDS.CV;
 
   // Run type color using existing theme.palette.accent tokens
   const getRunType = (run) => {

--- a/DashAI/front/src/components/models/ModelsRightBar.jsx
+++ b/DashAI/front/src/components/models/ModelsRightBar.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from "react";
+import { useStrategyKind } from "../../hooks/useStrategyKind";
+import { STRATEGY_KINDS } from "../../utils/splitsPayload";
 import PropTypes from "prop-types";
 import {
   Box,
@@ -211,7 +213,7 @@ export default function ModelsRightBar({ onToggle }) {
 
   // Determine if statistical tests should be shown (only for nested CV sessions)
   const isCv =
-    session?.evaluation_strategy === "CrossValidationEvaluationStrategy";
+    useStrategyKind(session?.evaluation_strategy) === STRATEGY_KINDS.CV;
 
   useEffect(() => {
     if (!isCv) {

--- a/DashAI/front/src/components/models/RunEditForm.jsx
+++ b/DashAI/front/src/components/models/RunEditForm.jsx
@@ -1,4 +1,6 @@
 import React, { useMemo } from "react";
+import { useStrategyKind } from "../../hooks/useStrategyKind";
+import { STRATEGY_KINDS } from "../../utils/splitsPayload";
 import PropTypes from "prop-types";
 import { Box, Typography, TextField } from "@mui/material";
 import { useTranslation } from "react-i18next";
@@ -39,6 +41,11 @@ export default function RunEditForm({
 }) {
   const { t } = useTranslation(["models", "common"]);
   const { selectedSession: session, datasetRowCount } = useModels();
+
+  // Nested cross-validation only applies to a folded strategy, which the
+  // backend reports rather than the strategy name implying it.
+  const isCrossValidation =
+    useStrategyKind(session?.evaluation_strategy) === STRATEGY_KINDS.CV;
 
   const outerSplit = useMemo(() => {
     return session?.splits ? JSON.parse(session.splits) : null;
@@ -82,8 +89,7 @@ export default function RunEditForm({
           />
         </Box>
 
-        {session?.evaluation_strategy ===
-          "CrossValidationEvaluationStrategy" && (
+        {isCrossValidation && (
           <NestedCVSelector
             useNestedCV={editedUseNestedCV}
             onChange={setEditedUseNestedCV}

--- a/DashAI/front/src/components/models/SessionVisualization.jsx
+++ b/DashAI/front/src/components/models/SessionVisualization.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from "react";
+import { useStrategyKind } from "../../hooks/useStrategyKind";
+import { STRATEGY_KINDS } from "../../utils/splitsPayload";
 import { Box, Typography, Divider, Button, ToggleButton } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useParams, useNavigate } from "react-router-dom";
@@ -60,7 +62,7 @@ export default function SessionVisualization() {
   const [isDragOver, setIsDragOver] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const isCrossValidation =
-    session?.evaluation_strategy === "CrossValidationEvaluationStrategy";
+    useStrategyKind(session?.evaluation_strategy) === STRATEGY_KINDS.CV;
 
   // This component stays mounted across session navigations (same route,
   // different :sessionId), so metricSplit would otherwise carry over from

--- a/DashAI/front/src/components/models/SessionVisualization.jsx
+++ b/DashAI/front/src/components/models/SessionVisualization.jsx
@@ -189,6 +189,21 @@ export default function SessionVisualization() {
       [runs],
     );
 
+  const availableSplits = React.useMemo(
+    () =>
+      [
+        hasTrainMetrics && "train",
+        hasValidationMetrics && "validation",
+        hasTestMetrics && "test",
+      ].filter(Boolean),
+    [hasTrainMetrics, hasValidationMetrics, hasTestMetrics],
+  );
+
+  const effectiveSplit =
+    availableSplits.length === 0 || availableSplits.includes(metricSplit)
+      ? metricSplit
+      : availableSplits[0];
+
   const handleTrainWithTour = (run) => {
     if (onTrain) onTrain(run);
     if (sessionTourContext?.run && sessionTourContext?.stepIndex === 5) {
@@ -569,7 +584,7 @@ export default function SessionVisualization() {
                     hasValidationMetrics ||
                     hasTestMetrics) && (
                     <PillToggleButtonGroup
-                      value={metricSplit}
+                      value={effectiveSplit}
                       onChange={(e, newValue) => {
                         if (newValue !== null) setMetricSplit(newValue);
                       }}
@@ -615,7 +630,7 @@ export default function SessionVisualization() {
                     onViewDetails={handleViewDetails}
                     onDelete={onDeleteRun}
                     onRowClick={handleRowClick}
-                    metricSplit={metricSplit}
+                    metricSplit={effectiveSplit}
                   />
 
                   {/* Graphs and statistical tests button toggle just when cross validation is being used */}
@@ -663,7 +678,7 @@ export default function SessionVisualization() {
                   {view === "graphs" ? (
                     <ResultsGraphs
                       runs={runs}
-                      selectedSplit={metricSplit}
+                      selectedSplit={effectiveSplit}
                       onSplitChange={setMetricSplit}
                       metrics={allMetrics}
                     />

--- a/DashAI/front/src/components/models/modelSession/PrepareDatasetStep.jsx
+++ b/DashAI/front/src/components/models/modelSession/PrepareDatasetStep.jsx
@@ -79,6 +79,9 @@ function PrepareDatasetStep({
 
   // Cross-Validation configuration states
   const [cvType, setCvType] = useState(null);
+  // Which holdout splitter this task uses. Resolved from the task rather
+  // than hardcoded, so a time series cannot be handed a shuffling one.
+  const [holdoutType, setHoldoutType] = useState(null);
   const [groupColumn, setGroupColumn] = useState("");
 
   const defaultParitionsIndex = {
@@ -249,7 +252,11 @@ function PrepareDatasetStep({
       evaluation_strategy: evaluationStrategy,
     };
 
-    const splitterName = resolveSplitterName(evaluationStrategy, cvType);
+    const splitterName = resolveSplitterName(
+      evaluationStrategy,
+      cvType,
+      holdoutType,
+    );
     if (splitterName) {
       updatedExpData.splits = buildSplitsPayload({
         splitterName,
@@ -318,6 +325,7 @@ function PrepareDatasetStep({
     inputColumnNames,
     outputColumnNames,
     cvType,
+    holdoutType,
     groupColumn,
     evaluationStrategy,
     rowsPartitionsIndex,
@@ -366,6 +374,8 @@ function PrepareDatasetStep({
         setEvaluationStrategy={setEvaluationStrategy}
         cvType={cvType}
         setCvType={setCvType}
+        holdoutType={holdoutType}
+        setHoldoutType={setHoldoutType}
         groupColumn={groupColumn}
         setGroupColumn={setGroupColumn}
         inputColumnNames={inputColumnNames}
@@ -382,6 +392,7 @@ function PrepareDatasetStep({
     paramsError,
     evaluationStrategy,
     cvType,
+    holdoutType,
     groupColumn,
     inputColumnNames,
   ]);

--- a/DashAI/front/src/components/models/modelSession/PrepareDatasetStep.jsx
+++ b/DashAI/front/src/components/models/modelSession/PrepareDatasetStep.jsx
@@ -25,6 +25,7 @@ import { useModels } from "../ModelsContext";
 import {
   buildSplitsPayload,
   resolveSplitterName,
+  STRATEGY_KINDS,
   SPLIT_TYPES,
 } from "../../../utils/splitsPayload";
 /**
@@ -82,6 +83,10 @@ function PrepareDatasetStep({
   // Which holdout splitter this task uses. Resolved from the task rather
   // than hardcoded, so a time series cannot be handed a shuffling one.
   const [holdoutType, setHoldoutType] = useState(null);
+  // The split shape of the selected strategy, reported by the backend. The
+  // screens used to compare strategy names, which is why a new strategy
+  // rendered nothing at all.
+  const [strategyKind, setStrategyKind] = useState(null);
   const [groupColumn, setGroupColumn] = useState("");
 
   const defaultParitionsIndex = {
@@ -252,18 +257,12 @@ function PrepareDatasetStep({
       evaluation_strategy: evaluationStrategy,
     };
 
-    const splitterName = resolveSplitterName(
-      evaluationStrategy,
-      cvType,
-      holdoutType,
-    );
+    const splitterName = resolveSplitterName(strategyKind, cvType, holdoutType);
     if (splitterName) {
       updatedExpData.splits = buildSplitsPayload({
         splitterName,
         splitType:
-          evaluationStrategy === "HoldoutEvaluationStrategy"
-            ? splitType
-            : SPLIT_TYPES.CV,
+          strategyKind === STRATEGY_KINDS.HOLDOUT ? splitType : SPLIT_TYPES.CV,
         params: {
           ...(splitterParams ?? {}),
           // The group column select is rendered by hand, so its value is not
@@ -326,6 +325,7 @@ function PrepareDatasetStep({
     outputColumnNames,
     cvType,
     holdoutType,
+    strategyKind,
     groupColumn,
     evaluationStrategy,
     rowsPartitionsIndex,
@@ -376,6 +376,8 @@ function PrepareDatasetStep({
         setCvType={setCvType}
         holdoutType={holdoutType}
         setHoldoutType={setHoldoutType}
+        strategyKind={strategyKind}
+        setStrategyKind={setStrategyKind}
         groupColumn={groupColumn}
         setGroupColumn={setGroupColumn}
         inputColumnNames={inputColumnNames}
@@ -393,6 +395,7 @@ function PrepareDatasetStep({
     evaluationStrategy,
     cvType,
     holdoutType,
+    strategyKind,
     groupColumn,
     inputColumnNames,
   ]);

--- a/DashAI/front/src/components/models/modelSession/SplitDatasetRows.jsx
+++ b/DashAI/front/src/components/models/modelSession/SplitDatasetRows.jsx
@@ -21,9 +21,12 @@ import FormSchemaLayout from "../../shared/FormSchemaLayout";
 import {
   defaultHoldoutSplitter,
   filterByPartitioning,
+  findStrategy,
   FOLD_PARTITIONING,
   HOLDOUT_PARTITIONING,
   resolveSplitterName,
+  STRATEGY_KINDS,
+  strategyKindOf,
 } from "../../../utils/splitsPayload";
 import { useTranslation } from "react-i18next";
 import { useSnackbar } from "notistack";
@@ -91,6 +94,8 @@ function SplitDatasetRows({
   setCvType,
   holdoutType,
   setHoldoutType,
+  strategyKind,
+  setStrategyKind,
   groupColumn,
   setGroupColumn,
   inputColumnNames,
@@ -117,11 +122,7 @@ function SplitDatasetRows({
 
   // The splitter's own parameters come from the schema generated form; only the
   // rules the schema cannot express are checked here.
-  const splitterName = resolveSplitterName(
-    evaluationStrategy,
-    cvType,
-    holdoutType,
-  );
+  const splitterName = resolveSplitterName(strategyKind, cvType, holdoutType);
   const isIndexMode =
     splitType === SPLIT_TYPES.MANUAL || splitType === SPLIT_TYPES.PREDEFINED;
   const params = splitterParams ?? {};
@@ -186,7 +187,7 @@ function SplitDatasetRows({
   // Rules that span several fields, which a per field schema cannot express.
   let splitsMessage = "";
   if (
-    evaluationStrategy === "HoldoutEvaluationStrategy" &&
+    strategyKind === STRATEGY_KINDS.HOLDOUT &&
     splitType === SPLIT_TYPES.RANDOM
   ) {
     if (trainIsEmpty) {
@@ -194,10 +195,7 @@ function SplitDatasetRows({
     } else if (proportionsAreNumbers && !proportionsSumToOne) {
       splitsMessage = t("experiments:error.splitsMustSumToOne");
     }
-  } else if (
-    evaluationStrategy === "CrossValidationEvaluationStrategy" &&
-    tooManyFolds
-  ) {
+  } else if (strategyKind === STRATEGY_KINDS.CV && tooManyFolds) {
     splitsMessage = t("experiments:error.foldsMustBeLessThanDatasetSize", {
       datasetSize: datasetInfo.total_rows,
     });
@@ -209,6 +207,7 @@ function SplitDatasetRows({
   const [groupColumnError, setGroupColumnError] = useState(true);
   const [allowedCvTypes, setAllowedCvTypes] = useState([]);
   const [allowedHoldoutTypes, setAllowedHoldoutTypes] = useState([]);
+  const [allowedStrategies, setAllowedStrategies] = useState([]);
 
   // Update allowed CV types when task changes
   useEffect(() => {
@@ -224,6 +223,15 @@ function SplitDatasetRows({
         setAllowedHoldoutTypes(
           filterByPartitioning(response, HOLDOUT_PARTITIONING),
         );
+
+        // Which strategies exist is a property of the task too, so a
+        // forecasting session cannot be pointed at one that scores its
+        // training partition.
+        const strategies = await getComponents({
+          selectTypes: ["EvaluationStrategy"],
+          relatedComponent: taskName,
+        });
+        setAllowedStrategies(strategies);
       } catch (error) {
         console.error("Error fetching splitters:", error);
         enqueueSnackbar(t("models:error.fetchingStatisticalTests"), {
@@ -244,6 +252,24 @@ function SplitDatasetRows({
   useEffect(() => {
     setHoldoutType(defaultHoldoutSplitter(allowedHoldoutTypes));
   }, [allowedHoldoutTypes]);
+
+  // Publish the split shape so the rest of the session reads it instead of
+  // comparing strategy names.
+  useEffect(() => {
+    setStrategyKind(
+      strategyKindOf(findStrategy(allowedStrategies, evaluationStrategy)),
+    );
+  }, [allowedStrategies, evaluationStrategy, setStrategyKind]);
+
+  // And for the strategy itself, which the session used to start on by name.
+  useEffect(() => {
+    if (!allowedStrategies.length) return;
+    if (findStrategy(allowedStrategies, evaluationStrategy)) return;
+    const holdout = allowedStrategies.find(
+      (strategy) => strategyKindOf(strategy) === STRATEGY_KINDS.HOLDOUT,
+    );
+    setEvaluationStrategy((holdout ?? allowedStrategies[0]).name);
+  }, [allowedStrategies, evaluationStrategy, setEvaluationStrategy]);
 
   const handleSplitTypeChange = (_e, newType) => {
     if (!newType) return;
@@ -307,7 +333,7 @@ function SplitDatasetRows({
       setSplitsReady(false);
       return;
     }
-    if (evaluationStrategy === "HoldoutEvaluationStrategy") {
+    if (strategyKind === STRATEGY_KINDS.HOLDOUT) {
       if (splitType === SPLIT_TYPES.PREDEFINED) {
         setSplitsReady(true);
       } else if (
@@ -325,7 +351,7 @@ function SplitDatasetRows({
       } else {
         setSplitsReady(false);
       }
-    } else if (evaluationStrategy === "CrossValidationEvaluationStrategy") {
+    } else if (strategyKind === STRATEGY_KINDS.CV) {
       setSplitsReady(
         Boolean(splitterName) && !tooManyFolds && !groupColumnError,
       );
@@ -397,24 +423,23 @@ function SplitDatasetRows({
             fullWidth
             size="small"
           >
-            <ToggleButton
-              value="HoldoutEvaluationStrategy"
-              sx={{ textTransform: "none", fontSize: "0.8rem" }}
-            >
-              {t("experiments:label.holdout")}
-            </ToggleButton>
-            <ToggleButton
-              value="CrossValidationEvaluationStrategy"
-              sx={{ textTransform: "none", fontSize: "0.8rem" }}
-            >
-              {t("experiments:label.crossValidation")}
-            </ToggleButton>
+            {allowedStrategies.map((strategy) => (
+              <ToggleButton
+                key={strategy.name}
+                value={strategy.name}
+                sx={{ textTransform: "none", fontSize: "0.8rem" }}
+              >
+                {strategyKindOf(strategy) === STRATEGY_KINDS.CV
+                  ? t("experiments:label.crossValidation")
+                  : t("experiments:label.holdout")}
+              </ToggleButton>
+            ))}
           </ToggleButtonGroup>
         </Box>
       </Paper>
 
       {/* HOLDOUT SECTION */}
-      {evaluationStrategy === "HoldoutEvaluationStrategy" && (
+      {strategyKind === STRATEGY_KINDS.HOLDOUT && (
         <>
           {/* Split type selector */}
           <Paper
@@ -524,7 +549,7 @@ function SplitDatasetRows({
       )}
 
       {/* CROSS-VALIDATION SECTION */}
-      {evaluationStrategy === "CrossValidationEvaluationStrategy" && (
+      {strategyKind === STRATEGY_KINDS.CV && (
         <>
           {/* CV Type Selector */}
           <SplitsCard label={t("experiments:label.cvType")}>
@@ -613,6 +638,8 @@ SplitDatasetRows.propTypes = {
   cvType: PropTypes.object,
   holdoutType: PropTypes.object,
   setHoldoutType: PropTypes.func,
+  strategyKind: PropTypes.string,
+  setStrategyKind: PropTypes.func,
   setCvType: PropTypes.func.isRequired,
   groupColumn: PropTypes.string,
   setGroupColumn: PropTypes.func.isRequired,

--- a/DashAI/front/src/components/models/modelSession/SplitDatasetRows.jsx
+++ b/DashAI/front/src/components/models/modelSession/SplitDatasetRows.jsx
@@ -18,7 +18,13 @@ import {
 import { DescriptionBlock } from "../../shared/FormSchemaFieldCard";
 import FormSchema from "../../shared/FormSchema";
 import FormSchemaLayout from "../../shared/FormSchemaLayout";
-import { resolveSplitterName } from "../../../utils/splitsPayload";
+import {
+  defaultHoldoutSplitter,
+  filterByPartitioning,
+  FOLD_PARTITIONING,
+  HOLDOUT_PARTITIONING,
+  resolveSplitterName,
+} from "../../../utils/splitsPayload";
 import { useTranslation } from "react-i18next";
 import { useSnackbar } from "notistack";
 import { getComponents } from "../../../api/component";
@@ -83,6 +89,8 @@ function SplitDatasetRows({
   setEvaluationStrategy,
   cvType,
   setCvType,
+  holdoutType,
+  setHoldoutType,
   groupColumn,
   setGroupColumn,
   inputColumnNames,
@@ -109,7 +117,11 @@ function SplitDatasetRows({
 
   // The splitter's own parameters come from the schema generated form; only the
   // rules the schema cannot express are checked here.
-  const splitterName = resolveSplitterName(evaluationStrategy, cvType);
+  const splitterName = resolveSplitterName(
+    evaluationStrategy,
+    cvType,
+    holdoutType,
+  );
   const isIndexMode =
     splitType === SPLIT_TYPES.MANUAL || splitType === SPLIT_TYPES.PREDEFINED;
   const params = splitterParams ?? {};
@@ -196,6 +208,7 @@ function SplitDatasetRows({
 
   const [groupColumnError, setGroupColumnError] = useState(true);
   const [allowedCvTypes, setAllowedCvTypes] = useState([]);
+  const [allowedHoldoutTypes, setAllowedHoldoutTypes] = useState([]);
 
   // Update allowed CV types when task changes
   useEffect(() => {
@@ -205,7 +218,12 @@ function SplitDatasetRows({
           selectTypes: ["Splitter"],
           relatedComponent: taskName,
         });
-        setAllowedCvTypes(response);
+        // A holdout splitter is not a cross-validation method, so the two
+        // kinds are kept apart rather than both landing in the CV dropdown.
+        setAllowedCvTypes(filterByPartitioning(response, FOLD_PARTITIONING));
+        setAllowedHoldoutTypes(
+          filterByPartitioning(response, HOLDOUT_PARTITIONING),
+        );
       } catch (error) {
         console.error("Error fetching splitters:", error);
         enqueueSnackbar(t("models:error.fetchingStatisticalTests"), {
@@ -221,6 +239,11 @@ function SplitDatasetRows({
   useEffect(() => {
     setCvType(allowedCvTypes.length > 0 ? allowedCvTypes[0] : null);
   }, [allowedCvTypes]);
+
+  // Same for the holdout splitter, which used to be a hardcoded name.
+  useEffect(() => {
+    setHoldoutType(defaultHoldoutSplitter(allowedHoldoutTypes));
+  }, [allowedHoldoutTypes]);
 
   const handleSplitTypeChange = (_e, newType) => {
     if (!newType) return;
@@ -588,6 +611,8 @@ SplitDatasetRows.propTypes = {
   evaluationStrategy: PropTypes.string.isRequired,
   setEvaluationStrategy: PropTypes.func.isRequired,
   cvType: PropTypes.object,
+  holdoutType: PropTypes.object,
+  setHoldoutType: PropTypes.func,
   setCvType: PropTypes.func.isRequired,
   groupColumn: PropTypes.string,
   setGroupColumn: PropTypes.func.isRequired,

--- a/DashAI/front/src/components/models/runResults/ResultsTabsHeader.jsx
+++ b/DashAI/front/src/components/models/runResults/ResultsTabsHeader.jsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { useStrategyKind } from "../../../hooks/useStrategyKind";
+import { STRATEGY_KINDS } from "../../../utils/splitsPayload";
 import PropTypes from "prop-types";
 import { Box, Typography, Tab, Tooltip, Chip } from "@mui/material";
 import { useTranslation } from "react-i18next";
@@ -64,8 +66,7 @@ export default function ResultsTabsHeader({
   // Get session from context to check if the evaluation strategy is Cross Validation
   const { selectedSession } = useModels();
   const isCrossValidation =
-    selectedSession?.evaluation_strategy ===
-    "CrossValidationEvaluationStrategy";
+    useStrategyKind(selectedSession?.evaluation_strategy) === STRATEGY_KINDS.CV;
   const isNestedCrossValidation = !!run?.nested;
 
   // Cross-validation runs can only be explained when the session reserved rows

--- a/DashAI/front/src/hooks/useStrategyKind.js
+++ b/DashAI/front/src/hooks/useStrategyKind.js
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { getComponents } from "../api/component";
+
+/**
+ * How each evaluation strategy divides the dataset, once fetched.
+ *
+ * Strategy names never change for a given session, so the answer is cached
+ * across components: several screens ask the same question about the same
+ * session and none of them should trigger its own request.
+ */
+const kindCache = new Map();
+
+/**
+ * Read the split shape of the strategy a session uses.
+ *
+ * Screens used to ask this by comparing the stored strategy name against a
+ * literal, which meant every new strategy silently read as "not cross
+ * validation" and rendered the wrong controls. The backend reports the shape,
+ * so it is read rather than guessed.
+ *
+ * @param {string|null} strategyName a session's evaluation_strategy
+ * @returns {string|null} "holdout", "cv", or null while unknown
+ */
+export function useStrategyKind(strategyName) {
+  const [kind, setKind] = useState(() => kindCache.get(strategyName) ?? null);
+
+  useEffect(() => {
+    if (!strategyName) {
+      setKind(null);
+      return undefined;
+    }
+
+    if (kindCache.has(strategyName)) {
+      setKind(kindCache.get(strategyName));
+      return undefined;
+    }
+
+    let cancelled = false;
+    const fetchKind = async () => {
+      try {
+        const component = await getComponents({ model: strategyName });
+        const value = component?.metadata?.kind ?? null;
+        kindCache.set(strategyName, value);
+        if (!cancelled) setKind(value);
+      } catch (error) {
+        console.error(`Error fetching the ${strategyName} metadata`, error);
+        if (!cancelled) setKind(null);
+      }
+    };
+
+    fetchKind();
+    return () => {
+      cancelled = true;
+    };
+  }, [strategyName]);
+
+  return kind;
+}
+
+export default useStrategyKind;

--- a/DashAI/front/src/utils/splitsPayload.js
+++ b/DashAI/front/src/utils/splitsPayload.js
@@ -62,19 +62,67 @@ export const buildSplitsPayload = ({
   return payload;
 };
 
+/** Splitters that produce one set of partitions rather than several folds. */
+export const HOLDOUT_PARTITIONING = "holdout";
+/** Splitters that produce several train and validation pairs. */
+export const FOLD_PARTITIONING = "folds";
+
+/**
+ * Keep only the splitters that pair with a given evaluation strategy.
+ *
+ * The backend reports how each splitter carves the dataset, so which strategy
+ * it belongs to is read from the component rather than inferred from its name.
+ *
+ * @param {Array} splitters splitter components compatible with the task
+ * @param {string} partitioning HOLDOUT_PARTITIONING or FOLD_PARTITIONING
+ * @returns {Array} the splitters that carve the dataset that way
+ */
+export const filterByPartitioning = (splitters, partitioning) =>
+  (splitters ?? []).filter(
+    (splitter) => splitter?.metadata?.partitioning === partitioning,
+  );
+
 /**
  * Resolve the registry name of the splitter a session configuration uses.
  *
- * Holdout has a single splitter; cross-validation picks one from the registry.
+ * Both strategies now pick from the splitters the task allows. Holdout used to
+ * return the literal "HoldoutSplitter" whatever the task was, which offered a
+ * shuffling splitter for time series: shuffling a series trains a model on its
+ * own future and reports a score it could never reproduce, with nothing raising
+ * an error.
  *
  * @param {string} evaluationStrategy the selected evaluation strategy
  * @param {object} cvType the splitter component selected for cross-validation
+ * @param {object} holdoutType the splitter component selected for holdout
  * @returns {string|null} the splitter name, or null when none is resolved yet
  */
-export const resolveSplitterName = (evaluationStrategy, cvType) => {
-  if (evaluationStrategy === HOLDOUT_STRATEGY) return "HoldoutSplitter";
+export const resolveSplitterName = (
+  evaluationStrategy,
+  cvType,
+  holdoutType = null,
+) => {
+  if (evaluationStrategy === HOLDOUT_STRATEGY) return holdoutType?.name ?? null;
   if (evaluationStrategy === CV_STRATEGY) return cvType?.name ?? null;
   return null;
+};
+
+/**
+ * Choose which holdout splitter a task should start on.
+ *
+ * Every task that had one before keeps it, so enabling this selection changes
+ * nothing for them. A task without it, which today means forecasting, takes the
+ * only holdout splitter it allows.
+ *
+ * @param {Array} holdoutSplitters the task's holdout splitter components
+ * @returns {object|null} the splitter to select by default
+ */
+export const defaultHoldoutSplitter = (holdoutSplitters) => {
+  const options = holdoutSplitters ?? [];
+  return (
+    options.find((splitter) => splitter?.name === "HoldoutSplitter") ??
+    options[0] ??
+    null
+  );
 };
 
 /**

--- a/DashAI/front/src/utils/splitsPayload.js
+++ b/DashAI/front/src/utils/splitsPayload.js
@@ -5,8 +5,35 @@ export const SPLIT_TYPES = {
   CV: "cv",
 };
 
-export const HOLDOUT_STRATEGY = "HoldoutEvaluationStrategy";
-export const CV_STRATEGY = "CrossValidationEvaluationStrategy";
+/**
+ * How an evaluation strategy divides the dataset.
+ *
+ * Read from the component's metadata rather than from its name. Comparing
+ * names meant a new strategy rendered no split controls at all, since none of
+ * the checks scattered through these screens matched it.
+ */
+export const STRATEGY_KINDS = {
+  HOLDOUT: "holdout",
+  CV: "cv",
+};
+
+/**
+ * Read the split shape a strategy component declares.
+ *
+ * @param {object} strategy an EvaluationStrategy component
+ * @returns {string|null} "holdout", "cv", or null when it declares neither
+ */
+export const strategyKindOf = (strategy) => strategy?.metadata?.kind ?? null;
+
+/**
+ * Find the strategy component a session's stored strategy name refers to.
+ *
+ * @param {Array} strategies strategy components allowed for the task
+ * @param {string} name the stored evaluation_strategy
+ * @returns {object|null} the matching component
+ */
+export const findStrategy = (strategies, name) =>
+  (strategies ?? []).find((strategy) => strategy?.name === name) ?? null;
 
 // Proportions describe a random split only. Manual and predefined splits carry
 // the row indexes instead, and the backend splitter picks its index branch when
@@ -91,18 +118,18 @@ export const filterByPartitioning = (splitters, partitioning) =>
  * own future and reports a score it could never reproduce, with nothing raising
  * an error.
  *
- * @param {string} evaluationStrategy the selected evaluation strategy
+ * @param {string} strategyKind the split shape of the selected strategy
  * @param {object} cvType the splitter component selected for cross-validation
  * @param {object} holdoutType the splitter component selected for holdout
  * @returns {string|null} the splitter name, or null when none is resolved yet
  */
 export const resolveSplitterName = (
-  evaluationStrategy,
+  strategyKind,
   cvType,
   holdoutType = null,
 ) => {
-  if (evaluationStrategy === HOLDOUT_STRATEGY) return holdoutType?.name ?? null;
-  if (evaluationStrategy === CV_STRATEGY) return cvType?.name ?? null;
+  if (strategyKind === STRATEGY_KINDS.HOLDOUT) return holdoutType?.name ?? null;
+  if (strategyKind === STRATEGY_KINDS.CV) return cvType?.name ?? null;
   return null;
 };
 

--- a/tests/back/evaluation/test_forecasting_strategies.py
+++ b/tests/back/evaluation/test_forecasting_strategies.py
@@ -1,0 +1,153 @@
+"""Evaluation strategies that know what a forecast is.
+
+Two things the ordinary strategies assume do not hold for a forecaster.
+
+They score the training partition, which for a forecaster would mean asking a
+model about dates it was fitted on. That is a fit statistic, not a forecast,
+and putting the two in one results table invites a comparison that means
+nothing.
+
+And holdout keeps the validation partition out of the final fit, which is
+right when validation is a held out sample and wrong when it is simply the
+most recent history. Leaving it out makes the model reach across the whole
+validation window before it arrives at the first test row.
+"""
+
+import pandas as pd
+import pytest
+
+from DashAI.back.core.enums.metrics import SplitEnum
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    select_columns,
+    to_dashai_dataset,
+    transform_dataset_with_schema,
+)
+from DashAI.back.evaluation.cv import CrossValidationEvaluationStrategy
+from DashAI.back.evaluation.forecasting_cv import (
+    ForecastingCrossValidationEvaluationStrategy,
+)
+from DashAI.back.evaluation.forecasting_holdout import (
+    ForecastingHoldoutEvaluationStrategy,
+)
+from DashAI.back.evaluation.holdout import HoldoutEvaluationStrategy
+from DashAI.back.models.forecasting.exponential_smoothing import ExponentialSmoothing
+from DashAI.back.splitters.temporal_holdout import TemporalHoldoutSplitter
+
+FORECASTING_STRATEGIES = [
+    ForecastingHoldoutEvaluationStrategy,
+    ForecastingCrossValidationEvaluationStrategy,
+]
+
+
+def _split(n=60):
+    season = [10.0, 20.0, 30.0, 40.0, 35.0, 25.0, 15.0, 12.0, 18.0, 28.0, 38.0, 22.0]
+    values = [v + i * 0.8 for i, v in enumerate(season * (n // 12))]
+    dates = pd.date_range("2022-01-01", periods=n, freq="MS").strftime("%Y-%m-%d")
+    dataset = transform_dataset_with_schema(
+        to_dashai_dataset(pd.DataFrame({"date": dates.tolist(), "v": values})),
+        {
+            "date": {"type": "Date", "dtype": "%Y-%m-%d"},
+            "v": {"type": "Float", "dtype": "float64"},
+        },
+    )
+    x, y = select_columns(dataset, ["date"], ["v"])
+    return TemporalHoldoutSplitter(
+        {"train": 0.6, "validation": 0.2, "test": 0.2}
+    ).split(x, y)
+
+
+# --- what each strategy declares ---------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", FORECASTING_STRATEGIES)
+def test_forecasting_strategies_serve_forecasting(strategy):
+    assert strategy.COMPATIBLE_COMPONENTS == ["ForecastingTask"]
+
+
+def test_the_ordinary_strategies_no_longer_serve_forecasting():
+    for strategy in (HoldoutEvaluationStrategy, CrossValidationEvaluationStrategy):
+        assert "ForecastingTask" not in strategy.COMPATIBLE_COMPONENTS
+        assert "RegressionTask" in strategy.COMPATIBLE_COMPONENTS
+
+
+def test_each_strategy_declares_the_shape_of_its_splits():
+    # The frontend renders holdout controls or fold controls from this rather
+    # than from the strategy's class name, which it used to compare against.
+    assert ForecastingHoldoutEvaluationStrategy.get_metadata()["kind"] == "holdout"
+    assert HoldoutEvaluationStrategy.get_metadata()["kind"] == "holdout"
+    assert ForecastingCrossValidationEvaluationStrategy.get_metadata()["kind"] == "cv"
+    assert CrossValidationEvaluationStrategy.get_metadata()["kind"] == "cv"
+
+
+# --- which partitions get scored ---------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", FORECASTING_STRATEGIES)
+def test_forecasting_strategies_do_not_score_the_training_partition(strategy):
+    assert SplitEnum.TRAIN not in strategy.SCORED_SPLITS
+
+
+def test_the_holdout_strategy_scores_validation_and_test():
+    assert ForecastingHoldoutEvaluationStrategy.SCORED_SPLITS == (
+        SplitEnum.VALIDATION,
+        SplitEnum.TEST,
+    )
+
+
+def test_the_ordinary_holdout_strategy_still_scores_all_three():
+    assert HoldoutEvaluationStrategy.SCORED_SPLITS == (
+        SplitEnum.TRAIN,
+        SplitEnum.VALIDATION,
+        SplitEnum.TEST,
+    )
+
+
+# --- the final fit -----------------------------------------------------------
+
+
+def test_the_kept_model_is_fitted_through_validation():
+    xs, ys, _ = _split()
+    strategy = ForecastingHoldoutEvaluationStrategy.__new__(
+        ForecastingHoldoutEvaluationStrategy
+    )
+    model = ExponentialSmoothing(seasonal="add", season_length=12)
+
+    strategy._fit_final_model(model, xs, ys)
+
+    last_validation_date = pd.to_datetime(xs["validation"].to_pandas().iloc[:, 0]).max()
+    assert model._last_train_date == last_validation_date
+
+
+def test_the_kept_model_forecasts_test_from_closer_than_a_trial_fit():
+    from DashAI.back.metrics.regression.mae import MAE
+
+    xs, ys, _ = _split()
+    strategy = ForecastingHoldoutEvaluationStrategy.__new__(
+        ForecastingHoldoutEvaluationStrategy
+    )
+
+    trial = ExponentialSmoothing(seasonal="add", season_length=12)
+    trial.train(xs["train"], ys["train"])
+
+    kept = ExponentialSmoothing(seasonal="add", season_length=12)
+    strategy._fit_final_model(kept, xs, ys)
+
+    assert MAE.score(ys["test"], kept.predict(xs["test"])) < MAE.score(
+        ys["test"], trial.predict(xs["test"])
+    )
+
+
+def test_a_session_without_validation_rows_still_fits():
+    xs, ys, _ = _split()
+    empty = xs["validation"].select(range(0))
+    xs = {**xs, "validation": empty}
+    ys = {**ys, "validation": ys["validation"].select(range(0))}
+    strategy = ForecastingHoldoutEvaluationStrategy.__new__(
+        ForecastingHoldoutEvaluationStrategy
+    )
+    model = ExponentialSmoothing(seasonal="add", season_length=12)
+
+    strategy._fit_final_model(model, xs, ys)
+
+    last_train_date = pd.to_datetime(xs["train"].to_pandas().iloc[:, 0]).max()
+    assert model._last_train_date == last_train_date

--- a/tests/back/evaluation/test_forecasting_strategies.py
+++ b/tests/back/evaluation/test_forecasting_strategies.py
@@ -151,3 +151,55 @@ def test_a_session_without_validation_rows_still_fits():
 
     last_train_date = pd.to_datetime(xs["train"].to_pandas().iloc[:, 0]).max()
     assert model._last_train_date == last_train_date
+
+
+# --- hyperparameter trials ---------------------------------------------------
+
+
+class _RecordingModel:
+    """Stands in for a model, noting which partitions it is asked to score."""
+
+    def __init__(self):
+        self.scored = []
+
+    def train(self, *args, **kwargs):
+        return self
+
+    def predict(self, x):
+        import numpy as np
+
+        return np.zeros(len(x))
+
+    def prepare_output(self, y, is_fit=False):
+        return y
+
+    def calculate_metrics(self, split, level=None, **kwargs):
+        self.scored.append(split)
+
+
+def _evaluate_with(strategy_class):
+    from DashAI.back.metrics.regression.mae import MAE
+
+    xs, ys, _ = _split()
+    strategy = strategy_class.__new__(strategy_class)
+    model = _RecordingModel()
+    strategy.evaluate(model, xs, ys, MAE)
+    return model.scored
+
+
+def test_a_forecasting_trial_never_scores_the_training_partition():
+    # The optimizer runs this once per trial. Asking for training metrics
+    # means predicting on dates the model was fitted on, which a forecaster
+    # refuses, so every trial failed and hyperparameter search could not run
+    # at all.
+    scored = _evaluate_with(ForecastingHoldoutEvaluationStrategy)
+
+    assert SplitEnum.TRAIN not in scored
+    assert SplitEnum.VALIDATION in scored
+
+
+def test_an_ordinary_trial_still_scores_both():
+    scored = _evaluate_with(HoldoutEvaluationStrategy)
+
+    assert SplitEnum.TRAIN in scored
+    assert SplitEnum.VALIDATION in scored

--- a/tests/back/models/test_forecasting_horizon.py
+++ b/tests/back/models/test_forecasting_horizon.py
@@ -1,0 +1,131 @@
+"""Forecasts must line up with the dates they were asked for.
+
+A forecasting model used to read only how many rows it was handed and forecast
+that many steps past the end of training. That is right for the partition that
+directly follows training, and wrong for every later one: with a train,
+validation and test split, the test partition was scored against a forecast of
+the validation window, so every test metric was measured against the wrong
+rows and looked far worse than the model deserved.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from DashAI.back.core.enums.metrics import SplitEnum
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    select_columns,
+    to_dashai_dataset,
+    transform_dataset_with_schema,
+)
+from DashAI.back.models.forecasting.arima import ARIMA
+from DashAI.back.models.forecasting.exponential_smoothing import ExponentialSmoothing
+from DashAI.back.models.forecasting.naive import NaiveForecaster
+from DashAI.back.models.forecasting.seasonal_naive import SeasonalNaiveForecaster
+
+ALL_MODELS = [NaiveForecaster, SeasonalNaiveForecaster, ARIMA, ExponentialSmoothing]
+
+
+def _split(n=50, freq="D"):
+    """A perfectly linear daily series, split train / validation / test."""
+    from DashAI.back.splitters.temporal_holdout import TemporalHoldoutSplitter
+
+    dates = pd.date_range("2020-01-01", periods=n, freq=freq).strftime("%Y-%m-%d")
+    dataset = transform_dataset_with_schema(
+        to_dashai_dataset(
+            pd.DataFrame({"date": dates.tolist(), "v": [float(i) for i in range(n)]})
+        ),
+        {
+            "date": {"type": "Date", "dtype": "%Y-%m-%d"},
+            "v": {"type": "Float", "dtype": "float64"},
+        },
+    )
+    x, y = select_columns(dataset, ["date"], ["v"])
+    splitter = TemporalHoldoutSplitter({"train": 0.6, "validation": 0.2, "test": 0.2})
+    return splitter.split(x, y)
+
+
+def _actual(y_split):
+    return np.asarray(y_split.to_pandas().iloc[:, 0], dtype=float)
+
+
+def test_the_test_partition_is_forecast_at_its_own_dates():
+    # The regression this file exists for. On a perfectly linear series ARIMA
+    # should land on the test values; before the fix it returned the
+    # validation window and was off by exactly len(validation).
+    xs, ys, _ = _split()
+    model = ARIMA(p=1, d=1, q=0)
+    model.train(xs["train"], ys["train"])
+
+    forecast = np.asarray(model.predict(xs["test"]), dtype=float)
+
+    assert forecast == pytest.approx(_actual(ys["test"]), abs=0.5)
+
+
+def test_the_validation_partition_still_lines_up():
+    xs, ys, _ = _split()
+    model = ARIMA(p=1, d=1, q=0)
+    model.train(xs["train"], ys["train"])
+
+    forecast = np.asarray(model.predict(xs["validation"]), dtype=float)
+
+    assert forecast == pytest.approx(_actual(ys["validation"]), abs=0.5)
+
+
+def test_a_later_partition_is_further_ahead_than_an_earlier_one():
+    # True of any model that does not forecast a flat line: the test window is
+    # further from the training data than the validation window is.
+    xs, ys, _ = _split()
+    model = ARIMA(p=1, d=1, q=0)
+    model.train(xs["train"], ys["train"])
+
+    validation = np.asarray(model.predict(xs["validation"]), dtype=float)
+    test = np.asarray(model.predict(xs["test"]), dtype=float)
+
+    assert test[0] > validation[-1]
+
+
+@pytest.mark.parametrize("model_class", ALL_MODELS)
+def test_every_model_returns_one_value_per_requested_row(model_class):
+    xs, ys, _ = _split()
+    model = model_class()
+    model.train(xs["train"], ys["train"])
+
+    assert len(model.predict(xs["test"])) == len(xs["test"])
+
+
+@pytest.mark.parametrize("model_class", ALL_MODELS)
+def test_monthly_dates_are_counted_in_months_not_days(model_class):
+    # The gap between one row and the next is 28 to 31 days, so a fixed day
+    # count would drift. What matters is how many periods ahead a date is.
+    xs, ys, _ = _split(n=48, freq="MS")
+    model = model_class()
+    model.train(xs["train"], ys["train"])
+
+    forecast = np.asarray(model.predict(xs["test"]), dtype=float)
+
+    assert len(forecast) == len(xs["test"])
+    assert np.isfinite(forecast).all()
+
+
+@pytest.mark.parametrize("model_class", ALL_MODELS)
+def test_forecasting_models_record_no_train_metrics(model_class):
+    # An in sample fit statistic invites comparison against test error, which
+    # means nothing for a forecaster, so these models report none.
+    model = model_class()
+    xs, ys, _ = _split()
+    model.train(xs["train"], ys["train"])
+
+    assert model.calculate_metrics(split=SplitEnum.TRAIN) is None
+
+
+@pytest.mark.parametrize("model_class", ALL_MODELS)
+def test_asking_for_a_date_inside_the_training_range_is_refused(model_class):
+    # These models forecast forward only. Returning something for a past date
+    # would quietly produce a number that is not a forecast at all.
+    xs, ys, _ = _split()
+    model = model_class()
+    model.train(xs["train"], ys["train"])
+
+    with pytest.raises(ValueError, match="inside the training data"):
+        model.predict(xs["train"])

--- a/tests/back/models/test_forecasting_horizon.py
+++ b/tests/back/models/test_forecasting_horizon.py
@@ -49,6 +49,14 @@ def _actual(y_split):
     return np.asarray(y_split.to_pandas().iloc[:, 0], dtype=float)
 
 
+def _rows(dataset, start, stop):
+    """A contiguous slice of a dataset, keeping its column types."""
+    return to_dashai_dataset(
+        dataset.to_pandas().iloc[start:stop].reset_index(drop=True),
+        types=dict(dataset.types),
+    )
+
+
 def test_the_test_partition_is_forecast_at_its_own_dates():
     # The regression this file exists for. On a perfectly linear series ARIMA
     # should land on the test values; before the fix it returned the
@@ -129,3 +137,74 @@ def test_asking_for_a_date_inside_the_training_range_is_refused(model_class):
 
     with pytest.raises(ValueError, match="inside the training data"):
         model.predict(xs["train"])
+
+
+@pytest.mark.parametrize("freq", ["MS", "ME", "QS"])
+def test_a_calendar_series_stays_aligned_over_a_long_horizon(freq):
+    # A calendar period is not a fixed number of days. Reading the distance to
+    # a date in days and dividing by the typical gap drifts: months run 28 to
+    # 31, the median lands on 31, and after roughly two years the count is a
+    # whole period short. Two different months then collapse onto the same
+    # forecast and every later row is off by one.
+    xs, ys, _ = _split(n=180, freq=freq)
+    model = NaiveForecaster()
+    model.train(xs["train"], ys["train"])
+
+    steps = model._steps_ahead(xs["test"])
+
+    first = len(xs["validation"]) + 1
+    assert list(steps) == list(range(first, first + len(xs["test"])))
+
+
+def test_a_seasonal_monthly_series_is_forecast_exactly():
+    # The value level version of the same thing: a seasonal naive forecaster
+    # given the right season length on a perfectly seasonal series should get
+    # every month right, and the drift used to spoil more than half of them.
+    dates = pd.date_range("2016-01-01", periods=120, freq="MS").strftime("%Y-%m-%d")
+    series = [float(10 * (i % 12)) for i in range(120)]
+    dataset = transform_dataset_with_schema(
+        to_dashai_dataset(pd.DataFrame({"date": dates.tolist(), "v": series})),
+        {
+            "date": {"type": "Date", "dtype": "%Y-%m-%d"},
+            "v": {"type": "Float", "dtype": "float64"},
+        },
+    )
+    x, y = select_columns(dataset, ["date"], ["v"])
+    cut = 60
+
+    model = SeasonalNaiveForecaster(season_length=12)
+    model.train(_rows(x, 0, cut), _rows(y, 0, cut))
+
+    forecast = np.asarray(model.predict(_rows(x, cut, 120)), dtype=float)
+
+    assert forecast == pytest.approx(series[cut:])
+
+
+def test_an_irregular_series_still_forecasts_by_typical_gap():
+    # No regular grid to count positions on, so the reading falls back to how
+    # many typical gaps each date lies past the end of training. That is the
+    # best available answer rather than a refusal.
+    dates = [
+        "2026-01-01",
+        "2026-01-05",
+        "2026-01-06",
+        "2026-02-01",
+        "2026-02-15",
+        "2026-03-02",
+    ]
+    dataset = transform_dataset_with_schema(
+        to_dashai_dataset(
+            pd.DataFrame({"date": dates, "v": [float(i) for i in range(6)]})
+        ),
+        {
+            "date": {"type": "Date", "dtype": "%Y-%m-%d"},
+            "v": {"type": "Float", "dtype": "float64"},
+        },
+    )
+    x, y = select_columns(dataset, ["date"], ["v"])
+
+    model = NaiveForecaster()
+    model.train(_rows(x, 0, 4), _rows(y, 0, 4))
+
+    assert model._freq_alias is None
+    assert len(model.predict(_rows(x, 4, 6))) == 2

--- a/tests/back/models/test_forecasting_models.py
+++ b/tests/back/models/test_forecasting_models.py
@@ -31,7 +31,25 @@ def _y(values):
 
 
 def _fit(model, values):
+    model._trained_on = len(values)
     return model.train(_x(len(values)), _y(values))
+
+
+def _future(model, steps):
+    """The dates that follow the training data, which is all these models forecast.
+
+    Predicting is date driven rather than row driven: a model works out how far
+    past the end of training each requested date falls. Handing it the first
+    rows of the series would be asking for a fit, not a forecast, and is
+    refused.
+    """
+    trained_on = model._trained_on
+    return transform_dataset_with_schema(
+        to_dashai_dataset(
+            pd.DataFrame({"date": _dates(trained_on + steps)[trained_on:]})
+        ),
+        {"date": {"type": "Date", "dtype": "%Y-%m-%d"}},
+    )
 
 
 # --- the shared contract -----------------------------------------------------
@@ -42,7 +60,7 @@ def test_every_model_forecasts_one_value_per_requested_row(model_class):
     model = model_class()
     _fit(model, list(range(1, 31)))
 
-    forecast = model.predict(_x(4))
+    forecast = model.predict(_future(model, 4))
 
     assert len(forecast) == 4
     assert np.isfinite(np.asarray(forecast, dtype=float)).all()
@@ -58,15 +76,15 @@ def test_every_model_is_declared_for_the_forecasting_task(model_class):
 def test_every_model_round_trips_through_save_and_load(model_class, tmp_path):
     model = model_class()
     _fit(model, list(range(1, 31)))
-    expected = list(np.asarray(model.predict(_x(3)), dtype=float))
+    expected = list(np.asarray(model.predict(_future(model, 3)), dtype=float))
 
     path = tmp_path / "model.joblib"
     model.save(str(path))
     restored = model_class.load(str(path))
 
-    assert list(np.asarray(restored.predict(_x(3)), dtype=float)) == pytest.approx(
-        expected
-    )
+    restored_forecast = np.asarray(restored.predict(_future(model, 3)), dtype=float)
+
+    assert list(restored_forecast) == pytest.approx(expected)
 
 
 @pytest.mark.parametrize("model_class", ALL_MODELS)
@@ -82,14 +100,14 @@ def test_naive_carries_the_last_value_forward():
     model = NaiveForecaster()
     _fit(model, [10.0, 20.0, 35.0])
 
-    assert list(model.predict(_x(3))) == pytest.approx([35.0, 35.0, 35.0])
+    assert list(model.predict(_future(model, 3))) == pytest.approx([35.0, 35.0, 35.0])
 
 
 def test_naive_on_a_flat_series_predicts_that_constant():
     model = NaiveForecaster()
     _fit(model, [7.0] * 10)
 
-    assert list(model.predict(_x(4))) == pytest.approx([7.0] * 4)
+    assert list(model.predict(_future(model, 4))) == pytest.approx([7.0] * 4)
 
 
 def test_seasonal_naive_repeats_the_last_season():
@@ -97,7 +115,7 @@ def test_seasonal_naive_repeats_the_last_season():
     _fit(model, [1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0])
 
     # The last full season is 10, 20, 30, 40, and it repeats from there.
-    assert list(model.predict(_x(6))) == pytest.approx(
+    assert list(model.predict(_future(model, 6))) == pytest.approx(
         [10.0, 20.0, 30.0, 40.0, 10.0, 20.0]
     )
 
@@ -106,7 +124,7 @@ def test_seasonal_naive_with_a_season_of_one_is_the_naive_forecast():
     model = SeasonalNaiveForecaster(season_length=1)
     _fit(model, [10.0, 20.0, 35.0])
 
-    assert list(model.predict(_x(2))) == pytest.approx([35.0, 35.0])
+    assert list(model.predict(_future(model, 2))) == pytest.approx([35.0, 35.0])
 
 
 def test_seasonal_naive_needs_a_full_season_of_history():
@@ -125,7 +143,7 @@ def test_arima_follows_a_linear_trend():
     model = ARIMA(p=1, d=1, q=0)
     _fit(model, list(range(1, 41)))
 
-    forecast = np.asarray(model.predict(_x(3)), dtype=float)
+    forecast = np.asarray(model.predict(_future(model, 3)), dtype=float)
 
     assert forecast == pytest.approx([41.0, 42.0, 43.0], abs=0.5)
 
@@ -134,7 +152,7 @@ def test_exponential_smoothing_tracks_the_level_of_a_flat_series():
     model = ExponentialSmoothing()
     _fit(model, [5.0] * 30)
 
-    forecast = np.asarray(model.predict(_x(3)), dtype=float)
+    forecast = np.asarray(model.predict(_future(model, 3)), dtype=float)
 
     assert forecast == pytest.approx([5.0, 5.0, 5.0], abs=0.1)
 
@@ -144,6 +162,6 @@ def test_exponential_smoothing_can_use_a_seasonal_component():
     model = ExponentialSmoothing(seasonal="add", season_length=4)
     _fit(model, season * 8)
 
-    forecast = np.asarray(model.predict(_x(4)), dtype=float)
+    forecast = np.asarray(model.predict(_future(model, 4)), dtype=float)
 
     assert forecast == pytest.approx(season, abs=1.0)

--- a/tests/back/optimizers/test_optimizer_task_gating.py
+++ b/tests/back/optimizers/test_optimizer_task_gating.py
@@ -1,0 +1,43 @@
+"""Which tasks each optimizer is offered for.
+
+Adding a task does not by itself make the components that gate on tasks aware
+of it. Forecasting was registered with models, metrics and splitters but not
+with any optimizer, so the optimizer dropdown came up empty and hyperparameter
+search was unreachable for it.
+"""
+
+from DashAI.back.optimizers.optuna_optimizer import OptunaOptimizer
+
+
+def test_optuna_serves_forecasting():
+    # ARIMA's p, d and q, and the season lengths on the other models, are all
+    # declared as optimizable, so there is something for it to search.
+    assert "ForecastingTask" in OptunaOptimizer.COMPATIBLE_COMPONENTS
+
+
+def test_optuna_keeps_serving_the_tasks_it_already_did():
+    for task in (
+        "TabularClassificationTask",
+        "TextClassificationTask",
+        "TranslationTask",
+        "RegressionTask",
+    ):
+        assert task in OptunaOptimizer.COMPATIBLE_COMPONENTS
+
+
+def test_every_forecasting_model_declares_something_to_optimize():
+    # An optimizer with nothing to search would be a pointless offer.
+    from DashAI.back.models.forecasting.arima import ARIMA
+    from DashAI.back.models.forecasting.exponential_smoothing import (
+        ExponentialSmoothing,
+    )
+    from DashAI.back.models.forecasting.seasonal_naive import SeasonalNaiveForecaster
+
+    for model in (ARIMA, SeasonalNaiveForecaster, ExponentialSmoothing):
+        fields = model.SCHEMA.model_json_schema()["properties"]
+        optimizable = [
+            name
+            for name, spec in fields.items()
+            if "optimize" in str(spec.get("placeholder", ""))
+        ]
+        assert optimizable, f"{model.__name__} has no optimizable field"

--- a/tests/back/optimizers/test_optuna_pruning_integration.py
+++ b/tests/back/optimizers/test_optuna_pruning_integration.py
@@ -32,15 +32,15 @@ from DashAI.back.optimizers.optuna_optimizer import OptunaOptimizer
 
 
 def _holdout_evaluate(model, input_dataset, output_dataset, metric):
-    """The real holdout evaluation path, called unbound.
+    """The real holdout evaluation path, on a strategy with no factory.
 
-    `evaluate` never touches `self`, and building a full strategy instance
-    needs a `ModelFactory` this test does not. If either stops being true,
-    this helper fails loudly and the test should switch to a real instance.
+    `evaluate` reads which partitions its strategy scores, so it needs a real
+    instance rather than None for self. Building one through __init__ would
+    need a `ModelFactory` this test does not have, and does not need: the only
+    thing read off the instance is a class attribute.
     """
-    return HoldoutEvaluationStrategy.evaluate(
-        None, model, input_dataset, output_dataset, metric
-    )
+    strategy = HoldoutEvaluationStrategy.__new__(HoldoutEvaluationStrategy)
+    return strategy.evaluate(model, input_dataset, output_dataset, metric)
 
 
 EPOCHS = 12

--- a/tests/back/optimizers/test_optuna_real_model.py
+++ b/tests/back/optimizers/test_optuna_real_model.py
@@ -43,15 +43,15 @@ from DashAI.back.optimizers.optuna_optimizer import OptunaOptimizer
 
 
 def _holdout_evaluate(model, input_dataset, output_dataset, metric):
-    """The real holdout evaluation path, called unbound.
+    """The real holdout evaluation path, on a strategy with no factory.
 
-    `evaluate` never touches `self`, and building a full strategy instance
-    needs a `ModelFactory` this test does not. If either stops being true,
-    this helper fails loudly and the test should switch to a real instance.
+    `evaluate` reads which partitions its strategy scores, so it needs a real
+    instance rather than None for self. Building one through __init__ would
+    need a `ModelFactory` this test does not have, and does not need: the only
+    thing read off the instance is a class attribute.
     """
-    return HoldoutEvaluationStrategy.evaluate(
-        None, model, input_dataset, output_dataset, metric
-    )
+    strategy = HoldoutEvaluationStrategy.__new__(HoldoutEvaluationStrategy)
+    return strategy.evaluate(model, input_dataset, output_dataset, metric)
 
 
 EPOCHS = 3

--- a/tests/back/splitters/test_splitter_partitioning.py
+++ b/tests/back/splitters/test_splitter_partitioning.py
@@ -1,0 +1,78 @@
+"""The splitter metadata and task gating the frontend resolves splitters from.
+
+Before this, the holdout path in the frontend hardcoded ``HoldoutSplitter``
+whatever the task was, so a forecasting session was offered a splitter that
+shuffles. Shuffling a series trains a model on its own future and reports a
+score it could never reproduce, and nothing about it raises an error. The
+frontend now reads both the partitioning and the task compatibility from the
+registry, which is what these tests pin.
+"""
+
+import pytest
+
+from DashAI.back.splitters.group_k_fold import GroupKFoldSplitter
+from DashAI.back.splitters.holdout import HoldoutSplitter
+from DashAI.back.splitters.k_fold import KFoldSplitter
+from DashAI.back.splitters.rolling_origin import RollingOriginSplitter
+from DashAI.back.splitters.temporal_holdout import TemporalHoldoutSplitter
+
+HOLDOUT_SPLITTERS = [HoldoutSplitter, TemporalHoldoutSplitter]
+FOLD_SPLITTERS = [KFoldSplitter, GroupKFoldSplitter, RollingOriginSplitter]
+
+
+@pytest.mark.parametrize("splitter", HOLDOUT_SPLITTERS)
+def test_holdout_splitters_report_their_partitioning(splitter):
+    assert splitter.get_metadata()["partitioning"] == "holdout"
+
+
+@pytest.mark.parametrize("splitter", FOLD_SPLITTERS)
+def test_fold_splitters_report_their_partitioning(splitter):
+    assert splitter.get_metadata()["partitioning"] == "folds"
+
+
+def test_fold_splitters_keep_reporting_their_inner_splitters():
+    # The partitioning key is added alongside what was already there rather
+    # than replacing it, since nested CV reads this.
+    metadata = KFoldSplitter.get_metadata()
+
+    assert "compatibleInnerSplitters" in metadata
+    assert metadata["partitioning"] == "folds"
+
+
+def test_the_shuffling_holdout_splitter_is_not_offered_for_forecasting():
+    # The whole point of the fix: this splitter can shuffle, so forecasting
+    # must not be able to reach it.
+    assert "ForecastingTask" not in HoldoutSplitter.COMPATIBLE_COMPONENTS
+
+
+def test_the_shuffling_holdout_splitter_still_serves_every_other_task():
+    for task in (
+        "TabularClassificationTask",
+        "TextClassificationTask",
+        "ImageClassificationTask",
+        "TranslationTask",
+        "RegressionTask",
+    ):
+        assert task in HoldoutSplitter.COMPATIBLE_COMPONENTS
+
+
+def test_the_temporal_splitter_does_not_inherit_the_other_ones_tasks():
+    # Both share a base class, and the registry unions COMPATIBLE_COMPONENTS
+    # along the MRO. Declaring the task list on a shared parent would offer a
+    # temporal split for image classification, which means nothing there.
+    assert set(TemporalHoldoutSplitter.COMPATIBLE_COMPONENTS) == {
+        "ForecastingTask",
+        "RegressionTask",
+    }
+
+
+def test_forecasting_can_reach_a_holdout_splitter_at_all():
+    # If no holdout splitter were compatible, the frontend would resolve None
+    # and the holdout strategy would silently stop working for forecasting.
+    reachable = [
+        splitter
+        for splitter in HOLDOUT_SPLITTERS
+        if "ForecastingTask" in splitter.COMPATIBLE_COMPONENTS
+    ]
+
+    assert reachable == [TemporalHoldoutSplitter]

--- a/tests/back/splitters/test_splitter_partitioning.py
+++ b/tests/back/splitters/test_splitter_partitioning.py
@@ -56,14 +56,15 @@ def test_the_shuffling_holdout_splitter_still_serves_every_other_task():
         assert task in HoldoutSplitter.COMPATIBLE_COMPONENTS
 
 
+def test_the_temporal_splitters_are_offered_for_forecasting_alone():
+    for splitter in (TemporalHoldoutSplitter, RollingOriginSplitter):
+        assert splitter.COMPATIBLE_COMPONENTS == ["ForecastingTask"]
+
+
 def test_the_temporal_splitter_does_not_inherit_the_other_ones_tasks():
-    # Both share a base class, and the registry unions COMPATIBLE_COMPONENTS
-    # along the MRO. Declaring the task list on a shared parent would offer a
-    # temporal split for image classification, which means nothing there.
-    assert set(TemporalHoldoutSplitter.COMPATIBLE_COMPONENTS) == {
-        "ForecastingTask",
-        "RegressionTask",
-    }
+    assert "TabularClassificationTask" not in (
+        TemporalHoldoutSplitter.COMPATIBLE_COMPONENTS
+    )
 
 
 def test_forecasting_can_reach_a_holdout_splitter_at_all():

--- a/tests/back/tasks/test_forecasting_ordering.py
+++ b/tests/back/tasks/test_forecasting_ordering.py
@@ -1,0 +1,112 @@
+"""A forecasting dataset has to be in date order before anything else happens.
+
+Row order is taken as time order everywhere downstream: the temporal splitter
+carves partitions by position, and the models hand statsmodels the values in
+row order. Neither checks, so a file that is not sorted by its date column
+produces partitions that are not periods of time and a model fitted on a
+scrambled series, with nothing reporting a problem.
+
+Sorting belongs to the task: it sees the whole dataset and knows which column
+is the date, and it runs before the split. The splitter cannot do it, because
+on the windowed route it receives lag columns and no date at all.
+"""
+
+import pandas as pd
+import pytest
+
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    to_dashai_dataset,
+    transform_dataset_with_schema,
+)
+from DashAI.back.tasks.forecasting_task import ForecastingTask
+
+SHUFFLED = ["2020-03-01", "2020-01-01", "2020-04-01", "2020-02-01"]
+VALUES = [30.0, 10.0, 40.0, 20.0]
+
+
+def _dataset(dates, values, date_format="%Y-%m-%d"):
+    return transform_dataset_with_schema(
+        to_dashai_dataset(pd.DataFrame({"date": dates, "v": values})),
+        {
+            "date": {"type": "Date", "dtype": date_format},
+            "v": {"type": "Float", "dtype": "float64"},
+        },
+    )
+
+
+def test_rows_come_back_in_date_order():
+    prepared = ForecastingTask().prepare_for_task(
+        _dataset(SHUFFLED, VALUES), ["date"], ["v"]
+    )
+
+    frame = prepared.to_pandas()
+    assert list(frame["date"]) == [
+        "2020-01-01",
+        "2020-02-01",
+        "2020-03-01",
+        "2020-04-01",
+    ]
+
+
+def test_the_target_travels_with_its_own_date():
+    # The failure that matters: a sort that moved the dates but not the values
+    # would silently pair every observation with the wrong day.
+    prepared = ForecastingTask().prepare_for_task(
+        _dataset(SHUFFLED, VALUES), ["date"], ["v"]
+    )
+
+    frame = prepared.to_pandas()
+    assert list(frame["v"]) == [10.0, 20.0, 30.0, 40.0]
+
+
+def test_an_already_sorted_dataset_is_left_as_it_is():
+    ordered = ["2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"]
+    values = [10.0, 20.0, 30.0, 40.0]
+
+    prepared = ForecastingTask().prepare_for_task(
+        _dataset(ordered, values), ["date"], ["v"]
+    )
+
+    frame = prepared.to_pandas()
+    assert list(frame["date"]) == ordered
+    assert list(frame["v"]) == values
+
+
+def test_sorting_reads_the_columns_declared_format():
+    # Day first dates sort wrongly as text: "01/02/2020" precedes "31/01/2020"
+    # alphabetically while following it in time.
+    dates = ["31/01/2020", "01/02/2020", "15/01/2020"]
+    prepared = ForecastingTask().prepare_for_task(
+        _dataset(dates, [31.0, 1.0, 15.0], date_format="%d/%m/%Y"),
+        ["date"],
+        ["v"],
+    )
+
+    frame = prepared.to_pandas()
+    assert list(frame["date"]) == ["15/01/2020", "31/01/2020", "01/02/2020"]
+    assert list(frame["v"]) == [15.0, 31.0, 1.0]
+
+
+def test_the_declared_types_survive_the_sort():
+    from DashAI.back.types.value_types import Date
+
+    prepared = ForecastingTask().prepare_for_task(
+        _dataset(SHUFFLED, VALUES), ["date"], ["v"]
+    )
+
+    assert isinstance(prepared.types["date"], Date)
+    assert prepared.types["date"].format == "%Y-%m-%d"
+
+
+def test_an_unreadable_date_is_still_rejected_by_validation():
+    # Sorting must not swallow the type checking that ran before it.
+    dataset = transform_dataset_with_schema(
+        to_dashai_dataset(pd.DataFrame({"note": ["a", "b"], "v": [1.0, 2.0]})),
+        {
+            "note": {"type": "Text", "dtype": "string"},
+            "v": {"type": "Float", "dtype": "float64"},
+        },
+    )
+
+    with pytest.raises(TypeError):
+        ForecastingTask().prepare_for_task(dataset, ["note"], ["v"])


### PR DESCRIPTION
## Summary

Six fixes found by running the forecasting task on real data, after the four feature branches had landed. Each was a case of a component being added without the things that gate on it, or of new code assuming something the surrounding code did not guarantee.

The two that changed results rather than availability:

**Forecasts were scored against the wrong rows.** `predict` read only how many rows it was handed and forecast that many steps past the end of training. That is right for the partition directly after training and wrong for every later one: with a train, validation and test split, the test partition was scored against a forecast of the validation window. On a linear series ARIMA was off by exactly `len(validation)`.

**The kept model was fitted from too far back.** Holdout kept validation out of the final fit, which is right when validation is a held out sample and wrong when it is simply the most recent history. Measured at roughly three times the error on a seasonal series.

```
Splitter           ForecastingTask  RollingOriginSplitter, TemporalHoldoutSplitter
Splitter           RegressionTask   GroupKFold, Holdout, KFold, LeaveOneOut, RepeatedKFold
EvaluationStrategy ForecastingTask  ForecastingCrossValidation, ForecastingHoldout
EvaluationStrategy RegressionTask   CrossValidation, Holdout
Optimizer          ForecastingTask  OptunaOptimizer
```

---

## Type of Change

Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

**Forecasts at the right dates**

- `DashAI/back/models/forecasting/base_forecasting_model.py`: record where training ends and the typical gap between its rows, then turn each requested date into a number of periods ahead. Order does not matter, gaps and duplicates are fine, monthly rows count in months. A date inside the training range is refused rather than answered.
- `DashAI/back/models/forecasting/{naive,seasonal_naive,arima,exponential_smoothing}.py`: forecast at the requested dates instead of counting rows.

**Rows in date order**

- `DashAI/back/tasks/forecasting_task.py`: **sort by the date column, reading the format the column declares. Everything downstream treats row order as time order and none of it checks.**
- `DashAI/back/job/model_job.py`: select from the prepared dataset rather than the loaded one, without which the sorting had no effect at all.

**Evaluation that knows what a forecast is**

- `DashAI/back/evaluation/forecasting_holdout.py`: new. Scores validation on a model fitted on training data alone, then refits through validation and scores test.
- `DashAI/back/evaluation/forecasting_cv.py`: new. Records no in sample metrics; rolling origin folds already train on everything before their own validation window.
- `DashAI/back/evaluation/base_evaluation_strategy.py`: strategies declare `KIND` and `SCORED_SPLITS`.
- `DashAI/back/evaluation/{holdout,cv}.py`: read `SCORED_SPLITS` instead of naming the training partition; implementations move to `SinglePartitionEvaluationStrategy` and `FoldEvaluationStrategy` so the task lists do not reach the forecasting subclasses through the registry's MRO union.

**Splitter and strategy selection driven by the task**

- `DashAI/back/splitters/base_splitter.py`, `fold_splitter.py`: declare `PARTITIONING`, so the frontend can tell a holdout splitter from a fold splitter.
- `DashAI/back/splitters/holdout.py`: partitioning logic moves to `PartitionSplitter`; `HoldoutSplitter` declares the five tasks it suits, forecasting deliberately absent.
- `DashAI/back/splitters/{temporal_holdout,rolling_origin}.py`: declare `ForecastingTask` alone.
- `DashAI/front/src/utils/splitsPayload.js`: resolve a splitter from the task's list, and key on the strategy's declared kind rather than its name.
- `DashAI/front/src/hooks/useStrategyKind.js`: new. Reads a session's strategy kind from the backend, cached.
- Nine frontend components: branch on the declared kind instead of comparing strategy names.

**Optimizer**

- `DashAI/back/optimizers/optuna_optimizer.py`: serve `ForecastingTask`, which had models, metrics and splitters but no optimizer.

---

## Testing (optional)

Full Forecasting workflow:
- Upload a times series dataset and confirm the date column is typed `Date`. If it lands as `Categorical`, change it straight to `Date`, without passing through `Text`.
- Create a forecasting model session. The splitter list must offer Temporal Holdout and Rolling Origin and nothing else, and the Temporal Holdout form must show three proportions with no shuffle, no stratify and no seed.