### PR TITLE
Fix fold split toggles and live train toggle visibility

### DIFF
--- a/DashAI/back/evaluation/base_evaluation_strategy.py
+++ b/DashAI/back/evaluation/base_evaluation_strategy.py
@@ -36,9 +36,16 @@ class BaseEvaluationStrategy(metaclass=ABCMeta):
         -------
         dict
             Mapping with ``kind``, which says whether this strategy splits the
-            dataset once or into folds.
+            dataset once or into folds, and ``scored_splits``, the partitions
+            it writes metrics for. A screen that offers one control per
+            partition reads the latter instead of assuming all three exist:
+            a forecasting strategy scores no training partition, so asking it
+            for train metrics finds nothing.
         """
-        return {"kind": cls.KIND}
+        return {
+            "kind": cls.KIND,
+            "scored_splits": [split.value for split in cls.SCORED_SPLITS],
+        }
 
     def __init__(
         self,

--- a/DashAI/front/src/components/models/FoldMetricsChart.jsx
+++ b/DashAI/front/src/components/models/FoldMetricsChart.jsx
@@ -26,6 +26,10 @@ import ResultsGraphsParameters from "../../pages/results/components/ResultsGraph
 import PillToggleButtonGroup from "../shared/PillToggleButtonGroup";
 import PlotActions from "../shared/PlotActions";
 import { getTraceColors } from "../../utils/chartColors";
+import { useStrategyMetadata } from "../../hooks/useStrategyKind";
+import { useModels } from "./ModelsContext";
+
+const FOLD_SPLITS = ["TRAIN", "VALIDATION"];
 
 // ─── Pure helpers (defined outside component — stable references) ─────────────
 
@@ -175,17 +179,37 @@ export default function FoldMetricsChart({ run }) {
   const [error, setError] = useState(null);
   const [chartType, setChartType] = useState("boxplot");
   const [foldScope, setFoldScope] = useState("default");
-  const [split, setSplit] = useState("TRAIN");
+  const [split, setSplit] = useState(null);
   const [selectedMetrics, setSelectedMetrics] = useState([]);
 
   const selectedMetricsRef = useRef([]);
 
-  const metricSplit = split.toLowerCase();
+  const metricSplit = split?.toLowerCase() ?? null;
   const isNestedCV = !!run.nested;
+
+  const strategyName =
+    useModels()?.selectedSession?.evaluation_strategy ?? null;
+  const strategyMetadata = useStrategyMetadata(strategyName);
+  const awaitingStrategy = !!strategyName && strategyMetadata === null;
+
+  const foldSplits = useMemo(() => {
+    const scored = strategyMetadata?.scored_splits;
+    if (!Array.isArray(scored)) return FOLD_SPLITS;
+    const available = FOLD_SPLITS.filter((name) =>
+      scored.includes(name.toLowerCase()),
+    );
+    return available.length > 0 ? available : FOLD_SPLITS;
+  }, [strategyMetadata]);
+
+  useEffect(() => {
+    setSplit((current) =>
+      foldSplits.includes(current) ? current : foldSplits[0],
+    );
+  }, [foldSplits]);
 
   // ── Fetch ──────────────────────────────────────────────────────────────────
   useEffect(() => {
-    if (!run) return;
+    if (!run || !split || awaitingStrategy) return;
 
     setLoading(true);
     setError(null);
@@ -238,7 +262,7 @@ export default function FoldMetricsChart({ run }) {
     return () => controller.abort();
     // selectedRepetition intentionally excluded — we only read it as "current value at fetch time"
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [run, metricSplit, foldScope, isNestedCV]);
+  }, [run, metricSplit, foldScope, isNestedCV, awaitingStrategy]);
 
   // ── Derived data ───────────────────────────────────────────────────────────
 
@@ -395,7 +419,7 @@ export default function FoldMetricsChart({ run }) {
     );
   }
 
-  if (loading) {
+  if (loading || awaitingStrategy || !split) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
         <CircularProgress />
@@ -456,14 +480,18 @@ export default function FoldMetricsChart({ run }) {
             if (v) setSplit(v);
           }}
         >
-          <ToggleButton value="TRAIN" sx={{ px: 1.5 }}>
-            {t("models:label.train")}
-          </ToggleButton>
+          {foldSplits.includes("TRAIN") && (
+            <ToggleButton value="TRAIN" sx={{ px: 1.5 }}>
+              {t("models:label.train")}
+            </ToggleButton>
+          )}
           {/* A fold is scored on its validation partition; the reserved
               rows produce a single value, with nothing to chart per fold. */}
-          <ToggleButton value="VALIDATION" sx={{ px: 1.5 }}>
-            {t("models:label.validation")}
-          </ToggleButton>
+          {foldSplits.includes("VALIDATION") && (
+            <ToggleButton value="VALIDATION" sx={{ px: 1.5 }}>
+              {t("models:label.validation")}
+            </ToggleButton>
+          )}
         </PillToggleButtonGroup>
       </Box>
 

--- a/DashAI/front/src/components/models/LiveMetricsChart.jsx
+++ b/DashAI/front/src/components/models/LiveMetricsChart.jsx
@@ -14,6 +14,10 @@ import ResultsGraphsParameters from "../../pages/results/components/ResultsGraph
 import PillToggleButtonGroup from "../shared/PillToggleButtonGroup";
 import PlotActions from "../shared/PlotActions";
 import { getTraceColors } from "../../utils/chartColors";
+import { useStrategyMetadata } from "../../hooks/useStrategyKind";
+import { useModels } from "./ModelsContext";
+
+const SPLITS = ["TRAIN", "VALIDATION", "TEST"];
 
 function toFinalValue(value) {
   const resolved = Array.isArray(value)
@@ -315,10 +319,27 @@ export function LiveMetricsChart({ run, modelSessionDetail = null }) {
     return (modelSessionDetail.test_metrics ?? []).length > 0;
   }, [modelSessionDetail]);
 
+  const strategyName =
+    useModels()?.selectedSession?.evaluation_strategy ?? null;
+  const strategyMetadata = useStrategyMetadata(strategyName);
+
+  const availableSplits = useMemo(() => {
+    const scored = strategyMetadata?.scored_splits;
+    const offered = Array.isArray(scored)
+      ? SPLITS.filter((name) => scored.includes(name.toLowerCase()))
+      : SPLITS;
+    const withTest = hasTestSplit
+      ? offered
+      : offered.filter((name) => name !== "TEST");
+    return withTest.length > 0 ? withTest : SPLITS;
+  }, [strategyMetadata, hasTestSplit]);
+
   // Never leave the group pointing at a button that is no longer rendered.
   useEffect(() => {
-    if (!hasTestSplit && split === "TEST") setSplit("TRAIN");
-  }, [hasTestSplit, split]);
+    setSplit((current) =>
+      availableSplits.includes(current) ? current : availableSplits[0],
+    );
+  }, [availableSplits]);
 
   return (
     <Box
@@ -364,13 +385,17 @@ export function LiveMetricsChart({ run, modelSessionDetail = null }) {
             backdropFilter: "blur(8px)",
           }}
         >
-          <ToggleButton value="TRAIN" sx={{ px: 1.5 }}>
-            {t("models:label.train")}
-          </ToggleButton>
-          <ToggleButton value="VALIDATION" sx={{ px: 1.5 }}>
-            {t("models:label.validation")}
-          </ToggleButton>
-          {hasTestSplit && (
+          {availableSplits.includes("TRAIN") && (
+            <ToggleButton value="TRAIN" sx={{ px: 1.5 }}>
+              {t("models:label.train")}
+            </ToggleButton>
+          )}
+          {availableSplits.includes("VALIDATION") && (
+            <ToggleButton value="VALIDATION" sx={{ px: 1.5 }}>
+              {t("models:label.validation")}
+            </ToggleButton>
+          )}
+          {availableSplits.includes("TEST") && (
             <ToggleButton value="TEST" sx={{ px: 1.5 }}>
               {t("models:label.test")}
             </ToggleButton>

--- a/DashAI/front/src/components/models/ModelComparisonTable.jsx
+++ b/DashAI/front/src/components/models/ModelComparisonTable.jsx
@@ -115,22 +115,20 @@ function ModelComparisonTable({
       color: theme.palette.accent.teal,
       label: "HPO",
     },
-    ...(isCrossValidation
-      ? {
-          nestedCv: {
-            bg: "#585370",
-            border: "#585370",
-            color: "#585370",
-            label: "CV anidado",
-          },
-        }
-      : {}),
+    nestedCv: {
+      bg: "#585370",
+      border: "#585370",
+      color: "#585370",
+      label: "CV anidado",
+    },
   };
 
-  const runTypeLegend = Object.entries(runTypeStyles).map(([key, value]) => ({
-    key,
-    ...value,
-  }));
+  const runTypeLegend = Object.entries(runTypeStyles)
+    .filter(([key]) => key !== "nestedCv" || isCrossValidation)
+    .map(([key, value]) => ({
+      key,
+      ...value,
+    }));
 
   const getMetricColumns = () => {
     const metricsSet = new Set();
@@ -442,7 +440,7 @@ function ModelComparisonTable({
     state: { columnOrder },
     muiTableBodyRowProps: ({ row }) => {
       const runType = getRunType(row.original);
-      const { bg, border } = runTypeStyles[runType];
+      const { bg, border } = runTypeStyles[runType] ?? runTypeStyles.withoutHpo;
       return {
         onClick: () => {
           if (onRowClick) onRowClick(row.original.id);

--- a/DashAI/front/src/hooks/useStrategyKind.js
+++ b/DashAI/front/src/hooks/useStrategyKind.js
@@ -2,59 +2,65 @@ import { useEffect, useState } from "react";
 import { getComponents } from "../api/component";
 
 /**
- * How each evaluation strategy divides the dataset, once fetched.
+ * What each evaluation strategy declares about itself, once fetched.
  *
  * Strategy names never change for a given session, so the answer is cached
  * across components: several screens ask the same question about the same
  * session and none of them should trigger its own request.
  */
-const kindCache = new Map();
+const metadataCache = new Map();
 
 /**
- * Read the split shape of the strategy a session uses.
+ * Read the metadata an evaluation strategy declares.
  *
- * Screens used to ask this by comparing the stored strategy name against a
- * literal, which meant every new strategy silently read as "not cross
- * validation" and rendered the wrong controls. The backend reports the shape,
- * so it is read rather than guessed.
+ * Screens used to answer these questions by comparing the stored strategy
+ * name against a literal, which meant every new strategy silently read as
+ * "not cross validation" and rendered the wrong controls. The backend reports
+ * what it does, so it is read rather than guessed.
  *
  * @param {string|null} strategyName a session's evaluation_strategy
- * @returns {string|null} "holdout", "cv", or null while unknown
+ * @returns {object|null} the strategy metadata, or null while it is unknown
  */
-export function useStrategyKind(strategyName) {
-  const [kind, setKind] = useState(() => kindCache.get(strategyName) ?? null);
+export function useStrategyMetadata(strategyName) {
+  const [metadata, setMetadata] = useState(
+    () => metadataCache.get(strategyName) ?? null,
+  );
 
   useEffect(() => {
     if (!strategyName) {
-      setKind(null);
+      setMetadata(null);
       return undefined;
     }
 
-    if (kindCache.has(strategyName)) {
-      setKind(kindCache.get(strategyName));
+    if (metadataCache.has(strategyName)) {
+      setMetadata(metadataCache.get(strategyName));
       return undefined;
     }
 
     let cancelled = false;
-    const fetchKind = async () => {
+    const fetchMetadata = async () => {
       try {
         const component = await getComponents({ model: strategyName });
-        const value = component?.metadata?.kind ?? null;
-        kindCache.set(strategyName, value);
-        if (!cancelled) setKind(value);
+        const value = component?.metadata ?? {};
+        metadataCache.set(strategyName, value);
+        if (!cancelled) setMetadata(value);
       } catch (error) {
         console.error(`Error fetching the ${strategyName} metadata`, error);
-        if (!cancelled) setKind(null);
+        if (!cancelled) setMetadata({});
       }
     };
 
-    fetchKind();
+    fetchMetadata();
     return () => {
       cancelled = true;
     };
   }, [strategyName]);
 
-  return kind;
+  return metadata;
+}
+
+export function useStrategyKind(strategyName) {
+  return useStrategyMetadata(strategyName)?.kind ?? null;
 }
 
 export default useStrategyKind;

--- a/tests/back/evaluation/test_forecasting_strategies.py
+++ b/tests/back/evaluation/test_forecasting_strategies.py
@@ -82,6 +82,31 @@ def test_each_strategy_declares_the_shape_of_its_splits():
 # --- which partitions get scored ---------------------------------------------
 
 
+def test_each_strategy_declares_which_partitions_it_scores():
+    """The fold charts build one toggle per scored partition.
+
+    Reading it from the strategy is what stops them from asking for the train
+    fold metrics a forecasting run never wrote.
+    """
+    assert ForecastingCrossValidationEvaluationStrategy.get_metadata()[
+        "scored_splits"
+    ] == ["validation", "test"]
+    assert ForecastingHoldoutEvaluationStrategy.get_metadata()["scored_splits"] == [
+        "validation",
+        "test",
+    ]
+    assert CrossValidationEvaluationStrategy.get_metadata()["scored_splits"] == [
+        "train",
+        "validation",
+        "test",
+    ]
+    assert HoldoutEvaluationStrategy.get_metadata()["scored_splits"] == [
+        "train",
+        "validation",
+        "test",
+    ]
+
+
 @pytest.mark.parametrize("strategy", FORECASTING_STRATEGIES)
 def test_forecasting_strategies_do_not_score_the_training_partition(strategy):
     assert SplitEnum.TRAIN not in strategy.SCORED_SPLITS


### PR DESCRIPTION
## Summary

The metric charts assumed every evaluation strategy scores a training partition. A forecasting strategy does not: fitting on the training rows and then scoring the model on those same rows would report a fit as a forecast, so `ForecastingHoldoutEvaluationStrategy` and `ForecastingCrossValidationEvaluationStrategy` write validation and test metrics only.

Both charts opened on a `TRAIN` toggle regardless. The fold chart asked the backend for fold metrics that were never written, and the live chart opened on an empty panel. Neither had any way to know, because the split buttons were hardcoded.

Evaluation strategies now report which partitions they score, and both charts build their toggles from that instead of from a fixed list. A third fix rides along, same class of bug: the comparison table assumed every session is cross-validated and crashed on a nested run when it was not.

---

## Type of Change

Check all that apply like this [x]:

- [x] Backend change
- [x] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)

- `DashAI/back/evaluation/base_evaluation_strategy.py`: `get_metadata` now reports `scored_splits` beside `kind`, taken from the strategy's own `SCORED_SPLITS`. A screen that offers one control per partition reads this rather than assuming all three exist.
- `DashAI/front/src/hooks/useStrategyKind.js`: the hook was renamed and widened to `useStrategyMetadata`, returning the whole metadata object instead of just `kind`, with the same cross component cache. `useStrategyKind` stays as a thin wrapper over it, so every existing caller is untouched.
- `DashAI/front/src/components/models/FoldMetricsChart.jsx`: the `TRAIN`/`VALIDATION` toggles are built from `scored_splits`, and the selected split starts as `null` and resolves to the first partition the strategy actually scores. The fetch is held until the strategy metadata arrives, so no request goes out for metrics that were never written, and the spinner covers that wait.
- `DashAI/front/src/components/models/LiveMetricsChart.jsx`: same treatment for the `TRAIN`/`VALIDATION`/`TEST` toggles. The previous effect only corrected a stale `TEST` selection; it now keeps the selection on any partition still being offered, which folds in the old behaviour.
- `DashAI/front/src/components/models/ModelComparisonTable.jsx`: `nestedCv` is always defined in `runTypeStyles` and the legend does the cross-validation filtering, with a fallback on the row lookup so no run type can crash the table over a missing style.
- `tests/back/evaluation/test_forecasting_strategies.py`: asserts each strategy reports the partitions it scores, forecasting strategies naming validation and test, the ordinary ones naming all three.

---

## Testing (Optional)

- On the forecasting session's fold chart, only a `Validation` toggle is offered and it is selected on open. No `Train` toggle, no empty chart, no failed request in the network tab.
- On the ordinary session's fold chart, `Train` and `Validation` are both offered and `Train` is still the default, as before.
- On the forecasting session's live chart during a run, `Train` is absent and the panel opens on `Validation` with data in it.
- On the ordinary session's live chart, all three toggles behave as before, and `Test` still appears only once test metrics exist.
- Switch between the two sessions without reloading. The toggles must follow the session rather than keeping the previous one's set.
- Open a session that has nested cross-validation runs. The comparison table renders rather than throwing, and the nested rows carry their colour.
- Open a session with nested runs that is **not** cross-validated. The table renders and the `CV anidado` entry stays out of the legend.

