### PR TITLE
Add exogenous forecasting models (ARIMAX, SARIMAX, and linear regression)

### DIFF
--- a/DashAI/back/initial_components.py
+++ b/DashAI/back/initial_components.py
@@ -191,10 +191,14 @@ from DashAI.back.models.efficientnet_b0_image_classifier import (
     EfficientNetB0ImageClassifier,
 )
 from DashAI.back.models.forecasting.arima import ARIMA
+from DashAI.back.models.forecasting.exogenous_linear_regression import (
+    ExogenousLinearRegression,
+)
 from DashAI.back.models.forecasting.exponential_smoothing import (
     ExponentialSmoothing,
 )
 from DashAI.back.models.forecasting.naive import NaiveForecaster
+from DashAI.back.models.forecasting.sarimax import SARIMAX
 from DashAI.back.models.forecasting.seasonal_naive import (
     SeasonalNaiveForecaster,
 )
@@ -500,6 +504,8 @@ def get_initial_components():
         NaiveForecaster,
         SeasonalNaiveForecaster,
         ARIMA,
+        SARIMAX,
+        ExogenousLinearRegression,
         ExponentialSmoothing,
         TextToImageGenerationTask,
         TextToTextGenerationTask,

--- a/DashAI/back/models/forecasting/arima.py
+++ b/DashAI/back/models/forecasting/arima.py
@@ -140,9 +140,14 @@ class ARIMA(ForecastingModel):
     average part (``q``) lets recent forecast errors feed back in.
 
     It is the standard reference model for a series without a strong seasonal
-    pattern. For seasonality, prefer :class:`ExponentialSmoothing` with a
-    seasonal component, since seasonal ARIMA would need three more orders that
-    this wrapper does not expose.
+    pattern. For seasonality, prefer :class:`SARIMAX`, which adds the three
+    seasonal orders this one does not expose, or
+    :class:`ExponentialSmoothing`.
+
+    Explanatory variables are optional. Given any, the model regresses the
+    series on them and models what is left over as an ARIMA, which is why it
+    serves both forecasting tasks: with the date alone it is the plain ARIMA
+    above, and with variables beside it, an ARIMA with regressors.
 
     The orders are not chosen automatically. ``d = 1`` suits a series that
     trends, ``d = 0`` one that hovers around a level, and the DashAI optimizer
@@ -155,6 +160,8 @@ class ARIMA(ForecastingModel):
     """
 
     SCHEMA = ARIMASchema
+    COMPATIBLE_COMPONENTS = ["ForecastingTask", "ExogenousForecastingTask"]
+    SUPPORTS_EXOGENOUS = True
     DESCRIPTION = MultilingualString(
         en=(
             "Models a series from its own past values and past errors, after "
@@ -217,9 +224,10 @@ class ARIMA(ForecastingModel):
         Parameters
         ----------
         x_train : DashAIDataset
-            The date column. statsmodels is given the values in order and the
-            spacing is assumed regular; the dates are kept so a later
-            partition can be forecast at its own dates.
+            The date column, and any numeric columns beside it, which are
+            taken as explanatory variables. statsmodels is given the values in
+            order and the spacing is assumed regular; the dates are kept so a
+            later partition can be forecast at its own dates.
         y_train : DashAIDataset
             The series to forecast.
         x_validation : DashAIDataset, optional
@@ -249,26 +257,35 @@ class ARIMA(ForecastingModel):
                 f"{len(series)}."
             )
 
+        self._remember_exogenous(x_train)
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self._result = _ARIMA(series, order=(self.p, self.d, self.q)).fit()
+            self._result = _ARIMA(
+                series,
+                exog=self._exogenous_of(x_train),
+                order=(self.p, self.d, self.q),
+            ).fit()
 
         self._history = list(series)
         self._remember_dates(x_train)
         self._fitted = True
         return self
 
-    def _forecast(self, steps: int) -> "np.ndarray":
+    def _forecast(self, steps: int, exog: "np.ndarray | None" = None) -> "np.ndarray":
         """Forecast the next ``steps`` periods after the end of the history.
 
         Parameters
         ----------
         steps : int
             How many periods to forecast.
+        exog : np.ndarray, optional
+            The explanatory variables over those periods, when the model was
+            fitted with any.
 
         Returns
         -------
         np.ndarray
             One value per period, in order.
         """
-        return self._result.forecast(steps=steps)
+        return self._result.forecast(steps=steps, exog=exog)

--- a/DashAI/back/models/forecasting/base_forecasting_model.py
+++ b/DashAI/back/models/forecasting/base_forecasting_model.py
@@ -414,10 +414,14 @@ class ForecastingModel(BaseModel):
         it, so the variables have to cover the horizon too. The requested rows
         need not: a test partition that starts a validation window after the
         training data leaves the periods in between with no values at all.
-        Those are filled by interpolating between the rows that do have them,
-        which is the same bargain the forecast itself makes across such a gap,
-        where the model's own output stands in for the periods nobody asked
-        about.
+        Those are filled by interpolating between the rows that do have them.
+
+        The filled rows are scaffolding, not data. An explanatory variable
+        enters a forecast at the period it belongs to, so the value returned
+        for a requested step is built from that step's own row and from the
+        history of the series, never from a filled row. The filled rows
+        produce the values at their own steps, which are discarded. Whatever
+        they hold, the requested rows come back the same.
 
         Parameters
         ----------

--- a/DashAI/back/models/forecasting/base_forecasting_model.py
+++ b/DashAI/back/models/forecasting/base_forecasting_model.py
@@ -19,8 +19,10 @@ class ForecastingModel(BaseModel):
     is a date column, and everything the model knows comes from the history of
     the series itself. Two consequences shape the interface.
 
-    ``train`` reads the series out of ``y_train`` and ignores the feature
-    matrix, because there is nothing in it to learn from.
+    ``train`` reads the series out of ``y_train``. A model that declares
+    ``SUPPORTS_EXOGENOUS`` also reads the numeric columns beside the date as
+    explanatory variables; the rest ignore the feature matrix, because for
+    them there is nothing in it to learn from.
 
     ``predict`` reads the **dates** it is handed and works out how far each one
     lies beyond the end of training, then returns the forecast for exactly
@@ -33,15 +35,22 @@ class ForecastingModel(BaseModel):
     That is why the windowed route through ``TimeSeriesWindowConverter`` and
     ``RegressionTask`` exists alongside this one. It turns the history into
     real features, which is the only way an ordinary regressor can help.
+
+    Each model names the tasks it serves itself rather than inheriting a list
+    from here. A model that reads only the date belongs to ``ForecastingTask``
+    alone, one that requires explanatory variables to
+    ``ExogenousForecastingTask`` alone, and one that can do either belongs to
+    both.
     """
 
-    COMPATIBLE_COMPONENTS = ["ForecastingTask"]
+    SUPPORTS_EXOGENOUS: bool = False
 
     def __init__(self, **kwargs):
         """Initialize the shared forecasting state."""
         super().__init__(**kwargs)
         self._history: List[float] = []
         self._fitted = False
+        self._exogenous_columns: List[str] = []
         # Where the training data ends and how far apart its rows sit, which
         # is what lets predict turn a date into a number of steps ahead.
         self._last_train_date = None
@@ -286,15 +295,19 @@ class ForecastingModel(BaseModel):
             One forecast value per requested row.
         """
         self._require_fitted()
-        return self._forecast_at(x, self._forecast)
+        return self._forecast_at(x)
 
-    def _forecast(self, steps: int) -> "np.ndarray":
+    def _forecast(self, steps: int, exog: "np.ndarray | None" = None) -> "np.ndarray":
         """Forecast the next ``steps`` periods after the end of the history.
 
         Parameters
         ----------
         steps : int
             How many periods to forecast.
+        exog : np.ndarray, optional
+            The explanatory variables over those periods, one row per step.
+            Passed only to a model that declares ``SUPPORTS_EXOGENOUS`` and
+            was fitted with variables.
 
         Returns
         -------
@@ -310,15 +323,13 @@ class ForecastingModel(BaseModel):
             "A forecasting model must say how it forecasts a number of steps."
         )
 
-    def _forecast_at(self, x: "DashAIDataset", forecast) -> "np.ndarray":
+    def _forecast_at(self, x: "DashAIDataset") -> "np.ndarray":
         """Pick the forecast values for the requested dates.
 
         Parameters
         ----------
         x : DashAIDataset
             The rows that were requested.
-        forecast : callable
-            Takes a number of steps and returns that many forecast values.
 
         Returns
         -------
@@ -328,8 +339,110 @@ class ForecastingModel(BaseModel):
         import numpy as np
 
         steps = self._steps_ahead(x)
-        values = np.asarray(forecast(int(steps.max())), dtype=float)
-        return values[steps - 1]
+        horizon = int(steps.max())
+
+        if self._exogenous_columns:
+            values = self._forecast(horizon, self._exogenous_over(x, steps, horizon))
+        else:
+            values = self._forecast(horizon)
+
+        return np.asarray(values, dtype=float)[steps - 1]
+
+    def _remember_exogenous(self, x_train: "DashAIDataset") -> None:
+        """Record which input columns are explanatory variables.
+
+        Everything that is not the date column is one. A model that does not
+        support them records none, so it goes on forecasting from the history
+        alone even if the columns are there.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            The training input.
+        """
+        from DashAI.back.types.value_types import Date
+
+        if not self.SUPPORTS_EXOGENOUS:
+            self._exogenous_columns = []
+            return
+
+        self._exogenous_columns = [
+            name
+            for name in x_train.column_names
+            if not isinstance(x_train.types.get(name), Date)
+        ]
+
+    def _exogenous_of(self, x: "DashAIDataset") -> "np.ndarray | None":
+        """Read the explanatory variables out of a set of rows.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            Rows holding the columns recorded at training time.
+
+        Returns
+        -------
+        np.ndarray or None
+            One row per observation and one column per variable, in the order
+            the columns were recorded, or ``None`` when there are none.
+
+        Raises
+        ------
+        ValueError
+            If a column the model was fitted with is missing.
+        """
+        if not self._exogenous_columns:
+            return None
+
+        frame = x.to_pandas()
+        missing = [name for name in self._exogenous_columns if name not in frame]
+        if missing:
+            raise ValueError(
+                f"{type(self).__name__} was fitted with the explanatory "
+                f"variables {self._exogenous_columns}, but "
+                f"{missing} are not among the columns it was given."
+            )
+
+        return frame[self._exogenous_columns].to_numpy(dtype=float)
+
+    def _exogenous_over(
+        self, x: "DashAIDataset", steps: "np.ndarray", horizon: int
+    ) -> "np.ndarray":
+        """Lay the explanatory variables out over every step of the horizon.
+
+        A model forecasts a whole horizon and the requested rows are read off
+        it, so the variables have to cover the horizon too. The requested rows
+        need not: a test partition that starts a validation window after the
+        training data leaves the periods in between with no values at all.
+        Those are filled by interpolating between the rows that do have them,
+        which is the same bargain the forecast itself makes across such a gap,
+        where the model's own output stands in for the periods nobody asked
+        about.
+
+        Parameters
+        ----------
+        x : DashAIDataset
+            The rows that were requested.
+        steps : np.ndarray
+            How many periods past training each requested row falls.
+        horizon : int
+            The furthest step being forecast.
+
+        Returns
+        -------
+        np.ndarray
+            One row per step from 1 to ``horizon``, in that order.
+        """
+        import pandas as pd
+
+        given = pd.DataFrame(self._exogenous_of(x), index=steps)
+        given = given[~given.index.duplicated()]
+
+        return (
+            given.reindex(range(1, horizon + 1))
+            .interpolate(limit_direction="both")
+            .to_numpy(dtype=float)
+        )
 
     def save(self, filename: str) -> None:
         """Serialise the model to disk using joblib.

--- a/DashAI/back/models/forecasting/exogenous_linear_regression.py
+++ b/DashAI/back/models/forecasting/exogenous_linear_regression.py
@@ -1,0 +1,290 @@
+from typing import TYPE_CHECKING
+
+from DashAI.back.core.schema_fields import (
+    BaseSchema,
+    bool_field,
+    optimizer_float_field,
+    schema_field,
+)
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.forecasting.base_forecasting_model import ForecastingModel
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+class ExogenousLinearRegressionSchema(BaseSchema):
+    """Schema that configures the exogenous linear regression forecaster."""
+
+    include_trend: schema_field(
+        bool_field(),
+        True,
+        description=MultilingualString(
+            en=(
+                "Whether to add the period number as an extra variable, which "
+                "lets the model fit a steady drift up or down that the "
+                "explanatory variables do not account for."
+            ),
+            es=(
+                "Si se agrega el numero de periodo como variable adicional, lo "
+                "que permite al modelo ajustar una deriva sostenida hacia "
+                "arriba o abajo que las variables explicativas no explican."
+            ),
+            pt=(
+                "Se o numero do periodo e adicionado como variavel extra, o "
+                "que permite ao modelo ajustar uma deriva sustentada para cima "
+                "ou para baixo que as variaveis explicativas nao explicam."
+            ),
+            de=(
+                "Ob die Periodennummer als zusaetzliche Variable aufgenommen "
+                "wird, womit das Modell eine stetige Drift abbilden kann, die "
+                "die erklaerenden Variablen nicht erfassen."
+            ),
+            zh="是否将期数作为额外变量加入，使模型能拟合解释变量无法说明的持续上升或下降趋势。",
+        ),
+        alias=MultilingualString(
+            en="Include a time trend",
+            es="Incluir tendencia temporal",
+            pt="Incluir tendencia temporal",
+            de="Zeittrend einbeziehen",
+            zh="包含时间趋势",
+        ),
+    )  # type: ignore
+    regularization: schema_field(
+        optimizer_float_field(ge=0.0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": 0.0,
+            "lower_bound": 0.0,
+            "upper_bound": 10.0,
+        },
+        description=MultilingualString(
+            en=(
+                "How hard to pull the coefficients towards zero, the ridge "
+                "penalty. 0 is ordinary least squares. Raise it when the "
+                "explanatory variables move together, which otherwise makes "
+                "the coefficients large and unstable."
+            ),
+            es=(
+                "Con cuanta fuerza se llevan los coeficientes hacia cero, la "
+                "penalizacion ridge. 0 es minimos cuadrados ordinarios. "
+                "Aumentarla cuando las variables explicativas se mueven "
+                "juntas, lo que de otro modo vuelve los coeficientes grandes e "
+                "inestables."
+            ),
+            pt=(
+                "Com que forca os coeficientes sao puxados para zero, a "
+                "penalizacao ridge. 0 e minimos quadrados ordinarios. Aumente "
+                "quando as variaveis explicativas se movem juntas, o que de "
+                "outro modo torna os coeficientes grandes e instaveis."
+            ),
+            de=(
+                "Wie stark die Koeffizienten gegen null gezogen werden, die "
+                "Ridge-Strafe. 0 ist die gewoehnliche Kleinste-Quadrate-"
+                "Schaetzung. Erhoehen, wenn sich die erklaerenden Variablen "
+                "gemeinsam bewegen, was die Koeffizienten sonst gross und "
+                "instabil macht."
+            ),
+            zh=(
+                "将系数向零收缩的强度，即 ridge 惩罚。0 表示普通最小二乘。"
+                "当解释变量同向变动时应调高，否则系数会变得很大且不稳定。"
+            ),
+        ),
+        alias=MultilingualString(
+            en="Regularization",
+            es="Regularizacion",
+            pt="Regularizacao",
+            de="Regularisierung",
+            zh="正则化",
+        ),
+    )  # type: ignore
+
+
+class ExogenousLinearRegression(ForecastingModel):
+    """Forecast a series as a straight line in its explanatory variables.
+
+    The series is regressed on the variables measured beside it, and the
+    forecast for a future period is that fit read at the values the variables
+    take there. Nothing carries over from one period to the next: this model
+    has no memory of the series at all, only of how the series responds to the
+    things that move it.
+
+    That is exactly what makes it worth having next to :class:`ARIMA` and
+    :class:`SARIMAX`. Those two model the series and treat the variables as a
+    correction; this one does the opposite, so a large gap between their
+    scores says whether the series is driven by its own momentum or by
+    something outside it. It is also the one model here whose coefficients can
+    be read directly as "one more unit of this changes the forecast by that".
+
+    Because it looks nowhere but at the variables, it is offered for
+    :class:`ExogenousForecastingTask` alone and cannot forecast from a date
+    column on its own.
+
+    References
+    ----------
+    - [1] https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html
+    - [2] https://otexts.com/fpp3/regression.html
+    """
+
+    SCHEMA = ExogenousLinearRegressionSchema
+    COMPATIBLE_COMPONENTS = ["ExogenousForecastingTask"]
+    SUPPORTS_EXOGENOUS = True
+    DESCRIPTION = MultilingualString(
+        en=(
+            "Fits the series as a straight line in the variables measured "
+            "beside it and reads the forecast off that line. Ignores the "
+            "history of the series, so it says how much of it the variables "
+            "explain on their own."
+        ),
+        es=(
+            "Ajusta la serie como una recta en las variables medidas junto a "
+            "ella y lee el pronostico sobre esa recta. Ignora la historia de "
+            "la serie, por lo que indica cuanto explican las variables por si "
+            "solas."
+        ),
+        pt=(
+            "Ajusta a serie como uma reta nas variaveis medidas ao seu lado e "
+            "le a previsao sobre essa reta. Ignora a historia da serie, pelo "
+            "que indica quanto as variaveis explicam por si so."
+        ),
+        de=(
+            "Passt die Reihe als Gerade in den daneben gemessenen Variablen an "
+            "und liest die Prognose von dieser Geraden ab. Ignoriert die "
+            "Vergangenheit der Reihe und zeigt damit, wie viel die Variablen "
+            "allein erklaeren."
+        ),
+        zh=(
+            "把序列拟合为与其一同测量的变量的线性函数，并据此读出预测值。"
+            "不使用序列自身的历史，因此能说明这些变量单独解释了多少。"
+        ),
+    )
+    DISPLAY_NAME = MultilingualString(
+        en="Exogenous Linear Regression",
+        es="Regresion Lineal Exogena",
+        pt="Regressao Linear Exogena",
+        de="Exogene lineare Regression",
+        zh="外生变量线性回归",
+    )
+
+    def __init__(
+        self, include_trend: bool = True, regularization: float = 0.0, **kwargs
+    ):
+        """Initialise the model.
+
+        Parameters
+        ----------
+        include_trend : bool
+            Whether the period number joins the explanatory variables.
+        regularization : float
+            The ridge penalty, 0 for ordinary least squares.
+        **kwargs
+            Ignored, accepted for consistency with the other models.
+        """
+        super().__init__(**kwargs)
+        self.include_trend = include_trend
+        self.regularization = regularization
+        self._model = None
+        self._observations = 0
+
+    def _design(self, exog: "np.ndarray", start: int) -> "np.ndarray":
+        """Build the matrix the regression is fitted on or read at.
+
+        Parameters
+        ----------
+        exog : np.ndarray
+            The explanatory variables, one row per period.
+        start : int
+            The period number of the first row, counted from the start of
+            training. The trend has to keep counting past the training data,
+            otherwise a forecast would sit at the same point on the line as
+            the first training row.
+
+        Returns
+        -------
+        np.ndarray
+            The variables, with the period number appended when a trend was
+            asked for.
+        """
+        import numpy as np
+
+        if not self.include_trend:
+            return exog
+
+        trend = np.arange(start, start + len(exog), dtype=float).reshape(-1, 1)
+        return np.hstack([exog, trend])
+
+    def train(
+        self,
+        x_train: "DashAIDataset",
+        y_train: "DashAIDataset",
+        x_validation: "DashAIDataset" = None,
+        y_validation: "DashAIDataset" = None,
+    ) -> "ExogenousLinearRegression":
+        """Fit the line through the training periods.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            The date column and the numeric columns beside it, which are the
+            explanatory variables. The dates are kept so a later partition can
+            be forecast at its own dates.
+        y_train : DashAIDataset
+            The series to forecast.
+        x_validation : DashAIDataset, optional
+            Unused.
+        y_validation : DashAIDataset, optional
+            Unused.
+
+        Returns
+        -------
+        ExogenousLinearRegression
+            The fitted model.
+
+        Raises
+        ------
+        ValueError
+            If no explanatory variables were given, since the model has
+            nothing else to forecast from.
+        """
+        from sklearn.linear_model import Ridge
+
+        self._remember_exogenous(x_train)
+        exog = self._exogenous_of(x_train)
+        if exog is None:
+            raise ValueError(
+                "ExogenousLinearRegression forecasts from explanatory "
+                "variables alone, but it was given only a date column. Use a "
+                "model that reads the history of the series, such as ARIMA."
+            )
+
+        series = self._series(y_train)
+        self._model = Ridge(alpha=self.regularization).fit(
+            self._design(exog, start=1), series
+        )
+
+        self._history = list(series)
+        self._observations = len(series)
+        self._remember_dates(x_train)
+        self._fitted = True
+        return self
+
+    def _forecast(self, steps: int, exog: "np.ndarray | None" = None) -> "np.ndarray":
+        """Read the fitted line at the variables of the next ``steps`` periods.
+
+        Parameters
+        ----------
+        steps : int
+            How many periods to forecast.
+        exog : np.ndarray, optional
+            The explanatory variables over those periods, one row per step.
+
+        Returns
+        -------
+        np.ndarray
+            One value per period, in order.
+        """
+        return self._model.predict(
+            self._design(exog[:steps], start=self._observations + 1)
+        )

--- a/DashAI/back/models/forecasting/exponential_smoothing.py
+++ b/DashAI/back/models/forecasting/exponential_smoothing.py
@@ -166,6 +166,7 @@ class ExponentialSmoothing(ForecastingModel):
     """
 
     SCHEMA = ExponentialSmoothingSchema
+    COMPATIBLE_COMPONENTS = ["ForecastingTask"]
     DESCRIPTION = MultilingualString(
         en=(
             "Forecasts from a weighted average that favours recent "

--- a/DashAI/back/models/forecasting/naive.py
+++ b/DashAI/back/models/forecasting/naive.py
@@ -32,6 +32,7 @@ class NaiveForecaster(ForecastingModel):
     """
 
     SCHEMA = NaiveForecasterSchema
+    COMPATIBLE_COMPONENTS = ["ForecastingTask"]
     DESCRIPTION = MultilingualString(
         en=(
             "Predicts that every future value equals the last observed one. "

--- a/DashAI/back/models/forecasting/sarimax.py
+++ b/DashAI/back/models/forecasting/sarimax.py
@@ -1,0 +1,456 @@
+from typing import TYPE_CHECKING
+
+from DashAI.back.core.schema_fields import BaseSchema, optimizer_int_field, schema_field
+from DashAI.back.core.utils import MultilingualString
+from DashAI.back.models.forecasting.base_forecasting_model import ForecastingModel
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from DashAI.back.dataloaders.classes.dashai_dataset import DashAIDataset
+
+
+def _order_field(
+    name: str, meaning: MultilingualString, default: int, upper: int, alias: str
+):
+    """Build one of the seven SARIMAX order fields.
+
+    The seven share a shape and differ only in what they mean and where they
+    start, so writing them out separately would be seven copies of the same
+    twelve lines.
+
+    Parameters
+    ----------
+    name : str
+        The conventional name of the term, for example ``p`` or ``P``.
+    meaning : MultilingualString
+        The description shown to the user.
+    default : int
+        Value used when the user does not change it.
+    upper : int
+        Upper bound offered when the value is optimized.
+    alias : str
+        Label shown beside the field.
+
+    Returns
+    -------
+    Any
+        A configured schema field.
+    """
+    return schema_field(
+        optimizer_int_field(ge=0),
+        placeholder={
+            "optimize": False,
+            "fixed_value": default,
+            "lower_bound": 0,
+            "upper_bound": upper,
+        },
+        description=meaning,
+        alias=MultilingualString(en=alias, es=alias, pt=alias, de=alias, zh=alias),
+    )
+
+
+class SARIMAXSchema(BaseSchema):
+    """Schema that configures the SARIMAX model."""
+
+    p: _order_field(
+        "p",
+        MultilingualString(
+            en=(
+                "How many past values the forecast is a weighted sum of, the "
+                "autoregressive order."
+            ),
+            es=(
+                "De cuantos valores pasados es suma ponderada el pronostico, "
+                "el orden autorregresivo."
+            ),
+            pt=(
+                "De quantos valores passados a previsao e soma ponderada, a "
+                "ordem autorregressiva."
+            ),
+            de=(
+                "Aus wie vielen vergangenen Werten die Prognose gewichtet "
+                "gebildet wird, die autoregressive Ordnung."
+            ),
+            zh="预测由多少个过去的值加权求和得到，即自回归阶数。",
+        ),
+        1,
+        5,
+        "Order p",
+    )  # type: ignore
+    d: _order_field(
+        "d",
+        MultilingualString(
+            en=(
+                "How many times to difference the series before modelling it. "
+                "1 removes a straight trend, 0 suits a series that already "
+                "hovers around a fixed level."
+            ),
+            es=(
+                "Cuantas veces diferenciar la serie antes de modelarla. 1 "
+                "elimina una tendencia lineal, 0 sirve para una serie que ya "
+                "oscila alrededor de un nivel fijo."
+            ),
+            pt=(
+                "Quantas vezes diferenciar a serie antes de modela-la. 1 "
+                "remove uma tendencia linear, 0 serve para uma serie que ja "
+                "oscila em torno de um nivel fixo."
+            ),
+            de=(
+                "Wie oft die Reihe vor der Modellierung differenziert wird. 1 "
+                "entfernt einen linearen Trend, 0 passt zu einer Reihe, die "
+                "bereits um ein festes Niveau schwankt."
+            ),
+            zh=(
+                "建模前对序列做几次差分。1 可去除线性趋势，"
+                "0 适用于已经围绕固定水平波动的序列。"
+            ),
+        ),
+        1,
+        2,
+        "Order d",
+    )  # type: ignore
+    q: _order_field(
+        "q",
+        MultilingualString(
+            en=(
+                "How many past forecast errors feed into the next forecast, "
+                "the moving average order."
+            ),
+            es=(
+                "Cuantos errores de pronostico pasados alimentan el siguiente "
+                "pronostico, el orden de media movil."
+            ),
+            pt=(
+                "Quantos erros de previsao passados alimentam a proxima "
+                "previsao, a ordem de media movel."
+            ),
+            de=(
+                "Wie viele vergangene Prognosefehler in die naechste Prognose "
+                "einfliessen, die Ordnung des gleitenden Mittels."
+            ),
+            zh="有多少个过去的预测误差参与下一次预测，即移动平均阶数。",
+        ),
+        0,
+        5,
+        "Order q",
+    )  # type: ignore
+    seasonal_p: _order_field(
+        "P",
+        MultilingualString(
+            en=(
+                "The autoregressive order across seasons: how many values one "
+                "season apart, two seasons apart and so on the forecast is a "
+                "weighted sum of."
+            ),
+            es=(
+                "El orden autorregresivo entre estaciones: de cuantos valores "
+                "separados por una estacion, dos estaciones y asi es suma "
+                "ponderada el pronostico."
+            ),
+            pt=(
+                "A ordem autorregressiva entre estacoes: de quantos valores "
+                "separados por uma estacao, duas estacoes e assim por diante a "
+                "previsao e soma ponderada."
+            ),
+            de=(
+                "Die autoregressive Ordnung ueber Saisons hinweg: aus wie "
+                "vielen Werten im Abstand einer Saison, zweier Saisons und so "
+                "weiter die Prognose gebildet wird."
+            ),
+            zh="跨季节的自回归阶数：预测由相隔一个、两个季节等的多少个值加权求和得到。",
+        ),
+        0,
+        2,
+        "Seasonal order P",
+    )  # type: ignore
+    seasonal_d: _order_field(
+        "D",
+        MultilingualString(
+            en=(
+                "How many times to difference the series one season apart. 1 "
+                "removes a pattern that repeats at the same size every cycle."
+            ),
+            es=(
+                "Cuantas veces diferenciar la serie con un desfase de una "
+                "estacion. 1 elimina un patron que se repite con el mismo "
+                "tamano en cada ciclo."
+            ),
+            pt=(
+                "Quantas vezes diferenciar a serie com desfasamento de uma "
+                "estacao. 1 remove um padrao que se repete com o mesmo tamanho "
+                "em cada ciclo."
+            ),
+            de=(
+                "Wie oft die Reihe im Abstand einer Saison differenziert wird. "
+                "1 entfernt ein Muster, das sich in jedem Zyklus gleich stark "
+                "wiederholt."
+            ),
+            zh=(
+                "按一个季节的间隔对序列做几次差分。"
+                "1 可去除每个周期以相同幅度重复的模式。"
+            ),
+        ),
+        0,
+        1,
+        "Seasonal order D",
+    )  # type: ignore
+    seasonal_q: _order_field(
+        "Q",
+        MultilingualString(
+            en="The moving average order across seasons.",
+            es="El orden de media movil entre estaciones.",
+            pt="A ordem de media movel entre estacoes.",
+            de="Die Ordnung des gleitenden Mittels ueber Saisons hinweg.",
+            zh="跨季节的移动平均阶数。",
+        ),
+        0,
+        2,
+        "Seasonal order Q",
+    )  # type: ignore
+    season_length: _order_field(
+        "s",
+        MultilingualString(
+            en=(
+                "How many observations make up one full cycle: 12 for monthly "
+                "data repeating yearly, 7 for daily data repeating weekly. "
+                "Leave it at 0 to model no season at all."
+            ),
+            es=(
+                "Cuantas observaciones forman un ciclo completo: 12 para datos "
+                "mensuales que se repiten cada ano, 7 para datos diarios que se "
+                "repiten cada semana. Dejar en 0 para no modelar estacion."
+            ),
+            pt=(
+                "Quantas observacoes formam um ciclo completo: 12 para dados "
+                "mensais que se repetem a cada ano, 7 para dados diarios que se "
+                "repetem a cada semana. Deixe em 0 para nao modelar estacao."
+            ),
+            de=(
+                "Wie viele Beobachtungen einen vollen Zyklus bilden: 12 fuer "
+                "monatliche Daten mit jaehrlicher Wiederholung, 7 fuer "
+                "taegliche mit woechentlicher. Bei 0 wird keine Saison "
+                "modelliert."
+            ),
+            zh=(
+                "一个完整周期包含多少个观测值：月度数据按年重复为 12，"
+                "日度数据按周重复为 7。保持为 0 表示不建模季节性。"
+            ),
+        ),
+        0,
+        12,
+        "Season length",
+    )  # type: ignore
+
+
+class SARIMAX(ForecastingModel):
+    """ARIMA with a seasonal part and explanatory variables.
+
+    SARIMAX is ARIMA with two additions. The seasonal orders (``P``, ``D``,
+    ``Q``, and the season length ``s``) repeat the autoregressive,
+    differencing and moving average ideas at a lag of one whole cycle, which
+    is what lets it model a pattern that comes back every December rather
+    than one that depends only on last month. The ``X`` is for the exogenous
+    variables: the series is regressed on them and what is left over is
+    modelled as a seasonal ARIMA.
+
+    Both additions are optional, which is why the model is offered for both
+    forecasting tasks. Left at a season length of 0 and given only a date, it
+    is an ordinary ARIMA. It is the model to reach for when a series has a
+    seasonal pattern and something measurable driving it, which
+    :class:`ARIMA` covers only halfway and :class:`ExponentialSmoothing` not
+    at all.
+
+    The orders are not chosen automatically, and there are seven of them. A
+    reasonable starting point is a seasonal difference (``D = 1``) with the
+    season length of the data when the pattern is obvious, leaving the rest
+    as they are, and letting the DashAI optimizer search from there.
+
+    References
+    ----------
+    - [1] https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html
+    - [2] https://otexts.com/fpp3/seasonal-arima.html
+    """
+
+    SCHEMA = SARIMAXSchema
+    COMPATIBLE_COMPONENTS = ["ForecastingTask", "ExogenousForecastingTask"]
+    SUPPORTS_EXOGENOUS = True
+    DESCRIPTION = MultilingualString(
+        en=(
+            "ARIMA extended with a seasonal part and with explanatory "
+            "variables. Suits a series that repeats on a cycle, is driven by "
+            "something measurable, or both."
+        ),
+        es=(
+            "ARIMA ampliado con una parte estacional y con variables "
+            "explicativas. Sirve para una serie que se repite en ciclos, que "
+            "esta impulsada por algo medible, o ambas cosas."
+        ),
+        pt=(
+            "ARIMA ampliado com uma parte sazonal e com variaveis "
+            "explicativas. Serve para uma serie que se repete em ciclos, que e "
+            "impulsionada por algo mensuravel, ou ambas."
+        ),
+        de=(
+            "ARIMA, erweitert um einen saisonalen Teil und um erklaerende "
+            "Variablen. Passt zu einer Reihe, die sich zyklisch wiederholt, von "
+            "etwas Messbarem getrieben wird, oder beides."
+        ),
+        zh=(
+            "在 ARIMA 基础上加入季节性部分和解释变量。"
+            "适用于呈周期重复、受可测量因素驱动，或两者兼有的序列。"
+        ),
+    )
+    DISPLAY_NAME = MultilingualString(
+        en="SARIMAX", es="SARIMAX", pt="SARIMAX", de="SARIMAX", zh="SARIMAX"
+    )
+
+    def __init__(
+        self,
+        p: int = 1,
+        d: int = 1,
+        q: int = 0,
+        seasonal_p: int = 0,
+        seasonal_d: int = 0,
+        seasonal_q: int = 0,
+        season_length: int = 0,
+        **kwargs,
+    ):
+        """Initialise the model with its orders.
+
+        Parameters
+        ----------
+        p : int
+            Autoregressive order.
+        d : int
+            Number of differences.
+        q : int
+            Moving average order.
+        seasonal_p : int
+            Seasonal autoregressive order.
+        seasonal_d : int
+            Number of seasonal differences.
+        seasonal_q : int
+            Seasonal moving average order.
+        season_length : int
+            Observations in one full cycle, or 0 for no seasonal part.
+        **kwargs
+            Ignored, accepted for consistency with the other models.
+        """
+        super().__init__(**kwargs)
+        self.p = p
+        self.d = d
+        self.q = q
+        self.seasonal_p = seasonal_p
+        self.seasonal_d = seasonal_d
+        self.seasonal_q = seasonal_q
+        self.season_length = season_length
+        self._result = None
+
+    @property
+    def _seasonal_order(self) -> tuple:
+        """State the seasonal order the way statsmodels expects it.
+
+        Returns
+        -------
+        tuple
+            The four seasonal terms, all zero when no season was asked for.
+        """
+        if self.season_length < 2:
+            return (0, 0, 0, 0)
+        return (
+            self.seasonal_p,
+            self.seasonal_d,
+            self.seasonal_q,
+            self.season_length,
+        )
+
+    def train(
+        self,
+        x_train: "DashAIDataset",
+        y_train: "DashAIDataset",
+        x_validation: "DashAIDataset" = None,
+        y_validation: "DashAIDataset" = None,
+    ) -> "SARIMAX":
+        """Fit the model to the series and its explanatory variables.
+
+        Parameters
+        ----------
+        x_train : DashAIDataset
+            The date column, and any numeric columns beside it, which are
+            taken as explanatory variables. statsmodels is given the values in
+            order and the spacing is assumed regular; the dates are kept so a
+            later partition can be forecast at its own dates.
+        y_train : DashAIDataset
+            The series to forecast.
+        x_validation : DashAIDataset, optional
+            Unused.
+        y_validation : DashAIDataset, optional
+            Unused.
+
+        Returns
+        -------
+        SARIMAX
+            The fitted model.
+
+        Raises
+        ------
+        ValueError
+            If the series is too short for the requested orders, or shorter
+            than two full cycles when a seasonal part was asked for.
+        """
+        import warnings
+
+        from statsmodels.tsa.statespace.sarimax import SARIMAX as _SARIMAX
+
+        series = self._series(y_train)
+        needed = self.p + self.d + self.q
+        if len(series) <= needed:
+            raise ValueError(
+                f"A SARIMAX({self.p},{self.d},{self.q}) needs more than "
+                f"{needed} observations, but the series has {len(series)}."
+            )
+
+        seasonal_order = self._seasonal_order
+        if seasonal_order[3] and len(series) < 2 * seasonal_order[3]:
+            raise ValueError(
+                f"A season of {seasonal_order[3]} needs at least "
+                f"{2 * seasonal_order[3]} observations to be seen twice, but "
+                f"the series has {len(series)}."
+            )
+
+        self._remember_exogenous(x_train)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self._result = _SARIMAX(
+                series,
+                exog=self._exogenous_of(x_train),
+                order=(self.p, self.d, self.q),
+                seasonal_order=seasonal_order,
+                enforce_stationarity=False,
+                enforce_invertibility=False,
+            ).fit(disp=False)
+
+        self._history = list(series)
+        self._remember_dates(x_train)
+        self._fitted = True
+        return self
+
+    def _forecast(self, steps: int, exog: "np.ndarray | None" = None) -> "np.ndarray":
+        """Forecast the next ``steps`` periods after the end of the history.
+
+        Parameters
+        ----------
+        steps : int
+            How many periods to forecast.
+        exog : np.ndarray, optional
+            The explanatory variables over those periods, when the model was
+            fitted with any.
+
+        Returns
+        -------
+        np.ndarray
+            One value per period, in order.
+        """
+        return self._result.forecast(steps=steps, exog=exog)

--- a/DashAI/back/models/forecasting/seasonal_naive.py
+++ b/DashAI/back/models/forecasting/seasonal_naive.py
@@ -85,6 +85,7 @@ class SeasonalNaiveForecaster(ForecastingModel):
     """
 
     SCHEMA = SeasonalNaiveForecasterSchema
+    COMPATIBLE_COMPONENTS = ["ForecastingTask"]
     DESCRIPTION = MultilingualString(
         en=(
             "Predicts that each value repeats the one a full season earlier, "

--- a/tests/back/models/test_exogenous_forecasting_models.py
+++ b/tests/back/models/test_exogenous_forecasting_models.py
@@ -121,6 +121,26 @@ def test_a_forecast_far_ahead_reads_the_variables_of_its_own_rows(model_class):
 
 
 @pytest.mark.parametrize("model_class", EXOGENOUS_MODELS)
+def test_the_filled_gap_never_reaches_the_requested_rows(model_class):
+    model = _fit(model_class())
+    tail = np.array([[200.0, 0.0], [201.0, 1.0], [202.0, 0.0]])
+    horizon = 23
+
+    scaffolding = {
+        "flat": np.tile(tail[0], (horizon - len(tail), 1)),
+        "wild": np.tile([-5000.0, 99.0], (horizon - len(tail), 1)),
+        "zero": np.zeros((horizon - len(tail), 2)),
+    }
+    forecasts = {
+        label: np.asarray(model._forecast(horizon, np.vstack([gap, tail])))[-3:]
+        for label, gap in scaffolding.items()
+    }
+
+    assert list(forecasts["wild"]) == pytest.approx(list(forecasts["flat"]))
+    assert list(forecasts["zero"]) == pytest.approx(list(forecasts["flat"]))
+
+
+@pytest.mark.parametrize("model_class", EXOGENOUS_MODELS)
 def test_a_missing_variable_is_refused_rather_than_ignored(model_class):
     model = _fit(model_class())
     without = _x(3, start=model._trained_on, with_exogenous=False)

--- a/tests/back/models/test_exogenous_forecasting_models.py
+++ b/tests/back/models/test_exogenous_forecasting_models.py
@@ -1,0 +1,187 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from DashAI.back.dataloaders.classes.dashai_dataset import (
+    to_dashai_dataset,
+    transform_dataset_with_schema,
+)
+from DashAI.back.models.forecasting.arima import ARIMA
+from DashAI.back.models.forecasting.exogenous_linear_regression import (
+    ExogenousLinearRegression,
+)
+from DashAI.back.models.forecasting.exponential_smoothing import ExponentialSmoothing
+from DashAI.back.models.forecasting.naive import NaiveForecaster
+from DashAI.back.models.forecasting.sarimax import SARIMAX
+from DashAI.back.models.forecasting.seasonal_naive import SeasonalNaiveForecaster
+
+EXOGENOUS_MODELS = [ARIMA, SARIMAX, ExogenousLinearRegression]
+HISTORY_ONLY_MODELS = [NaiveForecaster, SeasonalNaiveForecaster, ExponentialSmoothing]
+BOTH_TASK_MODELS = [ARIMA, SARIMAX]
+
+TYPES = {
+    "date": {"type": "Date", "dtype": "%Y-%m-%d"},
+    "price": {"type": "Float", "dtype": "float64"},
+    "promo": {"type": "Integer", "dtype": "int64"},
+}
+
+
+def _dates(n, start=0):
+    return [f"2026-{1 + i // 28:02d}-{1 + i % 28:02d}" for i in range(start, start + n)]
+
+
+def _x(n, start=0, with_exogenous=True):
+    columns = {"date": _dates(n, start)}
+    if with_exogenous:
+        columns["price"] = [float(10 + i) for i in range(start, start + n)]
+        columns["promo"] = [i % 2 for i in range(start, start + n)]
+    return transform_dataset_with_schema(
+        to_dashai_dataset(pd.DataFrame(columns)),
+        {name: TYPES[name] for name in columns},
+    )
+
+
+def _y(values):
+    return to_dashai_dataset(pd.DataFrame({"target": [float(v) for v in values]}))
+
+
+def _series(n):
+    return [3.0 * (10 + i) + 2.0 * (i % 2) for i in range(n)]
+
+
+def _fit(model, n=40, with_exogenous=True):
+    model._trained_on = n
+    return model.train(_x(n, with_exogenous=with_exogenous), _y(_series(n)))
+
+
+def _future(model, steps, with_exogenous=True):
+    return _x(steps, start=model._trained_on, with_exogenous=with_exogenous)
+
+
+@pytest.mark.parametrize("model_class", EXOGENOUS_MODELS)
+def test_every_exogenous_model_serves_the_exogenous_task(model_class):
+    assert "ExogenousForecastingTask" in model_class.COMPATIBLE_COMPONENTS
+    assert model_class.SUPPORTS_EXOGENOUS is True
+
+
+@pytest.mark.parametrize("model_class", BOTH_TASK_MODELS)
+def test_a_model_that_can_do_without_variables_serves_both_tasks(model_class):
+    assert model_class.COMPATIBLE_COMPONENTS == [
+        "ForecastingTask",
+        "ExogenousForecastingTask",
+    ]
+
+
+@pytest.mark.parametrize("model_class", HISTORY_ONLY_MODELS)
+def test_a_model_that_reads_only_the_date_stays_out_of_the_exogenous_task(model_class):
+    assert model_class.COMPATIBLE_COMPONENTS == ["ForecastingTask"]
+    assert model_class.SUPPORTS_EXOGENOUS is False
+
+
+def test_a_model_that_needs_variables_is_not_offered_the_plain_task():
+    assert ExogenousLinearRegression.COMPATIBLE_COMPONENTS == [
+        "ExogenousForecastingTask"
+    ]
+
+
+@pytest.mark.parametrize("model_class", EXOGENOUS_MODELS)
+def test_every_exogenous_model_forecasts_one_value_per_requested_row(model_class):
+    model = _fit(model_class())
+
+    forecast = model.predict(_future(model, 4))
+
+    assert len(forecast) == 4
+    assert np.isfinite(np.asarray(forecast, dtype=float)).all()
+
+
+@pytest.mark.parametrize("model_class", EXOGENOUS_MODELS)
+def test_the_variables_change_the_forecast(model_class):
+    model = _fit(model_class())
+    rows = _future(model, 3)
+
+    doubled = rows.to_pandas()
+    doubled["price"] = doubled["price"] * 2
+    doubled = transform_dataset_with_schema(to_dashai_dataset(doubled), TYPES)
+
+    assert not np.allclose(
+        np.asarray(model.predict(rows), dtype=float),
+        np.asarray(model.predict(doubled), dtype=float),
+    )
+
+
+@pytest.mark.parametrize("model_class", EXOGENOUS_MODELS)
+def test_a_forecast_far_ahead_reads_the_variables_of_its_own_rows(model_class):
+    model = _fit(model_class())
+    far = _x(3, start=model._trained_on + 10)
+
+    forecast = np.asarray(model.predict(far), dtype=float)
+
+    assert len(forecast) == 3
+    assert np.isfinite(forecast).all()
+
+
+@pytest.mark.parametrize("model_class", EXOGENOUS_MODELS)
+def test_a_missing_variable_is_refused_rather_than_ignored(model_class):
+    model = _fit(model_class())
+    without = _x(3, start=model._trained_on, with_exogenous=False)
+
+    with pytest.raises(ValueError, match="not among the columns"):
+        model.predict(without)
+
+
+@pytest.mark.parametrize("model_class", EXOGENOUS_MODELS)
+def test_every_exogenous_model_round_trips_through_save_and_load(model_class, tmp_path):
+    model = _fit(model_class())
+    expected = list(np.asarray(model.predict(_future(model, 3)), dtype=float))
+
+    path = tmp_path / "model.joblib"
+    model.save(str(path))
+    restored = model_class.load(str(path))
+
+    assert list(
+        np.asarray(restored.predict(_future(model, 3)), dtype=float)
+    ) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("model_class", BOTH_TASK_MODELS)
+def test_a_dual_model_still_forecasts_from_the_date_alone(model_class):
+    model = _fit(model_class(), with_exogenous=False)
+
+    forecast = model.predict(_future(model, 4, with_exogenous=False))
+
+    assert len(forecast) == 4
+    assert np.isfinite(np.asarray(forecast, dtype=float)).all()
+
+
+def test_the_linear_model_refuses_a_date_with_nothing_beside_it():
+    with pytest.raises(ValueError, match="explanatory"):
+        _fit(ExogenousLinearRegression(), with_exogenous=False)
+
+
+def test_the_linear_model_recovers_a_linear_relationship():
+    model = _fit(ExogenousLinearRegression(include_trend=False), n=40)
+
+    forecast = np.asarray(model.predict(_future(model, 3)), dtype=float)
+    expected = _series(43)[40:]
+
+    assert list(forecast) == pytest.approx(expected, abs=1e-6)
+
+
+def test_sarimax_without_a_season_length_models_no_season():
+    assert SARIMAX(season_length=1)._seasonal_order == (0, 0, 0, 0)
+    assert SARIMAX(season_length=0, seasonal_d=1)._seasonal_order == (0, 0, 0, 0)
+    assert SARIMAX(season_length=4, seasonal_d=1)._seasonal_order == (0, 1, 0, 4)
+
+
+def test_sarimax_refuses_a_season_it_cannot_see_twice():
+    with pytest.raises(ValueError, match="seen twice"):
+        _fit(SARIMAX(season_length=12), n=20)
+
+
+def test_a_history_only_model_ignores_variables_it_is_handed():
+    model = NaiveForecaster()
+    model._trained_on = 30
+    model.train(_x(30), _y(_series(30)))
+
+    assert model._exogenous_columns == []
+    assert len(model.predict(_future(model, 2))) == 2


### PR DESCRIPTION
## Summary

`ExogenousForecastingTask` had no models to run. `ForecastingModel` now reads the numeric columns beside the date as explanatory variables when the model declares `SUPPORTS_EXOGENOUS`.

Three models serve the new task, and the split between them is the point:

| Model | Reads a date alone | Needs variables | Tasks |
| --- | --- | --- | --- |
| `ARIMA` | yes | no | both |
| `SARIMAX` (new) | yes | no | both |
| `ExogenousLinearRegression` (new) | no | yes | exogenous only |
| `NaiveForecaster`, `SeasonalNaiveForecaster`, `ExponentialSmoothing` | yes | cannot use them | plain only |

`ARIMA` gains an `exog` term, so with a date alone it is the plain ARIMA it was, and with variables beside it an ARIMA with regressors. `SARIMAX` adds the seasonal orders `ARIMA` does not expose, and is likewise optional in both. `ExogenousLinearRegression` fits the series as a straight line in the variables with no memory of its own history, which is what makes it worth comparing against the other two: a large gap between their scores says whether the series is driven by its own momentum or by something outside it.

---

## Type of Change

Check all that apply like this [x]:

- [x] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/models/forecasting/base_forecasting_model.py`: added `SUPPORTS_EXOGENOUS`, `_remember_exogenous`, `_exogenous_of` and `_exogenous_over`. `_forecast_at` no longer takes a callable and passes the exogenous matrix when the model was fitted with variables. `_forecast` gained an optional `exog` argument. `COMPATIBLE_COMPONENTS` was removed from this class, see Notes.
- `DashAI/back/models/forecasting/arima.py`: fits and forecasts with `exog`. Declares both tasks and `SUPPORTS_EXOGENOUS`.
- `DashAI/back/models/forecasting/sarimax.py`: new. Seven orders (`p`, `d`, `q`, `P`, `D`, `Q`, season length), the seasonal part disabled at a season length below 2. Refuses a season the series is too short to show twice. Declares both tasks.
- `DashAI/back/models/forecasting/exogenous_linear_regression.py`: new. Ridge on the variables, with an optional period number trend so a drift the variables do not account for can still be fitted. Refuses a date column with nothing beside it. Declares the exogenous task alone.
- `DashAI/back/models/forecasting/naive.py`, `seasonal_naive.py`, `exponential_smoothing.py`: each now declares `COMPATIBLE_COMPONENTS = ["ForecastingTask"]` for itself.
- `DashAI/back/initial_components.py`: registers `SARIMAX` and `ExogenousLinearRegression`.
- `tests/back/models/test_exogenous_forecasting_models.py`: new. Covers which tasks each model declares, one value per requested row, the variables actually changing the forecast, a forecast far past the training data, a missing variable being refused, save/load round trips, the dual models still working from a date alone, the linear model recovering a known linear relationship, and the SARIMAX seasonal guards.

---

## Testing


- **Plain forecasting regression:** Train ARIMA, Naive, Seasonal Naive and Exponential Smoothing on `Forecasting` using only `date` as input. ARIMA scores should match `develop`, and all models should train successfully.

- **Task/model compatibility:** Verify `Forecasting` offers ARIMA, SARIMAX, Naive, Seasonal Naive and Exponential Smoothing, but not Exogenous Linear Regression. Verify `Forecasting with Exogenous Variables` offers only ARIMA, SARIMAX and Exogenous Linear Regression.

- **Input validation:** On `Forecasting with Exogenous Variables`, verify `date` + `exg_1` is accepted, `date` alone and `exg_1` alone are rejected, multiple date columns are rejected, and column order does not matter.

- **Training and prediction:** Train ARIMA, SARIMAX and Exogenous Linear Regression with `date` + `exg_1` + `exg_2`. Verify Temporal Holdout/Rolling Origin are the only available splitters, metrics produce values, and future predictions respond to changes in the exogenous variables. Missing variables and dates inside the training window must be rejected.

---

## Notes

Exogenous variables are used **contemporaneously**:

```
y[t] = b * x[t] + n[t]
```

The models do not automatically use `x[t-1]`, `x[t-2]`, etc. Future forecasts therefore require the exogenous values for the requested forecast rows.

Intermediate exogenous rows may be interpolated when the forecast horizon contains gaps. These values do not affect the requested forecast rows, as verified by regression tests.

Lagged exogenous variables are out of scope and would require extending the time series windowing/conversion pipeline.
