### PR TITLE
Add ClassOverlapExplorer to metadata contract blacklist

### DIFF
--- a/tests/back/test_component_metadata_contract.py
+++ b/tests/back/test_component_metadata_contract.py
@@ -146,6 +146,7 @@ def test_the_declared_blacklists_are_the_ones_we_think_they_are():
         name for name, metadata in FILTERING if metadata["non_allowed_dtypes"]
     )
     assert with_blacklist == [
+        "ClassOverlapExplorer",
         "CorrelationMatrixExplorer",
         "CovarianceMatrixExplorer",
         "ECDFPlotExplorer",


### PR DESCRIPTION
## Summary
Updated the test for declared component blacklists to reflect the current list of components with non allowed data types. The `ClassOverlapExplorer` was added to the expected blacklist so the test matches the current component metadata configuration.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [x] Bug fix
- [ ] Documentation

---

## Changes (by file)
- `test_component_metadata_contract.py`: Added `ClassOverlapExplorer` to the expected list of blacklisted components with non allowed data types.