### PR TITLE
Fix regression prediction crashes

### DIFF
--- a/DashAI/back/job/predict_job.py
+++ b/DashAI/back/job/predict_job.py
@@ -12,6 +12,7 @@ from DashAI.back.dependencies.database.models import Dataset, ModelSession, Pred
 from DashAI.back.job.base_job import BaseJob, JobError
 from DashAI.back.models.base_model import BaseModel
 from DashAI.back.tasks.base_task import BaseTask
+from DashAI.back.tasks.regression_task import RegressionTask
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import sessionmaker
@@ -481,6 +482,14 @@ class PredictJob(BaseJob):
                     for key, value in trained_schema.items()
                     if key in model_session.input_columns + model_session.output_columns
                 }
+
+                # Regression models predict continuous values regardless of
+                # the training target's original dtype (e.g. a target column
+                # that happened to hold only integer-looking values), so the
+                # output column's saved schema must reflect that instead of
+                # inheriting the training dataset's type.
+                if isinstance(task, RegressionTask):
+                    filtered_schema[output_col] = {"type": "Float", "dtype": "float64"}
 
                 # Store num of rows, columns, and column names
                 dataset_with_prediction.compute_base_metadata()

--- a/DashAI/back/models/scikit_learn/sklearn_like_model.py
+++ b/DashAI/back/models/scikit_learn/sklearn_like_model.py
@@ -79,6 +79,12 @@ class SklearnLikeModel(CategoricalEncoderMixin, BaseModel):
         """
         x_processed = self.prepare_dataset(x_train, is_fit=True).to_pandas()
         y_processed = self.prepare_output(y_train, is_fit=True).to_pandas()
+        # Every task using this base class has outputs_cardinality 1, so this
+        # is always a single column. Passed as a DataFrame, some estimators
+        # (e.g. LinearRegression) keep predictions 2D to match; squeezing to a
+        # Series here keeps fit/predict shapes 1D for every estimator alike.
+        if y_processed.shape[1] == 1:
+            y_processed = y_processed.iloc[:, 0]
         return super().fit(x_processed, y_processed)
 
     def predict(self, x: "DashAIDataset"):


### PR DESCRIPTION
## Summary
Predicting with a trained regression model crashed in two different, unrelated ways depending on which estimator was used. First, saving the results always inherited the target column's original type from the training dataset, so if that column happened to be integer-valued, PyArrow refused to cast a genuinely fractional prediction (e.g. `6.87`) into `int64`. Second, some estimators (e.g. `LinearRegression`) returned 2D `(n, 1)` predictions instead of 1D `(n,)` because the training target was fed to `.fit()` as a single-column DataFrame instead of a flat array. Tree/ensemble estimators like `AdaBoostRegressor` silently flattened this internally, but linear estimators preserved the 2D shape, and the dataset-saving step only accepts 1D arrays.

---

## Type of Change
Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `DashAI/back/job/predict_job.py`: when saving prediction results, force the output column's schema to `Float` for `RegressionTask` instead of inheriting the training dataset's original (possibly `Integer`) column type, so fractional predictions no longer fail PyArrow's cast.
- `DashAI/back/models/scikit_learn/sklearn_like_model.py`: squeeze the training target to a 1-D `Series` before calling `.fit()`, so every scikit-learn estimator (not just the ones that flatten it internally) trains and predicts with a consistent 1-D shape.

---

## Testing
- Reproduced both crashes before the fix (integer-schema cast failure with a fractional prediction, and 2D-shape failure with `LinearRegression`) and confirmed both are resolved after.
- Ran `tests/back/models/test_tabular_class_models.py`, `tests/back/api/test_predict_api.py`, and `tests/back/api/test_model_session_api.py`. All pass, confirming classification models (which share the same base class) are unaffected.
