### PR TITLE
fix(metrics): share one guarded scoring loop between calculate_metrics and compute_metrics

### DIFF
--- a/DashAI/back/evaluation/cv.py
+++ b/DashAI/back/evaluation/cv.py
@@ -210,6 +210,28 @@ class FoldEvaluationStrategy(BaseEvaluationStrategy):
             )
             validation_scores = model.compute_metrics(split=SplitEnum.VALIDATION)
 
+            # The goal metric can be missing from the fold's scores: either it
+            # is not among the validation metrics chosen for the run, or it
+            # scored a non-finite value and was dropped. Neither is a fold to
+            # skip -- the objective would then be the mean of a different set of
+            # folds on each trial, and those means are not comparable -- so name
+            # what is missing and stop.
+            #
+            # RuntimeError and not ValueError on purpose: `study.optimize` runs
+            # with `catch=UNFITTABLE_TRIAL_ERRORS`, which includes ValueError,
+            # so a ValueError raised here would be swallowed into "all N trials
+            # failed, narrow the ranges and try again" -- the wrong advice for a
+            # run whose optimization metric was never computed.
+            if metric.__name__ not in validation_scores:
+                scored = ", ".join(sorted(validation_scores)) or "none"
+                raise RuntimeError(
+                    f"Fold {i} produced no value for the optimization metric "
+                    f"'{metric.__name__}'. Metrics scored on this fold: "
+                    f"{scored}. Check that this metric is selected as a "
+                    f"validation metric for the run, and that it is defined "
+                    f"for the fold's data."
+                )
+
             # Collect the goal metric value from this fold
             folds_results.append(validation_scores[metric.__name__])
 

--- a/DashAI/back/models/base_model.py
+++ b/DashAI/back/models/base_model.py
@@ -3,7 +3,7 @@
 import logging
 import math
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Final, final
+from typing import TYPE_CHECKING, Any, Dict, Final, Optional, final
 
 from kink import di
 
@@ -242,6 +242,79 @@ class BaseModel(ConfigObject, metaclass=ABCMeta):
 
             db.commit()
 
+    def _score_split(
+        self,
+        split: SplitEnum,
+        x_data: "DashAIDataset" = None,
+        y_data: "DashAIDataset" = None,
+    ) -> Optional[Dict[str, float]]:
+        """Score the metrics declared for a split, dropping non-finite results.
+
+        This is the one scoring loop behind ``calculate_metrics``, which
+        persists the scores, and ``compute_metrics``, which returns them. They
+        used to carry a copy each and the copies drifted: only the logging one
+        dropped non-finite scores, so a NaN that was too suspect to write to
+        the database still reached the objective of an HPO trial through the
+        other, and poisoned every comparison downstream of it.
+
+        Parameters
+        ----------
+        split : SplitEnum
+            The data split to evaluate (TRAIN, VALIDATION, or TEST).
+        x_data : DashAIDataset, optional
+            Input features. If None, the dataset stored in the model for the
+            given split is used. Defaults to None.
+        y_data : DashAIDataset, optional
+            Target labels. If None, the labels stored in the model for the
+            given split are used. Defaults to None.
+
+        Returns
+        -------
+        Optional[Dict[str, float]]
+            The finite scores keyed by metric name, or None when there was
+            nothing to score: no metrics declared for the split, or no data
+            available for it. None and an empty dict are different answers --
+            the first says the question could not be asked, the second that
+            every metric was asked and none returned a usable number.
+        """
+        metrics = getattr(self, f"{split.value}_metrics", None)
+
+        # No metrics declared for this split: nothing to ask.
+        if not metrics:
+            return None
+
+        # Load data if not provided
+        if x_data is None or y_data is None:
+            if self.x_data is None or self.y_data is None:
+                return None
+            x_data = self.x_data[split.value]
+            y_data = self.y_data[split.value]
+
+        # If data is empty after retrieval, there is nothing to score
+        if x_data is None or y_data is None:
+            return None
+
+        # Make predictions and transform outputs
+        y_pred = self.predict(x_data)
+        y_transformed = self.prepare_output(y_data, is_fit=False)
+
+        # Calculate metric scores
+        results = {}
+        for metric in metrics:
+            score = metric.score(y_transformed, y_pred)
+            if not math.isfinite(score):
+                logger.warning(
+                    "Metric %s returned a non-finite value (%s) for split %s "
+                    "(e.g. only one class present in the split). Skipping.",
+                    metric.__name__,
+                    score,
+                    split,
+                )
+                continue
+            results[metric.__name__] = score
+
+        return results
+
     @final
     def calculate_metrics(
         self,
@@ -276,43 +349,16 @@ class BaseModel(ConfigObject, metaclass=ABCMeta):
             labels stored in the model for the given split are used.
             Defaults to None.
         """
-        # Get the appropriate metrics based on split
-        metrics_attr = f"{split.value}_metrics"
-        metrics = getattr(self, metrics_attr, None)
-
-        # If no metrics or run_id, skip calculation
-        if not metrics or not self.run_id:
+        # If no metrics or run_id, skip calculation. The run_id is checked
+        # before scoring rather than after: without a run there is nowhere to
+        # persist the result, and predicting only to discard the numbers is
+        # wasted work.
+        if not getattr(self, f"{split.value}_metrics", None) or not self.run_id:
             return
 
-        # Load data if not provided
-        if x_data is None or y_data is None:
-            if self.x_data is None or self.y_data is None:
-                return
-            x_data = self.x_data[split.value]
-            y_data = self.y_data[split.value]
-
-        # If data is empty after retrieval, skip calculation
-        if x_data is None or y_data is None:
+        results = self._score_split(split, x_data=x_data, y_data=y_data)
+        if results is None:
             return
-
-        # Make predictions and transform outputs
-        y_pred = self.predict(x_data)
-        y_transformed = self.prepare_output(y_data, is_fit=False)
-
-        # Calculate metric scores
-        results = {}
-        for metric in metrics:
-            score = metric.score(y_transformed, y_pred)
-            if not math.isfinite(score):
-                logger.warning(
-                    "Metric %s returned a non-finite value (%s) for split %s "
-                    "(e.g. only one class present in the split). Skipping.",
-                    metric.__name__,
-                    score,
-                    split,
-                )
-                continue
-            results[metric.__name__] = score
 
         # Save to database
         self._save_metrics(
@@ -334,8 +380,9 @@ class BaseModel(ConfigObject, metaclass=ABCMeta):
         ):
             self._epoch_reporter(results, log_index)
 
-    # Create a function similar to calculate_metrics that returns the scores
-    # instead of saving them to the database, to be used in the CV evaluation loop
+    # The sibling of calculate_metrics: same scoring loop, but the scores are
+    # returned instead of written to the database. Used by the CV evaluation
+    # loop, where they become the objective of an HPO trial.
     def compute_metrics(
         self,
         split: SplitEnum = SplitEnum.TEST,
@@ -361,38 +408,14 @@ class BaseModel(ConfigObject, metaclass=ABCMeta):
         Returns
         -------
         Dict[str, float]
-            A dictionary mapping metric names to their computed scores.
+            A dictionary mapping metric names to their computed scores. A
+            metric that scored a non-finite value is absent from the mapping
+            rather than present with a NaN: see ``_score_split``. Callers that
+            need a particular metric must therefore check that it is there.
         """
-        # Get the appropriate metrics based on split
-        metrics_attr = f"{split.value}_metrics"
-        metrics = getattr(self, metrics_attr, None)
-
-        # If no metrics, return empty dict
-        if not metrics:
-            return {}
-
-        # Load data if not provided
-        if x_data is None or y_data is None:
-            if self.x_data is None or self.y_data is None:
-                return {}
-            x_data = self.x_data[split.value]
-            y_data = self.y_data[split.value]
-
-        # If data is empty after retrieval, return empty dict
-        if x_data is None or y_data is None:
-            return {}
-
-        # Make predictions and transform outputs
-        y_pred = self.predict(x_data)
-        y_transformed = self.prepare_output(y_data, is_fit=False)
-
-        # Calculate metric scores
-        results = {}
-        for metric in metrics:
-            score = metric.score(y_transformed, y_pred)
-            results[metric.__name__] = score
-
-        return results
+        # "Nothing to score" and "nothing scored finite" answer this method's
+        # question the same way: no usable numbers for this split.
+        return self._score_split(split, x_data=x_data, y_data=y_data) or {}
 
     def prepare_dataset(
         self, dataset: "DashAIDataset", is_fit: bool = False

--- a/tests/back/evaluation/test_cv_goal_metric.py
+++ b/tests/back/evaluation/test_cv_goal_metric.py
@@ -1,0 +1,100 @@
+"""A fold that produced no objective must say so, not raise ``KeyError``.
+
+``FoldEvaluationStrategy.evaluate`` indexed the fold's validation scores with
+the goal metric's name and trusted it to be there. It is not always: the metric
+may not be among the validation metrics selected for the run, and since
+``compute_metrics`` drops non-finite scores it can also be missing because it
+was undefined on that fold's data. Both are configuration problems, and both
+surfaced as a bare ``KeyError`` with a metric name in it, several frames below
+where the choice was made.
+
+Skipping the fold instead would be worse than either: the objective would then
+be the mean of a different set of folds on each trial, and those means are not
+comparable, so the study would rank trials by which folds happened to work.
+"""
+
+import pytest
+
+from DashAI.back.core.enums.metrics import SplitEnum
+from DashAI.back.evaluation.cv import FoldEvaluationStrategy
+
+
+class R2:
+    """The goal metric, as a class: ``evaluate`` looks it up by ``__name__``.
+
+    Named rather than given a ``__name__`` attribute, because assigning one in
+    a class body does not change what ``cls.__name__`` returns -- ``type``
+    defines it as a data descriptor, which wins over the class dict.
+    """
+
+    @staticmethod
+    def score(y_true, y_pred):  # pragma: no cover - never reached here
+        return 0.0
+
+
+class _StubModel:
+    """A model whose only interesting behaviour is what it scores."""
+
+    def __init__(self, scores):
+        self._scores = scores
+        self.x_data = None
+        self.y_data = None
+
+    def train(self, *args, **kwargs):
+        return self
+
+    def compute_metrics(self, split=SplitEnum.TEST, **kwargs):
+        return dict(self._scores)
+
+    def _save_metrics(self, **kwargs):
+        pass
+
+
+def _strategy():
+    """A strategy with no factory: only its class attributes are read here."""
+    return FoldEvaluationStrategy.__new__(FoldEvaluationStrategy)
+
+
+#: Two entries make one fold: the last element is the pool, not a fold.
+FOLDS = [{"train": [], "validation": []}, {"train": [], "test": []}]
+
+
+def test_a_missing_goal_metric_names_itself():
+    """The error has to carry the metric asked for and the metrics obtained."""
+    model = _StubModel({"MSE": 0.5, "MAE": 0.3})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _strategy().evaluate(model, FOLDS, FOLDS, R2)
+
+    message = str(excinfo.value)
+    assert "R2" in message, "the error does not name the metric that is missing"
+    assert "MAE, MSE" in message, "the error does not name what was scored"
+
+
+def test_it_is_not_a_valueerror():
+    """``study.optimize`` catches ValueError, so this must not be one.
+
+    ``OptunaOptimizer`` runs the study with ``catch=UNFITTABLE_TRIAL_ERRORS``,
+    which includes ``ValueError``. Raising one here would be swallowed trial by
+    trial and reported as "all N trials failed, narrow the ranges and try
+    again" -- advice that has nothing to do with a metric that was never
+    computed. The same reasoning is already written into the optimizer, where
+    an unsupported parameter type raises ``TypeError`` for this exact reason.
+    """
+    from DashAI.back.optimizers.optuna_optimizer import UNFITTABLE_TRIAL_ERRORS
+
+    model = _StubModel({"MSE": 0.5})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _strategy().evaluate(model, FOLDS, FOLDS, R2)
+
+    assert not isinstance(excinfo.value, UNFITTABLE_TRIAL_ERRORS), (
+        "the optimizer would catch this and report it as an unfittable trial"
+    )
+
+
+def test_a_fold_with_the_goal_metric_still_returns_its_mean():
+    """The guard must not change the answer when there is nothing wrong."""
+    model = _StubModel({"R2": 0.75})
+
+    assert _strategy().evaluate(model, FOLDS, FOLDS, R2) == pytest.approx(0.75)

--- a/tests/back/models/test_metric_scoring.py
+++ b/tests/back/models/test_metric_scoring.py
@@ -1,0 +1,123 @@
+"""A non-finite score must not leave by one door and stay in through the other.
+
+``calculate_metrics`` and ``compute_metrics`` used to carry a copy each of the
+same scoring loop, and the copies drifted. Only the first dropped non-finite
+scores: the second returned the NaN untouched, and that is the one the CV
+evaluation loop calls to build the objective of an HPO trial. So a metric too
+suspect to be written to the database was still comparable enough to decide
+which hyperparameters won -- and every comparison against a NaN is False, so
+the trial that produced it could never be beaten and could never win.
+
+These tests pin the two methods to one loop by asserting they agree.
+"""
+
+import math
+
+import pytest
+
+from DashAI.back.core.enums.metrics import LevelEnum, SplitEnum
+from DashAI.back.models.base_model import BaseModel
+
+
+class _Metric:
+    """The smallest thing the scoring loop accepts: a name and a score."""
+
+    def __init__(self, name, value):
+        self.__name__ = name
+        self._value = value
+
+    def score(self, y_true, y_pred):
+        return self._value
+
+
+class _StubModel(BaseModel):
+    """A model that predicts nothing, so only the scoring loop is under test."""
+
+    def train(self, *args, **kwargs):
+        return self
+
+    def save(self, filename):  # pragma: no cover - not exercised here
+        raise NotImplementedError
+
+    def load(self, filename):  # pragma: no cover - not exercised here
+        raise NotImplementedError
+
+    def predict(self, x):
+        return [0.0]
+
+    def prepare_output(self, dataset, is_fit=False):
+        return dataset
+
+
+@pytest.fixture(name="model")
+def fixture_model():
+    model = _StubModel()
+    model.run_id = 1
+    model.x_data = None
+    model.y_data = None
+    model.train_metrics = None
+    model.test_metrics = None
+    model.validation_metrics = None
+    return model
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_compute_metrics_drops_non_finite_scores(model, bad):
+    """The value that must never reach an objective must never be returned.
+
+    Before the shared loop, ``compute_metrics`` returned ``{"good": 1.0,
+    "bad": nan}``: the mean of a fold's scores was then NaN, and NaN compares
+    False against every other trial in both directions.
+    """
+    model.validation_metrics = [_Metric("good", 1.0), _Metric("bad", bad)]
+
+    scores = model.compute_metrics(split=SplitEnum.VALIDATION, x_data=[], y_data=[])
+
+    assert scores == {"good": 1.0}, (
+        f"a {bad} score survived into the mapping the HPO objective is built from"
+    )
+    assert all(math.isfinite(v) for v in scores.values())
+
+
+def test_both_methods_agree_on_what_was_scored(model):
+    """The two entry points must report the same set of metrics.
+
+    This is the assertion that would have caught the drift: whatever the policy
+    on non-finite scores is, the logged metrics and the optimized metrics have
+    to be the same ones, or the run is tuned on numbers nobody can see.
+    """
+    model.validation_metrics = [_Metric("good", 1.0), _Metric("bad", float("nan"))]
+
+    persisted = {}
+    model._save_metrics = lambda **kwargs: persisted.update(kwargs["results"])
+
+    model.calculate_metrics(
+        split=SplitEnum.VALIDATION,
+        level=LevelEnum.LAST,
+        x_data=[],
+        y_data=[],
+    )
+    returned = model.compute_metrics(split=SplitEnum.VALIDATION, x_data=[], y_data=[])
+
+    assert persisted == returned
+
+
+def test_no_metrics_declared_returns_an_empty_mapping(model):
+    """A split with no metrics is not an error, and must not look like a score."""
+    assert model.compute_metrics(split=SplitEnum.VALIDATION, x_data=[], y_data=[]) == {}
+
+
+def test_every_metric_non_finite_is_not_the_same_as_no_metrics(model):
+    """Both answer ``{}`` to the caller, but only one gets logged about.
+
+    ``_score_split`` distinguishes them -- ``None`` for a question that could
+    not be asked, an empty dict for one whose answers were all unusable -- and
+    ``calculate_metrics`` relies on that to persist an empty result rather than
+    skip the split silently.
+    """
+    model.validation_metrics = [_Metric("bad", float("nan"))]
+
+    assert model._score_split(SplitEnum.VALIDATION, x_data=[], y_data=[]) == {}
+
+    model.validation_metrics = None
+    assert model._score_split(SplitEnum.VALIDATION, x_data=[], y_data=[]) is None


### PR DESCRIPTION
… metric

`calculate_metrics` and `compute_metrics` carried a copy each of the same scoring loop, and the copies drifted: only the first dropped non-finite scores. The second is the one the CV evaluation loop calls to build the objective of an HPO trial, so a metric too suspect to write to the database was still trusted to decide which hyperparameters won -- and every comparison against a NaN is False in both directions, so that trial could neither be beaten nor win.

Both now delegate to `BaseModel._score_split`, which owns the data loading, the prediction, the scoring and the `math.isfinite` guard. It returns None when there was nothing to score and a dict otherwise, which lets the two callers keep their different contracts: `calculate_metrics` persists an empty result (every metric was asked and none was usable) but skips when there was nothing to ask, while `compute_metrics` collapses both to `{}`.

Second half: `cv.py` indexed the fold's validation scores with the goal metric's name and trusted it to be there. It is not always -- the metric may not be among the run's validation metrics, and now that non-finite scores are dropped it can also be missing because it was undefined on that fold. Both are configuration errors, and both surfaced as a bare KeyError several frames below where the choice was made. It now raises with the metric asked for and the metrics actually scored.

RuntimeError and not ValueError on purpose: `study.optimize` runs with `catch=UNFITTABLE_TRIAL_ERRORS`, which includes ValueError, so a ValueError here would be swallowed into "all N trials failed, narrow the ranges and try again". The same reasoning is already written into optuna_optimizer.py, where an unsupported parameter type raises TypeError for this exact reason. A test asserts the exception is not one the optimizer catches.

Closes #843


Claude-Session: https://claude.ai/code/session_01BzZ6td4VJdRDe76UndWZY3

## Summary
Short explanation of what changed and why.

---

## Type of Change
Check all that apply like this [x]:

- [ ] Backend change
- [ ] Frontend change
- [ ] CI / Workflow change
- [ ] Build / Packaging change
- [ ] Bug fix
- [ ] Documentation

---

## Changes (by file)
Briefly list the important modified files and what was done.

Example:
- `path/to/file.py`: description
- `another/file.tsx`: description

---

## Testing (optional)
Only add if there's something reviewers should verify.

---

## Notes (optional)
Additional context or considerations.
