### PR TITLE
Fix notebook plotly remount crash

### DIFF
--- a/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
+++ b/DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx
@@ -83,6 +83,7 @@ export default function DatasetsCenterContent() {
   if (selectedNotebookId && selectedOption === "notebook") {
     return (
       <NotebookVisualization
+        key={selectedNotebookId}
         notebook={selectedNotebook}
         existingDatasets={datasets}
       />

--- a/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
+++ b/DashAI/front/src/components/notebooks/notebook/NotebookView.jsx
@@ -411,6 +411,7 @@ export default function NotebookView({ notebook }) {
           style={{ height: "100%" }}
           initialTopMostItemIndex={listSize > 1 ? listSize - 1 : 0}
           data={explorersAndConverters}
+          computeItemKey={(index, item) => `${item.type}-${item.id}`}
           itemContent={(index, item) => (
             <RowItem
               item={item}


### PR DESCRIPTION
## Summary
When two notebooks contained the same type of explorer (e.g. two correlation heatmaps) in the same list position, switching between notebooks (or deleting/reordering an item within a single notebook's explorer list) crashed the app with `Uncaught runtime errors: Something went wrong with axis scaling` inside Plotly's `drawColorBar`. Neither the notebook view nor its virtualized list gave React a stable identity per notebook/item, so React reused the same `<Plot>` DOM instance across structurally different figures instead of unmounting/remounting it. Plotly's incremental `Plotly.react()` update path can't safely patch a plot div's internal axis/colorbar state across genuinely different figures, which triggered the crash. Adding proper `key`s forces a clean remount whenever the underlying notebook or list item actually changes, so each figure always gets a fresh Plotly instance.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/front/src/components/notebooks/dataset/DatasetsCenterContent.jsx`: added `key={selectedNotebookId}` to `<NotebookVisualization>` so switching notebooks fully remounts the notebook subtree (including all explorer plots) instead of reusing the previous notebook's component instances.
- `DashAI/front/src/components/notebooks/notebook/NotebookView.jsx`: added `computeItemKey={(index, item) => \`${item.type}-${item.id}\`}` to the `Virtuoso` list so explorer/converter rows are identified by their actual id instead of by list position, preventing component/Plot reuse when items are deleted or reordered.

---

## Testing
- Created two notebooks with the same explorer type (same position in each list) and switched between them. No crash and each plot renders correctly.
- Within a single notebook, added two explorers of the same type with structurally different figures and deleted the first one to shift list positions.